### PR TITLE
update module dependencies

### DIFF
--- a/apollo-compiler/build.gradle
+++ b/apollo-compiler/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile dep.moshi
   compile dep.pluralizer
   compile dep.jsr305
-  compile project (":apollo-api")
+  compile project(":apollo-api")
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-converters/moshi/build.gradle
+++ b/apollo-converters/moshi/build.gradle
@@ -3,11 +3,18 @@ apply plugin: 'java'
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
+configurations {
+  compileOnly
+}
+
+sourceSets.test.compileClasspath += configurations.compileOnly
+sourceSets.test.runtimeClasspath += configurations.compileOnly
+
 dependencies {
   compile dep.moshi
   compile dep.jsr305
   compile dep.retrofitMoshiConverter
-  compile project (":apollo-api")
+  compileOnly project(":apollo-api")
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-converters/pojo/build.gradle
+++ b/apollo-converters/pojo/build.gradle
@@ -3,6 +3,13 @@ apply plugin: 'java'
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
+configurations {
+  compileOnly
+}
+
+sourceSets.test.compileClasspath += configurations.compileOnly
+sourceSets.test.runtimeClasspath += configurations.compileOnly
+
 tasks.withType(Checkstyle) {
   exclude '**/pojo/BufferedSourceJsonReader.java'
   exclude '**/pojo/JsonScope.java'
@@ -11,7 +18,7 @@ tasks.withType(Checkstyle) {
 dependencies {
   compile dep.jsr305
   compile dep.retrofit
-  compile project (":apollo-api")
+  compileOnly project (":apollo-api")
 
   testCompile dep.moshi
   testCompile dep.retrofitMoshiConverter

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   compile dep.jsr305
   compile dep.retrofit
   compile dep.supportAnnotations
-  compile project (":apollo-api")
+  provided project (":apollo-api")
   testCompile dep.junit
   testCompile dep.truth
 }

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   compile project(':apollo-converters:moshi')
   compile project(':apollo-converters:pojo')
   compile project(":apollo-runtime")
-  compile project(":apollo-api")
   compile 'io.reactivex.rxjava2:rxjava:2.0.3'
   compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
   compile 'com.squareup.retrofit2:adapter-rxjava2:2.2.0-SNAPSHOT'


### PR DESCRIPTION
we now dynamically add the apollo-api dependency through the plugin.

This updates the module to deal with the change and avoid conflicts when different modules reference different versions.