### PR TITLE
Restrict overriding custom scalar types

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
@@ -13,7 +13,7 @@ public final class Field {
   private final ObjectReader objectReader;
   private final ListReader listReader;
   private final boolean optional;
-  private final TypeMapping typeMapping;
+  private final ScalarType scalarType;
 
   public static Field forString(String responseName, String fieldName, Map<String, Object> arguments,
       boolean optional) {
@@ -55,12 +55,12 @@ public final class Field {
   }
 
   public static <T> Field forCustomType(String responseName, String fieldName, Map<String, Object> arguments,
-      boolean optional, TypeMapping typeMapping) {
-    return new Field(Type.CUSTOM, responseName, fieldName, arguments, null, null, optional, typeMapping);
+      boolean optional, ScalarType scalarType) {
+    return new Field(Type.CUSTOM, responseName, fieldName, arguments, null, null, optional, scalarType);
   }
 
   private Field(Type type, String responseName, String fieldName, Map<String, Object> arguments,
-      ObjectReader objectReader, ListReader listReader, boolean optional, TypeMapping typeMapping) {
+      ObjectReader objectReader, ListReader listReader, boolean optional, ScalarType scalarType) {
     this.type = type;
     this.responseName = responseName;
     this.fieldName = fieldName;
@@ -69,7 +69,7 @@ public final class Field {
     this.objectReader = objectReader;
     this.listReader = listReader;
     this.optional = optional;
-    this.typeMapping = typeMapping;
+    this.scalarType = scalarType;
   }
 
   public Type type() {
@@ -100,8 +100,8 @@ public final class Field {
     return listReader;
   }
 
-  public TypeMapping typeMapping() {
-    return typeMapping;
+  public ScalarType scalarType() {
+    return scalarType;
   }
 
   public static enum Type {
@@ -135,6 +135,6 @@ public final class Field {
 
     Boolean readBoolean() throws IOException;
 
-    <T> T readCustomType(TypeMapping typeMapping) throws IOException;
+    <T> T readCustomType(ScalarType scalarType) throws IOException;
   }
 }

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarType.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarType.java
@@ -1,0 +1,5 @@
+package com.apollographql.android.api.graphql;
+
+public interface ScalarType {
+  String name();
+}

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarType.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarType.java
@@ -1,5 +1,5 @@
 package com.apollographql.android.api.graphql;
 
 public interface ScalarType {
-  String name();
+  String typeName();
 }

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarTypeMapping.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/ScalarTypeMapping.java
@@ -1,7 +1,0 @@
-package com.apollographql.android.api.graphql;
-
-public interface ScalarTypeMapping {
-  String type();
-
-  Class clazz();
-}

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/TypeMapping.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/TypeMapping.java
@@ -1,7 +1,0 @@
-package com.apollographql.android.api.graphql;
-
-public interface TypeMapping {
-  String type();
-
-  Class clazz();
-}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
@@ -28,7 +28,7 @@ class CustomEnumTypeSpecBuilder(
 
   private fun scalarMappingTypeSpec(scalarType: String) =
       TypeSpec.anonymousClassBuilder("")
-          .addMethod(MethodSpec.methodBuilder("name")
+          .addMethod(MethodSpec.methodBuilder("typeName")
               .addModifiers(Modifier.PUBLIC)
               .returns(java.lang.String::class.java)
               .addStatement("return \$S", scalarType)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.TypeMapping
+import com.apollographql.android.api.graphql.ScalarType
 import com.apollographql.android.compiler.ir.CodeGenerationContext
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
@@ -13,7 +13,7 @@ class CustomEnumTypeSpecBuilder(
   fun build(): TypeSpec =
       TypeSpec.enumBuilder(className(context))
           .addAnnotation(Annotations.GENERATED_BY_APOLLO)
-          .addSuperinterface(TypeMapping::class.java)
+          .addSuperinterface(ScalarType::class.java)
           .addModifiers(Modifier.PUBLIC)
           .addEnumConstants()
           .build()
@@ -21,23 +21,17 @@ class CustomEnumTypeSpecBuilder(
   private fun TypeSpec.Builder.addEnumConstants(): TypeSpec.Builder {
     context.customTypeMap.forEach { mapping ->
       val constantName = mapping.key.removeSuffix("!").toUpperCase()
-      addEnumConstant(constantName, scalarMappingTypeSpec(mapping.key, mapping.value))
+      addEnumConstant(constantName, scalarMappingTypeSpec(mapping.key))
     }
     return this
   }
 
-  private fun scalarMappingTypeSpec(scalarType: String, javaClassName: String) =
+  private fun scalarMappingTypeSpec(scalarType: String) =
       TypeSpec.anonymousClassBuilder("")
-          .addMethod(MethodSpec.methodBuilder("type")
+          .addMethod(MethodSpec.methodBuilder("name")
               .addModifiers(Modifier.PUBLIC)
               .returns(java.lang.String::class.java)
               .addStatement("return \$S", scalarType)
-              .build())
-          .addMethod(MethodSpec.methodBuilder("clazz")
-              .addModifiers(Modifier.PUBLIC)
-              .returns(Class::class.java)
-              .addStatement("return \$T.class", ClassName.get(javaClassName.substringBeforeLast("."),
-                  javaClassName.substringAfterLast(".")))
               .build())
           .build()
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -15,24 +15,20 @@ open class GraphQLCompiler {
     val irPackageName = irFile.absolutePath.formatPackageName()
     val fragmentsPackage = if (irPackageName.length > 0) "$irPackageName.fragment" else "fragment"
     val typesPackage = if (irPackageName.length > 0) "$irPackageName.type" else "type"
+    val customScalarTypeMap = customScalarTypeMap(ir.typesUsed, customTypeMap)
     val codeGenerationContext = CodeGenerationContext(!generateClasses, emptyList(), ir.typesUsed, fragmentsPackage,
-        typesPackage, customTypeMap)
+        typesPackage, customScalarTypeMap)
     val operationTypeBuilders = ir.operations.map { OperationTypeSpecBuilder(it, ir.fragments) }
-    (operationTypeBuilders + ir.fragments + ir.typesUsed).forEach {
+    (operationTypeBuilders + ir.fragments + ir.typesUsed.supportedTypeDeclarations()).forEach {
       val packageName = javaFilePackageName(it, irPackageName, fragmentsPackage, typesPackage)
       val typeSpec = it.toTypeSpec(codeGenerationContext)
       JavaFile.builder(packageName, typeSpec).build().writeTo(outputDir)
     }
 
-    if (customTypeMap.isNotEmpty()) {
+    if (codeGenerationContext.customTypeMap.isNotEmpty()) {
       val typeSpec = CustomEnumTypeSpecBuilder(codeGenerationContext).build()
       JavaFile.builder(typesPackage, typeSpec).build().writeTo(outputDir)
     }
-  }
-
-  companion object {
-    const val FILE_EXTENSION = "graphql"
-    val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
   }
 
   private fun String.formatPackageName(): String {
@@ -51,5 +47,19 @@ open class GraphQLCompiler {
       is TypeDeclaration -> return typesPackage
     }
     return irPackage
+  }
+
+  private fun List<TypeDeclaration>.supportedTypeDeclarations() =
+    filter { it.kind == TypeDeclaration.KIND_ENUM || it.kind == TypeDeclaration.KIND_INPUT_OBJECT_TYPE }
+
+  private fun customScalarTypeMap(typeDeclarations: List<TypeDeclaration>,
+      customTypeMap: Map<String, String>): Map<String, String> {
+    val customScalarTypes = typeDeclarations.filter { it.kind == TypeDeclaration.KIND_SCALAR_TYPE }.map { it.name }
+    return customTypeMap.filter { customScalarTypes.contains(it.key) }
+  }
+
+  companion object {
+    const val FILE_EXTENSION = "graphql"
+    val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/TypeDeclaration.kt
@@ -13,9 +13,9 @@ data class TypeDeclaration(
     val fields: List<TypeDeclarationField>?
 ) : CodeGenerator {
   override fun toTypeSpec(context: CodeGenerationContext): TypeSpec {
-    if (kind == "EnumType") {
+    if (kind == KIND_ENUM) {
       return enumTypeToTypeSpec()
-    } else if (kind == "InputObjectType") {
+    } else if (kind == KIND_INPUT_OBJECT_TYPE) {
       return inputObjectToTypeSpec(context)
     } else {
       throw UnsupportedOperationException("unsupported $kind type declaration")
@@ -42,4 +42,10 @@ data class TypeDeclaration(
 
   private fun inputObjectToTypeSpec(context: CodeGenerationContext) =
       InputObjectTypeSpecBuilder(name, fields ?: emptyList(), context).build()
+
+  companion object {
+    val KIND_INPUT_OBJECT_TYPE : String = "InputObjectType"
+    val KIND_ENUM : String = "EnumType"
+    val KIND_SCALAR_TYPE : String = "ScalarType"
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/CustomTypeExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/CustomTypeExpected.java
@@ -7,7 +7,7 @@ import javax.annotation.Generated;
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
   DATE {
-    public String type() {
+    public String typeName() {
       return "Date";
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/CustomTypeExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/CustomTypeExpected.java
@@ -1,20 +1,14 @@
 package com.example.custom_scalar_type.type;
 
-import com.apollographql.android.api.graphql.TypeMapping;
-import java.lang.Class;
+import com.apollographql.android.api.graphql.ScalarType;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
-public enum CustomType implements TypeMapping {
+public enum CustomType implements ScalarType {
   DATE {
     public String type() {
       return "Date";
-    }
-
-    public Class clazz() {
-      return Date.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.json
@@ -36,5 +36,11 @@
     }
   ],
   "fragments": [],
-  "typesUsed": []
+  "typesUsed": [
+    {
+      "kind": "ScalarType",
+      "name": "Date",
+      "description": null
+    }
+  ]
 }

--- a/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/CustomTypeExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/CustomTypeExpected.java
@@ -7,7 +7,7 @@ import javax.annotation.Generated;
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
   DATE {
-    public String type() {
+    public String typeName() {
       return "Date";
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/CustomTypeExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/CustomTypeExpected.java
@@ -1,20 +1,14 @@
 package com.example.pojo_custom_scalar_type.type;
 
-import com.apollographql.android.api.graphql.TypeMapping;
-import java.lang.Class;
+import com.apollographql.android.api.graphql.ScalarType;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
-public enum CustomType implements TypeMapping {
+public enum CustomType implements ScalarType {
   DATE {
     public String type() {
       return "Date";
-    }
-
-    public Class clazz() {
-      return Date.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/pojo_custom_scalar_type/TestQuery.json
@@ -36,5 +36,11 @@
     }
   ],
   "fragments": [],
-  "typesUsed": []
+  "typesUsed": [
+    {
+      "kind": "ScalarType",
+      "name": "Date",
+      "description": null
+    }
+  ]
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/android/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/android/compiler/CodegenTest.kt
@@ -71,9 +71,9 @@ class CodeGenTest(val testDir: File, val pkgName: String, val generatePOJO: Bool
           .filter { it.isDirectory }
           .map {
             if (it.name == "custom_scalar_type") {
-              arrayOf(it, it.name, false, mapOf("Date" to "java.util.Date"))
+              arrayOf(it, it.name, false, mapOf("Date" to "java.util.Date", "UnsupportedType" to "java.lang.Object"))
             } else if (it.name == "pojo_custom_scalar_type") {
-              arrayOf(it, it.name, true, mapOf("Date" to "java.util.Date"))
+              arrayOf(it, it.name, true, mapOf("Date" to "java.util.Date", "UnsupportedType" to "java.lang.Object"))
             } else {
               arrayOf(it, it.name, it.name.startsWith("pojo"), emptyMap<String, String>())
             }

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ApolloConverterFactory.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ApolloConverterFactory.java
@@ -2,7 +2,7 @@ package com.apollographql.android.converter.pojo;
 
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.TypeMapping;
+import com.apollographql.android.api.graphql.ScalarType;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
@@ -18,9 +18,9 @@ import retrofit2.Retrofit;
 
 /** TODO */
 public final class ApolloConverterFactory extends Converter.Factory {
-  private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-  private ApolloConverterFactory(Map<TypeMapping, CustomTypeAdapter> customTypeAdapters) {
+  private ApolloConverterFactory(Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
     this.customTypeAdapters = customTypeAdapters;
   }
 
@@ -36,11 +36,11 @@ public final class ApolloConverterFactory extends Converter.Factory {
   }
 
   public static class Builder {
-    private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters = new HashMap<>();
+    private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters = new HashMap<>();
 
-    public Builder withCustomTypeAdapter(@Nonnull TypeMapping typeMapping,
+    public Builder withCustomTypeAdapter(@Nonnull ScalarType scalarType,
         @Nonnull CustomTypeAdapter customTypeAdapter) {
-      customTypeAdapters.put(typeMapping, customTypeAdapter);
+      customTypeAdapters.put(scalarType, customTypeAdapter);
       return this;
     }
 

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ApolloResponseBodyConverter.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ApolloResponseBodyConverter.java
@@ -5,7 +5,7 @@ import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Response;
 import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.TypeMapping;
+import com.apollographql.android.api.graphql.ScalarType;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -18,9 +18,9 @@ import retrofit2.Converter;
 
 class ApolloResponseBodyConverter implements Converter<ResponseBody, Response<? extends Operation.Data>> {
   private final Type type;
-  private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-  ApolloResponseBodyConverter(Type type, Map<TypeMapping, CustomTypeAdapter> customTypeAdapters) {
+  ApolloResponseBodyConverter(Type type, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
     this.type = type;
     this.customTypeAdapters = customTypeAdapters;
   }

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/BufferedResponseReader.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/BufferedResponseReader.java
@@ -147,7 +147,7 @@ import java.util.Map;
     } else {
       CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(field.scalarType());
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + field.scalarType().name());
+        throw new RuntimeException("Can't resolve custom type adapter for " + field.scalarType().typeName());
       }
       return typeAdapter.decode(value.toString());
     }
@@ -192,7 +192,7 @@ import java.util.Map;
     @SuppressWarnings("unchecked") @Override public <T> T readCustomType(ScalarType scalarType) throws IOException {
       CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(scalarType);
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.name());
+        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.typeName());
       }
       return typeAdapter.decode(value.toString());
     }

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/BufferedResponseReader.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/BufferedResponseReader.java
@@ -2,7 +2,7 @@ package com.apollographql.android.converter.pojo;
 
 import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.TypeMapping;
+import com.apollographql.android.api.graphql.ScalarType;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -12,9 +12,9 @@ import java.util.Map;
 
 @SuppressWarnings("WeakerAccess") final class BufferedResponseReader implements ResponseReader {
   private final Map<String, Object> buffer;
-  private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-  BufferedResponseReader(Map<String, Object> buffer, Map<TypeMapping, CustomTypeAdapter> customTypeAdapters) {
+  BufferedResponseReader(Map<String, Object> buffer, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
     this.buffer = buffer;
     this.customTypeAdapters = customTypeAdapters;
   }
@@ -145,9 +145,9 @@ import java.util.Map;
     if (value == null) {
       return null;
     } else {
-      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(field.typeMapping());
+      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(field.scalarType());
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + field.typeMapping().type());
+        throw new RuntimeException("Can't resolve custom type adapter for " + field.scalarType().name());
       }
       return typeAdapter.decode(value.toString());
     }
@@ -162,9 +162,9 @@ import java.util.Map;
 
   private static class BufferedListItemReader implements Field.ListItemReader {
     private final Object value;
-    private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters;
+    private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-    BufferedListItemReader(Object value, Map<TypeMapping, CustomTypeAdapter> customTypeAdapters) {
+    BufferedListItemReader(Object value, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
       this.value = value;
       this.customTypeAdapters = customTypeAdapters;
     }
@@ -189,10 +189,10 @@ import java.util.Map;
       return (Boolean) value;
     }
 
-    @SuppressWarnings("unchecked") @Override public <T> T readCustomType(TypeMapping typeMapping) throws IOException {
-      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(typeMapping);
+    @SuppressWarnings("unchecked") @Override public <T> T readCustomType(ScalarType scalarType) throws IOException {
+      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(scalarType);
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + typeMapping.type());
+        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.name());
       }
       return typeAdapter.decode(value.toString());
     }

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ResponseJsonStreamReader.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ResponseJsonStreamReader.java
@@ -193,7 +193,7 @@ import java.util.Map;
     } else {
       CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(scalarType);
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.name());
+        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.typeName());
       }
       String value = jsonReader.nextString();
       return typeAdapter.decode(value);

--- a/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ResponseJsonStreamReader.java
+++ b/apollo-converters/pojo/src/main/java/com/apollographql/android/converter/pojo/ResponseJsonStreamReader.java
@@ -2,7 +2,7 @@ package com.apollographql.android.converter.pojo;
 
 import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.TypeMapping;
+import com.apollographql.android.api.graphql.ScalarType;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -14,9 +14,9 @@ import java.util.Map;
 
 @SuppressWarnings("WeakerAccess") final class ResponseJsonStreamReader implements ResponseReader {
   private final JsonReader jsonReader;
-  private final Map<TypeMapping, CustomTypeAdapter> customTypeAdapters;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-  ResponseJsonStreamReader(JsonReader jsonReader, Map<TypeMapping, CustomTypeAdapter> customTypeAdapters) {
+  ResponseJsonStreamReader(JsonReader jsonReader, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
     this.jsonReader = jsonReader;
     this.customTypeAdapters = customTypeAdapters;
   }
@@ -185,15 +185,15 @@ import java.util.Map;
     }
   }
 
-  @SuppressWarnings("unchecked") <T> T nextCustomType(boolean optional, TypeMapping typeMapping) throws IOException {
+  @SuppressWarnings("unchecked") <T> T nextCustomType(boolean optional, ScalarType scalarType) throws IOException {
     checkNextValue(optional);
     if (jsonReader.peek() == JsonReader.Token.NULL) {
       jsonReader.skipValue();
       return null;
     } else {
-      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(typeMapping);
+      CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(scalarType);
       if (typeAdapter == null) {
-        throw new RuntimeException("Can't resolve custom type adapter for " + typeMapping.type());
+        throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.name());
       }
       String value = jsonReader.nextString();
       return typeAdapter.decode(value);
@@ -233,7 +233,7 @@ import java.util.Map;
   }
 
   private <T> T readCustomType(Field field) throws IOException {
-    return nextCustomType(field.optional(), field.typeMapping());
+    return nextCustomType(field.optional(), field.scalarType());
   }
 
   private boolean isNextObject() throws IOException {
@@ -344,8 +344,8 @@ import java.util.Map;
       return streamReader.nextBoolean(false);
     }
 
-    @Override public <T> T readCustomType(TypeMapping typeMapping) throws IOException {
-      return streamReader.nextCustomType(false, typeMapping);
+    @Override public <T> T readCustomType(ScalarType scalarType) throws IOException {
+      return streamReader.nextCustomType(false, scalarType);
     }
   }
 }

--- a/apollo-converters/pojo/src/test/java/com/apollographql/android/converter/pojo/CustomType.java
+++ b/apollo-converters/pojo/src/test/java/com/apollographql/android/converter/pojo/CustomType.java
@@ -10,7 +10,7 @@ import javax.annotation.Generated;
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
   DATETIME {
-    public String type() {
+    public String typeName() {
       return "DateTime";
     }
   }

--- a/apollo-converters/pojo/src/test/java/com/apollographql/android/converter/pojo/CustomType.java
+++ b/apollo-converters/pojo/src/test/java/com/apollographql/android/converter/pojo/CustomType.java
@@ -1,20 +1,17 @@
 package com.apollographql.android.converter.pojo;
 
-import com.apollographql.android.api.graphql.TypeMapping;
+import com.apollographql.android.api.graphql.ScalarType;
+
 import java.lang.Class;
 import java.lang.String;
 import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
-public enum CustomType implements TypeMapping {
+public enum CustomType implements ScalarType {
   DATETIME {
     public String type() {
       return "DateTime";
-    }
-
-    public Class clazz() {
-      return Date.class;
     }
   }
 }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -22,7 +22,7 @@ import okio.Okio;
 public class ApolloCodeGenInstallTask extends NpmTask {
   static final String NAME = "installApolloCodegen";
   private static final String INSTALL_DIR = "node_modules/apollo-codegen";
-  private static final String APOLLOCODEGEN_VERSION = "0.10.1";
+  private static final String APOLLOCODEGEN_VERSION = "0.10.3";
 
   @OutputDirectory private File installDir;
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginPojoAndroidTest.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginPojoAndroidTest.groovy
@@ -23,12 +23,12 @@ class ApolloPluginPojoAndroidTest extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withPluginClasspath()
-        .withArguments("build")
+        .withArguments("generateApolloClasses")
         .forwardStdError(new OutputStreamWriter(System.err))
         .build()
 
     then:
-    result.task(":build").outcome == TaskOutcome.SUCCESS
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
     // IR Files generated successfully
     assert new File(testProjectDir,
         "build/generated/source/apollo/generatedIR/src/main/graphql/com/example/ReleaseAPI.json").isFile()

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/pojo.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/pojo.gradle
@@ -38,7 +38,6 @@ repositories {
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.apollographql.android:api:0.0.1-SNAPSHOT'
   compile 'com.fernandocejas:arrow:1.0.0'
 }
 
@@ -47,6 +46,7 @@ apollo {
   customTypeMapping {
     DateTime = "java.util.Date"
     OptionalString = "com.fernandocejas.arrow.optional.Optional"
+    UnsupportedType = "java.lang.Object"
   }
 }
 


### PR DESCRIPTION
This PR is the last part of #88 and addresses issue with custom type mapping.
User won't be able override any GraphQL type with own type, only scalar types that defined in `typesUsed` of IR.json (GraphQL custom scalar types) are eligible for mapping.

Small refactoring, renaming TypeMapping to ScalarType

Closes #88 