### PR TITLE
Fix travis scripts and README to reflect org rename

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -5,7 +5,7 @@
 # Adapted from https://coderwall.com/p/9b_lfq and
 # http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
-SLUG="apollostack/apollo-android"
+SLUG="apollographql/apollo-android"
 JDK="oraclejdk8"
 BRANCH="master"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apollo GraphQL Client for Android
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollostack/apollo-android/master/LICENSE) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack)
-[![Build status](https://travis-ci.org/apollostack/apollo-android.svg?branch=master)](https://travis-ci.org/apollostack/apollo-android)
+[![GitHub license](https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000)](https://raw.githubusercontent.com/apollographql/apollo-android/master/LICENSE) [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollostack.com/#slack)
+[![Build status](https://travis-ci.org/apollographql/apollo-android.svg?branch=master)](https://travis-ci.org/apollographql/apollo-android)
 
 This is a Gradle plugin and set of libraries that generate Java code based on a GraphQL schema and query documents.
 The plugin uses `apollo-codegen` under the hood.


### PR DESCRIPTION
This should fix the snapshot deployment.
After merged, will cut v0.0.1 release