### PR TITLE
Increase minor snapshot version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.android
-VERSION_NAME=0.2.0-SNAPSHOT
+VERSION_NAME=0.2.1-SNAPSHOT
 
 POM_URL=https://github.com/apollostack/apollo-android/
 POM_SCM_URL=https://github.com/apollostack/apollo-android/


### PR DESCRIPTION
Don't know why but gradle still downloads the previous version of gradle plugin and doesn't pick up the latest compiler changes. So bumped up the minor version of snapshot