### PR TITLE
Introduce test breakage in input_object_type test

### DIFF
--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.json
@@ -16,8 +16,8 @@
       "source": "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    stars\n    commentary\n  }\n}",
       "fields": [
         {
-          "responseName": "createReview",
-          "fieldName": "createReview",
+          "responseName": "testQuery",
+          "fieldName": "testQuery",
           "type": "Review",
           "fields": [
             {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQueryExpected.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQueryExpected.java
@@ -87,9 +87,9 @@ public final class TestQuery implements Mutation<TestQuery.Variables> {
   }
 
   public interface Data extends Operation.Data {
-    @Nullable CreateReview createReview();
+    @Nullable TestQuery testQuery();
 
-    interface CreateReview {
+    interface TestQuery {
       int stars();
 
       @Nullable String commentary();
@@ -99,18 +99,18 @@ public final class TestQuery implements Mutation<TestQuery.Variables> {
       }
 
       interface Creator {
-        CreateReview create(int stars, @Nullable String commentary);
+        TestQuery create(int stars, @Nullable String commentary);
       }
     }
 
     interface Factory {
       Creator creator();
 
-      CreateReview.Factory createReviewFactory();
+      TestQuery.Factory testQueryFactory();
     }
 
     interface Creator {
-      Data create(@Nullable CreateReview createReview);
+      Data create(@Nullable TestQuery testQuery);
     }
   }
 }


### PR DESCRIPTION
There appears to be an issue where a nested structure that results in
multiple classes of the same name is not well-supported. This change to
the `input_object_type` test highlights the issue.

This breakage highlights issue #169 