### PR TITLE
fix apollo-codegen install task up-to-date check

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -42,7 +42,7 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
+        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:0.2.1"))
         project.getGradle().removeListener(this)
       }
 

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -42,7 +42,7 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:0.2.1"))
+        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
         project.getGradle().removeListener(this)
       }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -30,14 +30,14 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     installDir = getProject().file(INSTALL_DIR);
 
     final File apolloPackageFile = getProject().file("package.json");
-    final boolean isDifferentCodegenVersion = isDifferentCodegenVersion(getApolloVersion());
+    final boolean isSameCodegenVersion = isSameApolloCodegenVersion(getApolloVersion());
 
-    if (isDifferentCodegenVersion) {
-      Utils.deleteDirectory(new File(INSTALL_DIR));
+    if (!isSameCodegenVersion) {
+      Utils.deleteDirectory(installDir);
     }
     getOutputs().upToDateWhen(new Spec<Task>() {
       public boolean isSatisfiedBy(Task element) {
-        return apolloPackageFile.isFile() && isDifferentCodegenVersion;
+        return apolloPackageFile.isFile() && isSameCodegenVersion;
       }
     });
 
@@ -71,7 +71,7 @@ public class ApolloCodeGenInstallTask extends NpmTask {
       return null;
     }
   }
-  private boolean isDifferentCodegenVersion(String packageVersion) {
+  private boolean isSameApolloCodegenVersion(String packageVersion) {
     return packageVersion != null && packageVersion.equals(APOLLOCODEGEN_VERSION);
   }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -1,18 +1,15 @@
 package com.apollographql.android.gradle;
 
+import com.google.common.collect.Lists;
+
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 
 import org.gradle.api.Task;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
 
-import com.google.common.collect.Lists;
-
 import com.moowork.gradle.node.npm.NpmTask;
-import com.squareup.moshi.JsonReader;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -37,16 +34,17 @@ public class ApolloCodeGenInstallTask extends NpmTask {
 
     getOutputs().upToDateWhen(new Spec<Task>() {
       public boolean isSatisfiedBy(Task element) {
-        return !(apolloPackageFile.isFile() || (apolloVersion != null && apolloVersion.equals(APOLLOCODEGEN_VERSION)));
+        return apolloPackageFile.isFile() && apolloVersion != null && apolloVersion.equals(APOLLOCODEGEN_VERSION);
       }
     });
+
     if (!apolloPackageFile.isFile()) {
       writePackageFile(apolloPackageFile);
     }
     setArgs(Lists.newArrayList("install", "apollo-codegen@" + APOLLOCODEGEN_VERSION, "--save", "--save-exact"));
   }
 
-  static class PackageJson {
+  private static class PackageJson {
     String version;
   }
   /**

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -30,11 +30,14 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     installDir = getProject().file(INSTALL_DIR);
 
     final File apolloPackageFile = getProject().file("package.json");
-    final String apolloVersion = getApolloVersion();
+    final boolean isDifferentCodegenVersion = isDifferentCodegenVersion(getApolloVersion());
 
+    if (isDifferentCodegenVersion) {
+      Utils.deleteDirectory(new File(INSTALL_DIR));
+    }
     getOutputs().upToDateWhen(new Spec<Task>() {
       public boolean isSatisfiedBy(Task element) {
-        return apolloPackageFile.isFile() && apolloVersion != null && apolloVersion.equals(APOLLOCODEGEN_VERSION);
+        return apolloPackageFile.isFile() && isDifferentCodegenVersion;
       }
     });
 
@@ -67,6 +70,9 @@ public class ApolloCodeGenInstallTask extends NpmTask {
       e.printStackTrace();
       return null;
     }
+  }
+  private boolean isDifferentCodegenVersion(String packageVersion) {
+    return packageVersion != null && packageVersion.equals(APOLLOCODEGEN_VERSION);
   }
 
   /**

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/Utils.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/Utils.java
@@ -1,7 +1,25 @@
 package com.apollographql.android.gradle;
 
+import java.io.File;
+
 public class Utils {
   public static String capitalize(String s) {
     return s.substring(0, 1).toUpperCase() + s.substring(1);
+  }
+
+  public static void deleteDirectory(File directory) {
+    if (directory.exists()){
+      File[] files = directory.listFiles();
+      if (files != null){
+        for (File file : files) {
+          if (file.isDirectory()) {
+            deleteDirectory(file);
+          } else {
+            file.delete();
+          }
+        }
+      }
+    }
+    directory.delete();
   }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginBasicAndroidTest.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/ApolloPluginBasicAndroidTest.groovy
@@ -40,7 +40,20 @@ class ApolloPluginBasicAndroidTest extends Specification {
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/Films.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/fragment/SpeciesInformation.java").isFile()
   }
-  
+
+  def "installApolloCodegenTask is up to date if no changes occur to node_modules and package.json"() {
+    setup: "a testProject with a previous build run"
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("installApolloCodegen")
+        .forwardStdError(new OutputStreamWriter(System.err)).build()
+
+    then:
+    result.task(":installApolloCodegen").outcome == TaskOutcome.UP_TO_DATE
+  }
+
   def "installApolloCodegenTask gets outdated if node_modules directory is altered"() {
     setup: "a testProject with a deleted node_modules directory"
     FileUtils.deleteDirectory(new File(testProjectDir, "node_modules"))

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
@@ -37,35 +37,6 @@ class ApolloCodeGenInstallTaskSpec extends Specification {
     task.dependsOn.contains("nodeSetup")
   }
 
-  def "configures the npm install params"() {
-    setup:
-    def project = ProjectBuilder.builder().build()
-    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
-
-    when:
-    ApolloPluginTestHelper.applyApolloPlugin(project)
-    project.evaluate()
-
-    then:
-    project.tasks.getByName(ApolloCodeGenInstallTask.NAME).args.equals(
-        ["install", "apollo-codegen@$ApolloCodeGenInstallTask.APOLLOCODEGEN_VERSION", "--save", "--save-exact"])
-  }
-
-  def "task creates node_modules/apollo-codegen output dir"() {
-    setup:
-    def project = ProjectBuilder.builder().build()
-    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
-
-    when:
-    ApolloPluginTestHelper.applyApolloPlugin(project)
-    project.evaluate()
-
-    then:
-    project.tasks.getByName(ApolloCodeGenInstallTask.NAME).outputs.hasOutput
-    project.tasks.getByName(ApolloCodeGenInstallTask.NAME).outputs.files
-        .contains(project.file(ApolloCodeGenInstallTask.INSTALL_DIR))
-  }
-
   def "task creates a package.json file in project root"() {
     setup:
     def project = ProjectBuilder.builder().build()


### PR DESCRIPTION
This is an attempt at fixing the errors on windows machines (Working towards #209)

As seen on several issues on GitHub, running `npm cache clean` before `npm install` can fix the errors in #209 stack-trace. 

Running that doesn't come at an extra cost since we're using a local fresh npm installation anyways and `ApolloCodegenInstallTask` runs only one and is up-to-date after.
(Unfortunately I can't verify that since I don't have a windows machine. If someone is able to verify, just checkout this branch and running `./gradlew apollo-gradle-plugin:test` should be sufficient)