### PR TITLE
Leave compiler test IR files with 4 spaces, use relative file path.

### DIFF
--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -39,9 +39,10 @@ class UpdateTestIRFilesTask extends DefaultTask {
 
   def generateIRFile(testDir) {
     logger.info("Generating IR file for: ${testDir.name}")
-    File queryFile = new File(testDir, 'TestQuery.graphql')
+    def testQueryFileName = 'TestQuery.graphql'
+    File queryFile = new File(testDir, testQueryFileName)
     if (!queryFile.exists()) {
-      logger.warn("Skipping generating IR file for test: ${testDir.name} Expected file TestQuery.json")
+      logger.warn("Skipping generating IR file for test: ${testDir.name}. Expected file `TestQuery.json` not found.")
       return
     }
     File outputFile = new File(testDir, 'TestQuery.json')
@@ -62,6 +63,14 @@ class UpdateTestIRFilesTask extends DefaultTask {
     def runtimeError = apolloCodeGenProcess.in.text
     if (runtimeError != null && !runtimeError.isEmpty()) {
       logger.error("Failed to generate IR file for: ${testDir.name} reason:" + runtimeError)
+    }
+
+    //Remove the "filePath" lines in the IR file. They are not needed by the compiler
+    //and pollute git history.
+    def outputFileContents = outputFile.text
+    outputFile.withWriter { w ->
+      w << outputFileContents.replaceAll("\"filePath\": \".*\"",
+          "\"filePath\": \"src/test/graphql/com/example/${testDir.name}/${testQueryFileName}\"")
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.graphql
@@ -3,5 +3,6 @@ query TestQuery {
     name
     birthDate
     appearanceDates
+    fieldWithUnsupportedType
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -24,6 +24,7 @@ public final class TestQuery implements Query<Operation.Variables> {
       + "    name\n"
       + "    birthDate\n"
       + "    appearanceDates\n"
+      + "    fieldWithUnsupportedType\n"
       + "  }\n"
       + "}";
 
@@ -95,11 +96,14 @@ public final class TestQuery implements Query<Operation.Variables> {
 
       private final @Nonnull List<Date> appearanceDates;
 
+      private final @Nonnull Object fieldWithUnsupportedType;
+
       public Hero(@Nonnull String name, @Nonnull Date birthDate,
-          @Nonnull List<Date> appearanceDates) {
+          @Nonnull List<Date> appearanceDates, @Nonnull Object fieldWithUnsupportedType) {
         this.name = name;
         this.birthDate = birthDate;
         this.appearanceDates = appearanceDates;
+        this.fieldWithUnsupportedType = fieldWithUnsupportedType;
       }
 
       public @Nonnull String name() {
@@ -114,12 +118,17 @@ public final class TestQuery implements Query<Operation.Variables> {
         return this.appearanceDates;
       }
 
+      public @Nonnull Object fieldWithUnsupportedType() {
+        return this.fieldWithUnsupportedType;
+      }
+
       @Override
       public String toString() {
         return "Hero{"
           + "name=" + name + ", "
           + "birthDate=" + birthDate + ", "
-          + "appearanceDates=" + appearanceDates
+          + "appearanceDates=" + appearanceDates + ", "
+          + "fieldWithUnsupportedType=" + fieldWithUnsupportedType
           + "}";
       }
 
@@ -132,7 +141,8 @@ public final class TestQuery implements Query<Operation.Variables> {
           Hero that = (Hero) o;
           return ((this.name == null) ? (that.name == null) : this.name.equals(that.name))
            && ((this.birthDate == null) ? (that.birthDate == null) : this.birthDate.equals(that.birthDate))
-           && ((this.appearanceDates == null) ? (that.appearanceDates == null) : this.appearanceDates.equals(that.appearanceDates));
+           && ((this.appearanceDates == null) ? (that.appearanceDates == null) : this.appearanceDates.equals(that.appearanceDates))
+           && ((this.fieldWithUnsupportedType == null) ? (that.fieldWithUnsupportedType == null) : this.fieldWithUnsupportedType.equals(that.fieldWithUnsupportedType));
         }
         return false;
       }
@@ -146,6 +156,8 @@ public final class TestQuery implements Query<Operation.Variables> {
         h ^= (birthDate == null) ? 0 : birthDate.hashCode();
         h *= 1000003;
         h ^= (appearanceDates == null) ? 0 : appearanceDates.hashCode();
+        h *= 1000003;
+        h ^= (fieldWithUnsupportedType == null) ? 0 : fieldWithUnsupportedType.hashCode();
         return h;
       }
 
@@ -157,7 +169,8 @@ public final class TestQuery implements Query<Operation.Variables> {
             @Override public Date read(final Field.ListItemReader reader) throws IOException {
               return reader.readCustomType(CustomType.DATE);
             }
-          })
+          }),
+          Field.forCustomType("fieldWithUnsupportedType", "fieldWithUnsupportedType", null, false, CustomType.UNSUPPORTEDTYPE)
         };
 
         @Override
@@ -179,10 +192,14 @@ public final class TestQuery implements Query<Operation.Variables> {
                   contentValues.appearanceDates = (List<Date>) value;
                   break;
                 }
+                case 3: {
+                  contentValues.fieldWithUnsupportedType = (Object) value;
+                  break;
+                }
               }
             }
           }, fields);
-          return new Hero(contentValues.name, contentValues.birthDate, contentValues.appearanceDates);
+          return new Hero(contentValues.name, contentValues.birthDate, contentValues.appearanceDates, contentValues.fieldWithUnsupportedType);
         }
 
         static final class __ContentValues {
@@ -191,6 +208,8 @@ public final class TestQuery implements Query<Operation.Variables> {
           Date birthDate;
 
           List<Date> appearanceDates;
+
+          Object fieldWithUnsupportedType;
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.json
@@ -1,46 +1,56 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    birthDate\n    appearanceDates\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "birthDate",
-              "fieldName": "birthDate",
-              "type": "Date!"
-            },
-            {
-              "responseName": "appearanceDates",
-              "fieldName": "appearanceDates",
-              "type": "[Date]!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": [
-    {
-      "kind": "ScalarType",
-      "name": "Date",
-      "description": "The `Date` scalar type represents date format."
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/custom_scalar_type/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    birthDate\n    appearanceDates\n    fieldWithUnsupportedType\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "birthDate",
+							"fieldName": "birthDate",
+							"type": "Date!"
+						},
+						{
+							"responseName": "appearanceDates",
+							"fieldName": "appearanceDates",
+							"type": "[Date!]!"
+						},
+						{
+							"responseName": "fieldWithUnsupportedType",
+							"fieldName": "fieldWithUnsupportedType",
+							"type": "UnsupportedType!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": [
+		{
+			"kind": "ScalarType",
+			"name": "Date",
+			"description": "The `Date` scalar type represents date format."
+		},
+		{
+			"kind": "ScalarType",
+			"name": "UnsupportedType",
+			"description": "UnsupportedType for testing"
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
@@ -19,5 +19,17 @@ public enum CustomType implements ScalarType {
     public Class javaType() {
       return Date.class;
     }
+  },
+
+  UNSUPPORTEDTYPE {
+    @Override
+    public String typeName() {
+      return "UnsupportedType";
+    }
+
+    @Override
+    public Class javaType() {
+      return Object.class;
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.json
@@ -1,31 +1,31 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name @include(if: false)\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!",
-              "isConditional": true
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/directives/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name @include(if: false)\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!",
+							"isConditional": true
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.json
@@ -1,60 +1,60 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    appearsIn\n    firstAppearsIn\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "appearsIn",
-              "fieldName": "appearsIn",
-              "type": "[Episode]!"
-            },
-            {
-              "responseName": "firstAppearsIn",
-              "fieldName": "firstAppearsIn",
-              "type": "Episode!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy (with special symbol $S)",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977. (with special symbol $S)"
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "jedi",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983. (JEDI in lowercase)"
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/enum_type/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    appearsIn\n    firstAppearsIn\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "appearsIn",
+							"fieldName": "appearsIn",
+							"type": "[Episode]!"
+						},
+						{
+							"responseName": "firstAppearsIn",
+							"fieldName": "firstAppearsIn",
+							"type": "Episode!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy (with special symbol $S)",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977. (with special symbol $S)"
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "jedi",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983. (JEDI in lowercase)"
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.json
@@ -1,82 +1,82 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [],
-          "fragmentSpreads": [
-            "HeroDetails"
-          ],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": [
-        "HeroDetails"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.graphql",
-      "fragmentName": "HeroDetails",
-      "source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
-      "typeCondition": "Character",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        },
-        {
-          "responseName": "friendsConnection",
-          "fieldName": "friendsConnection",
-          "type": "FriendsConnection!",
-          "fields": [
-            {
-              "responseName": "totalCount",
-              "fieldName": "totalCount",
-              "type": "Int"
-            },
-            {
-              "responseName": "edges",
-              "fieldName": "edges",
-              "type": "[FriendsEdge]",
-              "fields": [
-                {
-                  "responseName": "node",
-                  "fieldName": "node",
-                  "type": "Character",
-                  "fields": [
-                    {
-                      "responseName": "name",
-                      "fieldName": "name",
-                      "type": "String!"
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_friends_connection/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [],
+					"fragmentSpreads": [
+						"HeroDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_friends_connection/TestQuery.graphql",
+			"fragmentName": "HeroDetails",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
+			"typeCondition": "Character",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "friendsConnection",
+					"fieldName": "friendsConnection",
+					"type": "FriendsConnection!",
+					"fields": [
+						{
+							"responseName": "totalCount",
+							"fieldName": "totalCount",
+							"type": "Int"
+						},
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[FriendsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Character",
+									"fields": [
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.json
@@ -1,135 +1,135 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
-      "operationName": "AllStarships",
-      "operationType": "query",
-      "variables": [],
-      "source": "query AllStarships {\n  allStarships(first: 7) {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...starshipFragment\n      }\n    }\n  }\n}",
-      "fields": [
-        {
-          "responseName": "allStarships",
-          "fieldName": "allStarships",
-          "type": "StarshipsConnection",
-          "args": [
-            {
-              "name": "first",
-              "value": 7
-            }
-          ],
-          "fields": [
-            {
-              "responseName": "edges",
-              "fieldName": "edges",
-              "type": "[StarshipsEdge]",
-              "fields": [
-                {
-                  "responseName": "node",
-                  "fieldName": "node",
-                  "type": "Starship",
-                  "fields": [],
-                  "fragmentSpreads": [
-                    "starshipFragment"
-                  ],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": [
-        "starshipFragment",
-        "pilotFragment"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
-      "fragmentName": "starshipFragment",
-      "source": "fragment starshipFragment on Starship {\n  __typename\n  id\n  name\n  pilotConnection {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...pilotFragment\n      }\n    }\n  }\n}",
-      "typeCondition": "Starship",
-      "fields": [
-        {
-          "responseName": "id",
-          "fieldName": "id",
-          "type": "ID!"
-        },
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String"
-        },
-        {
-          "responseName": "pilotConnection",
-          "fieldName": "pilotConnection",
-          "type": "StarshipPilotsConnection",
-          "fields": [
-            {
-              "responseName": "edges",
-              "fieldName": "edges",
-              "type": "[StarshipPilotsEdge]",
-              "fields": [
-                {
-                  "responseName": "node",
-                  "fieldName": "node",
-                  "type": "Person",
-                  "fields": [],
-                  "fragmentSpreads": [
-                    "pilotFragment"
-                  ],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": [
-        "pilotFragment"
-      ]
-    },
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
-      "fragmentName": "pilotFragment",
-      "source": "fragment pilotFragment on Person {\n  __typename\n  name\n  homeworld {\n    __typename\n    name\n  }\n}",
-      "typeCondition": "Person",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String"
-        },
-        {
-          "responseName": "homeworld",
-          "fieldName": "homeworld",
-          "type": "Planet",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
+			"operationName": "AllStarships",
+			"operationType": "query",
+			"variables": [],
+			"source": "query AllStarships {\n  allStarships(first: 7) {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...starshipFragment\n      }\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "allStarships",
+					"fieldName": "allStarships",
+					"type": "StarshipsConnection",
+					"args": [
+						{
+							"name": "first",
+							"value": 7
+						}
+					],
+					"fields": [
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[StarshipsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Starship",
+									"fields": [],
+									"fragmentSpreads": [
+										"starshipFragment"
+									],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"starshipFragment",
+				"pilotFragment"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
+			"fragmentName": "starshipFragment",
+			"source": "fragment starshipFragment on Starship {\n  __typename\n  id\n  name\n  pilotConnection {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...pilotFragment\n      }\n    }\n  }\n}",
+			"typeCondition": "Starship",
+			"fields": [
+				{
+					"responseName": "id",
+					"fieldName": "id",
+					"type": "ID!"
+				},
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String"
+				},
+				{
+					"responseName": "pilotConnection",
+					"fieldName": "pilotConnection",
+					"type": "StarshipPilotsConnection",
+					"fields": [
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[StarshipPilotsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Person",
+									"fields": [],
+									"fragmentSpreads": [
+										"pilotFragment"
+									],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": [
+				"pilotFragment"
+			]
+		},
+		{
+			"filePath": "src/test/graphql/com/example/fragment_in_fragment/TestQuery.graphql",
+			"fragmentName": "pilotFragment",
+			"source": "fragment pilotFragment on Person {\n  __typename\n  name\n  homeworld {\n    __typename\n    name\n  }\n}",
+			"typeCondition": "Person",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String"
+				},
+				{
+					"responseName": "homeworld",
+					"fieldName": "homeworld",
+					"type": "Planet",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.json
@@ -1,167 +1,167 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "appearsIn",
-              "fieldName": "appearsIn",
-              "type": "[Episode]!"
-            }
-          ],
-          "fragmentSpreads": [
-            "HeroDetails"
-          ],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": [
-        "HeroDetails"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.graphql",
-      "fragmentName": "HeroDetails",
-      "source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
-      "typeCondition": "Character",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        },
-        {
-          "responseName": "friendsConnection",
-          "fieldName": "friendsConnection",
-          "type": "FriendsConnection!",
-          "fields": [
-            {
-              "responseName": "totalCount",
-              "fieldName": "totalCount",
-              "type": "Int"
-            },
-            {
-              "responseName": "edges",
-              "fieldName": "edges",
-              "type": "[FriendsEdge]",
-              "fields": [
-                {
-                  "responseName": "node",
-                  "fieldName": "node",
-                  "type": "Character",
-                  "fields": [
-                    {
-                      "responseName": "name",
-                      "fieldName": "name",
-                      "type": "String!"
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [
-        {
-          "typeCondition": "Droid",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "friendsConnection",
-              "fieldName": "friendsConnection",
-              "type": "FriendsConnection!",
-              "fields": [
-                {
-                  "responseName": "totalCount",
-                  "fieldName": "totalCount",
-                  "type": "Int"
-                },
-                {
-                  "responseName": "edges",
-                  "fieldName": "edges",
-                  "type": "[FriendsEdge]",
-                  "fields": [
-                    {
-                      "responseName": "node",
-                      "fieldName": "node",
-                      "type": "Character",
-                      "fields": [
-                        {
-                          "responseName": "name",
-                          "fieldName": "name",
-                          "type": "String!"
-                        }
-                      ],
-                      "fragmentSpreads": [],
-                      "inlineFragments": []
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            },
-            {
-              "responseName": "primaryFunction",
-              "fieldName": "primaryFunction",
-              "type": "String"
-            }
-          ],
-          "fragmentSpreads": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977."
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "JEDI",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "appearsIn",
+							"fieldName": "appearsIn",
+							"type": "[Episode]!"
+						}
+					],
+					"fragmentSpreads": [
+						"HeroDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.graphql",
+			"fragmentName": "HeroDetails",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
+			"typeCondition": "Character",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "friendsConnection",
+					"fieldName": "friendsConnection",
+					"type": "FriendsConnection!",
+					"fields": [
+						{
+							"responseName": "totalCount",
+							"fieldName": "totalCount",
+							"type": "Int"
+						},
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[FriendsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Character",
+									"fields": [
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [
+				{
+					"typeCondition": "Droid",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "friendsConnection",
+							"fieldName": "friendsConnection",
+							"type": "FriendsConnection!",
+							"fields": [
+								{
+									"responseName": "totalCount",
+									"fieldName": "totalCount",
+									"type": "Int"
+								},
+								{
+									"responseName": "edges",
+									"fieldName": "edges",
+									"type": "[FriendsEdge]",
+									"fields": [
+										{
+											"responseName": "node",
+											"fieldName": "node",
+											"type": "Character",
+											"fields": [
+												{
+													"responseName": "name",
+													"fieldName": "name",
+													"type": "String!"
+												}
+											],
+											"fragmentSpreads": [],
+											"inlineFragments": []
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						},
+						{
+							"responseName": "primaryFunction",
+							"fieldName": "primaryFunction",
+							"type": "String"
+						}
+					],
+					"fragmentSpreads": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.json
@@ -1,84 +1,84 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  r2: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n  luke: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n}",
-      "fields": [
-        {
-          "responseName": "r2",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [],
-          "fragmentSpreads": [
-            "HumanDetails",
-            "DroidDetails"
-          ],
-          "inlineFragments": []
-        },
-        {
-          "responseName": "luke",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [],
-          "fragmentSpreads": [
-            "HumanDetails",
-            "DroidDetails"
-          ],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": [
-        "HumanDetails",
-        "DroidDetails"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
-      "fragmentName": "HumanDetails",
-      "source": "fragment HumanDetails on Human {\n  __typename\n  name\n  height\n}",
-      "typeCondition": "Human",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        },
-        {
-          "responseName": "height",
-          "fieldName": "height",
-          "type": "Float"
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    },
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
-      "fragmentName": "DroidDetails",
-      "source": "fragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}",
-      "typeCondition": "Droid",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        },
-        {
-          "responseName": "primaryFunction",
-          "fieldName": "primaryFunction",
-          "type": "String"
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  r2: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n  luke: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n}",
+			"fields": [
+				{
+					"responseName": "r2",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [],
+					"fragmentSpreads": [
+						"HumanDetails",
+						"DroidDetails"
+					],
+					"inlineFragments": []
+				},
+				{
+					"responseName": "luke",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [],
+					"fragmentSpreads": [
+						"HumanDetails",
+						"DroidDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"HumanDetails",
+				"DroidDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
+			"fragmentName": "HumanDetails",
+			"source": "fragment HumanDetails on Human {\n  __typename\n  name\n  height\n}",
+			"typeCondition": "Human",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "height",
+					"fieldName": "height",
+					"type": "Float"
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		},
+		{
+			"filePath": "src/test/graphql/com/example/fragments_with_type_condition/TestQuery.graphql",
+			"fragmentName": "DroidDetails",
+			"source": "fragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}",
+			"typeCondition": "Droid",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "primaryFunction",
+					"fieldName": "primaryFunction",
+					"type": "String"
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.json
@@ -1,67 +1,67 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "friendsConnection",
-              "fieldName": "friendsConnection",
-              "type": "FriendsConnection!",
-              "fields": [
-                {
-                  "responseName": "totalCount",
-                  "fieldName": "totalCount",
-                  "type": "Int"
-                },
-                {
-                  "responseName": "edges",
-                  "fieldName": "edges",
-                  "type": "[FriendsEdge]",
-                  "fields": [
-                    {
-                      "responseName": "node",
-                      "fieldName": "node",
-                      "type": "Character",
-                      "fields": [
-                        {
-                          "responseName": "name",
-                          "fieldName": "name",
-                          "type": "String!"
-                        }
-                      ],
-                      "fragmentSpreads": [],
-                      "inlineFragments": []
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/hero_details/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "friendsConnection",
+							"fieldName": "friendsConnection",
+							"type": "FriendsConnection!",
+							"fields": [
+								{
+									"responseName": "totalCount",
+									"fieldName": "totalCount",
+									"type": "Int"
+								},
+								{
+									"responseName": "edges",
+									"fieldName": "edges",
+									"type": "[FriendsEdge]",
+									"fields": [
+										{
+											"responseName": "node",
+											"fieldName": "node",
+											"type": "Character",
+											"fields": [
+												{
+													"responseName": "name",
+													"fieldName": "name",
+													"type": "String!"
+												}
+											],
+											"fragmentSpreads": [],
+											"inlineFragments": []
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.json
@@ -1,30 +1,30 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/hero_name/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.json
@@ -1,111 +1,111 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n      }\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n      friends {\n        __typename\n        id\n      }\n    }\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": [
-            {
-              "typeCondition": "Human",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                },
-                {
-                  "responseName": "height",
-                  "fieldName": "height",
-                  "type": "Float"
-                },
-                {
-                  "responseName": "friends",
-                  "fieldName": "friends",
-                  "type": "[Character]",
-                  "fields": [
-                    {
-                      "responseName": "appearsIn",
-                      "fieldName": "appearsIn",
-                      "type": "[Episode]!"
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": []
-            },
-            {
-              "typeCondition": "Droid",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                },
-                {
-                  "responseName": "friends",
-                  "fieldName": "friends",
-                  "type": "[Character]",
-                  "fields": [
-                    {
-                      "responseName": "id",
-                      "fieldName": "id",
-                      "type": "ID!"
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                },
-                {
-                  "responseName": "primaryFunction",
-                  "fieldName": "primaryFunction",
-                  "type": "String"
-                }
-              ],
-              "fragmentSpreads": []
-            }
-          ]
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977."
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "JEDI",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n      }\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n      friends {\n        __typename\n        id\n      }\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": [
+						{
+							"typeCondition": "Human",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								},
+								{
+									"responseName": "height",
+									"fieldName": "height",
+									"type": "Float"
+								},
+								{
+									"responseName": "friends",
+									"fieldName": "friends",
+									"type": "[Character]",
+									"fields": [
+										{
+											"responseName": "appearsIn",
+											"fieldName": "appearsIn",
+											"type": "[Episode]!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": []
+						},
+						{
+							"typeCondition": "Droid",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								},
+								{
+									"responseName": "friends",
+									"fieldName": "friends",
+									"type": "[Character]",
+									"fields": [
+										{
+											"responseName": "id",
+											"fieldName": "id",
+											"type": "ID!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								},
+								{
+									"responseName": "primaryFunction",
+									"fieldName": "primaryFunction",
+									"type": "String"
+								}
+							],
+							"fragmentSpreads": []
+						}
+					]
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.json
@@ -1,127 +1,127 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "mutation",
-      "variables": [
-        {
-          "name": "ep",
-          "type": "Episode!"
-        },
-        {
-          "name": "review",
-          "type": "ReviewInput!"
-        }
-      ],
-      "source": "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}",
-      "fields": [
-        {
-          "responseName": "createReview",
-          "fieldName": "createReview",
-          "type": "Review",
-          "args": [
-            {
-              "name": "episode",
-              "value": {
-                "kind": "Variable",
-                "variableName": "ep"
-              }
-            },
-            {
-              "name": "review",
-              "value": {
-                "kind": "Variable",
-                "variableName": "review"
-              }
-            }
-          ],
-          "fields": [
-            {
-              "responseName": "stars",
-              "fieldName": "stars",
-              "type": "Int!"
-            },
-            {
-              "responseName": "commentary",
-              "fieldName": "commentary",
-              "type": "String"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977."
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "JEDI",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
-        }
-      ]
-    },
-    {
-      "kind": "InputObjectType",
-      "name": "ReviewInput",
-      "description": "The input object sent when someone is creating a new review",
-      "fields": [
-        {
-          "name": "stars",
-          "description": "0-5 stars",
-          "type": "Int!"
-        },
-        {
-          "name": "commentary",
-          "description": "Comment about the movie, optional",
-          "type": "String"
-        },
-        {
-          "name": "favoriteColor",
-          "description": "Favorite color, optional",
-          "type": "ColorInput!"
-        }
-      ]
-    },
-    {
-      "kind": "InputObjectType",
-      "name": "ColorInput",
-      "description": "The input object sent when passing in a color",
-      "fields": [
-        {
-          "name": "red",
-          "description": "",
-          "type": "Int!",
-          "defaultValue": 1
-        },
-        {
-          "name": "green",
-          "description": "",
-          "type": "Float",
-          "defaultValue": 0
-        },
-        {
-          "name": "blue",
-          "description": "",
-          "type": "Float!",
-          "defaultValue": 1.5
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/input_object_type/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "mutation",
+			"variables": [
+				{
+					"name": "ep",
+					"type": "Episode!"
+				},
+				{
+					"name": "review",
+					"type": "ReviewInput!"
+				}
+			],
+			"source": "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}",
+			"fields": [
+				{
+					"responseName": "createReview",
+					"fieldName": "createReview",
+					"type": "Review",
+					"args": [
+						{
+							"name": "episode",
+							"value": {
+								"kind": "Variable",
+								"variableName": "ep"
+							}
+						},
+						{
+							"name": "review",
+							"value": {
+								"kind": "Variable",
+								"variableName": "review"
+							}
+						}
+					],
+					"fields": [
+						{
+							"responseName": "stars",
+							"fieldName": "stars",
+							"type": "Int!"
+						},
+						{
+							"responseName": "commentary",
+							"fieldName": "commentary",
+							"type": "String"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		},
+		{
+			"kind": "InputObjectType",
+			"name": "ReviewInput",
+			"description": "The input object sent when someone is creating a new review",
+			"fields": [
+				{
+					"name": "stars",
+					"description": "0-5 stars",
+					"type": "Int!"
+				},
+				{
+					"name": "commentary",
+					"description": "Comment about the movie, optional",
+					"type": "String"
+				},
+				{
+					"name": "favoriteColor",
+					"description": "Favorite color, optional",
+					"type": "ColorInput!"
+				}
+			]
+		},
+		{
+			"kind": "InputObjectType",
+			"name": "ColorInput",
+			"description": "The input object sent when passing in a color",
+			"fields": [
+				{
+					"name": "red",
+					"description": "",
+					"type": "Int!",
+					"defaultValue": 1
+				},
+				{
+					"name": "green",
+					"description": "",
+					"type": "Float",
+					"defaultValue": 0
+				},
+				{
+					"name": "blue",
+					"description": "",
+					"type": "Float!",
+					"defaultValue": 1.5
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQuery.json
@@ -1,69 +1,69 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/simple_arguments/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [
-        {
-          "name": "episode",
-          "type": "Episode"
-        },
-        {
-          "name": "includeName",
-          "type": "Boolean!"
-        }
-      ],
-      "source": "query TestQuery($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "args": [
-            {
-              "name": "episode",
-              "value": {
-                "kind": "Variable",
-                "variableName": "episode"
-              }
-            }
-          ],
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!",
-              "isConditional": true
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977."
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "JEDI",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/simple_arguments/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [
+				{
+					"name": "episode",
+					"type": "Episode"
+				},
+				{
+					"name": "includeName",
+					"type": "Boolean!"
+				}
+			],
+			"source": "query TestQuery($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"args": [
+						{
+							"name": "episode",
+							"value": {
+								"kind": "Variable",
+								"variableName": "episode"
+							}
+						}
+					],
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!",
+							"isConditional": true
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.json
@@ -1,45 +1,45 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [],
-          "fragmentSpreads": [
-            "HeroDetails"
-          ],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": [
-        "HeroDetails"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.graphql",
-      "fragmentName": "HeroDetails",
-      "source": "fragment HeroDetails on Character {\n  __typename\n  name\n}",
-      "typeCondition": "Character",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/simple_fragment/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [],
+					"fragmentSpreads": [
+						"HeroDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/simple_fragment/TestQuery.graphql",
+			"fragmentName": "HeroDetails",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n}",
+			"typeCondition": "Character",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.json
@@ -1,63 +1,63 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n    }\n  }\n}",
-      "fields": [
-        {
-          "responseName": "hero",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": [
-            {
-              "typeCondition": "Human",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                },
-                {
-                  "responseName": "height",
-                  "fieldName": "height",
-                  "type": "Float"
-                }
-              ],
-              "fragmentSpreads": []
-            },
-            {
-              "typeCondition": "Droid",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                },
-                {
-                  "responseName": "primaryFunction",
-                  "fieldName": "primaryFunction",
-                  "type": "String"
-                }
-              ],
-              "fragmentSpreads": []
-            }
-          ]
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/simple_inline_fragment/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": [
+						{
+							"typeCondition": "Human",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								},
+								{
+									"responseName": "height",
+									"fieldName": "height",
+									"type": "Float"
+								}
+							],
+							"fragmentSpreads": []
+						},
+						{
+							"typeCondition": "Droid",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								},
+								{
+									"responseName": "primaryFunction",
+									"fieldName": "primaryFunction",
+									"type": "String"
+								}
+							],
+							"fragmentSpreads": []
+						}
+					]
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.json
@@ -1,50 +1,50 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    name\n  }\n}",
-      "fields": [
-        {
-          "responseName": "r2",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        },
-        {
-          "responseName": "luke",
-          "fieldName": "hero",
-          "type": "Character",
-          "args": [
-            {
-              "name": "episode",
-              "value": "EMPIRE"
-            }
-          ],
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/two_heroes/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    name\n  }\n}",
+			"fields": [
+				{
+					"responseName": "r2",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				},
+				{
+					"responseName": "luke",
+					"fieldName": "hero",
+					"type": "Character",
+					"args": [
+						{
+							"name": "episode",
+							"value": "EMPIRE"
+						}
+					],
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.json
@@ -1,55 +1,55 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.graphql",
-      "operationName": "TestQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    id\n    name\n  }\n}",
-      "fields": [
-        {
-          "responseName": "r2",
-          "fieldName": "hero",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        },
-        {
-          "responseName": "luke",
-          "fieldName": "hero",
-          "type": "Character",
-          "args": [
-            {
-              "name": "episode",
-              "value": "EMPIRE"
-            }
-          ],
-          "fields": [
-            {
-              "responseName": "id",
-              "fieldName": "id",
-              "type": "ID!"
-            },
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentsReferenced": []
-    }
-  ],
-  "fragments": [],
-  "typesUsed": []
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/two_heroes_unique/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    id\n    name\n  }\n}",
+			"fields": [
+				{
+					"responseName": "r2",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				},
+				{
+					"responseName": "luke",
+					"fieldName": "hero",
+					"type": "Character",
+					"args": [
+						{
+							"name": "episode",
+							"value": "EMPIRE"
+						}
+					],
+					"fields": [
+						{
+							"responseName": "id",
+							"fieldName": "id",
+							"type": "ID!"
+						},
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"fragments": [],
+	"typesUsed": []
 }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.json
@@ -1,166 +1,166 @@
 {
-  "operations": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.graphql",
-      "operationName": "HeroDetailQuery",
-      "operationType": "query",
-      "variables": [],
-      "source": "query HeroDetailQuery {\n  heroDetailQuery {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n        friends {\n          __typename\n          ...HeroDetails\n        }\n      }\n    }\n  }\n}",
-      "fields": [
-        {
-          "responseName": "heroDetailQuery",
-          "fieldName": "heroDetailQuery",
-          "type": "Character",
-          "fields": [
-            {
-              "responseName": "name",
-              "fieldName": "name",
-              "type": "String!"
-            },
-            {
-              "responseName": "friends",
-              "fieldName": "friends",
-              "type": "[Character]",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": [
-            {
-              "typeCondition": "Human",
-              "fields": [
-                {
-                  "responseName": "name",
-                  "fieldName": "name",
-                  "type": "String!"
-                },
-                {
-                  "responseName": "friends",
-                  "fieldName": "friends",
-                  "type": "[Character]",
-                  "fields": [
-                    {
-                      "responseName": "name",
-                      "fieldName": "name",
-                      "type": "String!"
-                    },
-                    {
-                      "responseName": "appearsIn",
-                      "fieldName": "appearsIn",
-                      "type": "[Episode]!"
-                    },
-                    {
-                      "responseName": "friends",
-                      "fieldName": "friends",
-                      "type": "[Character]",
-                      "fields": [],
-                      "fragmentSpreads": [
-                        "HeroDetails"
-                      ],
-                      "inlineFragments": []
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                },
-                {
-                  "responseName": "height",
-                  "fieldName": "height",
-                  "type": "Float"
-                }
-              ],
-              "fragmentSpreads": []
-            }
-          ]
-        }
-      ],
-      "fragmentsReferenced": [
-        "HeroDetails"
-      ]
-    }
-  ],
-  "fragments": [
-    {
-      "filePath": "/Users/ben_schwab/airapps/apollo-android/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.graphql",
-      "fragmentName": "HeroDetails",
-      "source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
-      "typeCondition": "Character",
-      "fields": [
-        {
-          "responseName": "name",
-          "fieldName": "name",
-          "type": "String!"
-        },
-        {
-          "responseName": "friendsConnection",
-          "fieldName": "friendsConnection",
-          "type": "FriendsConnection!",
-          "fields": [
-            {
-              "responseName": "totalCount",
-              "fieldName": "totalCount",
-              "type": "Int"
-            },
-            {
-              "responseName": "edges",
-              "fieldName": "edges",
-              "type": "[FriendsEdge]",
-              "fields": [
-                {
-                  "responseName": "node",
-                  "fieldName": "node",
-                  "type": "Character",
-                  "fields": [
-                    {
-                      "responseName": "name",
-                      "fieldName": "name",
-                      "type": "String!"
-                    }
-                  ],
-                  "fragmentSpreads": [],
-                  "inlineFragments": []
-                }
-              ],
-              "fragmentSpreads": [],
-              "inlineFragments": []
-            }
-          ],
-          "fragmentSpreads": [],
-          "inlineFragments": []
-        }
-      ],
-      "fragmentSpreads": [],
-      "inlineFragments": [],
-      "fragmentsReferenced": []
-    }
-  ],
-  "typesUsed": [
-    {
-      "kind": "EnumType",
-      "name": "Episode",
-      "description": "The episodes in the Star Wars trilogy",
-      "values": [
-        {
-          "name": "NEWHOPE",
-          "description": "Star Wars Episode IV: A New Hope, released in 1977."
-        },
-        {
-          "name": "EMPIRE",
-          "description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
-        },
-        {
-          "name": "JEDI",
-          "description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
-        }
-      ]
-    }
-  ]
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/unique_type_name/TestQuery.graphql",
+			"operationName": "HeroDetailQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query HeroDetailQuery {\n  heroDetailQuery {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n        friends {\n          __typename\n          ...HeroDetails\n        }\n      }\n    }\n  }\n}",
+			"fields": [
+				{
+					"responseName": "heroDetailQuery",
+					"fieldName": "heroDetailQuery",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "friends",
+							"fieldName": "friends",
+							"type": "[Character]",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": [
+						{
+							"typeCondition": "Human",
+							"fields": [
+								{
+									"responseName": "name",
+									"fieldName": "name",
+									"type": "String!"
+								},
+								{
+									"responseName": "friends",
+									"fieldName": "friends",
+									"type": "[Character]",
+									"fields": [
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!"
+										},
+										{
+											"responseName": "appearsIn",
+											"fieldName": "appearsIn",
+											"type": "[Episode]!"
+										},
+										{
+											"responseName": "friends",
+											"fieldName": "friends",
+											"type": "[Character]",
+											"fields": [],
+											"fragmentSpreads": [
+												"HeroDetails"
+											],
+											"inlineFragments": []
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								},
+								{
+									"responseName": "height",
+									"fieldName": "height",
+									"type": "Float"
+								}
+							],
+							"fragmentSpreads": []
+						}
+					]
+				}
+			],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/unique_type_name/TestQuery.graphql",
+			"fragmentName": "HeroDetails",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
+			"typeCondition": "Character",
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "friendsConnection",
+					"fieldName": "friendsConnection",
+					"type": "FriendsConnection!",
+					"fields": [
+						{
+							"responseName": "totalCount",
+							"fieldName": "totalCount",
+							"type": "Int"
+						},
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[FriendsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Character",
+									"fields": [
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		}
+	]
 }

--- a/apollo-compiler/src/test/graphql/schema.json
+++ b/apollo-compiler/src/test/graphql/schema.json
@@ -393,6 +393,22 @@
               "deprecationReason": null
             },
             {
+              "name": "fieldWithUnsupportedType",
+              "description": "The date character was born.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UnsupportedType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "appearanceDates",
               "description": "The dates of appearances",
               "args": [],
@@ -403,9 +419,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Date",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Date",
+                      "ofType": null
+                    }
                   }
                 }
               },
@@ -443,6 +463,16 @@
           "kind": "SCALAR",
           "name": "Date",
           "description": "The `Date` scalar type represents date format.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "UnsupportedType",
+          "description": "UnsupportedType for testing",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -895,6 +925,22 @@
               "deprecationReason": null
             },
             {
+              "name": "fieldWithUnsupportedType",
+              "description": "The date character was born.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UnsupportedType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "appearanceDates",
               "description": "The dates of appearances",
               "args": [],
@@ -905,9 +951,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Date",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Date",
+                      "ofType": null
+                    }
                   }
                 }
               },
@@ -1212,6 +1262,22 @@
               "deprecationReason": null
             },
             {
+              "name": "fieldWithUnsupportedType",
+              "description": "The date character was born.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UnsupportedType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "appearanceDates",
               "description": "The dates of appearances",
               "args": [],
@@ -1222,9 +1288,13 @@
                   "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Date",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Date",
+                      "ofType": null
+                    }
                   }
                 }
               },


### PR DESCRIPTION
To avoid meaningless diffs on regenerating IR files, let's leave them with 4 spaces.
Also, changes the file location to be relative. We do need this file location to run the tests,
but apollo codegen outputs absolute path, which again will cause meaningless file changes
on regenerating IR files.

374d4f4 fixes the missing edges cases on custom_scalar_type