### PR TITLE
don't add apollo-api dependency if running tests

### DIFF
--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -5,7 +5,7 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
   compile dep.jsr305
-  compile dep.jsr205
+  compile dep.jsr250
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -52,8 +52,10 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
-        project.getGradle().removeListener(this)
+        if (System.getProperty("apollographql.skipApi") != "true") {
+          compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
+          project.getGradle().removeListener(this)
+        }
       }
 
       @Override

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -23,12 +23,12 @@ class BasicAndroidSpec extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withPluginClasspath()
-        .withArguments("generateApolloClasses")
+        .withArguments("build", "-Dapollographql.skipApi=true")
         .forwardStdError(new OutputStreamWriter(System.err))
         .build()
 
     then:
-    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+    result.task(":build").outcome == TaskOutcome.SUCCESS
     // IR Files generated successfully
     assert new File(testProjectDir,
         "build/generated/source/apollo/generatedIR/release/src/main/graphql/ReleaseAPI.json").isFile()
@@ -38,6 +38,7 @@ class BasicAndroidSpec extends Specification {
     // Java classes generated successfully
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/Films.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/fragment/SpeciesInformation.java").isFile()
   }
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
@@ -71,7 +71,7 @@ class FlavoredMultiSchemaSpec extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withPluginClasspath()
-        .withArguments("build")
+        .withArguments("build", "-Dapollographql.skipApi=true")
         .forwardStdError(new OutputStreamWriter(System.err))
         .build()
 

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -46,14 +46,11 @@ dependencies {
   compile 'com.android.support:appcompat-v7:25.1.1'
   compile 'com.google.code.findbugs:jsr305:3.0.1'
   compile 'javax.annotation:jsr250-api:1.0'
-  compile 'com.fernandocejas:arrow:1.0.0'
 }
 
 apollo {
   customTypeMapping {
     DateTime = "java.util.Date"
-    OptionalString = "com.fernandocejas.arrow.optional.Optional"
-    UnsupportedType = "java.lang.Object"
   }
 }
 

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -28,6 +28,13 @@ android {
     textOutput 'stdout'
     ignore 'InvalidPackage', 'GoogleAppIndexingWarning', 'AllowBackup'
   }
+  sourceSets {
+    main {
+      java {
+        srcDirs += '../../../../apollo-api/src/main/java'
+      }
+    }
+  }
 }
 
 repositories {
@@ -37,6 +44,9 @@ repositories {
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.1'
+  compile 'com.google.code.findbugs:jsr305:3.0.1'
+  compile 'javax.annotation:jsr250-api:1.0'
+  compile 'com.fernandocejas:arrow:1.0.0'
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -39,6 +39,13 @@ android {
             versionNameSuffix "-full"
         }
     }
+  sourceSets {
+    main {
+      java {
+        srcDirs += '../../../../apollo-api/src/main/java'
+      }
+    }
+  }
 }
 
 repositories {
@@ -48,6 +55,8 @@ repositories {
 
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.1'
+  compile 'com.google.code.findbugs:jsr305:3.0.1'
+  compile 'javax.annotation:jsr250-api:1.0'
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -62,8 +62,6 @@ dependencies {
 apollo {
   customTypeMapping {
     DateTime = "java.util.Date"
-    OptionalString = "com.fernandocejas.arrow.optional.Optional"
-    UnsupportedType = "java.lang.Object"
   }
 }
 

--- a/apollo-gradle-plugin/src/test/testProject/android/schemaFilesFixtures/oldswapi.json
+++ b/apollo-gradle-plugin/src/test/testProject/android/schemaFilesFixtures/oldswapi.json
@@ -592,16 +592,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "OptionalString",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "FilmsConnection",
           "description": "A connection to a list of items.",
@@ -798,13 +788,9 @@
               "description": "The title of this film.",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "OptionalString",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ ext {
       rxjava2                 : 'io.reactivex.rxjava2:rxjava:2.0.5',
       rxandroid               : 'io.reactivex.rxjava2:rxandroid:2.0.1',
       jsr305                  : 'com.google.code.findbugs:jsr305:3.0.1',
-      jsr205                  : 'javax.annotation:jsr250-api:1.0',
+      jsr250                  : 'javax.annotation:jsr250-api:1.0',
       pluralizer              : 'com.github.cesarferreira:kotlin-pluralizer:0.2.9',
       appcompat               : 'com.android.support:appcompat-v7:25.0.1',
       retrofitRx2Adapter      : 'com.jakewharton.retrofit:retrofit2-rxjava2-adapter:1.0.0',


### PR DESCRIPTION
Instead of running the integration tests with `gradle build`, we now set a JVM
flag and run the test through `gradle build -Dapollographql.skipApi=true`. This
flag is checked by `ApolloPlugin` and if set to true, it doesn't add the
apollo-api dependency.

Now, build fixtures add the apollo-api classes to its source sets and so the
tests will run against the project version of apollo-api.

The jar archives would still include the apollo-api dependency as before.