### PR TITLE
Add orderIndependentCacheKey for field

### DIFF
--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -6,6 +6,9 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 dependencies {
   compile dep.jsr305
   compile dep.jsr250
+
+  testCompile dep.junit
+  testCompile dep.truth
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
@@ -105,17 +105,8 @@ public class Field {
 
   private String orderIndependentKey(Map<String, Object> objectMap, Operation.Variables variables) {
     if (isArgumentValueVariableType(objectMap)) {
-      Object variable = objectMap.get(VARIABLE_NAME_KEY);
-      //noinspection SuspiciousMethodCalls
-      Object resolvedVariable = variables.valueMap().get(variable);
-      if (resolvedVariable instanceof Map) {
-        //noinspection unchecked
-        return orderIndependentKey((Map<String, Object>) resolvedVariable, variables);
-      } else {
-        return resolvedVariable.toString();
-      }
+      return orderIndependentKeyForVariableArgument(objectMap, variables);
     }
-
     List<Map.Entry<String, Object>> sortedArguments = new ArrayList<>(objectMap.entrySet());
     Collections.sort(sortedArguments, new Comparator<Map.Entry<String, Object>>() {
       @Override public int compare(Map.Entry<String, Object> argumentOne, Map.Entry<String, Object> argumentTwo) {
@@ -151,6 +142,18 @@ public class Field {
     return objectMap.containsKey(VARIABLE_IDENTIFIER_KEY)
         && objectMap.get(VARIABLE_IDENTIFIER_KEY).equals(VARIABLE_IDENTIFIER_VALUE)
         && objectMap.containsKey(VARIABLE_NAME_KEY);
+  }
+
+  private String orderIndependentKeyForVariableArgument(Map<String, Object> objectMap, Operation.Variables variables) {
+    Object variable = objectMap.get(VARIABLE_NAME_KEY);
+    //noinspection SuspiciousMethodCalls
+    Object resolvedVariable = variables.valueMap().get(variable);
+    if (resolvedVariable instanceof Map) {
+      //noinspection unchecked
+      return orderIndependentKey((Map<String, Object>) resolvedVariable, variables);
+    } else {
+      return resolvedVariable.toString();
+    }
   }
 
   public enum Type {

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
@@ -1,7 +1,10 @@
 package com.apollographql.android.api.graphql;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 public class Field {
@@ -10,6 +13,10 @@ public class Field {
   private final String fieldName;
   private final Map<String, Object> arguments;
   private final boolean optional;
+
+  private static final String VARIABLE_IDENTIFIER_KEY = "kind";
+  private static final String VARIABLE_IDENTIFIER_VALUE = "Variable";
+  private static final String VARIABLE_NAME_KEY = "variableName";
 
   public static Field forString(String responseName, String fieldName, Map<String, Object> arguments,
       boolean optional) {
@@ -89,7 +96,64 @@ public class Field {
     return optional;
   }
 
-  public static enum Type {
+  public String cacheKey(Operation.Variables variables) {
+    if (arguments.isEmpty()) {
+      return fieldName();
+    }
+    return String.format("%s(%s)", fieldName(), orderIndependentKey(arguments, variables));
+  }
+
+  private String orderIndependentKey(Map<String, Object> objectMap, Operation.Variables variables) {
+    if (isArgumentValueVariableType(objectMap)) {
+      Object variable = objectMap.get(VARIABLE_NAME_KEY);
+      //noinspection SuspiciousMethodCalls
+      Object resolvedVariable = variables.valueMap().get(variable);
+      if (resolvedVariable instanceof Map) {
+        //noinspection unchecked
+        return orderIndependentKey((Map<String, Object>) resolvedVariable, variables);
+      } else {
+        return resolvedVariable.toString();
+      }
+    }
+
+    List<Map.Entry<String, Object>> sortedArguments = new ArrayList<>(objectMap.entrySet());
+    Collections.sort(sortedArguments, new Comparator<Map.Entry<String, Object>>() {
+      @Override public int compare(Map.Entry<String, Object> argumentOne, Map.Entry<String, Object> argumentTwo) {
+        return argumentOne.getKey().compareTo(argumentTwo.getKey());
+      }
+    });
+    StringBuilder independentKey = new StringBuilder();
+    for (int i = 0; i < sortedArguments.size(); i++) {
+      Map.Entry<String, Object> argument = sortedArguments.get(i);
+      if (argument.getValue() instanceof Map) {
+        //noinspection unchecked
+        final Map<String, Object> objectArg = (Map<String, Object>) argument.getValue();
+        boolean isArgumentVariable = isArgumentValueVariableType(objectArg);
+        independentKey
+            .append(argument.getKey())
+            .append(":")
+            .append(isArgumentVariable ? "" : "[")
+            .append(orderIndependentKey(objectArg, variables))
+            .append(isArgumentVariable ? "" : "]");
+      } else {
+        independentKey.append(argument.getKey())
+            .append(":")
+            .append(argument.getValue().toString());
+      }
+      if (i < sortedArguments.size() - 1) {
+        independentKey.append(",");
+      }
+    }
+    return independentKey.toString();
+  }
+
+  private boolean isArgumentValueVariableType(Map<String, Object> objectMap) {
+    return objectMap.containsKey(VARIABLE_IDENTIFIER_KEY)
+        && objectMap.get(VARIABLE_IDENTIFIER_KEY).equals(VARIABLE_IDENTIFIER_VALUE)
+        && objectMap.containsKey(VARIABLE_NAME_KEY);
+  }
+
+  public enum Type {
     STRING,
     INT,
     LONG,

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
@@ -1,10 +1,6 @@
-package com.apollographql.android.converter;
+package com.apollographql.android.api.graphql;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
-
-import junit.framework.Assert;
 
 import org.junit.Test;
 
@@ -12,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class CacheKeyForFieldTest {
 
@@ -27,7 +25,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero");
   }
 
   @Test
@@ -38,7 +36,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero");
   }
 
   @Test
@@ -53,7 +51,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
   }
 
   @Test
@@ -68,7 +66,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
   }
 
   @Test
@@ -88,7 +86,7 @@ public class CacheKeyForFieldTest {
         return map;
       }
     };
-    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
   }
 
   @Test
@@ -104,7 +102,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero(color:blue,episode:JEDI)", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(color:blue,episode:JEDI)");
   }
 
   @Test
@@ -127,7 +125,7 @@ public class CacheKeyForFieldTest {
         .put("episode", "JEDI")
         .build(), false);
 
-    Assert.assertEquals(fieldTwo.cacheKey(variables), field.cacheKey(variables));
+    assertThat(fieldTwo.cacheKey(variables)).isEqualTo(field.cacheKey(variables));
   }
 
   @Test
@@ -146,7 +144,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    Assert.assertEquals("hero(episode:JEDI,nested:[bar:2,foo:1])", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI,nested:[bar:2,foo:1])");
   }
 
   @Test
@@ -170,7 +168,7 @@ public class CacheKeyForFieldTest {
         return map;
       }
     };
-    Assert.assertEquals("hero(episode:JEDI,nested:[bar:2,foo:1])", field.cacheKey(variables));
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI,nested:[bar:2,foo:1])");
   }
 
 }

--- a/apollo-runtime/src/test/java/com/apollographql/android/converter/CacheKeyForFieldTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/converter/CacheKeyForFieldTest.java
@@ -1,0 +1,176 @@
+package com.apollographql.android.converter;
+
+import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+public class CacheKeyForFieldTest {
+
+  enum Episode {
+    JEDI
+  }
+
+  @Test
+  public void testFieldWithNoArguments() {
+    Field field = Field.forString("hero", "hero", null, false);
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithNoArgumentsWithAlias() {
+    Field field = Field.forString("r2", "hero", null, false);
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithArgument() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithArgumentAndAlias() {
+    //noinspection unchecked
+    Field field = Field.forString("r2", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithVariableArgument() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", new UnmodifiableMapBuilder<String, Object>(2)
+            .put("kind", "Variable")
+            .put("variableName", "episode")
+            .build())
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("episode", Episode.JEDI);
+        return map;
+      }
+    };
+    Assert.assertEquals("hero(episode:JEDI)", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithMultipleArgument() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .put("color", "blue")
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero(color:blue,episode:JEDI)", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithMultipleArgumentsOrderIndependent() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .put("color", "blue")
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+
+    //noinspection unchecked
+    Field fieldTwo = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("color", "blue")
+        .put("episode", "JEDI")
+        .build(), false);
+
+    Assert.assertEquals(fieldTwo.cacheKey(variables), field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithNestedObject() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .put("nested", new UnmodifiableMapBuilder<String, Object>(2)
+            .put("foo", 1)
+            .put("bar", 2)
+            .build())
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    Assert.assertEquals("hero(episode:JEDI,nested:[bar:2,foo:1])", field.cacheKey(variables));
+  }
+
+  @Test
+  public void testFieldWithNestedObjectAndVariables() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", "JEDI")
+        .put("nested", new UnmodifiableMapBuilder<String, Object>(2)
+            .put("foo", new UnmodifiableMapBuilder<String, Object>(2)
+                .put("kind", "Variable")
+                .put("variableName", "stars")
+                .build())
+            .put("bar", "2")
+            .build())
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("stars", 1);
+        return map;
+      }
+    };
+    Assert.assertEquals("hero(episode:JEDI,nested:[bar:2,foo:1])", field.cacheKey(variables));
+  }
+
+}


### PR DESCRIPTION
Closes [203](https://github.com/apollographql/apollo-android/issues/203)

Will return a cache key for a field, with variable arguments resolved. For example:

`hero(episode:JEDI,nested:[bar:2,foo:1])`.

This is [consistent with iOS](https://github.com/apollographql/apollo-ios/blob/master/Tests/ApolloTests/CacheKeyForFieldTests.swift): 