### PR TITLE
make client.newCall typesafe

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Mutation.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Mutation.java
@@ -1,4 +1,4 @@
 package com.apollographql.android.api.graphql;
 
-public interface Mutation<V extends Operation.Variables> extends Operation<V> {
+public interface Mutation<D extends Operation.Data, V extends Operation.Variables> extends Operation<D, V> {
 }

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Operation.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import javax.annotation.Nonnull;
 
 /** TODO */
-public interface Operation<V extends Operation.Variables> {
+public interface Operation<T extends Operation.Data, V extends Operation.Variables> {
   /** TODO */
   String queryDocument();
 

--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Query.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Query.java
@@ -1,5 +1,5 @@
 package com.apollographql.android.api.graphql;
 
 /** TODO */
-public interface Query<V extends Operation.Variables> extends Operation<V> {
+public interface Query<D extends Operation.Data, V extends Operation.Variables> extends Operation<D, V> {
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
@@ -11,6 +11,7 @@ class OperationTypeSpecBuilder(
 ) : CodeGenerator {
   private val OPERATION_TYPE_NAME = operation.operationName.capitalize()
   private val OPERATION_VARIABLES_CLASS_NAME = ClassName.get("", "$OPERATION_TYPE_NAME.Variables")
+  private val DATA_VARIABLES_CLASS_NAME = ClassName.get("", "$OPERATION_TYPE_NAME.Data")
 
   override fun toTypeSpec(context: CodeGenerationContext): TypeSpec {
     val newContext = context.plusReservedTypes(OPERATION_TYPE_NAME)
@@ -31,9 +32,9 @@ class OperationTypeSpecBuilder(
     val isMutation = operation.operationType == "mutation"
     val superInterfaceClassName = if (isMutation) ClassNames.GRAPHQL_MUTATION else ClassNames.GRAPHQL_QUERY
     return if (hasVariables) {
-      addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, OPERATION_VARIABLES_CLASS_NAME))
+      addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, DATA_VARIABLES_CLASS_NAME, OPERATION_VARIABLES_CLASS_NAME))
     } else {
-      addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, ClassNames.GRAPHQL_OPERATION_VARIABLES))
+      addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, DATA_VARIABLES_CLASS_NAME, ClassNames.GRAPHQL_OPERATION_VARIABLES))
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -20,7 +20,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<TestQuery.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode, $stars: Int!, $greenValue: Float!) {\n"
       + "  heroWithReview(episode: $episode, review: {stars: $stars, favoriteColor: {red: 0, green: $greenValue, blue: 0}}) {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -18,7 +18,7 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<TestQuery.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode, $includeName: Boolean!) {\n"
       + "  hero(episode: $episode) {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -13,7 +13,7 @@ import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class AllStarships implements Query<Operation.Variables> {
+public final class AllStarships implements Query<AllStarships.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query AllStarships {\n"
       + "  allStarships(first: 7) {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -14,7 +14,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -21,7 +21,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Mutation<TestQuery.Variables> {
+public final class TestQuery implements Mutation<TestQuery.Data, TestQuery.Variables> {
   public static final String OPERATION_DEFINITION = "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n"
       + "  createReview(episode: $ep, review: $review) {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -15,7 +15,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class TestQuery implements Query<Operation.Variables> {
+public final class TestQuery implements Query<TestQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
-public final class HeroDetailQuery implements Query<Operation.Variables> {
+public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query HeroDetailQuery {\n"
       + "  heroDetailQuery {\n"
       + "    __typename\n"

--- a/apollo-runtime/src/main/java/com/apollographql/android/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/ApolloCall.java
@@ -8,11 +8,13 @@ import java.io.IOException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public interface ApolloCall {
+public interface ApolloCall<T extends Operation.Data> {
 
-  @Nonnull <T extends Operation.Data> Response<T> execute() throws IOException;
+  void cancel();
 
-  @Nonnull <T extends Operation.Data> ApolloCall enqueue(@Nullable Callback<T> callback);
+  @Nonnull  Response<T> execute() throws IOException;
+
+  @Nonnull ApolloCall enqueue(@Nullable Callback<T> callback);
 
   @Nonnull ApolloCall network();
 
@@ -30,7 +32,8 @@ public interface ApolloCall {
     void onFailure(@Nonnull Exception e);
   }
 
-  interface Factory<R> {
-    @Nonnull <T extends Operation> R newCall(@Nonnull T operation);
+  interface Factory {
+    <D extends Operation.Data, V extends Operation.Variables> ApolloCall<D> newCall(@Nonnull Operation<D, V>
+        operation);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/ApolloCall.java
@@ -10,9 +10,8 @@ import javax.annotation.Nullable;
 
 public interface ApolloCall<T extends Operation.Data> {
 
-  void cancel();
 
-  @Nonnull  Response<T> execute() throws IOException;
+  @Nonnull Response<T> execute() throws IOException;
 
   @Nonnull ApolloCall enqueue(@Nullable Callback<T> callback);
 
@@ -22,9 +21,10 @@ public interface ApolloCall<T extends Operation.Data> {
 
   @Nonnull ApolloCall networkBeforeStale();
 
+  @Nonnull ApolloCall clone();
+
   void cancel();
 
-  @Nonnull ApolloCall clone();
 
   interface Callback<T extends Operation.Data> {
     void onResponse(@Nonnull Response<T> response);

--- a/apollo-runtime/src/main/java/com/apollographql/android/CallAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/CallAdapter.java
@@ -1,5 +1,7 @@
 package com.apollographql.android;
 
+import com.apollographql.android.api.graphql.Operation;
+
 public interface CallAdapter<R> {
-    R adapt(ApolloCall call);
+    R adapt(ApolloCall<? extends Operation.Data> call);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/CallAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/CallAdapter.java
@@ -3,5 +3,6 @@ package com.apollographql.android;
 import com.apollographql.android.api.graphql.Operation;
 
 public interface CallAdapter<R> {
+
     R adapt(ApolloCall<? extends Operation.Data> call);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloCallAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloCallAdapter.java
@@ -2,10 +2,13 @@ package com.apollographql.android.impl;
 
 import com.apollographql.android.ApolloCall;
 import com.apollographql.android.CallAdapter;
+import com.apollographql.android.api.graphql.Operation;
 
 public class ApolloCallAdapter implements CallAdapter<ApolloCall> {
-  @Override
-  public ApolloCall adapt(ApolloCall call) {
-    return call;
+
+
+
+  @Override public ApolloCall adapt(ApolloCall<? extends Operation.Data> call) {
+    return null;
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -22,8 +22,8 @@ import okhttp3.OkHttpClient;
 
 import static com.apollographql.android.impl.util.Utils.checkNotNull;
 
-public final class ApolloClient implements ApolloCall.Factory{
-  public static   Builder  builder() {
+public final class ApolloClient implements ApolloCall.Factory {
+  public static Builder builder() {
     return new Builder();
   }
 
@@ -33,7 +33,7 @@ public final class ApolloClient implements ApolloCall.Factory{
   private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
   private final Moshi moshi;
 
-  private ApolloClient(Builder  builder) {
+  private ApolloClient(Builder builder) {
     this.serverUrl = builder.serverUrl;
     this.httpCallFactory = builder.okHttpClient;
     this.httpCache = builder.httpCache;
@@ -42,9 +42,9 @@ public final class ApolloClient implements ApolloCall.Factory{
   }
 
 
-
   @Override
-  public <D extends Operation.Data, V extends Operation.Variables> ApolloCall<D> newCall(@Nonnull Operation<D, V> operation) {
+  public <D extends Operation.Data, V extends Operation.Variables>
+  ApolloCall<D> newCall(@Nonnull Operation<D, V> operation) {
     return new RealApolloCall<>(operation, serverUrl, httpCallFactory, httpCache, moshi,
         operation.responseFieldMapper(), customTypeAdapters);
   }
@@ -64,25 +64,25 @@ public final class ApolloClient implements ApolloCall.Factory{
       return this;
     }
 
-    public Builder  serverUrl(@Nonnull HttpUrl serverUrl) {
+    public Builder serverUrl(@Nonnull HttpUrl serverUrl) {
       this.serverUrl = checkNotNull(serverUrl, "serverUrl is null");
       return this;
 
     }
 
-    public Builder  serverUrl(@Nonnull String baseUrl) {
+    public Builder serverUrl(@Nonnull String baseUrl) {
       checkNotNull(baseUrl, "baseUrl == null");
       this.serverUrl = HttpUrl.parse(baseUrl);
       return this;
     }
 
-    public Builder  httpCache(HttpCache httpCache) {
+    public Builder httpCache(HttpCache httpCache) {
       this.httpCache = httpCache;
       return this;
     }
 
 
-    public <T> Builder  withCustomTypeAdapter(@Nonnull ScalarType scalarType,
+    public <T> Builder withCustomTypeAdapter(@Nonnull ScalarType scalarType,
         @Nonnull final CustomTypeAdapter<T> customTypeAdapter) {
       customTypeAdapters.put(scalarType, customTypeAdapter);
       moshiBuilder.add(scalarType.javaType(), new JsonAdapter<T>() {
@@ -100,7 +100,7 @@ public final class ApolloClient implements ApolloCall.Factory{
       return this;
     }
 
-    public ApolloClient  build() {
+    public ApolloClient build() {
       checkNotNull(okHttpClient, "okHttpClient is null");
       checkNotNull(serverUrl, "serverUrl is null");
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -1,7 +1,6 @@
 package com.apollographql.android.impl;
 
 import com.apollographql.android.ApolloCall;
-import com.apollographql.android.CallAdapter;
 import com.apollographql.android.CustomTypeAdapter;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.ScalarType;
@@ -23,9 +22,9 @@ import okhttp3.OkHttpClient;
 
 import static com.apollographql.android.impl.util.Utils.checkNotNull;
 
-public final class ApolloClient<R> implements ApolloCall.Factory<R> {
-  public static <B> Builder<B> builder() {
-    return new Builder<>();
+public final class ApolloClient implements ApolloCall.Factory{
+  public static   Builder  builder() {
+    return new Builder();
   }
 
   private final HttpUrl serverUrl;
@@ -33,64 +32,57 @@ public final class ApolloClient<R> implements ApolloCall.Factory<R> {
   private final HttpCache httpCache;
   private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
   private final Moshi moshi;
-  private CallAdapter<R> adapter;
 
-  private ApolloClient(Builder<R> builder) {
+  private ApolloClient(Builder  builder) {
     this.serverUrl = builder.serverUrl;
     this.httpCallFactory = builder.okHttpClient;
     this.httpCache = builder.httpCache;
     this.customTypeAdapters = builder.customTypeAdapters;
     this.moshi = builder.moshiBuilder.build();
-    this.adapter = builder.callAdapter;
   }
 
-  @Nonnull
-  public <T extends Operation> R newCall(@Nonnull T operation) {
-    RealApolloCall call = new RealApolloCall(operation, serverUrl, httpCallFactory, httpCache, moshi,
+
+
+  @Override
+  public <D extends Operation.Data, V extends Operation.Variables> ApolloCall<D> newCall(@Nonnull Operation<D, V> operation) {
+    return new RealApolloCall<>(operation, serverUrl, httpCallFactory, httpCache, moshi,
         operation.responseFieldMapper(), customTypeAdapters);
-    return adapter.adapt(call);
   }
 
-  public static class Builder<B> {
+  public static class Builder {
     OkHttpClient okHttpClient;
     HttpUrl serverUrl;
     HttpCache httpCache;
     final Map<ScalarType, CustomTypeAdapter> customTypeAdapters = new LinkedHashMap<>();
     Moshi.Builder moshiBuilder = new Moshi.Builder();
-    CallAdapter<B> callAdapter;
 
     private Builder() {
     }
 
-    public Builder<B> okHttpClient(@Nonnull OkHttpClient okHttpClient) {
+    public Builder okHttpClient(@Nonnull OkHttpClient okHttpClient) {
       this.okHttpClient = checkNotNull(okHttpClient, "okHttpClient is null");
       return this;
     }
 
-    public Builder<B> serverUrl(@Nonnull HttpUrl serverUrl) {
+    public Builder  serverUrl(@Nonnull HttpUrl serverUrl) {
       this.serverUrl = checkNotNull(serverUrl, "serverUrl is null");
       return this;
 
     }
 
-    public Builder<B> serverUrl(@Nonnull String baseUrl) {
+    public Builder  serverUrl(@Nonnull String baseUrl) {
       checkNotNull(baseUrl, "baseUrl == null");
       this.serverUrl = HttpUrl.parse(baseUrl);
       return this;
     }
 
-    public Builder<B> httpCache(HttpCache httpCache) {
+    public Builder  httpCache(HttpCache httpCache) {
       this.httpCache = httpCache;
       return this;
     }
 
-    public Builder<B> withCallAdapter(@Nonnull CallAdapter<B> callAdapter) {
-      checkNotNull(callAdapter, "callAdapter is null");
-      this.callAdapter = callAdapter;
-      return this;
-    }
 
-    public <T> Builder<B> withCustomTypeAdapter(@Nonnull ScalarType scalarType,
+    public <T> Builder  withCustomTypeAdapter(@Nonnull ScalarType scalarType,
         @Nonnull final CustomTypeAdapter<T> customTypeAdapter) {
       customTypeAdapters.put(scalarType, customTypeAdapter);
       moshiBuilder.add(scalarType.javaType(), new JsonAdapter<T>() {
@@ -108,16 +100,15 @@ public final class ApolloClient<R> implements ApolloCall.Factory<R> {
       return this;
     }
 
-    public ApolloClient<B> build() {
+    public ApolloClient  build() {
       checkNotNull(okHttpClient, "okHttpClient is null");
       checkNotNull(serverUrl, "serverUrl is null");
-      checkNotNull(callAdapter, "callAdapter is null");
 
       if (httpCache != null) {
         okHttpClient = okHttpClient.newBuilder().addInterceptor(new HttpCacheInterceptor(httpCache)).build();
       }
 
-      return new ApolloClient<>(this);
+      return new ApolloClient(this);
     }
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import okhttp3.Call;
 import okhttp3.HttpUrl;

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -24,7 +24,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okio.Buffer;
 
-final class RealApolloCall implements ApolloCall {
+final class RealApolloCall<T extends Operation.Data> implements ApolloCall<T> {
   private static final String ACCEPT_TYPE = "application/json";
   private static final String CONTENT_TYPE = "application/json";
   private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
@@ -60,7 +60,7 @@ final class RealApolloCall implements ApolloCall {
     this.responseBodyConverter = responseBodyConverter;
   }
 
-  @Override @Nonnull public <T extends Operation.Data> Response<T> execute() throws IOException {
+  @Nonnull @Override public Response<T> execute() throws IOException {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;
@@ -70,7 +70,7 @@ final class RealApolloCall implements ApolloCall {
     return parseHttpResponse(httpCall.execute());
   }
 
-  @Override @Nonnull public <T extends Operation.Data> ApolloCall enqueue(final Callback<T> callback) {
+  @Nonnull @Override public ApolloCall enqueue(@Nullable final Callback<T> callback) {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed");
       executed = true;

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/AllPlanets.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/AllPlanets.java
@@ -14,8 +14,8 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public final class AllPlanets implements Query<Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+final class AllPlanets implements Query<AllPlanets.Data, Operation.Variables>{
+    public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  allPlanets(first: 300) {\n"
       + "    planets {\n"
       + "      ...PlanetFragment\n"

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/CacheTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/CacheTest.java
@@ -38,7 +38,7 @@ import static com.google.common.truth.Truth.assertThat;
 public class CacheTest {
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
 
-  private ApolloClient<ApolloCall> apolloClient;
+  private ApolloClient apolloClient;
   private HttpCache httpCache;
   @Rule public final MockWebServer server = new MockWebServer();
   @Rule public InMemoryFileSystem fileSystem = new InMemoryFileSystem();
@@ -66,7 +66,6 @@ public class CacheTest {
         .okHttpClient(new OkHttpClient.Builder().build())
         .httpCache(httpCache)
         .withCustomTypeAdapter(CustomType.DATETIME, dateCustomTypeAdapter)
-        .withCallAdapter(new ApolloCallAdapter())
         .build();
   }
 
@@ -143,10 +142,9 @@ public class CacheTest {
   @Test public void noCacheStore() throws Exception {
     server.enqueue(mockResponse("src/test/graphql/allPlanetsResponse.json"));
 
-    ApolloClient<ApolloCall> apolloClient = ApolloClient.<ApolloCall>builder()
+    ApolloClient apolloClient = ApolloClient.<ApolloCall>builder()
         .serverUrl(server.url("/"))
         .okHttpClient(new OkHttpClient.Builder().build())
-        .withCallAdapter(new ApolloCallAdapter())
         .build();
 
     ApolloCall call = apolloClient.newCall(new AllPlanets());

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/IntegrationTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/IntegrationTest.java
@@ -45,8 +45,10 @@ import static com.google.common.truth.Truth.assertThat;
 public class IntegrationTest {
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
 
-  private ApolloClient<ApolloCall> apolloClient;
+  private ApolloClient apolloClient;
+  private HttpCache httpCache;
   @Rule public final MockWebServer server = new MockWebServer();
+  @Rule public InMemoryFileSystem fileSystem = new InMemoryFileSystem();
 
   @Before public void setUp() {
     CustomTypeAdapter<Date> dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
@@ -63,18 +65,26 @@ public class IntegrationTest {
       }
     };
 
+    DiskLruCacheStore diskLruCacheStore = new DiskLruCacheStore(fileSystem, new File("/cache/"), Integer.MAX_VALUE);
+    httpCache = new HttpCache(diskLruCacheStore);
+
     apolloClient = ApolloClient.<ApolloCall>builder()
         .serverUrl(server.url("/"))
         .okHttpClient(new OkHttpClient.Builder().build())
+        .httpCache(httpCache)
         .withCustomTypeAdapter(CustomType.DATETIME, dateCustomTypeAdapter)
-        .withCallAdapter(new ApolloCallAdapter())
         .build();
   }
+
+  @After public void tearDown() throws Exception {
+    httpCache.delete();
+  }
+
 
   @SuppressWarnings("ConstantConditions") @Test public void allPlanetQuery() throws Exception {
     server.enqueue(mockResponse("src/test/graphql/allPlanetsResponse.json"));
 
-    ApolloCall call = apolloClient.newCall(new AllPlanets());
+    ApolloCall<AllPlanets.Data> call = apolloClient.newCall(new AllPlanets());
     Response<AllPlanets.Data> body = call.execute();
     assertThat(body.isSuccessful()).isTrue();
 
@@ -129,6 +139,14 @@ public class IntegrationTest {
     assertThat(firstPlanet.filmConnection().films().get(0).fragments().filmFragment().title()).isEqualTo("A New Hope");
     assertThat(firstPlanet.filmConnection().films().get(0).fragments().filmFragment().producers()).isEqualTo(Arrays
         .asList("Gary Kurtz", "Rick McCallum"));
+
+    String cacheKey = ((RealApolloCall) call).httpCall.request().header(HttpCacheInterceptor.CACHE_KEY_HEADER);
+    okhttp3.Response cachedResponse = httpCache.read(cacheKey);
+    assertThat(cachedResponse).isNotNull();
+    assertThat(cachedResponse.body().source().readUtf8())
+        .isEqualTo(Files.toString(new File("src/test/graphql/allPlanetsResponse.json"), Charsets.UTF_8));
+
+    cachedResponse.body().source().close();
   }
 
   @Test public void errorResponse() throws Exception {
@@ -175,6 +193,14 @@ public class IntegrationTest {
         "2013-11-18T19:35:35Z", "2013-11-18T19:35:40Z", "2013-11-18T19:35:54Z", "2013-11-18T19:35:56Z",
         "2013-11-18T19:36:33Z", "2013-11-18T19:36:45Z", "2013-11-18T19:37:08Z", "2013-11-18T19:37:24Z",
         "2013-11-18T19:37:26Z", "2013-11-18T19:37:28Z"));
+
+    String cacheKey = ((RealApolloCall) call).httpCall.request().header(HttpCacheInterceptor.CACHE_KEY_HEADER);
+    okhttp3.Response cachedResponse = httpCache.read(cacheKey);
+    assertThat(cachedResponse).isNotNull();
+    assertThat(cachedResponse.body().source().readString(Charsets.UTF_8))
+        .isEqualTo(Files.toString(new File("src/test/graphql/productsWithDate.json"), Charsets.UTF_8));
+
+    cachedResponse.body().source().close();
   }
 
   @Test public void productsWithUnsupportedCustomScalarTypes() throws Exception {
@@ -193,6 +219,14 @@ public class IntegrationTest {
     assertThat(data.shop().products().edges().get(0).node().unsupportedCustomScalarTypeBool()).isEqualTo(Boolean.TRUE);
     assertThat(data.shop().products().edges().get(0).node().unsupportedCustomScalarTypeString()).isInstanceOf(String.class);
     assertThat(data.shop().products().edges().get(0).node().unsupportedCustomScalarTypeString()).isEqualTo("something");
+
+    String cacheKey = ((RealApolloCall) call).httpCall.request().header(HttpCacheInterceptor.CACHE_KEY_HEADER);
+    okhttp3.Response cachedResponse = httpCache.read(cacheKey);
+    assertThat(cachedResponse).isNotNull();
+    assertThat(cachedResponse.body().source().readString(Charsets.UTF_8))
+        .isEqualTo(Files.toString(new File("src/test/graphql/productsWithUnsupportedCustomScalarTypes.json"), Charsets.UTF_8));
+
+    cachedResponse.body().source().close();
   }
 
   @Test public void allPlanetQueryAsync() throws Exception {
@@ -213,6 +247,14 @@ public class IntegrationTest {
       }
     });
     latch.await();
+
+    String cacheKey = ((RealApolloCall) call).httpCall.request().header(HttpCacheInterceptor.CACHE_KEY_HEADER);
+    okhttp3.Response cachedResponse = httpCache.read(cacheKey);
+    assertThat(cachedResponse).isNotNull();
+    assertThat(cachedResponse.body().source().readString(Charsets.UTF_8))
+        .isEqualTo(Files.toString(new File("src/test/graphql/allPlanetsResponse.json"), Charsets.UTF_8));
+
+    cachedResponse.body().source().close();
   }
 
   private static MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-public final class ProductsWithDate implements Query<Operation.Variables> {
+public final class ProductsWithDate implements Query<ProductsWithDate.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query ProductsWithDate {\n"
       + "  shop {\n"
       + "    products(first: 10) {\n"

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithUnsupportedCustomScalarTypes.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithUnsupportedCustomScalarTypes.java
@@ -12,7 +12,8 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-public final class ProductsWithUnsupportedCustomScalarTypes implements Query<Operation.Variables> {
+public final class ProductsWithUnsupportedCustomScalarTypes implements Query<ProductsWithUnsupportedCustomScalarTypes
+    .Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query ProductsWithDate {\n"
       + "  shop {\n"
       + "    products(first: 10) {\n"


### PR DESCRIPTION
This was primary change
```public interface Operation<T extends Operation.Data, V extends Operation.Variables> ```

Now when you do client.newCall(Operation) it is typesafe to that operation.

Additionally I removed the additional parameter on `ApolloClient` for the `CallAdapter` it will not working since we cannot do a return type of a parameterized generic ie R<T> (because java).  My new plan to deal with the call adapter stuff is to make wrappers around the client. 