### PR TITLE
Memoize mappers

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/FragmentResponseFieldMapper.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/FragmentResponseFieldMapper.java
@@ -1,0 +1,7 @@
+package com.apollographql.android.api.graphql;
+
+import java.io.IOException;
+
+public interface FragmentResponseFieldMapper<T> {
+  T map(final ResponseReader responseReader, String conditionalType) throws IOException;
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
@@ -122,8 +122,7 @@ class OperationTypeSpecBuilder(
         .addModifiers(Modifier.PUBLIC)
         .returns(ParameterizedTypeName.get(ClassName.get(ResponseFieldMapper::class.java),
             WildcardTypeName.subtypeOf(com.apollographql.android.api.graphql.Operation.Data::class.java)))
-        .addStatement("return new \$L.\$L()", Operation.DATA_TYPE_NAME,
-            SchemaTypeResponseMapperBuilder.MAPPER_TYPE_NAME)
+        .addStatement("return new \$L.\$L()", Operation.DATA_TYPE_NAME, Util.MAPPER_TYPE_NAME)
         .build())
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
@@ -334,8 +334,7 @@ class SchemaTypeResponseMapperBuilder(
           .map { it.type.withoutAnnotations() }
           .map { it.let { if (it.isList()) it.listParamType() else it } }
           .filter { !it.isScalar() && !it.isCustomScalarType() }
-          .map { it.overrideTypeName(typeOverrideMap) }
-          .map { it as ClassName }
+          .map { it.overrideTypeName(typeOverrideMap) as ClassName }
           .plus(if (fragmentSpreads.isEmpty()) emptyList<ClassName>() else listOf(FRAGMENTS_CLASS))
           .map {
             val mapperClassName = it.mapper()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
@@ -16,74 +16,24 @@ import javax.lang.model.element.Modifier
  * Example of generated class:
  *
  * ```
- *public static final class Mapper implements ResponseFieldMapper<Hero> {
- *  final Field[] fields = {
- *    Field.forString("name", "name", null, false),
- *    Field.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE),
- *    Field.forList("appearanceDates", "appearanceDates", null, false, new Field.ListReader<Date>() {
- *      @Override public Date read(final Field.ListItemReader reader) throws IOException {
- *        return reader.readCustomType(CustomType.DATE);
- *      }
- *    }),
- *    Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
- *      @Override
- *      public Fragments read(String conditionalType, ResponseReader reader) throws IOException {
- *        return new Fragments.Mapper(conditionalType).map(reader);
- *      }
- *    }),
- *    Field.forObject("film", "film", null, true, new Field.ObjectReader<Hero>() {
- *      @Override public Film read(final ResponseReader reader) throws IOException {
- *        return new Film.Mapper().map(reader);
- *      }
- *    })
- *  };
+ *public static final class Mapper implements ResponseFieldMapper<Data> {
+ *     final Hero.Mapper heroFieldMapper = new Hero.Mapper();
  *
- *  @Override
- *  public Hero map(ResponseReader reader) throws IOException {
- *    final __ContentValues contentValues = new __ContentValues();
- *    reader.read(new ResponseReader.ValueHandler() {
- *      @Override
- *      public void handle(final int fieldIndex, final Object value) throws IOException {
- *        switch (fieldIndex) {
- *          case 0: {
- *            contentValues.name = (String) value;
- *            break;
- *          }
- *          case 1: {
- *            contentValues.birthDate = (Date) value;
- *            break;
- *          }
- *          case 2: {
- *            contentValues.appearanceDates = (List<? extends Date>) value;
- *            break;
- *          }
- *          case 3: {
- *            contentValues.fragments = (Fragments) value;
- *            break;
- *          }
- *          case 4: {
- *            contentValues.film = (Film) value;
- *            break;
- *          }
- *        }
- *      }
- *    }, fields);
- *    return new Hero(contentValues.name, contentValues.birthDate, contentValues.appearanceDates,
- *      fragments, film);
- *  }
+ *     final Field[] fields = {
+ *       Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
+ *         @Override public Hero read(final ResponseReader reader) throws IOException {
+ *           return heroFieldMapper.map(reader);
+ *         }
+ *       })
+ *     };
  *
- *  static final class __ContentValues {
- *    String name;
- *
- *    Date birthDate;
- *
- *    List<? extends Date> appearanceDates;
- *
- *    Fragments fragments;
- *
- *    Film film;
- *  }
- *}
+ *     @Override
+ *     public Data map(ResponseReader reader) throws IOException {
+ *       final Hero hero = reader.read(fields[0]);
+ *       return new Data(hero);
+ *     }
+ *   }
+ * }
  *
  * ```
  */
@@ -107,9 +57,10 @@ class SchemaTypeResponseMapperBuilder(
             .map { FieldSpec.builder(it.type.overrideTypeName(typeOverrideMap), it.name).build() })
         .let { if (fragmentSpreads.isNotEmpty()) it.plus(FRAGMENTS_FIELD) else it }
 
-    return TypeSpec.classBuilder(MAPPER_TYPE_NAME)
+    return TypeSpec.classBuilder(Util.MAPPER_TYPE_NAME)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
         .addSuperinterface(responseFieldMapperType)
+        .addFields(mapperFields())
         .addField(fieldArray(fields))
         .addMethod(mapMethod(contentValueFields))
         .build()
@@ -145,7 +96,7 @@ class SchemaTypeResponseMapperBuilder(
     } else if (fieldTypeName.isList()) {
       return listFieldFactoryCode(field, fieldTypeName)
     } else {
-      return objectFieldFactoryCode(field, "forObject", fieldTypeName.overrideTypeName(typeOverrideMap))
+      return objectFieldFactoryCode(field, "forObject", fieldTypeName.overrideTypeName(typeOverrideMap) as ClassName)
     }
   }
 
@@ -187,7 +138,7 @@ class SchemaTypeResponseMapperBuilder(
             } else if (rawFieldType.isScalar()) {
               scalarListFieldFactoryCode(field, rawFieldType)
             } else {
-              objectFieldFactoryCode(field, "forList", rawFieldType.overrideTypeName(typeOverrideMap))
+              objectFieldFactoryCode(field, "forList", rawFieldType.overrideTypeName(typeOverrideMap) as ClassName)
             })
         .build()
   }
@@ -244,14 +195,14 @@ class SchemaTypeResponseMapperBuilder(
         .build()
   }
 
-  private fun objectFieldFactoryCode(field: Field, factoryMethod: String, type: TypeName): CodeBlock {
+  private fun objectFieldFactoryCode(field: Field, factoryMethod: String, type: ClassName): CodeBlock {
     return CodeBlock.builder()
         .add("\$T.$factoryMethod(\$S, \$S, \$L, \$L, new \$T() {\n", API_RESPONSE_FIELD_TYPE, field.responseName,
             field.fieldName, field.argumentCodeBlock(), field.isOptional(), apiResponseFieldObjectReaderTypeName(type))
         .indent()
         .beginControlFlow("@Override public \$T read(final \$T \$L) throws \$T", type,
             ClassNames.API_RESPONSE_READER, READER_VAR, IOException::class.java)
-        .add(CodeBlock.of("return new \$T.Mapper().map(\$L);\n", type, READER_VAR))
+        .add(CodeBlock.of("return \$L.map(\$L);\n", type.mapperFieldName(), READER_VAR))
         .endControlFlow()
         .unindent()
         .add("})")
@@ -319,11 +270,11 @@ class SchemaTypeResponseMapperBuilder(
           .let { if (it is WildcardTypeName) it.upperBounds.first() else it }
 
   private fun inlineFragmentFieldFactoryCode(fragment: InlineFragment): CodeBlock {
-    val type = fragment.fieldSpec().type.withoutAnnotations().overrideTypeName(typeOverrideMap)
+    val type = fragment.fieldSpec().type.withoutAnnotations().overrideTypeName(typeOverrideMap) as ClassName
     fun readCodeBlock(): CodeBlock {
       return CodeBlock.builder()
           .beginControlFlow("if (\$L.equals(\$S))", CONDITIONAL_TYPE_VAR, fragment.typeCondition)
-          .add(CodeBlock.of("return new \$T.Mapper().map(\$L);\n", type, READER_PARAM.name))
+          .add(CodeBlock.of("return \$L.map(\$L);\n", type.mapperFieldName(), READER_PARAM.name))
           .nextControlFlow("else")
           .addStatement("return null")
           .endControlFlow()
@@ -352,19 +303,20 @@ class SchemaTypeResponseMapperBuilder(
   private fun fragmentsFieldFactoryCode(): CodeBlock {
     fun readCodeBlock(): CodeBlock {
       return CodeBlock.builder()
-          .add(CodeBlock.of("return new Fragments.Mapper(\$L).map(\$L);\n", CONDITIONAL_TYPE_VAR, READER_PARAM.name))
+          .addStatement("return \$L.map(\$L, \$L)", FRAGMENTS_CLASS.mapperFieldName(), READER_PARAM.name,
+              CONDITIONAL_TYPE_VAR)
           .build()
     }
 
     fun conditionalFieldReaderType() =
         TypeSpec.anonymousClassBuilder("")
-            .superclass(apiConditionalFieldReaderTypeName(ClassName.get("", "Fragments")))
+            .superclass(apiConditionalFieldReaderTypeName(FRAGMENTS_CLASS))
             .addMethod(MethodSpec
                 .methodBuilder("read")
                 .addModifiers(Modifier.PUBLIC)
                 .addAnnotation(Override::class.java)
                 .addException(IOException::class.java)
-                .returns(ClassName.get("", "Fragments"))
+                .returns(FRAGMENTS_CLASS)
                 .addParameter(ParameterSpec.builder(String::class.java, CONDITIONAL_TYPE_VAR).build())
                 .addParameter(READER_PARAM)
                 .addCode(readCodeBlock())
@@ -375,6 +327,23 @@ class SchemaTypeResponseMapperBuilder(
         conditionalFieldReaderType())
   }
 
+  private fun mapperFields() =
+      fields
+          .map { it.fieldSpec(customScalarTypeMap = context.customTypeMap) }
+          .plus(inlineFragments.map { it.fieldSpec() })
+          .map { it.type.withoutAnnotations() }
+          .map { it.let { if (it.isList()) it.listParamType() else it } }
+          .filter { !it.isScalar() && !it.isCustomScalarType() }
+          .map { it.overrideTypeName(typeOverrideMap) }
+          .map { it as ClassName }
+          .plus(if (fragmentSpreads.isEmpty()) emptyList<ClassName>() else listOf(FRAGMENTS_CLASS))
+          .map {
+            val mapperClassName = it.mapper()
+            FieldSpec.builder(mapperClassName, it.mapperFieldName(), Modifier.FINAL)
+                .initializer(CodeBlock.of("new \$L()", mapperClassName))
+                .build()
+          }
+
   private fun apiResponseFieldObjectReaderTypeName(type: TypeName) =
       ParameterizedTypeName.get(API_RESPONSE_FIELD_OBJECT_READER_TYPE, type)
 
@@ -382,12 +351,11 @@ class SchemaTypeResponseMapperBuilder(
       ParameterizedTypeName.get(API_RESPONSE_FIELD_CONDITIONAL_TYPE_READER_TYPE, type)
 
   companion object {
-    val MAPPER_TYPE_NAME: String = "Mapper"
     private val FRAGMENTS_FIELD = FieldSpec.builder(ClassName.get("", SchemaTypeSpecBuilder.FRAGMENTS_TYPE_NAME),
         SchemaTypeSpecBuilder.FRAGMENTS_TYPE_NAME.decapitalize()).build()
+    private val FRAGMENTS_CLASS = ClassName.get("", "Fragments")
     private val FIELDS_VAR = "fields"
     private val CONDITIONAL_TYPE_VAR = "conditionalType"
-    private val VALUE_PARAM = "value"
     private val READER_VAR = "reader"
     private val READER_PARAM = ParameterSpec.builder(ResponseReader::class.java, READER_VAR).build()
     private val SCALAR_TYPES = listOf(ClassNames.STRING, TypeName.INT, TypeName.INT.box(), TypeName.LONG,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/Util.kt
@@ -293,10 +293,16 @@ fun TypeSpec.withHashCodeImplementation(): TypeSpec {
       .build()
 }
 
+fun ClassName.mapper(): ClassName = ClassName.get(packageName(), simpleName(), Util.MAPPER_TYPE_NAME)
+
+fun ClassName.mapperFieldName(): String = "${simpleName().decapitalize()}${Util.FIELD_MAPPER_VAR}"
+
 object Util {
   const val CREATOR_TYPE_NAME: String = "Creator"
   const val CREATOR_CREATE_METHOD_NAME: String = "create"
   const val FACTORY_CREATOR_ACCESS_METHOD_NAME: String = "creator"
   const val FACTORY_TYPE_NAME: String = "Factory"
+  const val MAPPER_TYPE_NAME: String = "Mapper"
+  const val FIELD_MAPPER_VAR: String = "FieldMapper"
   val FACTORY_INTERFACE_TYPE: ClassName = ClassName.get("", FACTORY_TYPE_NAME)
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -227,6 +227,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final HeroWithReview.Mapper heroWithReviewFieldMapper = new HeroWithReview.Mapper();
+
       final Field[] fields = {
         Field.forObject("heroWithReview", "heroWithReview", new UnmodifiableMapBuilder<String, Object>(2)
           .put("review", new UnmodifiableMapBuilder<String, Object>(2)
@@ -249,7 +251,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
           .build())
         .build(), true, new Field.ObjectReader<HeroWithReview>() {
           @Override public HeroWithReview read(final ResponseReader reader) throws IOException {
-            return new HeroWithReview.Mapper().map(reader);
+            return heroWithReviewFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -194,6 +194,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
           .put("episode", new UnmodifiableMapBuilder<String, Object>(2)
@@ -202,7 +204,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
           .build())
         .build(), true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -185,10 +185,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -134,10 +134,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -176,10 +176,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -1,6 +1,7 @@
 package com.example.fragment_friends_connection;
 
 import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -161,18 +162,15 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
           return h;
         }
 
-        public static final class Mapper implements ResponseFieldMapper<Fragments> {
-          private final String conditionalType;
-
-          public Mapper(@Nonnull String conditionalType) {
-            this.conditionalType = conditionalType;
-          }
+        public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+          final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();
 
           @Override
-          public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+          public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType)
+              throws IOException {
             HeroDetails heroDetails = null;
             if (conditionalType.equals(HeroDetails.TYPE_CONDITION)) {
-              heroDetails = new HeroDetails.Mapper().map(reader);
+              heroDetails = heroDetailsFieldMapper.map(reader);
             }
             return new Fragments(heroDetails);
           }
@@ -180,12 +178,14 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
         final Field[] fields = {
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
             @Override
             public Fragments read(String conditionalType, ResponseReader reader) throws
                 IOException {
-              return new Fragments.Mapper(conditionalType).map(reader);
+              return fragmentsFieldMapper.map(reader, conditionalType);
             }
           })
         };
@@ -199,10 +199,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -220,10 +220,12 @@ public class HeroDetails {
       }
 
       public static final class Mapper implements ResponseFieldMapper<Edge> {
+        final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
         final Field[] fields = {
           Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
             @Override public Node read(final ResponseReader reader) throws IOException {
-              return new Node.Mapper().map(reader);
+              return nodeFieldMapper.map(reader);
             }
           })
         };
@@ -237,11 +239,13 @@ public class HeroDetails {
     }
 
     public static final class Mapper implements ResponseFieldMapper<FriendsConnection> {
+      final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
       final Field[] fields = {
         Field.forInt("totalCount", "totalCount", null, true),
         Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
           @Override public Edge read(final ResponseReader reader) throws IOException {
-            return new Edge.Mapper().map(reader);
+            return edgeFieldMapper.map(reader);
           }
         })
       };
@@ -256,11 +260,13 @@ public class HeroDetails {
   }
 
   public static final class Mapper implements ResponseFieldMapper<HeroDetails> {
+    final FriendsConnection.Mapper friendsConnectionFieldMapper = new FriendsConnection.Mapper();
+
     final Field[] fields = {
       Field.forString("name", "name", null, false),
       Field.forObject("friendsConnection", "friendsConnection", null, false, new Field.ObjectReader<FriendsConnection>() {
         @Override public FriendsConnection read(final ResponseReader reader) throws IOException {
-          return new FriendsConnection.Mapper().map(reader);
+          return friendsConnectionFieldMapper.map(reader);
         }
       })
     };

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -1,6 +1,7 @@
 package com.example.fragment_in_fragment;
 
 import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -247,18 +248,15 @@ public final class AllStarships implements Query<AllStarships.Data, Operation.Va
               return h;
             }
 
-            public static final class Mapper implements ResponseFieldMapper<Fragments> {
-              private final String conditionalType;
-
-              public Mapper(@Nonnull String conditionalType) {
-                this.conditionalType = conditionalType;
-              }
+            public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+              final StarshipFragment.Mapper starshipFragmentFieldMapper = new StarshipFragment.Mapper();
 
               @Override
-              public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+              public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType)
+                  throws IOException {
                 StarshipFragment starshipFragment = null;
                 if (conditionalType.equals(StarshipFragment.TYPE_CONDITION)) {
-                  starshipFragment = new StarshipFragment.Mapper().map(reader);
+                  starshipFragment = starshipFragmentFieldMapper.map(reader);
                 }
                 return new Fragments(starshipFragment);
               }
@@ -266,12 +264,14 @@ public final class AllStarships implements Query<AllStarships.Data, Operation.Va
           }
 
           public static final class Mapper implements ResponseFieldMapper<Node> {
+            final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
             final Field[] fields = {
               Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
                 @Override
                 public Fragments read(String conditionalType, ResponseReader reader) throws
                     IOException {
-                  return new Fragments.Mapper(conditionalType).map(reader);
+                  return fragmentsFieldMapper.map(reader, conditionalType);
                 }
               })
             };
@@ -285,10 +285,12 @@ public final class AllStarships implements Query<AllStarships.Data, Operation.Va
         }
 
         public static final class Mapper implements ResponseFieldMapper<Edge> {
+          final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
           final Field[] fields = {
             Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
               @Override public Node read(final ResponseReader reader) throws IOException {
-                return new Node.Mapper().map(reader);
+                return nodeFieldMapper.map(reader);
               }
             })
           };
@@ -302,10 +304,12 @@ public final class AllStarships implements Query<AllStarships.Data, Operation.Va
       }
 
       public static final class Mapper implements ResponseFieldMapper<AllStarship> {
+        final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
         final Field[] fields = {
           Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
             @Override public Edge read(final ResponseReader reader) throws IOException {
-              return new Edge.Mapper().map(reader);
+              return edgeFieldMapper.map(reader);
             }
           })
         };
@@ -319,12 +323,14 @@ public final class AllStarships implements Query<AllStarships.Data, Operation.Va
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final AllStarship.Mapper allStarshipFieldMapper = new AllStarship.Mapper();
+
       final Field[] fields = {
         Field.forObject("allStarships", "allStarships", new UnmodifiableMapBuilder<String, Object>(1)
           .put("first", "7.0")
         .build(), true, new Field.ObjectReader<AllStarship>() {
           @Override public AllStarship read(final ResponseReader reader) throws IOException {
-            return new AllStarship.Mapper().map(reader);
+            return allStarshipFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -123,11 +123,13 @@ public class PilotFragment {
   }
 
   public static final class Mapper implements ResponseFieldMapper<PilotFragment> {
+    final Homeworld.Mapper homeworldFieldMapper = new Homeworld.Mapper();
+
     final Field[] fields = {
       Field.forString("name", "name", null, true),
       Field.forObject("homeworld", "homeworld", null, true, new Field.ObjectReader<Homeworld>() {
         @Override public Homeworld read(final ResponseReader reader) throws IOException {
-          return new Homeworld.Mapper().map(reader);
+          return homeworldFieldMapper.map(reader);
         }
       })
     };

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -237,10 +237,12 @@ public class HeroDetails {
       }
 
       public static final class Mapper implements ResponseFieldMapper<Edge> {
+        final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
         final Field[] fields = {
           Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
             @Override public Node read(final ResponseReader reader) throws IOException {
-              return new Node.Mapper().map(reader);
+              return nodeFieldMapper.map(reader);
             }
           })
         };
@@ -254,11 +256,13 @@ public class HeroDetails {
     }
 
     public static final class Mapper implements ResponseFieldMapper<FriendsConnection> {
+      final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
       final Field[] fields = {
         Field.forInt("totalCount", "totalCount", null, true),
         Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
           @Override public Edge read(final ResponseReader reader) throws IOException {
-            return new Edge.Mapper().map(reader);
+            return edgeFieldMapper.map(reader);
           }
         })
       };
@@ -472,10 +476,12 @@ public class HeroDetails {
         }
 
         public static final class Mapper implements ResponseFieldMapper<Edge> {
+          final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
           final Field[] fields = {
             Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
               @Override public Node read(final ResponseReader reader) throws IOException {
-                return new Node.Mapper().map(reader);
+                return nodeFieldMapper.map(reader);
               }
             })
           };
@@ -489,11 +495,13 @@ public class HeroDetails {
       }
 
       public static final class Mapper implements ResponseFieldMapper<FriendsConnection1> {
+        final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
         final Field[] fields = {
           Field.forInt("totalCount", "totalCount", null, true),
           Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
             @Override public Edge read(final ResponseReader reader) throws IOException {
-              return new Edge.Mapper().map(reader);
+              return edgeFieldMapper.map(reader);
             }
           })
         };
@@ -508,11 +516,13 @@ public class HeroDetails {
     }
 
     public static final class Mapper implements ResponseFieldMapper<AsDroid> {
+      final FriendsConnection1.Mapper friendsConnection1FieldMapper = new FriendsConnection1.Mapper();
+
       final Field[] fields = {
         Field.forString("name", "name", null, false),
         Field.forObject("friendsConnection", "friendsConnection", null, false, new Field.ObjectReader<FriendsConnection1>() {
           @Override public FriendsConnection1 read(final ResponseReader reader) throws IOException {
-            return new FriendsConnection1.Mapper().map(reader);
+            return friendsConnection1FieldMapper.map(reader);
           }
         }),
         Field.forString("primaryFunction", "primaryFunction", null, true)
@@ -529,18 +539,22 @@ public class HeroDetails {
   }
 
   public static final class Mapper implements ResponseFieldMapper<HeroDetails> {
+    final FriendsConnection.Mapper friendsConnectionFieldMapper = new FriendsConnection.Mapper();
+
+    final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
+
     final Field[] fields = {
       Field.forString("name", "name", null, false),
       Field.forObject("friendsConnection", "friendsConnection", null, false, new Field.ObjectReader<FriendsConnection>() {
         @Override public FriendsConnection read(final ResponseReader reader) throws IOException {
-          return new FriendsConnection.Mapper().map(reader);
+          return friendsConnectionFieldMapper.map(reader);
         }
       }),
       Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsDroid>() {
         @Override
         public AsDroid read(String conditionalType, ResponseReader reader) throws IOException {
           if (conditionalType.equals("Droid")) {
-            return new AsDroid.Mapper().map(reader);
+            return asDroidFieldMapper.map(reader);
           } else {
             return null;
           }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -1,6 +1,7 @@
 package com.example.fragments_with_type_condition;
 
 import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -191,22 +192,21 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
           return h;
         }
 
-        public static final class Mapper implements ResponseFieldMapper<Fragments> {
-          private final String conditionalType;
+        public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+          final HumanDetails.Mapper humanDetailsFieldMapper = new HumanDetails.Mapper();
 
-          public Mapper(@Nonnull String conditionalType) {
-            this.conditionalType = conditionalType;
-          }
+          final DroidDetails.Mapper droidDetailsFieldMapper = new DroidDetails.Mapper();
 
           @Override
-          public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+          public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType)
+              throws IOException {
             HumanDetails humanDetails = null;
             DroidDetails droidDetails = null;
             if (conditionalType.equals(HumanDetails.TYPE_CONDITION)) {
-              humanDetails = new HumanDetails.Mapper().map(reader);
+              humanDetails = humanDetailsFieldMapper.map(reader);
             }
             if (conditionalType.equals(DroidDetails.TYPE_CONDITION)) {
-              droidDetails = new DroidDetails.Mapper().map(reader);
+              droidDetails = droidDetailsFieldMapper.map(reader);
             }
             return new Fragments(humanDetails, droidDetails);
           }
@@ -214,12 +214,14 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<R2> {
+        final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
         final Field[] fields = {
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
             @Override
             public Fragments read(String conditionalType, ResponseReader reader) throws
                 IOException {
-              return new Fragments.Mapper(conditionalType).map(reader);
+              return fragmentsFieldMapper.map(reader, conditionalType);
             }
           })
         };
@@ -319,22 +321,21 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
           return h;
         }
 
-        public static final class Mapper implements ResponseFieldMapper<Fragments> {
-          private final String conditionalType;
+        public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+          final HumanDetails.Mapper humanDetailsFieldMapper = new HumanDetails.Mapper();
 
-          public Mapper(@Nonnull String conditionalType) {
-            this.conditionalType = conditionalType;
-          }
+          final DroidDetails.Mapper droidDetailsFieldMapper = new DroidDetails.Mapper();
 
           @Override
-          public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+          public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType)
+              throws IOException {
             HumanDetails humanDetails = null;
             DroidDetails droidDetails = null;
             if (conditionalType.equals(HumanDetails.TYPE_CONDITION)) {
-              humanDetails = new HumanDetails.Mapper().map(reader);
+              humanDetails = humanDetailsFieldMapper.map(reader);
             }
             if (conditionalType.equals(DroidDetails.TYPE_CONDITION)) {
-              droidDetails = new DroidDetails.Mapper().map(reader);
+              droidDetails = droidDetailsFieldMapper.map(reader);
             }
             return new Fragments(humanDetails, droidDetails);
           }
@@ -342,12 +343,14 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Luke> {
+        final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
         final Field[] fields = {
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
             @Override
             public Fragments read(String conditionalType, ResponseReader reader) throws
                 IOException {
-              return new Fragments.Mapper(conditionalType).map(reader);
+              return fragmentsFieldMapper.map(reader, conditionalType);
             }
           })
         };
@@ -361,15 +364,19 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final R2.Mapper r2FieldMapper = new R2.Mapper();
+
+      final Luke.Mapper lukeFieldMapper = new Luke.Mapper();
+
       final Field[] fields = {
         Field.forObject("r2", "hero", null, true, new Field.ObjectReader<R2>() {
           @Override public R2 read(final ResponseReader reader) throws IOException {
-            return new R2.Mapper().map(reader);
+            return r2FieldMapper.map(reader);
           }
         }),
         Field.forObject("luke", "hero", null, true, new Field.ObjectReader<Luke>() {
           @Override public Luke read(final ResponseReader reader) throws IOException {
-            return new Luke.Mapper().map(reader);
+            return lukeFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -284,10 +284,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
           }
 
           public static final class Mapper implements ResponseFieldMapper<Edge> {
+            final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
             final Field[] fields = {
               Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
                 @Override public Node read(final ResponseReader reader) throws IOException {
-                  return new Node.Mapper().map(reader);
+                  return nodeFieldMapper.map(reader);
                 }
               })
             };
@@ -301,11 +303,13 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
         }
 
         public static final class Mapper implements ResponseFieldMapper<FriendsConnection> {
+          final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
           final Field[] fields = {
             Field.forInt("totalCount", "totalCount", null, true),
             Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
               @Override public Edge read(final ResponseReader reader) throws IOException {
-                return new Edge.Mapper().map(reader);
+                return edgeFieldMapper.map(reader);
               }
             })
           };
@@ -320,11 +324,13 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final FriendsConnection.Mapper friendsConnectionFieldMapper = new FriendsConnection.Mapper();
+
         final Field[] fields = {
           Field.forString("name", "name", null, false),
           Field.forObject("friendsConnection", "friendsConnection", null, false, new Field.ObjectReader<FriendsConnection>() {
             @Override public FriendsConnection read(final ResponseReader reader) throws IOException {
-              return new FriendsConnection.Mapper().map(reader);
+              return friendsConnectionFieldMapper.map(reader);
             }
           })
         };
@@ -339,10 +345,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -135,10 +135,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -279,12 +279,14 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
         }
 
         public static final class Mapper implements ResponseFieldMapper<AsHuman> {
+          final Friend.Mapper friendFieldMapper = new Friend.Mapper();
+
           final Field[] fields = {
             Field.forString("name", "name", null, false),
             Field.forDouble("height", "height", null, true),
             Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend>() {
               @Override public Friend read(final ResponseReader reader) throws IOException {
-                return new Friend.Mapper().map(reader);
+                return friendFieldMapper.map(reader);
               }
             })
           };
@@ -412,11 +414,13 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
         }
 
         public static final class Mapper implements ResponseFieldMapper<AsDroid> {
+          final Friend.Mapper friendFieldMapper = new Friend.Mapper();
+
           final Field[] fields = {
             Field.forString("name", "name", null, false),
             Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend>() {
               @Override public Friend read(final ResponseReader reader) throws IOException {
-                return new Friend.Mapper().map(reader);
+                return friendFieldMapper.map(reader);
               }
             }),
             Field.forString("primaryFunction", "primaryFunction", null, true)
@@ -433,13 +437,17 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
+
+        final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
+
         final Field[] fields = {
           Field.forString("name", "name", null, false),
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman>() {
             @Override
             public AsHuman read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Human")) {
-                return new AsHuman.Mapper().map(reader);
+                return asHumanFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -449,7 +457,7 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
             @Override
             public AsDroid read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Droid")) {
-                return new AsDroid.Mapper().map(reader);
+                return asDroidFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -468,10 +476,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -213,6 +213,8 @@ public final class TestQuery implements Mutation<TestQuery.Data, TestQuery.Varia
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final CreateReview.Mapper createReviewFieldMapper = new CreateReview.Mapper();
+
       final Field[] fields = {
         Field.forObject("createReview", "createReview", new UnmodifiableMapBuilder<String, Object>(2)
           .put("review", new UnmodifiableMapBuilder<String, Object>(2)
@@ -225,7 +227,7 @@ public final class TestQuery implements Mutation<TestQuery.Data, TestQuery.Varia
           .build())
         .build(), true, new Field.ObjectReader<CreateReview>() {
           @Override public CreateReview read(final ResponseReader reader) throws IOException {
-            return new CreateReview.Mapper().map(reader);
+            return createReviewFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -377,6 +377,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
           }
 
           public static final class Mapper implements ResponseFieldMapper<Friend> {
+            final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
+
             final Field[] fields = {
               Field.forString("name", "name", null, false),
               Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman1>() {
@@ -384,7 +386,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
                 public AsHuman1 read(String conditionalType, ResponseReader reader) throws
                     IOException {
                   if (conditionalType.equals("Human")) {
-                    return new AsHuman1.Mapper().map(reader);
+                    return asHuman1FieldMapper.map(reader);
                   } else {
                     return null;
                   }
@@ -402,11 +404,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
         }
 
         public static final class Mapper implements ResponseFieldMapper<AsHuman> {
+          final Friend.Mapper friendFieldMapper = new Friend.Mapper();
+
           final Field[] fields = {
             Field.forString("name", "name", null, false),
             Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend>() {
               @Override public Friend read(final ResponseReader reader) throws IOException {
-                return new Friend.Mapper().map(reader);
+                return friendFieldMapper.map(reader);
               }
             })
           };
@@ -585,6 +589,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
           }
 
           public static final class Mapper implements ResponseFieldMapper<Friend> {
+            final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
+
             final Field[] fields = {
               Field.forString("name", "name", null, false),
               Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman>() {
@@ -592,7 +598,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
                 public AsHuman read(String conditionalType, ResponseReader reader) throws
                     IOException {
                   if (conditionalType.equals("Human")) {
-                    return new AsHuman.Mapper().map(reader);
+                    return asHumanFieldMapper.map(reader);
                   } else {
                     return null;
                   }
@@ -610,11 +616,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
         }
 
         public static final class Mapper implements ResponseFieldMapper<AsDroid> {
+          final Friend.Mapper friendFieldMapper = new Friend.Mapper();
+
           final Field[] fields = {
             Field.forString("name", "name", null, false),
             Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend>() {
               @Override public Friend read(final ResponseReader reader) throws IOException {
-                return new Friend.Mapper().map(reader);
+                return friendFieldMapper.map(reader);
               }
             })
           };
@@ -629,13 +637,17 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
+
+        final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
+
         final Field[] fields = {
           Field.forString("name", "name", null, false),
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman>() {
             @Override
             public AsHuman read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Human")) {
-                return new AsHuman.Mapper().map(reader);
+                return asHumanFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -645,7 +657,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
             @Override
             public AsDroid read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Droid")) {
-                return new AsDroid.Mapper().map(reader);
+                return asDroidFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -664,6 +676,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
           .put("episode", new UnmodifiableMapBuilder<String, Object>(2)
@@ -672,7 +686,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Variable
           .build())
         .build(), true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -249,6 +249,8 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final GraphQlListOfObject.Mapper graphQlListOfObjectFieldMapper = new GraphQlListOfObject.Mapper();
+
       final Field[] fields = {
         Field.forString("graphQlString", "graphQlString", null, true),
         Field.forString("graphQlIdNullable", "graphQlIdNullable", null, true),
@@ -266,7 +268,7 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
         }),
         Field.forList("graphQlListOfObjects", "graphQlListOfObjects", null, true, new Field.ObjectReader<GraphQlListOfObject>() {
           @Override public GraphQlListOfObject read(final ResponseReader reader) throws IOException {
-            return new GraphQlListOfObject.Mapper().map(reader);
+            return graphQlListOfObjectFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -1,6 +1,7 @@
 package com.example.simple_fragment;
 
 import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -161,18 +162,15 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
           return h;
         }
 
-        public static final class Mapper implements ResponseFieldMapper<Fragments> {
-          private final String conditionalType;
-
-          public Mapper(@Nonnull String conditionalType) {
-            this.conditionalType = conditionalType;
-          }
+        public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+          final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();
 
           @Override
-          public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+          public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType)
+              throws IOException {
             HeroDetails heroDetails = null;
             if (conditionalType.equals(HeroDetails.TYPE_CONDITION)) {
-              heroDetails = new HeroDetails.Mapper().map(reader);
+              heroDetails = heroDetailsFieldMapper.map(reader);
             }
             return new Fragments(heroDetails);
           }
@@ -180,12 +178,14 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
         final Field[] fields = {
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
             @Override
             public Fragments read(String conditionalType, ResponseReader reader) throws
                 IOException {
-              return new Fragments.Mapper(conditionalType).map(reader);
+              return fragmentsFieldMapper.map(reader, conditionalType);
             }
           })
         };
@@ -199,10 +199,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -281,13 +281,17 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
       }
 
       public static final class Mapper implements ResponseFieldMapper<Hero> {
+        final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
+
+        final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
+
         final Field[] fields = {
           Field.forString("name", "name", null, false),
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman>() {
             @Override
             public AsHuman read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Human")) {
-                return new AsHuman.Mapper().map(reader);
+                return asHumanFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -297,7 +301,7 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
             @Override
             public AsDroid read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Droid")) {
-                return new AsDroid.Mapper().map(reader);
+                return asDroidFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -316,10 +320,12 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       final Field[] fields = {
         Field.forObject("hero", "hero", null, true, new Field.ObjectReader<Hero>() {
           @Override public Hero read(final ResponseReader reader) throws IOException {
-            return new Hero.Mapper().map(reader);
+            return heroFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
@@ -202,17 +202,21 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final R2.Mapper r2FieldMapper = new R2.Mapper();
+
+      final Luke.Mapper lukeFieldMapper = new Luke.Mapper();
+
       final Field[] fields = {
         Field.forObject("r2", "hero", null, true, new Field.ObjectReader<R2>() {
           @Override public R2 read(final ResponseReader reader) throws IOException {
-            return new R2.Mapper().map(reader);
+            return r2FieldMapper.map(reader);
           }
         }),
         Field.forObject("luke", "hero", new UnmodifiableMapBuilder<String, Object>(1)
           .put("episode", "EMPIRE")
         .build(), true, new Field.ObjectReader<Luke>() {
           @Override public Luke read(final ResponseReader reader) throws IOException {
-            return new Luke.Mapper().map(reader);
+            return lukeFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -216,17 +216,21 @@ public final class TestQuery implements Query<TestQuery.Data, Operation.Variable
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final R2.Mapper r2FieldMapper = new R2.Mapper();
+
+      final Luke.Mapper lukeFieldMapper = new Luke.Mapper();
+
       final Field[] fields = {
         Field.forObject("r2", "hero", null, true, new Field.ObjectReader<R2>() {
           @Override public R2 read(final ResponseReader reader) throws IOException {
-            return new R2.Mapper().map(reader);
+            return r2FieldMapper.map(reader);
           }
         }),
         Field.forObject("luke", "hero", new UnmodifiableMapBuilder<String, Object>(1)
           .put("episode", "EMPIRE")
         .build(), true, new Field.ObjectReader<Luke>() {
           @Override public Luke read(final ResponseReader reader) throws IOException {
-            return new Luke.Mapper().map(reader);
+            return lukeFieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -1,6 +1,7 @@
 package com.example.unique_type_name;
 
 import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -414,18 +415,15 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
                 return h;
               }
 
-              public static final class Mapper implements ResponseFieldMapper<Fragments> {
-                private final String conditionalType;
-
-                public Mapper(@Nonnull String conditionalType) {
-                  this.conditionalType = conditionalType;
-                }
+              public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+                final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();
 
                 @Override
-                public @Nonnull Fragments map(ResponseReader reader) throws IOException {
+                public @Nonnull Fragments map(ResponseReader reader,
+                    @Nonnull String conditionalType) throws IOException {
                   HeroDetails heroDetails = null;
                   if (conditionalType.equals(HeroDetails.TYPE_CONDITION)) {
-                    heroDetails = new HeroDetails.Mapper().map(reader);
+                    heroDetails = heroDetailsFieldMapper.map(reader);
                   }
                   return new Fragments(heroDetails);
                 }
@@ -433,12 +431,14 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
             }
 
             public static final class Mapper implements ResponseFieldMapper<Friend2> {
+              final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
               final Field[] fields = {
                 Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
                   @Override
                   public Fragments read(String conditionalType, ResponseReader reader) throws
                       IOException {
-                    return new Fragments.Mapper(conditionalType).map(reader);
+                    return fragmentsFieldMapper.map(reader, conditionalType);
                   }
                 })
               };
@@ -452,6 +452,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
           }
 
           public static final class Mapper implements ResponseFieldMapper<Friend1> {
+            final Friend2.Mapper friend2FieldMapper = new Friend2.Mapper();
+
             final Field[] fields = {
               Field.forString("name", "name", null, false),
               Field.forList("appearsIn", "appearsIn", null, false, new Field.ListReader<Episode>() {
@@ -461,7 +463,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
               }),
               Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend2>() {
                 @Override public Friend2 read(final ResponseReader reader) throws IOException {
-                  return new Friend2.Mapper().map(reader);
+                  return friend2FieldMapper.map(reader);
                 }
               })
             };
@@ -477,11 +479,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
         }
 
         public static final class Mapper implements ResponseFieldMapper<AsHuman> {
+          final Friend1.Mapper friend1FieldMapper = new Friend1.Mapper();
+
           final Field[] fields = {
             Field.forString("name", "name", null, false),
             Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend1>() {
               @Override public Friend1 read(final ResponseReader reader) throws IOException {
-                return new Friend1.Mapper().map(reader);
+                return friend1FieldMapper.map(reader);
               }
             }),
             Field.forDouble("height", "height", null, true)
@@ -498,18 +502,22 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
       }
 
       public static final class Mapper implements ResponseFieldMapper<HeroDetailQuery1> {
+        final Friend.Mapper friendFieldMapper = new Friend.Mapper();
+
+        final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
+
         final Field[] fields = {
           Field.forString("name", "name", null, false),
           Field.forList("friends", "friends", null, true, new Field.ObjectReader<Friend>() {
             @Override public Friend read(final ResponseReader reader) throws IOException {
-              return new Friend.Mapper().map(reader);
+              return friendFieldMapper.map(reader);
             }
           }),
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<AsHuman>() {
             @Override
             public AsHuman read(String conditionalType, ResponseReader reader) throws IOException {
               if (conditionalType.equals("Human")) {
-                return new AsHuman.Mapper().map(reader);
+                return asHumanFieldMapper.map(reader);
               } else {
                 return null;
               }
@@ -528,10 +536,12 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Operat
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final HeroDetailQuery1.Mapper heroDetailQuery1FieldMapper = new HeroDetailQuery1.Mapper();
+
       final Field[] fields = {
         Field.forObject("heroDetailQuery", "heroDetailQuery", null, true, new Field.ObjectReader<HeroDetailQuery1>() {
           @Override public HeroDetailQuery1 read(final ResponseReader reader) throws IOException {
-            return new HeroDetailQuery1.Mapper().map(reader);
+            return heroDetailQuery1FieldMapper.map(reader);
           }
         })
       };

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -220,10 +220,12 @@ public class HeroDetails {
       }
 
       public static final class Mapper implements ResponseFieldMapper<Edge> {
+        final Node.Mapper nodeFieldMapper = new Node.Mapper();
+
         final Field[] fields = {
           Field.forObject("node", "node", null, true, new Field.ObjectReader<Node>() {
             @Override public Node read(final ResponseReader reader) throws IOException {
-              return new Node.Mapper().map(reader);
+              return nodeFieldMapper.map(reader);
             }
           })
         };
@@ -237,11 +239,13 @@ public class HeroDetails {
     }
 
     public static final class Mapper implements ResponseFieldMapper<FriendsConnection> {
+      final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
+
       final Field[] fields = {
         Field.forInt("totalCount", "totalCount", null, true),
         Field.forList("edges", "edges", null, true, new Field.ObjectReader<Edge>() {
           @Override public Edge read(final ResponseReader reader) throws IOException {
-            return new Edge.Mapper().map(reader);
+            return edgeFieldMapper.map(reader);
           }
         })
       };
@@ -256,11 +260,13 @@ public class HeroDetails {
   }
 
   public static final class Mapper implements ResponseFieldMapper<HeroDetails> {
+    final FriendsConnection.Mapper friendsConnectionFieldMapper = new FriendsConnection.Mapper();
+
     final Field[] fields = {
       Field.forString("name", "name", null, false),
       Field.forObject("friendsConnection", "friendsConnection", null, false, new Field.ObjectReader<FriendsConnection>() {
         @Override public FriendsConnection read(final ResponseReader reader) throws IOException {
-          return new FriendsConnection.Mapper().map(reader);
+          return friendsConnectionFieldMapper.map(reader);
         }
       })
     };

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -4,7 +4,6 @@ import com.apollographql.android.ApolloCall;
 import com.apollographql.android.ApolloPrefetch;
 import com.apollographql.android.CustomTypeAdapter;
 import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ScalarType;
 import com.apollographql.android.cache.http.EvictionStrategy;
 import com.apollographql.android.cache.http.HttpCache;
@@ -19,7 +18,6 @@ import com.squareup.moshi.Moshi;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nonnull;
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -1,18 +1,14 @@
 package com.apollographql.android.impl;
 
 import com.apollographql.android.ApolloCall;
-import com.apollographql.android.CustomTypeAdapter;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
 import com.apollographql.android.cache.http.HttpCache;
 import com.apollographql.android.cache.normalized.Cache;
 import com.apollographql.android.impl.util.HttpException;
 import com.squareup.moshi.Moshi;
 
 import java.io.IOException;
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -32,20 +32,20 @@ final class RealApolloCall<T extends Operation.Data> extends BaseApolloCall impl
   private CacheControl cacheControl = CacheControl.DEFAULT;
 
   RealApolloCall(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory, HttpCache httpCache, Moshi moshi,
-      ResponseFieldMapper responseFieldMapper, Map<ScalarType, CustomTypeAdapter> customTypeAdapters, Cache cache) {
+      ResponseBodyConverter responseBodyConverter, Cache cache) {
     super(operation, serverUrl, httpCallFactory, moshi);
     this.cache = cache;
     this.httpCache = httpCache;
-    this.responseBodyConverter = new ResponseBodyConverter(operation, responseFieldMapper, customTypeAdapters);
+    this.responseBodyConverter = responseBodyConverter;
   }
 
   private RealApolloCall(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory, HttpCache httpCache,
-      CacheControl cacheControl, Moshi moshi, ResponseBodyConverter responseBodyConverter, Cache cache) {
+      Moshi moshi, ResponseBodyConverter responseBodyConverter, Cache cache, CacheControl cacheControl) {
     super(operation, serverUrl, httpCallFactory, moshi);
-    this.cache = cache;
     this.httpCache = httpCache;
-    this.cacheControl = cacheControl;
     this.responseBodyConverter = responseBodyConverter;
+    this.cache = cache;
+    this.cacheControl = cacheControl;
   }
 
   @Nonnull @Override public Response<T> execute() throws IOException {
@@ -135,8 +135,8 @@ final class RealApolloCall<T extends Operation.Data> extends BaseApolloCall impl
   }
 
   @Override @Nonnull public ApolloCall<T> clone() {
-    return new RealApolloCall<>(operation, serverUrl, httpCallFactory, httpCache, cacheControl, moshi,
-        responseBodyConverter, cache);
+    return new RealApolloCall<>(operation, serverUrl, httpCallFactory, httpCache, moshi, responseBodyConverter, cache,
+        cacheControl);
   }
 
   private <T extends Operation.Data> Response<T> handleResponse(okhttp3.Response response) throws IOException {

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
@@ -127,10 +127,12 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
           }
 
           public static final class Mapper implements ResponseFieldMapper<Edge> {
+            final Node.Mapper nodeMapper = new Node.Mapper();
+
             final Field[] fields = {
                 Field.forObject("node", "node", null, false, new Field.ObjectReader<Node>() {
                   @Override public Node read(final ResponseReader reader) throws IOException {
-                    return new Node.Mapper().map(reader);
+                    return nodeMapper.map(reader);
                   }
                 })
             };
@@ -144,10 +146,12 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
         }
 
         public static final class Mapper implements ResponseFieldMapper<Product> {
+          final Edge.Mapper edgeMapper = new Edge.Mapper();
+
           final Field[] fields = {
               Field.forList("edges", "edges", null, false, new Field.ObjectReader<Edge>() {
                 @Override public Edge read(final ResponseReader reader) throws IOException {
-                  return new Edge.Mapper().map(reader);
+                  return edgeMapper.map(reader);
                 }
               })
           };
@@ -161,10 +165,12 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
       }
 
       public static final class Mapper implements ResponseFieldMapper<Shop> {
+        final Product.Mapper productMapper = new Product.Mapper();
+
         final Field[] fields = {
             Field.forObject("products", "products", null, false, new Field.ObjectReader<Product>() {
               @Override public Product read(final ResponseReader reader) throws IOException {
-                return new Product.Mapper().map(reader);
+                return productMapper.map(reader);
               }
             })
         };
@@ -178,10 +184,12 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Shop.Mapper shopMapper = new Shop.Mapper();
+
       final Field[] fields = {
           Field.forObject("shop", "shop", null, false, new Field.ObjectReader<Shop>() {
             @Override public Shop read(final ResponseReader reader) throws IOException {
-              return new Shop.Mapper().map(reader);
+              return shopMapper.map(reader);
             }
           })
       };

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithUnsupportedCustomScalarTypes.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithUnsupportedCustomScalarTypes.java
@@ -152,10 +152,12 @@ public final class ProductsWithUnsupportedCustomScalarTypes implements Query<Pro
           }
 
           public static final class Mapper implements ResponseFieldMapper<Edge> {
+            final Node.Mapper nodeMapper = new Node.Mapper();
+
             final Field[] fields = {
                 Field.forObject("node", "node", null, false, new Field.ObjectReader<Node>() {
                   @Override public Node read(final ResponseReader reader) throws IOException {
-                    return new Node.Mapper().map(reader);
+                    return nodeMapper.map(reader);
                   }
                 })
             };
@@ -169,10 +171,12 @@ public final class ProductsWithUnsupportedCustomScalarTypes implements Query<Pro
         }
 
         public static final class Mapper implements ResponseFieldMapper<Product> {
+          final Edge.Mapper edgeMapper = new Edge.Mapper();
+
           final Field[] fields = {
               Field.forList("edges", "edges", null, false, new Field.ObjectReader<Edge>() {
                 @Override public Edge read(final ResponseReader reader) throws IOException {
-                  return new Edge.Mapper().map(reader);
+                  return edgeMapper.map(reader);
                 }
               })
           };
@@ -186,10 +190,12 @@ public final class ProductsWithUnsupportedCustomScalarTypes implements Query<Pro
       }
 
       public static final class Mapper implements ResponseFieldMapper<Shop> {
+        final Product.Mapper productMapper = new Product.Mapper();
+
         final Field[] fields = {
             Field.forObject("products", "products", null, false, new Field.ObjectReader<Product>() {
               @Override public Product read(final ResponseReader reader) throws IOException {
-                return new Product.Mapper().map(reader);
+                return productMapper.map(reader);
               }
             })
         };
@@ -203,10 +209,12 @@ public final class ProductsWithUnsupportedCustomScalarTypes implements Query<Pro
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Shop.Mapper shopMapper = new Shop.Mapper();
+
       final Field[] fields = {
           Field.forObject("shop", "shop", null, false, new Field.ObjectReader<Shop>() {
             @Override public Shop read(final ResponseReader reader) throws IOException {
-              return new Shop.Mapper().map(reader);
+              return shopMapper.map(reader);
             }
           })
       };


### PR DESCRIPTION
Closes #224 

Changes:
- nested mappers instantiated in default constructor (example https://github.com/apollographql/apollo-android/pull/273/files#diff-e0f8aa3bbca9447766d25967d5c39f5fR541)
- top level mappers for operations are kept in hashmap: https://github.com/apollographql/apollo-android/pull/273/files#diff-07ac49222007995fd70e4d0b091b9557