### PR TITLE
Prepare reader for normalized cache

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/ResponseReader.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/ResponseReader.java
@@ -4,11 +4,7 @@ import java.io.IOException;
 
 /** TODO **/
 public interface ResponseReader {
-  void read(ValueHandler handler, Field... fields) throws IOException;
-
   <T> T read(Field field) throws IOException;
-
-  Operation operation();
 
   interface ValueHandler {
     void handle(int fieldIndex, Object value) throws IOException;

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/Cache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/Cache.java
@@ -3,7 +3,6 @@ package com.apollographql.android.cache.normalized;
 import com.apollographql.android.api.graphql.Mutation;
 import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.impl.ResponseNormalizer;
 
 import java.util.Collection;
 import java.util.Map;

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/ResponseNormalizer.java
@@ -1,12 +1,8 @@
-package com.apollographql.android.impl;
+package com.apollographql.android.cache.normalized;
 
 import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.cache.normalized.Cache;
-import com.apollographql.android.cache.normalized.CacheKeyResolver;
-import com.apollographql.android.cache.normalized.CacheReference;
-import com.apollographql.android.cache.normalized.Record;
-import com.apollographql.android.cache.normalized.RecordSet;
+import com.apollographql.android.impl.ResponseReaderShadow;
 import com.apollographql.android.impl.util.SimpleStack;
 
 import java.util.ArrayList;
@@ -18,8 +14,7 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Object>> {
-
+public final class ResponseNormalizer implements ResponseReaderShadow<Map<String, Object>> {
   private SimpleStack<List<String>> pathStack;
   private SimpleStack<Record> recordStack;
   private SimpleStack<Object> valueStack;
@@ -30,16 +25,16 @@ public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Obje
   private Record currentRecord;
   private RecordSet recordSet;
 
+  ResponseNormalizer(CacheKeyResolver cacheKeyResolver) {
+    this.cacheKeyResolver = cacheKeyResolver;
+  }
+
   public Collection<Record> records() {
     return recordSet.allRecords();
   }
 
   public Set<String> dependentKeys() {
     return dependentKeys;
-  }
-
-  public ResponseNormalizer(CacheKeyResolver cacheKeyResolver) {
-    this.cacheKeyResolver = cacheKeyResolver;
   }
 
   @Override public void willResolveRootQuery(Operation operation) {
@@ -128,5 +123,4 @@ public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Obje
     }
     return stringBuilder.toString();
   }
-
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/CacheFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/CacheFieldValueResolver.java
@@ -1,0 +1,50 @@
+package com.apollographql.android.impl;
+
+import com.apollographql.android.api.graphql.Field;
+import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.android.cache.normalized.Cache;
+import com.apollographql.android.cache.normalized.CacheReference;
+import com.apollographql.android.cache.normalized.Record;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class CacheFieldValueResolver implements FieldValueResolver<Record> {
+  private final Cache cache;
+  private final Operation.Variables variables;
+
+  public CacheFieldValueResolver(Cache cache, Operation.Variables variables) {
+    this.cache = cache;
+    this.variables = variables;
+  }
+
+  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Record record, Field field) {
+    if (field instanceof Field.ObjectField) {
+      return (T) valueFor(record, (Field.ObjectField) field);
+    } else if (field instanceof Field.ScalarListField) {
+      return fieldValue(record, field);
+    } else if (field instanceof Field.ObjectListField) {
+      return (T) valueFor(record, (Field.ObjectListField) field);
+    } else {
+      return fieldValue(record, field);
+    }
+  }
+
+  private Record valueFor(Record record, Field.ObjectField field) {
+    CacheReference cacheReference = fieldValue(record, field);
+    return cacheReference != null ? cache.cacheStore().loadRecord(cacheReference.key()) : null;
+  }
+
+  private List<Record> valueFor(Record record, Field.ObjectListField field) {
+    List<CacheReference> values = fieldValue(record, field);
+    List<Record> result = new ArrayList<>();
+    for (CacheReference reference : values) {
+      result.add(cache.cacheStore().loadRecord(reference.key()));
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked") private <T> T fieldValue(Record record, Field field) {
+    return (T) record.field(field.cacheKey(variables));
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/FieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/FieldValueResolver.java
@@ -1,0 +1,7 @@
+package com.apollographql.android.impl;
+
+import com.apollographql.android.api.graphql.Field;
+
+interface FieldValueResolver<R> {
+  <T> T valueFor(R recordSet, Field field);
+}

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/MapFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/MapFieldValueResolver.java
@@ -1,0 +1,12 @@
+package com.apollographql.android.impl;
+
+import com.apollographql.android.api.graphql.Field;
+
+import java.util.Map;
+
+public class MapFieldValueResolver implements FieldValueResolver<Map<String, Object>> {
+
+  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Map<String, Object> map, Field field) {
+    return (T) map.get(field.responseName());
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -8,6 +8,7 @@ import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ScalarType;
 import com.apollographql.android.cache.http.HttpCache;
 import com.apollographql.android.cache.normalized.Cache;
+import com.apollographql.android.cache.normalized.ResponseNormalizer;
 import com.apollographql.android.impl.util.HttpException;
 import com.squareup.moshi.Moshi;
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
@@ -17,10 +17,10 @@ import java.util.Map;
   private final R recordSet;
   private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
   private final FieldValueResolver<R> fieldValueResolver;
-  private final ResponseReaderShadow readerShadow;
+  private final ResponseReaderShadow<R> readerShadow;
 
   RealResponseReader(Operation operation, R recordSet, FieldValueResolver<R> fieldValueResolver,
-      Map<ScalarType, CustomTypeAdapter> customTypeAdapters, ResponseReaderShadow readerShadow) {
+      Map<ScalarType, CustomTypeAdapter> customTypeAdapters, ResponseReaderShadow<R> readerShadow) {
     this.operation = operation;
     this.recordSet = recordSet;
     this.fieldValueResolver = fieldValueResolver;

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
@@ -12,27 +12,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-@SuppressWarnings("WeakerAccess") final class BufferedResponseReader implements ResponseReader {
-  private final Map<String, Object> buffer;
+@SuppressWarnings("WeakerAccess") final class RealResponseReader<R> implements ResponseReader {
   private final Operation operation;
+  private final R recordSet;
   private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  private final FieldValueResolver<R> fieldValueResolver;
   private final ResponseReaderShadow readerShadow;
 
-  BufferedResponseReader(Map<String, Object> buffer, Operation operation,
+  RealResponseReader(Operation operation, R recordSet, FieldValueResolver<R> fieldValueResolver,
       Map<ScalarType, CustomTypeAdapter> customTypeAdapters, ResponseReaderShadow readerShadow) {
-    this.buffer = buffer;
     this.operation = operation;
+    this.recordSet = recordSet;
+    this.fieldValueResolver = fieldValueResolver;
     this.customTypeAdapters = customTypeAdapters;
     this.readerShadow = readerShadow;
-  }
-
-  @Override public void read(ValueHandler handler, Field... fields) throws IOException {
-    int fieldIndex = 0;
-    for (Field field : fields) {
-      Object value = read(field);
-      handler.handle(fieldIndex, value);
-      fieldIndex++;
-    }
   }
 
   @Override public <T> T read(Field field) throws IOException {
@@ -89,12 +82,8 @@ import java.util.Map;
     }
   }
 
-  @Override public Operation operation() {
-    return operation;
-  }
-
   String readString(Field field) throws IOException {
-    String value = (String) buffer.get(field.responseName());
+    String value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
@@ -106,7 +95,7 @@ import java.util.Map;
   }
 
   Integer readInt(Field field) throws IOException {
-    BigDecimal value = (BigDecimal) buffer.get(field.responseName());
+    BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
@@ -118,7 +107,7 @@ import java.util.Map;
   }
 
   Long readLong(Field field) throws IOException {
-    BigDecimal value = (BigDecimal) buffer.get(field.responseName());
+    BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
@@ -130,7 +119,7 @@ import java.util.Map;
   }
 
   Double readDouble(Field field) throws IOException {
-    BigDecimal value = (BigDecimal) buffer.get(field.responseName());
+    BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     readerShadow.didParseScalar(value);
     if (value == null) {
@@ -143,7 +132,7 @@ import java.util.Map;
   }
 
   Boolean readBoolean(Field field) throws IOException {
-    Boolean value = (Boolean) buffer.get(field.responseName());
+    Boolean value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
@@ -155,22 +144,22 @@ import java.util.Map;
   }
 
   @SuppressWarnings("unchecked") <T> T readObject(Field.ObjectField field) throws IOException {
-    Map<String, Object> value = (Map<String, Object>) buffer.get(field.responseName());
+    R value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     readerShadow.willParseObject(value);
     if (value == null) {
       readerShadow.didParseNull();
       return null;
     } else {
-      final T parsedValue = (T) field.objectReader().read(new BufferedResponseReader(value, operation,
-          customTypeAdapters, readerShadow));
+      final T parsedValue = (T) field.objectReader().read(new RealResponseReader(operation, value,
+          fieldValueResolver, customTypeAdapters, readerShadow));
       readerShadow.didParseObject(value);
       return parsedValue;
     }
   }
 
   @SuppressWarnings("unchecked") <T> List<T> readScalarList(Field.ScalarListField field) throws IOException {
-    List values = (List) buffer.get(field.responseName());
+    List values = fieldValueResolver.valueFor(recordSet, field);
     checkValue(values, field.optional());
     if (values == null) {
       readerShadow.didParseNull();
@@ -180,7 +169,7 @@ import java.util.Map;
       for (int i = 0; i < values.size(); i++) {
         readerShadow.willParseElement(i);
         Object value = values.get(i);
-        T item = (T) field.listReader().read(new BufferedListItemReader(value, customTypeAdapters));
+        T item = (T) field.listReader().read(new ListItemReader(value, customTypeAdapters));
         readerShadow.didParseScalar(value);
         readerShadow.didParseElement(i);
         result.add(item);
@@ -191,7 +180,7 @@ import java.util.Map;
   }
 
   @SuppressWarnings("unchecked") <T> List<T> readObjectList(Field.ObjectListField field) throws IOException {
-    List values = (List) buffer.get(field.responseName());
+    List<R> values = fieldValueResolver.valueFor(recordSet, field);
     checkValue(values, field.optional());
     if (values == null) {
       return null;
@@ -199,12 +188,11 @@ import java.util.Map;
       List<T> result = new ArrayList<>();
       for (int i = 0; i < values.size(); i++) {
         readerShadow.willParseElement(i);
-        Object value = values.get(i);
-        final Map<String, Object> objectMap = (Map<String, Object>) value;
-        readerShadow.willParseObject(objectMap);
-        T item = (T) field.objectReader().read(new BufferedResponseReader(objectMap, operation,
+        R value = values.get(i);
+        readerShadow.willParseObject(value);
+        T item = (T) field.objectReader().read(new RealResponseReader(operation, value, fieldValueResolver,
             customTypeAdapters, readerShadow));
-        readerShadow.didParseObject(objectMap);
+        readerShadow.didParseObject(value);
         readerShadow.didParseElement(i);
         result.add(item);
       }
@@ -214,7 +202,7 @@ import java.util.Map;
   }
 
   @SuppressWarnings("unchecked") private <T> T readCustomType(Field.CustomTypeField field) {
-    Object value = buffer.get(field.responseName());
+    Object value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       return null;
@@ -231,10 +219,9 @@ import java.util.Map;
   }
 
   @SuppressWarnings("unchecked") private <T> T readConditional(Field.ConditionalTypeField field,
-      Operation.Variables variables) throws
-      IOException {
+      Operation.Variables variables) throws IOException {
     readerShadow.willResolve(field, variables);
-    String value = (String) buffer.get(field.responseName());
+    String value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
@@ -252,11 +239,11 @@ import java.util.Map;
     }
   }
 
-  private static class BufferedListItemReader implements Field.ListItemReader {
+  private static class ListItemReader implements Field.ListItemReader {
     private final Object value;
     private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
 
-    BufferedListItemReader(Object value, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+    ListItemReader(Object value, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
       this.value = value;
       this.customTypeAdapters = customTypeAdapters;
     }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
@@ -6,6 +6,7 @@ import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Response;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.android.cache.normalized.ResponseNormalizer;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,8 +27,8 @@ final class ResponseBodyConverter {
   }
 
   <T extends Operation.Data> Response<T> convert(ResponseBody responseBody,
-      final ResponseNormalizer responseNormalizer) throws IOException {
-    responseNormalizer.willResolveRootQuery(operation);
+      final ResponseReaderShadow<Map<String, Object>> responseReaderShadow) throws IOException {
+    responseReaderShadow.willResolveRootQuery(operation);
     BufferedSourceJsonReader jsonReader = null;
     try {
       jsonReader = new BufferedSourceJsonReader(responseBody.source());
@@ -44,7 +45,7 @@ final class ResponseBodyConverter {
             @Override public Object read(ResponseJsonStreamReader reader) throws IOException {
               Map<String, Object> buffer = reader.buffer();
               RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(operation, buffer,
-                  new MapFieldValueResolver(), customTypeAdapters, responseNormalizer);
+                  new MapFieldValueResolver(), customTypeAdapters, responseReaderShadow);
               return responseFieldMapper.map(realResponseReader);
             }
           });

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
@@ -6,7 +6,6 @@ import com.apollographql.android.api.graphql.Operation;
 import com.apollographql.android.api.graphql.Response;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ScalarType;
-import com.apollographql.android.cache.normalized.ResponseNormalizer;
 
 import java.io.IOException;
 import java.util.List;

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseBodyConverter.java
@@ -43,9 +43,9 @@ final class ResponseBodyConverter {
           data = (T) responseStreamReader.nextObject(false, new ResponseJsonStreamReader.ObjectReader<Object>() {
             @Override public Object read(ResponseJsonStreamReader reader) throws IOException {
               Map<String, Object> buffer = reader.buffer();
-              BufferedResponseReader bufferedResponseReader = new BufferedResponseReader(buffer, operation,
-                  customTypeAdapters, responseNormalizer);
-              return responseFieldMapper.map(bufferedResponseReader);
+              RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(operation, buffer,
+                  new MapFieldValueResolver(), customTypeAdapters, responseNormalizer);
+              return responseFieldMapper.map(realResponseReader);
             }
           });
         } else if ("errors".equals(name)) {

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseNormalizer.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-public class ResponseNormalizer implements ResponseReaderShadow {
+public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Object>> {
 
   private SimpleStack<List<String>> pathStack;
   private SimpleStack<Record> recordStack;

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
@@ -5,7 +5,7 @@ import com.apollographql.android.api.graphql.Operation;
 
 import java.util.List;
 
-interface ResponseReaderShadow<R> {
+public interface ResponseReaderShadow<R> {
 
   void willResolveRootQuery(Operation operation);
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
@@ -4,9 +4,8 @@ import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.Operation;
 
 import java.util.List;
-import java.util.Map;
 
-interface ResponseReaderShadow {
+interface ResponseReaderShadow<R> {
 
   void willResolveRootQuery(Operation operation);
 
@@ -16,9 +15,9 @@ interface ResponseReaderShadow {
 
   void didParseScalar(Object value);
 
-  void willParseObject(Map<String, Object> objectMap);
+  void willParseObject(R objectMap);
 
-  void didParseObject(Map<String, Object> objectMap);
+  void didParseObject(R objectMap);
 
   void didParseList(List array);
 


### PR DESCRIPTION
Part of #266 

Rename `BufferedResponseReader` to `RealResponseReader` and prepare it to be used in both cases: for reading from Map and from cache recordset via `FieldValueResolver`.

