### PR TITLE
Fix double parsing of double type in ResponseNormalizer

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
@@ -28,6 +28,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -324,6 +325,11 @@ public class ResponseNormalizationTest {
     Record lukeRecord = cacheStore.loadRecord("hero(episode:JEDI).friends.0");
     assertThat(lukeRecord.field("name")).isEqualTo("Luke Skywalker");
     assertThat(lukeRecord.field("height(unit:METER)")).isEqualTo(1.72);
+
+    final List<Object> friends = (List<Object>) cacheStore.loadRecord("hero(episode:JEDI)").field("friends");
+    assertThat(friends.get(0)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.0"));
+    assertThat(friends.get(1)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.1"));
+    assertThat(friends.get(2)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.2"));
   }
 
   @Test

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/BufferedResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/BufferedResponseReader.java
@@ -134,7 +134,6 @@ import java.util.Map;
   Double readDouble(Field field) throws IOException {
     BigDecimal value = (BigDecimal) buffer.get(field.responseName());
     checkValue(value, field.optional());
-    readerShadow.didParseScalar(value);
     if (value == null) {
       readerShadow.didParseNull();
       return null;
@@ -241,6 +240,7 @@ import java.util.Map;
     checkValue(value, field.optional());
     if (value == null) {
       readerShadow.didParseNull();
+      readerShadow.didResolve(field, variables);
       return null;
     } else {
       readerShadow.didParseScalar(value);


### PR DESCRIPTION
- Double type was being reported twice to normalizer
- Also found another potential issue for parsing conditional type and not reporting null value