### PR TITLE
fix: NPE on null argument when building cache key

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Field.java
@@ -148,7 +148,9 @@ public class Field {
     Object variable = objectMap.get(VARIABLE_NAME_KEY);
     //noinspection SuspiciousMethodCalls
     Object resolvedVariable = variables.valueMap().get(variable);
-    if (resolvedVariable instanceof Map) {
+    if (resolvedVariable == null) {
+      return null;
+    } else if (resolvedVariable instanceof Map) {
       //noinspection unchecked
       return orderIndependentKey((Map<String, Object>) resolvedVariable, variables);
     } else {

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
@@ -90,6 +90,26 @@ public class CacheKeyForFieldTest {
   }
 
   @Test
+  public void testFieldWithVariableArgumentNull() {
+    //noinspection unchecked
+    Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", new UnmodifiableMapBuilder<String, Object>(2)
+            .put("kind", "Variable")
+            .put("variableName", "episode")
+            .build())
+        .build(), false);
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("episode", null);
+        return map;
+      }
+    };
+    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:null)");
+  }
+
+  @Test
   public void testFieldWithMultipleArgument() {
     //noinspection unchecked
     Field field = Field.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)


### PR DESCRIPTION
fixes https://github.com/apollographql/apollo-android/issues/277

NPE thrown when building cache key and one of the query args are null