### PR TITLE
fix BufferedResopnseReader handling null on readCustomType

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/BufferedResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/BufferedResponseReader.java
@@ -220,6 +220,7 @@ import java.util.Map;
     Object value = buffer.get(field.responseName());
     checkValue(value, field.optional());
     if (value == null) {
+      readerShadow.didParseNull();
       return null;
     } else {
       CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(field.scalarType());

--- a/apollo-runtime/src/test/graphql/productsWithDate.json
+++ b/apollo-runtime/src/test/graphql/productsWithDate.json
@@ -62,6 +62,12 @@
               "title": "Platinum Aqua",
               "createdAt": "2013-11-18T19:37:28Z"
             }
+          },
+          {
+            "node": {
+              "title": "Platinum Aqua",
+              "createdAt": null
+            }
           }
         ]
       }

--- a/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/impl/ProductsWithDate.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public final class ProductsWithDate implements Query<ProductsWithDate.Data, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query ProductsWithDate {\n"
@@ -96,9 +97,9 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
           public static class Node {
             private @Nonnull String title;
 
-            private @Nonnull Date createdAt;
+            private @Nullable Date createdAt;
 
-            public Node(@Nonnull String title, @Nonnull Date createdAt) {
+            public Node(@Nonnull String title, @Nullable Date createdAt) {
               this.title = title;
               this.createdAt = createdAt;
             }
@@ -107,14 +108,14 @@ public final class ProductsWithDate implements Query<ProductsWithDate.Data, Oper
               return this.title;
             }
 
-            public @Nonnull Date createdAt() {
+            public @Nullable Date createdAt() {
               return this.createdAt;
             }
 
             public static final class Mapper implements ResponseFieldMapper<Node> {
               final Field[] fields = {
                   Field.forString("title", "title", null, false),
-                  Field.forCustomType("createdAt", "createdAt", null, false, CustomType.DATETIME)
+                  Field.forCustomType("createdAt", "createdAt", null, true, CustomType.DATETIME)
               };
 
               @Override


### PR DESCRIPTION
Fixes:https://github.com/apollographql/apollo-android/issues/283

A call to `readerShadow.didParseNull()` was missing from `BufferedResopnseReader.readCustomType()` when handling a null value causing the `ResponseNormalizer`'s `valueStack` to be out of sync

This PR adds the missing call and adds tests for when a null may be handled