### PR TITLE
check if apollo-api exists before adding it

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -75,6 +75,6 @@ open class GraphQLCompiler {
   companion object {
     const val FILE_EXTENSION = "graphql"
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
-    const val APOLLOCODEGEN_VERSION = "0.10.8"
+    const val APOLLOCODEGEN_VERSION = "0.10.9"
   }
 }

--- a/apollo-compiler/src/test/graphql/apollo-codegen.properties
+++ b/apollo-compiler/src/test/graphql/apollo-codegen.properties
@@ -1,1 +1,1 @@
-apollo-codegen version=0.10.8
+apollo-codegen version=0.10.9

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.json
@@ -29,6 +29,10 @@
 			"fragmentName": "HeroDetails",
 			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
 			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
 			"fields": [
 				{
 					"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestQuery.json
@@ -54,6 +54,9 @@
 			"fragmentName": "starshipFragment",
 			"source": "fragment starshipFragment on Starship {\n  __typename\n  id\n  name\n  pilotConnection {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...pilotFragment\n      }\n    }\n  }\n}",
 			"typeCondition": "Starship",
+			"possibleTypes": [
+				"Starship"
+			],
 			"fields": [
 				{
 					"responseName": "id",
@@ -105,6 +108,9 @@
 			"fragmentName": "pilotFragment",
 			"source": "fragment pilotFragment on Person {\n  __typename\n  name\n  homeworld {\n    __typename\n    name\n  }\n}",
 			"typeCondition": "Person",
+			"possibleTypes": [
+				"Person"
+			],
 			"fields": [
 				{
 					"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.json
@@ -40,6 +40,10 @@
 			"fragmentName": "HeroDetails",
 			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
 			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
 			"fields": [
 				{
 					"responseName": "name",
@@ -88,6 +92,9 @@
 			"inlineFragments": [
 				{
 					"typeCondition": "Droid",
+					"possibleTypes": [
+						"Droid"
+					],
 					"fields": [
 						{
 							"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.json
@@ -42,6 +42,9 @@
 			"fragmentName": "HumanDetails",
 			"source": "fragment HumanDetails on Human {\n  __typename\n  name\n  height\n}",
 			"typeCondition": "Human",
+			"possibleTypes": [
+				"Human"
+			],
 			"fields": [
 				{
 					"responseName": "name",
@@ -63,6 +66,9 @@
 			"fragmentName": "DroidDetails",
 			"source": "fragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}",
 			"typeCondition": "Droid",
+			"possibleTypes": [
+				"Droid"
+			],
 			"fields": [
 				{
 					"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.json
@@ -22,6 +22,9 @@
 					"inlineFragments": [
 						{
 							"typeCondition": "Human",
+							"possibleTypes": [
+								"Human"
+							],
 							"fields": [
 								{
 									"responseName": "name",
@@ -52,6 +55,9 @@
 						},
 						{
 							"typeCondition": "Droid",
+							"possibleTypes": [
+								"Droid"
+							],
 							"fields": [
 								{
 									"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.json
@@ -29,6 +29,10 @@
 			"fragmentName": "HeroDetails",
 			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n}",
 			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
 			"fields": [
 				{
 					"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.json
@@ -22,6 +22,9 @@
 					"inlineFragments": [
 						{
 							"typeCondition": "Human",
+							"possibleTypes": [
+								"Human"
+							],
 							"fields": [
 								{
 									"responseName": "name",
@@ -38,6 +41,9 @@
 						},
 						{
 							"typeCondition": "Droid",
+							"possibleTypes": [
+								"Droid"
+							],
 							"fields": [
 								{
 									"responseName": "name",

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestQuery.json
@@ -36,6 +36,9 @@
 					"inlineFragments": [
 						{
 							"typeCondition": "Human",
+							"possibleTypes": [
+								"Human"
+							],
 							"fields": [
 								{
 									"responseName": "name",
@@ -93,6 +96,10 @@
 			"fragmentName": "HeroDetails",
 			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
 			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
 			"fields": [
 				{
 					"responseName": "name",

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -5,10 +5,10 @@ import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
 import com.apollographql.android.VersionKt
 import com.google.common.collect.ImmutableList
-import com.google.common.collect.Lists
 import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.NodePlugin
 import org.gradle.api.DomainObjectCollection
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -24,6 +24,9 @@ import javax.inject.Inject
 class ApolloPlugin implements Plugin<Project> {
   private static final String NODE_VERSION = "6.7.0"
   public static final String TASK_GROUP = "apollo"
+  private static final String APOLLO_GROUP = "com.apollographql.android"
+  private static final String API_DEP_NAME = "api"
+
   private Project project
   private final FileResolver fileResolver
 
@@ -52,10 +55,17 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        if (System.getProperty("apollographql.skipApi") != "true") {
-          compileDepSet.add(project.dependencies.create("com.apollographql.android:api:${VersionKt.VERSION}"))
-          project.getGradle().removeListener(this)
+        def apolloDep = compileDepSet.find { dep ->
+          dep.group == APOLLO_GROUP
+          dep.name == API_DEP_NAME
         }
+        if (apolloDep != null && apolloDep.version != VersionKt.VERSION) {
+          throw new GradleException("apollo-api version ${apolloDep.version} isn't compatible with the plugin version ${VersionKt.VERSION}")
+        }
+        if (System.getProperty("apollographql.skipApi") != "true" && apolloDep == null) {
+          compileDepSet.add(project.dependencies.create("$APOLLO_GROUP:$API_DEP_NAME:$VersionKt.VERSION"))
+        }
+        project.getGradle().removeListener(this)
       }
 
       @Override

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -55,14 +55,14 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        def apolloDep = compileDepSet.find { dep ->
+        def apolloApiDep = compileDepSet.find { dep ->
           dep.group == APOLLO_GROUP
           dep.name == API_DEP_NAME
         }
-        if (apolloDep != null && apolloDep.version != VersionKt.VERSION) {
-          throw new GradleException("apollo-api version ${apolloDep.version} isn't compatible with the plugin version ${VersionKt.VERSION}")
+        if (apolloApiDep != null && apolloApiDep.version != VersionKt.VERSION) {
+          throw new GradleException("apollo-api version ${apolloApiDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
         }
-        if (System.getProperty("apollographql.skipApi") != "true" && apolloDep == null) {
+        if (System.getProperty("apollographql.skipApi") != "true" && apolloApiDep == null) {
           compileDepSet.add(project.dependencies.create("$APOLLO_GROUP:$API_DEP_NAME:$VersionKt.VERSION"))
         }
         project.getGradle().removeListener(this)


### PR DESCRIPTION
Closes #288 

Users can provide their own api dependency and exclude the JSR dependency and it should work as expected.

(As long as the api version matches the plugin version)

```
compile ('com.apollographql.android:api:0.2.2-SNAPSHOT') {
        exclude group: 'com.google.code.findbugs'
        exclude group: 'javax.annotation'
    }
```