### PR TITLE
Add CacheKey to avoid nullability in CacheKeyResolver

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
@@ -3,7 +3,10 @@ package com.apollographql.android.impl;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
+import android.support.annotation.NonNull;
+
 import com.apollographql.android.api.graphql.Response;
+import com.apollographql.android.cache.normalized.CacheKey;
 import com.apollographql.android.cache.normalized.CacheKeyResolver;
 import com.apollographql.android.impl.normalizer.EpisodeHeroName;
 import com.apollographql.android.impl.normalizer.HeroAndFriendsNames;
@@ -22,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import okhttp3.OkHttpClient;
@@ -47,8 +51,12 @@ public class NormalizedCacheTestCase {
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
         .normalizedCache(cacheStore, new CacheKeyResolver() {
-          @Nullable @Override public String resolve(Map<String, Object> jsonObject) {
-            return (String) jsonObject.get("id");
+          @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
+            String id = (String) jsonObject.get("id");
+            if (id == null || id.isEmpty()) {
+              return CacheKey.NO_KEY;
+            }
+            return CacheKey.from(id);
           }
         })
         .build();

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
@@ -3,9 +3,12 @@ package com.apollographql.android.impl;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 
+import android.support.annotation.NonNull;
+
 import com.apollographql.android.ApolloCall;
 import com.apollographql.android.CustomTypeAdapter;
 import com.apollographql.android.api.graphql.Response;
+import com.apollographql.android.cache.normalized.CacheKey;
 import com.apollographql.android.cache.normalized.Record;
 import com.apollographql.android.cache.normalized.CacheKeyResolver;
 import com.apollographql.android.cache.normalized.CacheReference;
@@ -33,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import okhttp3.OkHttpClient;
@@ -42,6 +46,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import static com.apollographql.android.impl.normalizer.type.Episode.EMPIRE;
 import static com.apollographql.android.impl.normalizer.type.Episode.JEDI;
 import static com.google.common.truth.Truth.assertThat;
+import static okhttp3.Protocol.get;
 
 public class ResponseNormalizationTest {
 
@@ -77,8 +82,12 @@ public class ResponseNormalizationTest {
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
         .normalizedCache(cacheStore, new CacheKeyResolver() {
-          @Nullable @Override public String resolve(Map<String, Object> jsonObject) {
-            return (String) jsonObject.get("id");
+          @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
+            String id = (String) jsonObject.get("id");
+            if (id == null || id.isEmpty()) {
+              return CacheKey.NO_KEY;
+            }
+            return CacheKey.from(id);
           }
         })
         .build();

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKey.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKey.java
@@ -1,0 +1,40 @@
+package com.apollographql.android.cache.normalized;
+
+import javax.annotation.Nonnull;
+
+import static com.apollographql.android.impl.util.Utils.checkNotNull;
+
+public final class CacheKey {
+  public static final CacheKey NO_KEY = new CacheKey("");
+
+  public static CacheKey from(@Nonnull String key) {
+    return new CacheKey(checkNotNull(key, "key == null"));
+  }
+
+  private final String key;
+
+  private CacheKey(@Nonnull String key) {
+    this.key = key;
+  }
+
+  public String key() {
+    return key;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof CacheKey)) return false;
+
+    CacheKey cacheKey = (CacheKey) o;
+
+    return key.equals(cacheKey.key);
+  }
+
+  @Override public int hashCode() {
+    return key.hashCode();
+  }
+
+  @Override public String toString() {
+    return key;
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKeyResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKeyResolver.java
@@ -7,18 +7,17 @@ import com.apollographql.android.api.graphql.Query;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public abstract class CacheKeyResolver {
   public static final CacheKeyResolver DEFAULT = new CacheKeyResolver() {
-    @Nullable @Override public String resolve(@Nonnull Map<String, Object> jsonObject) {
-      return null;
+    @Nonnull @Override public CacheKey resolve(@Nonnull Map<String, Object> jsonObject) {
+      return CacheKey.NO_KEY;
     }
   };
-  private static final String QUERY_ROOT_KEY = "QUERY_ROOT";
-  private static final String MUTATION_ROOT_KEY = "MUTATION_ROOT";
+  private static final CacheKey QUERY_ROOT_KEY = CacheKey.from("QUERY_ROOT");
+  private static final CacheKey MUTATION_ROOT_KEY = CacheKey.from("MUTATION_ROOT");
 
-  public static String rootKeyForOperation(@Nonnull Operation operation) {
+  public static CacheKey rootKeyForOperation(@Nonnull Operation operation) {
     if (operation instanceof Query) {
       return QUERY_ROOT_KEY;
     } else if (operation instanceof Mutation) {
@@ -27,5 +26,5 @@ public abstract class CacheKeyResolver {
     throw new IllegalArgumentException("Unknown operation type.");
   }
 
-  @Nullable public abstract String resolve(@Nonnull Map<String, Object> jsonObject);
+  @Nonnull public abstract CacheKey resolve(@Nonnull Map<String, Object> jsonObject);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/ResponseNormalizer.java
@@ -46,7 +46,7 @@ public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Obje
     dependentKeys = new HashSet<>();
 
     path = new ArrayList<>();
-    currentRecord = new Record(CacheKeyResolver.rootKeyForOperation(operation));
+    currentRecord = new Record(CacheKeyResolver.rootKeyForOperation(operation).key());
     recordSet = new RecordSet();
   }
 
@@ -75,15 +75,16 @@ public class ResponseNormalizer implements ResponseReaderShadow<Map<String, Obje
   @Override public void willParseObject(Map<String, Object> objectMap) {
     pathStack.push(path);
 
-    String cacheKey = cacheKeyResolver.resolve(objectMap);
-    if (cacheKey == null || cacheKey.isEmpty()) {
-      cacheKey = pathToString();
+    CacheKey cacheKey = cacheKeyResolver.resolve(objectMap);
+    String cacheKeyValue = cacheKey.key();
+    if (cacheKey == CacheKey.NO_KEY) {
+      cacheKeyValue = pathToString();
     } else {
       path = new ArrayList<>();
-      path.add(cacheKey);
+      path.add(cacheKeyValue);
     }
     recordStack.push(currentRecord);
-    currentRecord = new Record(cacheKey);
+    currentRecord = new Record(cacheKeyValue);
   }
 
   @Override public void didParseObject(Map<String, Object> objectMap) {

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -176,7 +176,7 @@ final class RealApolloCall<T extends Operation.Data> extends BaseApolloCall impl
   }
 
   @SuppressWarnings("unchecked") @Nullable private T cachedData() {
-    Record rootRecord = cache.read(CacheKeyResolver.rootKeyForOperation(operation));
+    Record rootRecord = cache.read(CacheKeyResolver.rootKeyForOperation(operation).key());
     if (rootRecord == null) {
       return null;
     }


### PR DESCRIPTION
closes https://github.com/apollographql/apollo-android/issues/291

I only changed the CacheKeyResolver to use this `CacheKey` as that seems like the major point of nullability.

However, we could go further and use `CacheKey` throughout our code base wherever we were using `String` keys, thoughts? 