### PR TITLE
Add runtime dependency through plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew build connectedCheck -x checkstyleTest --stacktrace
+  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace
 
 before_script:
   - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace
+  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:transformClassesWithDexForDebug -x :apollo-integration:transformClassesWithDexForRelease --stacktrace
 
 before_script:
   - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:transformClassesWithDexForDebug -x :apollo-integration:transformClassesWithDexForRelease --stacktrace
+  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace
 
 before_script:
   - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a

--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -4,7 +4,8 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compile apolloApiCompileDeps
+  compile dep.jsr305
+  compile dep.jsr250
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -4,8 +4,7 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compile dep.jsr305
-  compile dep.jsr250
+  compile apolloApiCompileDeps
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -24,8 +24,8 @@ import javax.inject.Inject
 class ApolloPlugin implements Plugin<Project> {
   private static final String NODE_VERSION = "6.7.0"
   public static final String TASK_GROUP = "apollo"
-  private static final String APOLLO_GROUP = "com.apollographql.android"
-  private static final String API_DEP_NAME = "api"
+  private static final String APOLLO_DEP_GROUP = "com.apollographql.android"
+  private static final String RUNTIME_DEP_NAME = "runtime"
 
   private Project project
   private final FileResolver fileResolver
@@ -56,16 +56,16 @@ class ApolloPlugin implements Plugin<Project> {
     project.getGradle().addListener(new DependencyResolutionListener() {
       @Override
       void beforeResolve(ResolvableDependencies resolvableDependencies) {
-        def apolloApiDep = compileDepSet.find { dep ->
-          dep.group == APOLLO_GROUP
-          dep.name == API_DEP_NAME
+        def apolloRuntimeDep = compileDepSet.find { dep ->
+          dep.group == APOLLO_DEP_GROUP
+          dep.name == RUNTIME_DEP_NAME
         }
-        if (apolloApiDep != null && apolloApiDep.version != VersionKt.VERSION) {
+        if (apolloRuntimeDep != null && apolloRuntimeDep.version != VersionKt.VERSION) {
           throw new GradleException(
-              "apollo-api version ${apolloApiDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
+              "apollo-runtime version ${apolloRuntimeDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
         }
-        if (System.getProperty("apollographql.skipApi") != "true" && apolloApiDep == null) {
-          compileDepSet.add(project.dependencies.create("$APOLLO_GROUP:$API_DEP_NAME:$VersionKt.VERSION"))
+        if (System.getProperty("apollographql.skipRuntimeDep") != "true" && apolloRuntimeDep == null) {
+          compileDepSet.add(project.dependencies.create("$APOLLO_DEP_GROUP:$RUNTIME_DEP_NAME:$VersionKt.VERSION"))
         }
       }
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -23,7 +23,7 @@ class BasicAndroidSpec extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withPluginClasspath()
-        .withArguments("build", "-Dapollographql.skipApi=true")
+        .withArguments("build", "-Dapollographql.skipRuntimeDep=true")
         .forwardStdError(new OutputStreamWriter(System.err))
         .build()
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
@@ -71,7 +71,7 @@ class FlavoredMultiSchemaSpec extends Specification {
     def result = GradleRunner.create()
         .withProjectDir(testProjectDir)
         .withPluginClasspath()
-        .withArguments("build", "-Dapollographql.skipApi=true")
+        .withArguments("build", "-Dapollographql.skipRuntimeDep=true")
         .forwardStdError(new OutputStreamWriter(System.err))
         .build()
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -109,7 +109,7 @@ class ApolloAndroidPluginSpec extends Specification {
     assert (project.extensions.findByType(ApolloExtension.class)) != null
   }
 
-  def "adds apollo-api dependency"() {
+  def "adds apollo-runtime dependency"() {
     given:
     def project = ProjectBuilder.builder().build()
     ApolloPluginTestHelper.setupDefaultAndroidProject(project)
@@ -120,7 +120,7 @@ class ApolloAndroidPluginSpec extends Specification {
 
     then:
     def apolloApi = project.configurations.getByName("compile").dependencies.find {
-      it.group == "com.apollographql.android" && it.name == "api"
+      it.group == "com.apollographql.android" && it.name == "runtime"
     }
     assert apolloApi != null
   }

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -32,7 +32,6 @@ android {
   sourceSets {
     main {
       java {
-        srcDirs += '../../../../apollo-runtime/src/main/java'
         srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
@@ -47,7 +46,6 @@ repositories {
 dependencies {
   compile dep.appcompat
   compile apolloApiCompileDeps
-  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  apply from: "../../../../gradle/dependencies.gradle"
+  apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
   }
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  compile dep.appcompat
+  compile supportDeps
   compile apolloApiCompileDeps
 }
 

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -32,6 +32,7 @@ android {
   sourceSets {
     main {
       java {
+        srcDirs += '../../../../apollo-runtime/src/main/java'
         srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
@@ -45,8 +46,8 @@ repositories {
 
 dependencies {
   compile dep.appcompat
-  compile dep.jsr305
-  compile dep.jsr250
+  compile apolloApiCompileDeps
+  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  apply from: "../../../../gradle/dependencies.gradle"
+  apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
   }
@@ -55,7 +55,7 @@ repositories {
 }
 
 dependencies {
-  compile dep.appcompat
+  compile supportDeps
   compile apolloApiCompileDeps
 }
 

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -19,7 +19,7 @@ android {
   buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
-    applicationId "com.example.apollographql.testProject.basic"
+    applicationId "com.example.apollographql.testProject.flavored"
     minSdkVersion androidConfig.minSdkVersion
     targetSdkVersion androidConfig.targetSdkVersion
   }
@@ -43,6 +43,7 @@ android {
   sourceSets {
     main {
       java {
+        srcDirs += '../../../../apollo-runtime/src/main/java'
         srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
@@ -56,8 +57,8 @@ repositories {
 
 dependencies {
   compile dep.appcompat
-  compile dep.jsr305
-  compile dep.jsr250
+  compile apolloApiCompileDeps
+  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -43,7 +43,6 @@ android {
   sourceSets {
     main {
       java {
-        srcDirs += '../../../../apollo-runtime/src/main/java'
         srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
@@ -58,7 +57,6 @@ repositories {
 dependencies {
   compile dep.appcompat
   compile apolloApiCompileDeps
-  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
@@ -32,7 +32,6 @@ android {
     main {
       java {
         srcDirs += '../../../../apollo-api/src/main/java'
-        srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
   }
@@ -46,7 +45,6 @@ repositories {
 dependencies {
   compile dep.appcompat
   compile apolloApiCompileDeps
-  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
@@ -32,6 +32,7 @@ android {
     main {
       java {
         srcDirs += '../../../../apollo-api/src/main/java'
+        srcDirs += '../../../../apollo-api/src/main/java'
       }
     }
   }
@@ -44,8 +45,8 @@ repositories {
 
 dependencies {
   compile dep.appcompat
-  compile dep.jsr305
-  compile dep.jsr250
+  compile apolloApiCompileDeps
+  compile apolloRuntimeCompileDeps
 }
 
 apollo {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  apply from: "../../../../gradle/dependencies.gradle"
+  apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
   }
@@ -43,7 +43,7 @@ repositories {
 }
 
 dependencies {
-  compile dep.appcompat
+  compile supportDeps
   compile apolloApiCompileDeps
 }
 

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-  provided project(':apollo-api')
+  compile project(':apollo-api')
   compile project(':apollo-runtime')
   compile project(':apollo-rxsupport')
   compile dep.appcompat

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -32,11 +32,8 @@ android {
 }
 
 dependencies {
-  compile dep.jsr305
-  compile dep.supportAnnotations
-  compile dep.okHttp
-  compile dep.moshi
-  provided project(":apollo-api")
+  compile apolloRuntimeCompileDeps
+  compile project(":apollo-api")
 
   testCompile dep.junit
   testCompile dep.truth

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -32,7 +32,11 @@ android {
 }
 
 dependencies {
-  compile apolloRuntimeCompileDeps
+  compile dep.jsr305
+  compile dep.supportAnnotations
+  compile dep.okHttp
+  compile dep.moshi
+
   compile project(":apollo-api")
 
   testCompile dep.junit

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -44,9 +44,7 @@ dependencies {
   testCompile dep.mockWebServer
   testCompile dep.okhttpTestSupport
   testCompile dep.mockito
-  testCompile project(":apollo-api")
 
-  androidTestCompile project(":apollo-api")
   androidTestCompile dep.truth
   androidTestCompile (dep.testRunner) {
     exclude module: 'support-annotations'

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -27,6 +27,7 @@ android {
 
 dependencies {
   compile dep.appcompat
+  compile dep.apolloApi
   compile dep.okhttpLoggingInterceptor
   compile dep.apolloRuntime
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,8 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=apollostack
 POM_DEVELOPER_NAME=Apollo
+
+# This prevents the plugin from adding the snapshot version of
+# apollo-runtime and api dependencies
+systemProp.apollographql.skipApi=true
+systemProp.apollographql.skipRuntime=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -46,3 +46,15 @@ ext.dep = [
     okhttpTestSupport       : "com.squareup.okhttp3:okhttp-testing-support:$versions.okHttpVersion",
     testRunner              : "com.android.support.test:runner:$versions.testRunner"
 ]
+
+ext.apolloRuntimeCompileDeps = [
+    dep.jsr305,
+    dep.supportAnnotations,
+    dep.okHttp,
+    dep.moshi
+]
+
+ext.apolloApiCompileDeps = [
+    dep.jsr305,
+    dep.jsr250
+]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,14 +47,4 @@ ext.dep = [
     testRunner              : "com.android.support.test:runner:$versions.testRunner"
 ]
 
-ext.apolloRuntimeCompileDeps = [
-    dep.jsr305,
-    dep.supportAnnotations,
-    dep.okHttp,
-    dep.moshi
-]
 
-ext.apolloApiCompileDeps = [
-    dep.jsr305,
-    dep.jsr250
-]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,6 +20,7 @@ ext.dep = [
     androidPlugin           : 'com.android.tools.build:gradle:2.3.0',
     apolloPlugin            : "com.apollographql.android:gradle-plugin:$versions.apolloVersion",
     apolloRuntime           : "com.apollographql.android:runtime:$versions.apolloVersion",
+    apolloApi               : "com.apollographql.android:api:$versions.apolloVersion",
     supportAnnotations      : 'com.android.support:support-annotations:25.1.0',
     compiletesting          : 'com.google.testing.compile:compile-testing:0.10',
     javaPoet                : 'com.squareup:javapoet:1.8.0',
@@ -46,5 +47,3 @@ ext.dep = [
     okhttpTestSupport       : "com.squareup.okhttp3:okhttp-testing-support:$versions.okHttpVersion",
     testRunner              : "com.android.support.test:runner:$versions.testRunner"
 ]
-
-

--- a/gradle/testFixturesDeps.gradle
+++ b/gradle/testFixturesDeps.gradle
@@ -1,0 +1,17 @@
+apply from: "../../../../gradle/dependencies.gradle"
+
+ext.supportDeps = [
+	dep.appcompat
+]
+
+ext.apolloRuntimeCompileDeps = [
+    dep.jsr305,
+    dep.supportAnnotations,
+    dep.okHttp,
+    dep.moshi
+]
+
+ext.apolloApiCompileDeps = [
+    dep.jsr305,
+    dep.jsr250
+]


### PR DESCRIPTION
adds the `apollo-runtime` dependency through the plugin (in a similar way to apollo-api)

Closes #132.