### PR TITLE
Introduce Apollo dispatcher for async calls

### DIFF
--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -26,6 +26,7 @@ android {
 }
 
 dependencies {
+  provided project(':apollo-api')
   compile project(':apollo-runtime')
   compile dep.appcompat
 

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
@@ -1,5 +1,7 @@
 package com.apollographql.android.impl;
 
+import com.google.common.base.Strings;
+
 import android.support.annotation.NonNull;
 
 import com.apollographql.android.ApolloCall;
@@ -44,7 +46,7 @@ public class AsyncNormalizedCacheTestCase {
         .normalizedCache(cacheStore, new CacheKeyResolver() {
           @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
             String id = (String) jsonObject.get("id");
-            if (id == null || id.isEmpty()) {
+            if (Strings.isNullOrEmpty(id)) {
               return CacheKey.NO_KEY;
             }
             return CacheKey.from(id);

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
@@ -1,0 +1,89 @@
+package com.apollographql.android.impl;
+
+import android.support.annotation.NonNull;
+
+import com.apollographql.android.ApolloCall;
+import com.apollographql.android.api.graphql.Response;
+import com.apollographql.android.cache.normalized.CacheControl;
+import com.apollographql.android.cache.normalized.CacheKey;
+import com.apollographql.android.cache.normalized.CacheKeyResolver;
+import com.apollographql.android.impl.normalizer.EpisodeHeroName;
+import com.apollographql.android.impl.normalizer.type.Episode;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.Assert.fail;
+
+public class AsyncNormalizedCacheTestCase {
+    private ApolloClient apolloClient;
+  private MockWebServer server;
+  private InMemoryCacheStore cacheStore;
+
+  @Before public void setUp() {
+    server = new MockWebServer();
+
+    OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+    cacheStore = new InMemoryCacheStore();
+
+    apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .okHttpClient(okHttpClient)
+        .normalizedCache(cacheStore, new CacheKeyResolver() {
+          @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
+            String id = (String) jsonObject.get("id");
+            if (id == null || id.isEmpty()) {
+              return CacheKey.NO_KEY;
+            }
+            return CacheKey.from(id);
+          }
+        })
+        .build();
+  }
+
+  private MockResponse mockResponse(String fileName) throws IOException {
+    return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
+  }
+
+  @Test public void testAsync() throws IOException, InterruptedException {
+    EpisodeHeroName query = new EpisodeHeroName(EpisodeHeroName.Variables.builder().episode(Episode.EMPIRE).build());
+
+    server.enqueue(mockResponse("HeroNameResponse.json"));
+    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    assertThat(body.isSuccessful()).isTrue();
+
+    for (int i = 0; i < 500; i++) {
+      server.enqueue(mockResponse("HeroNameResponse.json"));
+    }
+
+    final CountDownLatch latch = new CountDownLatch(1000);
+    for (int i = 0; i < 1000; i++) {
+      apolloClient.newCall(query).cacheControl(i % 2 == 0 ? CacheControl.NETWORK_FIRST : CacheControl.CACHE_ONLY)
+          .enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+            @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
+              assertThat(response.isSuccessful()).isTrue();
+              latch.countDown();
+            }
+
+            @Override public void onFailure(@Nonnull Exception e) {
+              fail("unexpected error: " + e);
+              latch.countDown();
+            }
+          });
+    }
+
+    latch.await(5, TimeUnit.SECONDS);
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
@@ -2,7 +2,6 @@ package com.apollographql.android.impl;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.android.ApolloCall;
 import com.apollographql.android.api.graphql.Response;
 import com.apollographql.android.cache.normalized.CacheControl;
 import com.apollographql.android.cache.normalized.CacheKey;
@@ -21,8 +20,11 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
@@ -31,11 +33,10 @@ import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
+import static com.apollographql.android.impl.Utils.immediateExecutorService;
 import static com.google.common.truth.Truth.assertThat;
-import static junit.framework.Assert.fail;
 
 public class NormalizedCacheTestCase {
-
   private ApolloClient apolloClient;
   private MockWebServer server;
   private InMemoryCacheStore cacheStore;
@@ -58,6 +59,7 @@ public class NormalizedCacheTestCase {
             return CacheKey.from(id);
           }
         })
+        .dispatcher(immediateExecutorService())
         .build();
   }
 
@@ -274,35 +276,5 @@ public class NormalizedCacheTestCase {
     assertThat(server.getRequestCount()).isEqualTo(2);
     assertThat(body.isSuccessful()).isTrue();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
-  }
-
-  @Test public void testAsync() throws IOException, InterruptedException {
-    EpisodeHeroName query = new EpisodeHeroName(EpisodeHeroName.Variables.builder().episode(Episode.EMPIRE).build());
-
-    server.enqueue(mockResponse("HeroNameResponse.json"));
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
-    assertThat(body.isSuccessful()).isTrue();
-
-    for (int i = 0; i < 500; i++) {
-      server.enqueue(mockResponse("HeroNameResponse.json"));
-    }
-
-    final CountDownLatch latch = new CountDownLatch(1000);
-    for (int i = 0; i < 1000; i++) {
-      apolloClient.newCall(query).cacheControl(i % 2 == 0 ? CacheControl.NETWORK_FIRST : CacheControl.CACHE_ONLY)
-          .enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
-            @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
-              assertThat(response.isSuccessful()).isTrue();
-              latch.countDown();
-            }
-
-            @Override public void onFailure(@Nonnull Exception e) {
-              fail("unexpected error: " + e);
-              latch.countDown();
-            }
-          });
-    }
-
-    latch.await(5, TimeUnit.SECONDS);
   }
 }

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
@@ -38,6 +38,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
+import static com.apollographql.android.impl.Utils.immediateExecutorService;
 import static com.apollographql.android.impl.normalizer.type.Episode.EMPIRE;
 import static com.apollographql.android.impl.normalizer.type.Episode.JEDI;
 import static com.google.common.truth.Truth.assertThat;
@@ -83,6 +84,7 @@ public class ResponseNormalizationTest {
             return CacheKey.from(id);
           }
         })
+        .dispatcher(immediateExecutorService())
         .build();
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/Utils.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/Utils.java
@@ -4,6 +4,10 @@ import com.google.common.io.CharStreams;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 public final class Utils {
 
@@ -12,18 +16,45 @@ public final class Utils {
 
   public static String readFileToString(final Class contextClass,
       final String streamIdentifier) throws IOException {
-    
+
     InputStreamReader inputStreamReader = null;
     try {
       inputStreamReader = new InputStreamReader(contextClass.getResourceAsStream(streamIdentifier));
       return CharStreams.toString(inputStreamReader);
     } catch (IOException e) {
       throw new IOException();
-    }
-    finally {
+    } finally {
       if (inputStreamReader != null) {
         inputStreamReader.close();
       }
     }
+  }
+
+  public static ExecutorService immediateExecutorService() {
+    return new AbstractExecutorService() {
+      @Override public void shutdown() {
+
+      }
+
+      @Override public List<Runnable> shutdownNow() {
+        return null;
+      }
+
+      @Override public boolean isShutdown() {
+        return false;
+      }
+
+      @Override public boolean isTerminated() {
+        return false;
+      }
+
+      @Override public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+        return false;
+      }
+
+      @Override public void execute(Runnable runnable) {
+        runnable.run();
+      }
+    };
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/http/HttpCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/http/HttpCache.java
@@ -74,9 +74,8 @@ public final class HttpCache {
           .build();
     } catch (Exception e) {
       //TODO log
-      return null;
-    } finally {
       closeQuietly(responseCacheRecord);
+      return null;
     }
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
@@ -1,6 +1,8 @@
 package com.apollographql.android.cache.normalized;
 
 import java.util.Collection;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import javax.annotation.Nonnull;
 
@@ -9,10 +11,12 @@ import static com.apollographql.android.impl.util.Utils.checkNotNull;
 public final class RealCache implements Cache {
   private final CacheStore cacheStore;
   private final CacheKeyResolver cacheKeyResolver;
+  private final ReadWriteLock lock;
 
   public RealCache(@Nonnull CacheStore cacheStore, @Nonnull CacheKeyResolver cacheKeyResolver) {
     this.cacheStore = cacheStore;
     this.cacheKeyResolver = cacheKeyResolver;
+    this.lock = new ReentrantReadWriteLock();
   }
 
   @Override @Nonnull public ResponseNormalizer responseNormalizer() {
@@ -20,18 +24,38 @@ public final class RealCache implements Cache {
   }
 
   @Override public void write(@Nonnull Record record) {
-    cacheStore.merge(checkNotNull(record, "record == null"));
+    lock.writeLock().lock();
+    try {
+      cacheStore.merge(checkNotNull(record, "record == null"));
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   @Override public void write(@Nonnull Collection<Record> recordSet) {
-    cacheStore.merge(checkNotNull(recordSet, "recordSet == null"));
+    lock.writeLock().lock();
+    try {
+      cacheStore.merge(checkNotNull(recordSet, "recordSet == null"));
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   @Override public Record read(@Nonnull String key) {
-    return cacheStore.loadRecord(checkNotNull(key, "key == null"));
+    lock.readLock().lock();
+    try {
+      return cacheStore.loadRecord(checkNotNull(key, "key == null"));
+    } finally {
+      lock.readLock().unlock();
+    }
   }
 
   @Override public Collection<Record> read(@Nonnull Collection<String> keys) {
-    return cacheStore.loadRecords(checkNotNull(keys, "keys == null"));
+    lock.readLock().lock();
+    try {
+      return cacheStore.loadRecords(checkNotNull(keys, "keys == null"));
+    } finally {
+      lock.readLock().unlock();
+    }
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -10,9 +10,9 @@ import com.apollographql.android.cache.http.EvictionStrategy;
 import com.apollographql.android.cache.http.HttpCache;
 import com.apollographql.android.cache.http.ResponseCacheStore;
 import com.apollographql.android.cache.normalized.Cache;
-import com.apollographql.android.cache.normalized.RealCache;
 import com.apollographql.android.cache.normalized.CacheKeyResolver;
 import com.apollographql.android.cache.normalized.CacheStore;
+import com.apollographql.android.cache.normalized.RealCache;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.JsonWriter;
 import com.squareup.moshi.Moshi;
@@ -32,7 +32,6 @@ import okhttp3.Call;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import okhttp3.internal.Util;
 
 import static com.apollographql.android.impl.util.Utils.checkNotNull;
 

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -156,8 +156,8 @@ public final class ApolloClient implements ApolloCall.Factory {
       return this;
     }
 
-    public Builder dispatcher(@Nonnull ExecutorService executorService) {
-      checkNotNull(executorService, "executorService == null");
+    public Builder dispatcher(@Nonnull ExecutorService dispatcher) {
+      checkNotNull(dispatcher, "dispatcher == null");
       this.dispatcher = dispatcher;
       return this;
     }


### PR DESCRIPTION
Closes #280 

Introduces dispatcher (`ExecutorService`) with unbound threads count and TTL 60 sec.
This dispatcher is going to be used when:
- `com.apollographql.android.impl.RealApolloCall#enqueue` called
- `com.apollographql.android.impl.RealApolloCall#handleResponse` saves to the cache.

`RealCache` gets `ReadWriteLock` for any cache operation (one thread can write to the cache, multiple can read).