### PR TITLE
check if guava exists in the list of resolved dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,7 @@ notifications:
 
 sudo: false
 
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/gradle/caches/
+    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -11,7 +11,7 @@ open class GraphQLCompiler {
   private val moshi = Moshi.Builder().build()
   private val irAdapter = moshi.adapter(CodeGenerationIR::class.java)
 
-  fun write(irFile: File, outputDir: File, customTypeMap: Map<String, String> = emptyMap()) {
+  fun write(irFile: File, outputDir: File, customTypeMap: Map<String, String> = emptyMap(), hasGuava: Boolean = false) {
     val ir = irAdapter.fromJson(irFile.readText())
     val irPackageName = irFile.absolutePath.formatPackageName()
     val fragmentsPackage = if (irPackageName.isNotEmpty()) "$irPackageName.fragment" else "fragment"
@@ -22,7 +22,8 @@ open class GraphQLCompiler {
         typeDeclarations = ir.typesUsed,
         fragmentsPackage = fragmentsPackage,
         typesPackage = typesPackage,
-        customTypeMap = supportedScalarTypeMapping
+        customTypeMap = supportedScalarTypeMapping,
+        hasGuava = hasGuava
     )
     ir.writeTypeUsed(context, outputDir)
     ir.writeFragments(context, outputDir)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/CodeGenerationContext.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/CodeGenerationContext.kt
@@ -5,7 +5,8 @@ data class CodeGenerationContext(
     val typeDeclarations: List<TypeDeclaration>,
     val fragmentsPackage: String = "",
     val typesPackage: String = "",
-    val customTypeMap: Map<String, String>
+    val customTypeMap: Map<String, String>,
+    val hasGuava: Boolean
 ) {
   fun plusReservedTypes(vararg typeName: String): CodeGenerationContext = plusReservedTypes(typeName.toList())
 
@@ -15,7 +16,8 @@ data class CodeGenerationContext(
           typeDeclarations = typeDeclarations,
           fragmentsPackage = fragmentsPackage,
           typesPackage = typesPackage,
-          customTypeMap = customTypeMap
+          customTypeMap = customTypeMap,
+          hasGuava = hasGuava
       )
 
   fun withReservedTypeNames(vararg typeName: String): CodeGenerationContext = withReservedTypeNames(typeName.asList())
@@ -26,6 +28,7 @@ data class CodeGenerationContext(
           typeDeclarations = typeDeclarations,
           fragmentsPackage = fragmentsPackage,
           typesPackage = typesPackage,
-          customTypeMap = customTypeMap
+          customTypeMap = customTypeMap,
+          hasGuava = hasGuava
       )
 }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -50,6 +50,7 @@ class ApolloPlugin implements Plugin<Project> {
     setupNode()
     project.extensions.create(ApolloExtension.NAME, ApolloExtension)
     createSourceSetExtensions()
+    def hasGuava = false
 
     def compileDepSet = project.configurations.getByName("compile").dependencies
     project.getGradle().addListener(new DependencyResolutionListener() {
@@ -60,25 +61,32 @@ class ApolloPlugin implements Plugin<Project> {
           dep.name == API_DEP_NAME
         }
         if (apolloApiDep != null && apolloApiDep.version != VersionKt.VERSION) {
-          throw new GradleException("apollo-api version ${apolloApiDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
+          throw new GradleException(
+              "apollo-api version ${apolloApiDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
         }
         if (System.getProperty("apollographql.skipApi") != "true" && apolloApiDep == null) {
           compileDepSet.add(project.dependencies.create("$APOLLO_GROUP:$API_DEP_NAME:$VersionKt.VERSION"))
         }
-        project.getGradle().removeListener(this)
       }
 
       @Override
-      void afterResolve(ResolvableDependencies resolvableDependencies) {}
+      void afterResolve(ResolvableDependencies resolvableDependencies) {
+        resolvableDependencies.getResolutionResult().allDependencies.each {
+          if (it.toString().contains("com.google.guava:guava")) {
+            hasGuava = true
+          }
+        }
+        project.getGradle().removeListener(this)
+      }
     })
 
     project.afterEvaluate {
       project.tasks.create(ApolloCodeGenInstallTask.NAME, ApolloCodeGenInstallTask.class)
-      addApolloTasks()
+      addApolloTasks(hasGuava)
     }
   }
 
-  private void addApolloTasks() {
+  private void addApolloTasks(boolean hasGuava) {
     Task apolloIRGenTask = project.task("generateApolloIR")
     apolloIRGenTask.group(TASK_GROUP)
     Task apolloClassGenTask = project.task("generateApolloClasses")
@@ -86,28 +94,28 @@ class ApolloPlugin implements Plugin<Project> {
 
     if (isAndroidProject()) {
       getVariants().all { v ->
-        addVariantTasks(v, apolloIRGenTask, apolloClassGenTask, v.sourceSets)
+        addVariantTasks(v, apolloIRGenTask, apolloClassGenTask, v.sourceSets, hasGuava)
       }
     } else {
       getSourceSets().all { sourceSet ->
-        addSourceSetTasks(sourceSet, apolloIRGenTask, apolloClassGenTask)
+        addSourceSetTasks(sourceSet, apolloIRGenTask, apolloClassGenTask, hasGuava)
       }
     }
   }
 
-  private void addVariantTasks(Object variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection<?> sourceSets) {
+  private void addVariantTasks(Object variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection<?> sourceSets, boolean hasGuava) {
     ApolloIRGenTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
-    ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name, project.apollo.customTypeMapping)
+    ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name, project.apollo.customTypeMapping, hasGuava)
     variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir)
     apolloIRGenTask.dependsOn(variantIRTask)
     apolloClassGenTask.dependsOn(variantClassTask)
   }
 
-  private void addSourceSetTasks(SourceSet sourceSet, Task apolloIRGenTask, Task apolloClassGenTask) {
+  private void addSourceSetTasks(SourceSet sourceSet, Task apolloIRGenTask, Task apolloClassGenTask, boolean hasGuava) {
     String taskName = "main".equals(sourceSet.name) ? "" : sourceSet.name
 
     ApolloIRGenTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
-    ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name, project.apollo.customTypeMapping)
+    ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name, project.apollo.customTypeMapping, hasGuava)
     apolloIRGenTask.dependsOn(sourceSetIRTask)
     apolloClassGenTask.dependsOn(sourceSetClassTask)
 
@@ -141,7 +149,7 @@ class ApolloPlugin implements Plugin<Project> {
     return task
   }
 
-  private ApolloClassGenTask createApolloClassGenTask(String name, Map<String, String> customTypeMapping) {
+  private ApolloClassGenTask createApolloClassGenTask(String name, Map<String, String> customTypeMapping, boolean hasGuava) {
     String taskName = String.format(ApolloClassGenTask.NAME, name.capitalize())
     ApolloClassGenTask task = project.tasks.create(taskName, ApolloClassGenTask) {
       group = TASK_GROUP
@@ -150,7 +158,7 @@ class ApolloPlugin implements Plugin<Project> {
       source = project.tasks.findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())).outputDir
       include "**${File.separatorChar}*API.json"
     }
-    task.init(name, customTypeMapping)
+    task.init(name, customTypeMapping, hasGuava)
     return task
   }
 

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -71,10 +71,8 @@ class ApolloPlugin implements Plugin<Project> {
 
       @Override
       void afterResolve(ResolvableDependencies resolvableDependencies) {
-        resolvableDependencies.getResolutionResult().allDependencies.each {
-          if (it.toString().contains("com.google.guava:guava")) {
-            hasGuava = true
-          }
+        hasGuava = resolvableDependencies.getResolutionResult().allDependencies.any {
+          it.toString().contains("com.google.guava:guava")
         }
         project.getGradle().removeListener(this)
       }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
@@ -21,11 +21,13 @@ public class ApolloClassGenTask extends SourceTask {
 
   @Internal private String variant;
   @Internal private Map<String, String> customTypeMapping;
+  @Internal boolean hasGuavaDep;
   @OutputDirectory private File outputDir;
 
-  public void init(String buildVariant, Map<String, String> typeMapping) {
+  public void init(String buildVariant, Map<String, String> typeMapping, boolean hasGuava) {
     variant = buildVariant;
     customTypeMapping = typeMapping;
+    hasGuavaDep = hasGuava;
     outputDir = new File(getProject().getBuildDir() + "/" + Joiner.on(File.separator).join(GraphQLCompiler.Companion
         .getOUTPUT_DIRECTORY()));
   }
@@ -35,7 +37,7 @@ public class ApolloClassGenTask extends SourceTask {
     inputs.outOfDate(new Action<InputFileDetails>() {
       @Override
       public void execute(InputFileDetails inputFileDetails) {
-        new GraphQLCompiler().write(inputFileDetails.getFile(), outputDir, customTypeMapping);
+        new GraphQLCompiler().write(inputFileDetails.getFile(), outputDir, customTypeMapping, hasGuavaDep);
       }
     });
   }


### PR DESCRIPTION
This is needed for choosing which Optional class to go with when doing the
codegen.

List of resolved dependencies includes those with an explicit `compile 'x'` statement as well as whatever other transitive dependencies they bring.

