### PR TITLE
capture npm install output and redirect to Gradle's logging system

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.gradle.api.Task;
+import org.gradle.api.logging.LogLevel;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
 
@@ -46,6 +47,7 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     }
     setArgs(Lists.newArrayList("install", "apollo-codegen@" + GraphQLCompiler.APOLLOCODEGEN_VERSION, "--save",
         "--save-exact"));
+    getLogging().captureStandardOutput(LogLevel.INFO);
   }
 
   private static class PackageJson {


### PR DESCRIPTION
Fixes this:

![image](https://cloud.githubusercontent.com/assets/7871596/23954929/dfcc48be-096e-11e7-8d4e-44ef9e6afd48.png)


This is hidees the noisy `npm install` output which displays the list of
dependencies as warnings/error messages in the IDE.

npm log is still accessible through `gradle installApolloCodegen --info`