### PR TITLE
Fix duplicate cache write caused by bad merge

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloCall.java
@@ -206,7 +206,6 @@ final class RealApolloCall<T extends Operation.Data> extends BaseApolloCall impl
             cache.write(normalizer.records());
           }
         });
-        cache.write(normalizer.records());
         dependentKeys = normalizer.dependentKeys();
         return convertedResponse;
       } catch (Exception rethrown) {


### PR DESCRIPTION
Looks like I messed up the merge on https://github.com/apollographql/apollo-android/pull/312 and double added the `cache.write`. The proper behavior is for this to be in the executor.