### PR TITLE
Shadow cache read to generate dependent keys.

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/android/api/graphql/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/android/api/graphql/Response.java
@@ -2,21 +2,24 @@ package com.apollographql.android.api.graphql;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /** Represents either a successful or failed response received from the GraphQL server. */
 public class Response<T> {
   private final Operation operation;
   private final T data;
   private final List<Error> errors;
+  private Set<String> dependentKeys;
 
   public Response(Operation operation) {
-    this(operation, null, null);
+    this(operation, null, null, null);
   }
 
-  public Response(Operation operation, T data, List<Error> errors) {
+  public Response(Operation operation, T data, List<Error> errors, Set<String> dependentKeys) {
     this.operation = operation;
     this.data = data;
     this.errors = errors != null ? errors : Collections.<Error>emptyList();
+    this.dependentKeys = dependentKeys != null ? dependentKeys : Collections.<String>emptySet();
   }
 
   public boolean isSuccessful() {
@@ -34,4 +37,9 @@ public class Response<T> {
   public List<Error> errors() {
     return errors;
   }
+
+  public Set<String> dependentKeys() {
+    return dependentKeys;
+  }
+
 }

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
@@ -43,7 +43,7 @@ public class ApolloWatcherTest {
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
-        .normalizedCache(cacheStore, new CacheKeyResolver() {
+        .normalizedCache(cacheStore, new CacheKeyResolver<Map<String, Object>>() {
           @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
             String id = (String) jsonObject.get("id");
             if (id == null || id.isEmpty()) {
@@ -231,6 +231,58 @@ public class ApolloWatcherTest {
     //To verify that the updated response comes from server use a different name change
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    secondResponseLatch.await();
+  }
+
+  @Test
+  public void testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() throws IOException, InterruptedException {
+    final CountDownLatch cacheWarmUpLatch = new CountDownLatch(1);
+    EpisodeHeroName query = new EpisodeHeroName(EpisodeHeroName.Variables.builder().episode(Episode.EMPIRE).build());
+    server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
+    apolloClient.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+      @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
+        cacheWarmUpLatch.countDown();
+      }
+
+      @Override public void onFailure(@Nonnull Exception e) {
+        Assert.fail(e.getMessage());
+        cacheWarmUpLatch.countDown();
+      }
+    });
+    cacheWarmUpLatch.await();
+
+    //Cache is now "warm" with response data
+
+    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
+    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+
+    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query)
+        .cacheControl(CacheControl.CACHE_ONLY)
+        .watcher();
+    watcher.enqueueAndWatch(
+        new ApolloCall.Callback<EpisodeHeroName.Data>() {
+          @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
+            if (secondResponseLatch.getCount() == 2) {
+              assertThat(response.data().hero().name()).isEqualTo("R2-D2");
+            } else if (secondResponseLatch.getCount() == 1) {
+              assertThat(response.data().hero().name()).isEqualTo("Artoo");
+            }
+            firstResponseLatch.countDown();
+            secondResponseLatch.countDown();
+          }
+
+          @Override public void onFailure(@Nonnull Exception e) {
+            Assert.fail(e.getMessage());
+            firstResponseLatch.countDown();
+            secondResponseLatch.countDown();
+          }
+        });
+
+    firstResponseLatch.await();
+    //Another newer call gets updated information
+    server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
+    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+
     secondResponseLatch.await();
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/AsyncNormalizedCacheTestCase.java
@@ -43,7 +43,7 @@ public class AsyncNormalizedCacheTestCase {
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
-        .normalizedCache(cacheStore, new CacheKeyResolver() {
+        .normalizedCache(cacheStore, new CacheKeyResolver<Map<String, Object>>() {
           @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
             String id = (String) jsonObject.get("id");
             if (Strings.isNullOrEmpty(id)) {

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/NormalizedCacheTestCase.java
@@ -20,12 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
@@ -50,7 +45,7 @@ public class NormalizedCacheTestCase {
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
-        .normalizedCache(cacheStore, new CacheKeyResolver() {
+        .normalizedCache(cacheStore, new CacheKeyResolver<Map<String, Object>>() {
           @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
             String id = (String) jsonObject.get("id");
             if (id == null || id.isEmpty()) {

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ResponseNormalizationTest.java
@@ -75,7 +75,7 @@ public class ResponseNormalizationTest {
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
         .okHttpClient(okHttpClient)
-        .normalizedCache(cacheStore, new CacheKeyResolver() {
+        .normalizedCache(cacheStore, new CacheKeyResolver<Map<String, Object>>() {
           @Nonnull @Override public CacheKey resolve(@NonNull Map<String, Object> jsonObject) {
             String id = (String) jsonObject.get("id");
             if (id == null || id.isEmpty()) {

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/Cache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/Cache.java
@@ -1,5 +1,6 @@
 package com.apollographql.android.cache.normalized;
 
+import java.util.Map;
 import java.util.Set;
 
 public interface Cache {
@@ -14,11 +15,13 @@ public interface Cache {
 
   void publish(Set<String> keys);
 
+  ResponseNormalizer<Map<String, Object>> networkResponseNormalizer();
+
+  ResponseNormalizer<Record> cacheResponseNormalizer();
+
   <R> R readTransaction(Transaction<ReadableCache, R> transaction);
 
   <R> R writeTransaction(Transaction<WriteableCache, R> transaction);
-
-  ResponseNormalizer responseNormalizer();
 
   Cache NO_CACHE = new NoOpCache();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKeyResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/CacheKeyResolver.java
@@ -8,12 +8,19 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-public abstract class CacheKeyResolver {
-  public static final CacheKeyResolver DEFAULT = new CacheKeyResolver() {
+public abstract class CacheKeyResolver<R> {
+  public static final CacheKeyResolver DEFAULT = new CacheKeyResolver<Map<String, Object>>() {
     @Nonnull @Override public CacheKey resolve(@Nonnull Map<String, Object> jsonObject) {
       return CacheKey.NO_KEY;
     }
   };
+
+  static final CacheKeyResolver<Record> RECORD  = new CacheKeyResolver<Record>() {
+    @Nonnull @Override public CacheKey resolve(@Nonnull Record record) {
+      return CacheKey.from(record.key());
+    }
+  };
+
   private static final CacheKey QUERY_ROOT_KEY = CacheKey.from("QUERY_ROOT");
   private static final CacheKey MUTATION_ROOT_KEY = CacheKey.from("MUTATION_ROOT");
 
@@ -26,5 +33,5 @@ public abstract class CacheKeyResolver {
     throw new IllegalArgumentException("Unknown operation type.");
   }
 
-  @Nonnull public abstract CacheKey resolve(@Nonnull Map<String, Object> jsonObject);
+  @Nonnull public abstract CacheKey resolve(@Nonnull R objectSource);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/NoOpCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/NoOpCache.java
@@ -2,6 +2,7 @@ package com.apollographql.android.cache.normalized;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -31,15 +32,21 @@ final class NoOpCache implements Cache, ReadableCache, WriteableCache {
 
   @Override public void publish(Set<String> keys) { }
 
+  @Override public ResponseNormalizer<Map<String, Object>> networkResponseNormalizer() {
+    //noinspection unchecked
+    return ResponseNormalizer.NO_OP_NORMALIZER;
+  }
+
+  @Override public ResponseNormalizer<Record> cacheResponseNormalizer() {
+    //noinspection unchecked
+    return ResponseNormalizer.NO_OP_NORMALIZER;
+  }
+
   @Override public <R> R readTransaction(Transaction<ReadableCache, R> transaction) {
     return transaction.execute(this);
   }
 
   @Override public <R> R writeTransaction(Transaction<WriteableCache, R> transaction) {
     return transaction.execute(this);
-  }
-
-  @Override public ResponseNormalizer responseNormalizer() {
-    return ResponseNormalizer.NO_OP_NORMALIZER;
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
@@ -4,6 +4,7 @@ package com.apollographql.android.cache.normalized;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -16,19 +17,24 @@ import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
 public final class RealCache implements Cache, ReadableCache, WriteableCache {
   private final CacheStore cacheStore;
-  private final CacheKeyResolver cacheKeyResolver;
+  private final CacheKeyResolver<Map<String, Object>> networkCacheKeyResolver;
   private final ReadWriteLock lock;
   private final Set<RecordChangeSubscriber> subscribers;
 
-  public RealCache(@Nonnull CacheStore cacheStore, @Nonnull CacheKeyResolver cacheKeyResolver) {
+  public RealCache(@Nonnull CacheStore cacheStore,
+      @Nonnull CacheKeyResolver<Map<String, Object>> networkCacheKeyResolver) {
     this.cacheStore = cacheStore;
-    this.cacheKeyResolver = cacheKeyResolver;
+    this.networkCacheKeyResolver = networkCacheKeyResolver;
     this.lock = new ReentrantReadWriteLock();
     this.subscribers = Collections.newSetFromMap(new WeakHashMap<RecordChangeSubscriber, Boolean>());
   }
 
-  @Override @Nonnull public ResponseNormalizer responseNormalizer() {
-    return new ResponseNormalizer(cacheKeyResolver);
+  @Override public ResponseNormalizer<Map<String, Object>> networkResponseNormalizer() {
+    return new ResponseNormalizer<>(networkCacheKeyResolver);
+  }
+
+  @Override public ResponseNormalizer<Record> cacheResponseNormalizer() {
+    return new ResponseNormalizer<>(CacheKeyResolver.RECORD);
   }
 
   @Override public synchronized void subscribe(RecordChangeSubscriber subscriber) {
@@ -40,18 +46,19 @@ public final class RealCache implements Cache, ReadableCache, WriteableCache {
   }
 
   @Override public void publish(@Nonnull Set<String> changedKeys) {
-    checkNotNull(changedKeys, "changedKeys == null");
-    if (changedKeys.isEmpty()) {
-      return;
+      checkNotNull(changedKeys, "changedKeys == null");
+      if (changedKeys.isEmpty()) {
+        return;
+      }
+      Set<RecordChangeSubscriber> iterableSubscribers;
+      synchronized (this) {
+        iterableSubscribers = new LinkedHashSet<>(subscribers);
+      }
+      for (RecordChangeSubscriber subscriber : iterableSubscribers) {
+        subscriber.onCacheKeysChanged(changedKeys);
+      }
     }
-    Set<RecordChangeSubscriber> iterableSubscribers;
-    synchronized (this) {
-      iterableSubscribers = new LinkedHashSet<>(subscribers);
-    }
-    for (RecordChangeSubscriber subscriber : iterableSubscribers) {
-      subscriber.onCacheKeysChanged(changedKeys);
-    }
-  }
+
 
   @Override public <R> R readTransaction(Transaction<ReadableCache, R> transaction) {
     lock.readLock().lock();

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/RealCache.java
@@ -46,19 +46,18 @@ public final class RealCache implements Cache, ReadableCache, WriteableCache {
   }
 
   @Override public void publish(@Nonnull Set<String> changedKeys) {
-      checkNotNull(changedKeys, "changedKeys == null");
-      if (changedKeys.isEmpty()) {
-        return;
-      }
-      Set<RecordChangeSubscriber> iterableSubscribers;
-      synchronized (this) {
-        iterableSubscribers = new LinkedHashSet<>(subscribers);
-      }
-      for (RecordChangeSubscriber subscriber : iterableSubscribers) {
-        subscriber.onCacheKeysChanged(changedKeys);
-      }
+    checkNotNull(changedKeys, "changedKeys == null");
+    if (changedKeys.isEmpty()) {
+      return;
     }
-
+    Set<RecordChangeSubscriber> iterableSubscribers;
+    synchronized (this) {
+      iterableSubscribers = new LinkedHashSet<>(subscribers);
+    }
+    for (RecordChangeSubscriber subscriber : iterableSubscribers) {
+      subscriber.onCacheKeysChanged(changedKeys);
+    }
+  }
 
   @Override public <R> R readTransaction(Transaction<ReadableCache, R> transaction) {
     lock.readLock().lock();

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ApolloClient.java
@@ -130,7 +130,7 @@ public final class ApolloClient implements ApolloCall.Factory {
     }
 
     public Builder normalizedCache(@Nonnull CacheStore cacheStore,
-        @Nonnull CacheKeyResolver cacheKeyResolver) {
+        @Nonnull CacheKeyResolver<Map<String, Object>> cacheKeyResolver) {
       checkNotNull(cacheStore, "cacheStore == null");
       checkNotNull(cacheKeyResolver, "cacheKeyResolver == null");
       this.cache = new RealCache(cacheStore, cacheKeyResolver);

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/HttpResponseBodyConverter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/HttpResponseBodyConverter.java
@@ -26,10 +26,9 @@ final class HttpResponseBodyConverter<D extends Operation.Data, W> {
     this.customTypeAdapters = customTypeAdapters;
   }
 
-   Response<W> convert(ResponseBody responseBody,
+  Response<W> convert(ResponseBody responseBody,
       final ResponseNormalizer<Map<String, Object>> networkResponseNormalizer) throws IOException {
-     networkResponseNormalizer.willResolveRootQuery(operation);
-     networkResponseNormalizer.willResolveRootQuery(operation);
+    networkResponseNormalizer.willResolveRootQuery(operation);
     BufferedSourceJsonReader jsonReader = null;
     try {
       jsonReader = new BufferedSourceJsonReader(responseBody.source());

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealApolloWatcher.java
@@ -71,7 +71,7 @@ final class RealApolloWatcher<T> implements ApolloWatcher<T> {
       @Override public void onResponse(@Nonnull Response<T> response) {
         if (isActive) {
           sourceCallback.onResponse(response);
-          dependentKeys = call.dependentKeys();
+          dependentKeys = response.dependentKeys();
           cache.subscribe(recordChangeSubscriber);
         }
       }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
@@ -20,11 +20,6 @@ import java.util.Map;
   private final ResponseReaderShadow<R> readerShadow;
 
   RealResponseReader(Operation operation, R recordSet, FieldValueResolver<R> fieldValueResolver,
-      Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
-    this(operation, recordSet, fieldValueResolver, customTypeAdapters, new EmptyResponseReaderShadow<R>());
-  }
-
-  RealResponseReader(Operation operation, R recordSet, FieldValueResolver<R> fieldValueResolver,
       Map<ScalarType, CustomTypeAdapter> customTypeAdapters, ResponseReaderShadow<R> readerShadow) {
     this.operation = operation;
     this.recordSet = recordSet;
@@ -281,38 +276,6 @@ import java.util.Map;
         throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.typeName());
       }
       return typeAdapter.decode(value.toString());
-    }
-  }
-
-  private static class EmptyResponseReaderShadow<R> implements ResponseReaderShadow<R> {
-    @Override public void willResolveRootQuery(Operation operation) {
-    }
-
-    @Override public void willResolve(Field field, Operation.Variables variables) {
-    }
-
-    @Override public void didResolve(Field field, Operation.Variables variables) {
-    }
-
-    @Override public void didParseScalar(Object value) {
-    }
-
-    @Override public void willParseObject(R objectMap) {
-    }
-
-    @Override public void didParseObject(R objectMap) {
-    }
-
-    @Override public void didParseList(List array) {
-    }
-
-    @Override public void willParseElement(int atIndex) {
-    }
-
-    @Override public void didParseElement(int atIndex) {
-    }
-
-    @Override public void didParseNull() {
     }
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/ResponseReaderShadow.java
@@ -15,9 +15,9 @@ public interface ResponseReaderShadow<R> {
 
   void didParseScalar(Object value);
 
-  void willParseObject(R objectMap);
+  void willParseObject(R objectSource);
 
-  void didParseObject(R objectMap);
+  void didParseObject(R objectSource);
 
   void didParseList(List array);
 


### PR DESCRIPTION
closes https://github.com/apollographql/apollo-android/issues/328

This enables query watching when the initial request was "CACHE_ONLY"

- Generifies `ResponseNormalizer` and `cacheKeyResolver` so we can resolve a key from a Record (just return the key)

- Moves dependentKeys inside of Response. This reduces mutable state stored in `ApolloCall`.

- temporarily disables integration tests (ran locally on mavenLocal() and they pass) because of API change. Will turn back on once snapshot is regenerated.