### PR TITLE
Generate operation builder instead of variables builder

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
@@ -6,6 +6,7 @@ import com.apollographql.android.api.graphql.Query
 import com.apollographql.android.api.graphql.ResponseReader
 import com.apollographql.android.api.graphql.internal.Optional
 import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder
+import com.apollographql.android.api.graphql.util.Utils
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
@@ -25,6 +26,7 @@ object ClassNames {
   val UNMODIFIABLE_MAP_BUILDER: ClassName = ClassName.get(UnmodifiableMapBuilder::class.java)
   val OPTIONAL: ClassName = ClassName.get(Optional::class.java)
   val GUAVA_OPTIONAL: ClassName = ClassName.get("com.google.common.base", "Optional")
+  val API_UTILS: ClassName = ClassName.get(Utils::class.java)
 
   fun <K : Any> parameterizedListOf(type: Class<K>): TypeName =
       ParameterizedTypeName.get(LIST, ClassName.get(type))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
@@ -17,7 +17,7 @@ object ClassNames {
   val GRAPHQL_OPERATION: ClassName = ClassName.get(Operation::class.java)
   val GRAPHQL_QUERY: ClassName = ClassName.get(Query::class.java)
   val GRAPHQL_MUTATION: ClassName = ClassName.get(Mutation::class.java)
-  val GRAPHQL_OPERATION_VARIABLES: TypeName = ClassName.get("", "${GRAPHQL_OPERATION.simpleName()}.Variables")
+  val GRAPHQL_OPERATION_VARIABLES: ClassName = ClassName.get("", "${GRAPHQL_OPERATION.simpleName()}.Variables")
   val ILLEGAL_STATE_EXCEPTION: TypeName = ClassName.get(IllegalStateException::class.java)
   val API_RESPONSE_READER: ClassName = ClassName.get(ResponseReader::class.java)
   val MAP: ClassName = ClassName.get(Map::class.java)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
@@ -10,7 +10,6 @@ class OperationTypeSpecBuilder(
     val fragments: List<Fragment>
 ) : CodeGenerator {
   private val OPERATION_TYPE_NAME = operation.operationName.capitalize()
-  private val OPERATION_VARIABLES_CLASS_NAME = ClassName.get("", "$OPERATION_TYPE_NAME.Variables")
   private val DATA_VAR_TYPE = ClassName.get("", "$OPERATION_TYPE_NAME.Data")
 
   override fun toTypeSpec(context: CodeGenerationContext): TypeSpec {
@@ -18,24 +17,24 @@ class OperationTypeSpecBuilder(
     return TypeSpec.classBuilder(OPERATION_TYPE_NAME)
         .addAnnotation(Annotations.GENERATED_BY_APOLLO)
         .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-        .addQuerySuperInterface(context, operation.variables.isNotEmpty())
+        .addQuerySuperInterface(context)
         .addOperationDefinition(operation)
         .addQueryDocumentDefinition(fragments, newContext)
+        .addConstructor(context)
         .addMethod(wrapDataMethod(context))
-        .addQueryConstructor(operation.variables.isNotEmpty())
         .addVariablesDefinition(operation.variables, newContext)
-        .addType(operation.toTypeSpec(newContext))
         .addResponseFieldMapperMethod()
+        .addBuilder(context)
+        .addType(operation.toTypeSpec(newContext))
         .build()
   }
 
-  private fun TypeSpec.Builder.addQuerySuperInterface(context: CodeGenerationContext,
-      hasVariables: Boolean): TypeSpec.Builder {
+  private fun TypeSpec.Builder.addQuerySuperInterface(context: CodeGenerationContext): TypeSpec.Builder {
     val isMutation = operation.operationType == "mutation"
     val superInterfaceClassName = if (isMutation) ClassNames.GRAPHQL_MUTATION else ClassNames.GRAPHQL_QUERY
-    return if (hasVariables) {
+    return if (operation.variables.isNotEmpty()) {
       addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, DATA_VAR_TYPE,
-          wrapperType(context), OPERATION_VARIABLES_CLASS_NAME))
+          wrapperType(context), variablesType()))
     } else {
       addSuperinterface(ParameterizedTypeName.get(superInterfaceClassName, DATA_VAR_TYPE,
           wrapperType(context), ClassNames.GRAPHQL_OPERATION_VARIABLES))
@@ -94,18 +93,16 @@ class OperationTypeSpecBuilder(
 
   private fun TypeSpec.Builder.addVariablesDefinition(variables: List<Variable>, context: CodeGenerationContext):
       TypeSpec.Builder {
-    val queryFieldClassName =
-        if (variables.isNotEmpty()) OPERATION_VARIABLES_CLASS_NAME else ClassNames.GRAPHQL_OPERATION_VARIABLES
-    addField(FieldSpec.builder(queryFieldClassName, VARIABLES_FIELD_NAME)
+    addField(FieldSpec.builder(variablesType(), VARIABLES_VAR)
         .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
         .build()
     )
 
-    addMethod(MethodSpec.methodBuilder(VARIABLES_ACCESSOR_NAME)
+    addMethod(MethodSpec.methodBuilder(VARIABLES_VAR)
         .addAnnotation(Annotations.OVERRIDE)
         .addModifiers(Modifier.PUBLIC)
-        .returns(queryFieldClassName)
-        .addStatement("return ${VARIABLES_FIELD_NAME}")
+        .returns(variablesType())
+        .addStatement("return \$L", VARIABLES_VAR)
         .build()
     )
 
@@ -114,25 +111,6 @@ class OperationTypeSpecBuilder(
     }
 
     return this
-  }
-
-  private fun TypeSpec.Builder.addQueryConstructor(hasVariables: Boolean): TypeSpec.Builder {
-    val methodBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC)
-    if (hasVariables) {
-      methodBuilder.addParameter(ParameterSpec.builder(OPERATION_VARIABLES_CLASS_NAME, VARIABLES_FIELD_NAME).build())
-    }
-    methodBuilder.addQueryConstructorCode(hasVariables)
-    return addMethod(methodBuilder.build())
-  }
-
-  private fun MethodSpec.Builder.addQueryConstructorCode(hasVariables: Boolean): MethodSpec.Builder {
-    val codeBuilder = CodeBlock.builder()
-    if (hasVariables) {
-      codeBuilder.addStatement("this.\$L = \$L", VARIABLES_FIELD_NAME, VARIABLES_FIELD_NAME)
-    } else {
-      codeBuilder.addStatement("this.\$L = \$T.EMPTY_VARIABLES", VARIABLES_FIELD_NAME, ClassNames.GRAPHQL_OPERATION)
-    }
-    return addCode(codeBuilder.build())
   }
 
   private fun TypeSpec.Builder.addResponseFieldMapperMethod(): TypeSpec.Builder {
@@ -150,11 +128,50 @@ class OperationTypeSpecBuilder(
     else -> DATA_VAR_TYPE
   }
 
+  private fun TypeSpec.Builder.addConstructor(context: CodeGenerationContext): TypeSpec.Builder {
+    val code = if (operation.variables.isEmpty()) {
+      CodeBlock.of("this.\$L = \$T.EMPTY_VARIABLES;\n", VARIABLES_VAR, ClassNames.GRAPHQL_OPERATION)
+    } else {
+      operation.variables
+          .map { it.name.decapitalize() }
+          .mapIndexed { i, v -> if (i > 0) CodeBlock.of(", \$L", v) else CodeBlock.of("\$L", v) }
+          .fold(CodeBlock.of("\$L = new \$T(", VARIABLES_VAR, variablesType()).toBuilder(), CodeBlock.Builder::add)
+          .add(");\n")
+          .build()
+    }
+    return MethodSpec.constructorBuilder()
+        .addModifiers(Modifier.PUBLIC)
+        .addParameters(operation.variables
+            .map { it.name.decapitalize() to it.type }
+            .map { it.first to JavaTypeResolver(context, context.typesPackage).resolve(it.second) }
+            .map { ParameterSpec.builder(it.second.unwrapOptionalType(), it.first).build() })
+        .addCode(code)
+        .build()
+        .let { addMethod(it) }
+  }
+
+  private fun TypeSpec.Builder.addBuilder(context: CodeGenerationContext): TypeSpec.Builder {
+    if (operation.variables.isEmpty()) {
+      return this
+    }
+    addMethod(BuilderTypeSpecBuilder.builderFactoryMethod())
+    return operation.variables
+        .map { it.name.decapitalize() to it.type }
+        .map { it.first to JavaTypeResolver(context, context.typesPackage).resolve(it.second).unwrapOptionalType() }
+        .let { BuilderTypeSpecBuilder(ClassName.get("", OPERATION_TYPE_NAME), it, emptyMap()) }
+        .let { addType(it.build()) }
+  }
+
+  private fun variablesType() =
+      if (operation.variables.isNotEmpty())
+        ClassName.get("", "$OPERATION_TYPE_NAME.Variables")
+      else
+        ClassNames.GRAPHQL_OPERATION_VARIABLES
+
   companion object {
     private val OPERATION_DEFINITION_FIELD_NAME = "OPERATION_DEFINITION"
     private val QUERY_DOCUMENT_FIELD_NAME = "QUERY_DOCUMENT"
     private val QUERY_DOCUMENT_ACCESSOR_NAME = "queryDocument"
-    private val VARIABLES_FIELD_NAME = "variables"
-    private val VARIABLES_ACCESSOR_NAME = "variables"
+    private val VARIABLES_VAR = "variables"
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/VariablesTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/VariablesTypeSpecBuilder.kt
@@ -19,7 +19,6 @@ class VariablesTypeSpecBuilder(
           .addConstructor()
           .addVariableAccessors()
           .addValueMapAccessor()
-          .addBuilder()
           .build()
 
   private fun TypeSpec.Builder.addVariableFields(): TypeSpec.Builder =
@@ -34,7 +33,7 @@ class VariablesTypeSpecBuilder(
   private fun TypeSpec.Builder.addValueMapField(): TypeSpec.Builder =
       addField(FieldSpec.builder(ClassNames.parameterizedMapOf(java.lang.String::class.java, Object::class.java),
           VALUE_MAP_FIELD_NAME)
-          .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+          .addModifiers(Modifier.PRIVATE, Modifier.FINAL, Modifier.TRANSIENT)
           .initializer("new \$T<>()", LinkedHashMap::class.java)
           .build())
 
@@ -77,7 +76,7 @@ class VariablesTypeSpecBuilder(
           .addStatement("return \$T.unmodifiableMap(\$L)", Collections::class.java, VALUE_MAP_FIELD_NAME)
           .build())
 
-  private fun TypeSpec.Builder.addBuilder(): TypeSpec.Builder {
+  fun TypeSpec.Builder.builder(): TypeSpec.Builder {
     if (variables.isEmpty()) {
       return this
     } else {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Variable.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Variable.kt
@@ -1,6 +1,8 @@
 package com.apollographql.android.compiler.ir
 
 data class Variable(
-  val name:String,
-  val type:String
-)
+    val name: String,
+    val type: String
+) {
+  fun optional(): Boolean = !type.endsWith(suffix = "!")
+}

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -34,8 +34,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   private final TestQuery.Variables variables;
 
-  public TestQuery(TestQuery.Variables variables) {
-    this.variables = variables;
+  public TestQuery(@Nullable Episode episode, int stars, double greenValue) {
+    variables = new TestQuery.Variables(episode, stars, greenValue);
   }
 
   @Override
@@ -58,6 +58,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return new Data.Mapper();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
@@ -65,7 +69,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private final double greenValue;
 
-    private final Map<String, Object> valueMap = new LinkedHashMap<>();
+    private final transient Map<String, Object> valueMap = new LinkedHashMap<>();
 
     Variables(@Nullable Episode episode, int stars, double greenValue) {
       this.episode = episode;
@@ -92,39 +96,35 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
     }
+  }
 
-    public static Builder builder() {
-      return new Builder();
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    private int stars;
+
+    private double greenValue;
+
+    Builder() {
     }
 
-    public static final class Builder {
-      private @Nullable Episode episode;
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
 
-      private int stars;
+    public Builder stars(int stars) {
+      this.stars = stars;
+      return this;
+    }
 
-      private double greenValue;
+    public Builder greenValue(double greenValue) {
+      this.greenValue = greenValue;
+      return this;
+    }
 
-      Builder() {
-      }
-
-      public Builder episode(@Nullable Episode episode) {
-        this.episode = episode;
-        return this;
-      }
-
-      public Builder stars(int stars) {
-        this.stars = stars;
-        return this;
-      }
-
-      public Builder greenValue(double greenValue) {
-        this.greenValue = greenValue;
-        return this;
-      }
-
-      public Variables build() {
-        return new Variables(episode, stars, greenValue);
-      }
+    public TestQuery build() {
+      return new TestQuery(episode, stars, greenValue);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -31,8 +31,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   private final TestQuery.Variables variables;
 
-  public TestQuery(TestQuery.Variables variables) {
-    this.variables = variables;
+  public TestQuery(@Nullable Episode episode, boolean includeName) {
+    variables = new TestQuery.Variables(episode, includeName);
   }
 
   @Override
@@ -55,12 +55,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return new Data.Mapper();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
     private final boolean includeName;
 
-    private final Map<String, Object> valueMap = new LinkedHashMap<>();
+    private final transient Map<String, Object> valueMap = new LinkedHashMap<>();
 
     Variables(@Nullable Episode episode, boolean includeName) {
       this.episode = episode;
@@ -81,32 +85,28 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
     }
+  }
 
-    public static Builder builder() {
-      return new Builder();
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    private boolean includeName;
+
+    Builder() {
     }
 
-    public static final class Builder {
-      private @Nullable Episode episode;
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
 
-      private boolean includeName;
+    public Builder includeName(boolean includeName) {
+      this.includeName = includeName;
+      return this;
+    }
 
-      Builder() {
-      }
-
-      public Builder episode(@Nullable Episode episode) {
-        this.episode = episode;
-        return this;
-      }
-
-      public Builder includeName(boolean includeName) {
-        this.includeName = includeName;
-        return this;
-      }
-
-      public Variables build() {
-        return new Variables(episode, includeName);
-      }
+    public TestQuery build() {
+      return new TestQuery(episode, includeName);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -7,6 +7,7 @@ import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ResponseReader;
 import com.apollographql.android.api.graphql.internal.Optional;
 import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.android.api.graphql.util.Utils;
 import com.example.input_object_type.type.Episode;
 import com.example.input_object_type.type.ReviewInput;
 import java.io.IOException;
@@ -36,6 +37,8 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
   private final TestQuery.Variables variables;
 
   public TestQuery(@Nonnull Episode ep, @Nonnull ReviewInput review) {
+    Utils.checkNotNull(ep, "ep == null");
+    Utils.checkNotNull(review, "review == null");
     variables = new TestQuery.Variables(ep, review);
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -35,8 +35,8 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
 
   private final TestQuery.Variables variables;
 
-  public TestQuery(TestQuery.Variables variables) {
-    this.variables = variables;
+  public TestQuery(@Nonnull Episode ep, @Nonnull ReviewInput review) {
+    variables = new TestQuery.Variables(ep, review);
   }
 
   @Override
@@ -59,12 +59,16 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     return new Data.Mapper();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nonnull Episode ep;
 
     private final @Nonnull ReviewInput review;
 
-    private final Map<String, Object> valueMap = new LinkedHashMap<>();
+    private final transient Map<String, Object> valueMap = new LinkedHashMap<>();
 
     Variables(@Nonnull Episode ep, @Nonnull ReviewInput review) {
       this.ep = ep;
@@ -85,34 +89,30 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
     }
+  }
 
-    public static Builder builder() {
-      return new Builder();
+  public static final class Builder {
+    private @Nonnull Episode ep;
+
+    private @Nonnull ReviewInput review;
+
+    Builder() {
     }
 
-    public static final class Builder {
-      private @Nonnull Episode ep;
+    public Builder ep(@Nonnull Episode ep) {
+      this.ep = ep;
+      return this;
+    }
 
-      private @Nonnull ReviewInput review;
+    public Builder review(@Nonnull ReviewInput review) {
+      this.review = review;
+      return this;
+    }
 
-      Builder() {
-      }
-
-      public Builder ep(@Nonnull Episode ep) {
-        this.ep = ep;
-        return this;
-      }
-
-      public Builder review(@Nonnull ReviewInput review) {
-        this.review = review;
-        return this;
-      }
-
-      public Variables build() {
-        if (ep == null) throw new IllegalStateException("ep can't be null");
-        if (review == null) throw new IllegalStateException("review can't be null");
-        return new Variables(ep, review);
-      }
+    public TestQuery build() {
+      if (ep == null) throw new IllegalStateException("ep can't be null");
+      if (review == null) throw new IllegalStateException("review can't be null");
+      return new TestQuery(ep, review);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -56,8 +56,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   private final TestQuery.Variables variables;
 
-  public TestQuery(TestQuery.Variables variables) {
-    this.variables = variables;
+  public TestQuery(@Nullable Episode episode) {
+    variables = new TestQuery.Variables(episode);
   }
 
   @Override
@@ -80,10 +80,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return new Data.Mapper();
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
-    private final Map<String, Object> valueMap = new LinkedHashMap<>();
+    private final transient Map<String, Object> valueMap = new LinkedHashMap<>();
 
     Variables(@Nullable Episode episode) {
       this.episode = episode;
@@ -98,25 +102,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
     }
+  }
 
-    public static Builder builder() {
-      return new Builder();
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    Builder() {
     }
 
-    public static final class Builder {
-      private @Nullable Episode episode;
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
 
-      Builder() {
-      }
-
-      public Builder episode(@Nullable Episode episode) {
-        this.episode = episode;
-        return this;
-      }
-
-      public Variables build() {
-        return new Variables(episode);
-      }
+    public TestQuery build() {
+      return new TestQuery(episode);
     }
   }
 


### PR DESCRIPTION
Move variables builder generation upper to operation.
So creation of query with arguments will be next:
```
TestQuery.builder().episode(Episode.NEWHOPE).stars(5).build()
```

Or via public constructor:
```
new TestQuery(Episode.NEWHOPE, 5)
```

@kassim 