### PR TITLE
update sample module to reflect plugin changes

### DIFF
--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
+skipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'
@@ -39,4 +40,10 @@ dependencies {
 
 apollo {
   customTypeMapping['Date'] = "java.util.Date"
+}
+
+// This prevents the plugin from adding the snapshot version of
+// apollo-runtime dependencies to the dependencies set
+def skipApolloRuntimeDep() {
+  System.setProperty("apollographql.skipRuntimeDep", "true")
 }

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -27,7 +27,6 @@ android {
 
 dependencies {
   compile dep.appcompat
-  compile dep.apolloApi
   compile dep.okhttpLoggingInterceptor
   compile dep.apolloRuntime
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,3 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=apollostack
 POM_DEVELOPER_NAME=Apollo
 
-# This prevents the plugin from adding the snapshot version of
-# apollo-runtime and api dependencies
-systemProp.apollographql.skipApi=true
-systemProp.apollographql.skipRuntime=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,7 +20,6 @@ ext.dep = [
     androidPlugin           : 'com.android.tools.build:gradle:2.3.0',
     apolloPlugin            : "com.apollographql.android:gradle-plugin:$versions.apolloVersion",
     apolloRuntime           : "com.apollographql.android:runtime:$versions.apolloVersion",
-    apolloApi               : "com.apollographql.android:api:$versions.apolloVersion",
     supportAnnotations      : 'com.android.support:support-annotations:25.1.0',
     compiletesting          : 'com.google.testing.compile:compile-testing:0.10',
     javaPoet                : 'com.squareup:javapoet:1.8.0',


### PR DESCRIPTION
Fixes some stuff after #311 and changed where the system property is set. For the `apollo-integration` module, the system property is set in the build script.

With this and #311, the plugin now adds `apollo-runtime` (which includes api in its dependency list).

(The old behaviour is still preserved, if the user provides their own `compile dep.apollo-runtime` this would be used instead, if it matches the plugin version number.)