### PR TITLE
minor cleanup 

### DIFF
--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-compiler/build.gradle
+++ b/apollo-compiler/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
+clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_6
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -27,7 +27,7 @@ class GraphQLCompiler {
     )
     ir.writeTypeUsed(context, args.outputDir)
     ir.writeFragments(context, args.outputDir)
-    ir.writeOperations(context, irPackageName, args.outputDir)
+    ir.writeOperations(context, args.outputDir)
   }
 
   private fun CodeGenerationIR.writeFragments(context: CodeGenerationContext, outputDir: File) {
@@ -49,7 +49,7 @@ class GraphQLCompiler {
     }
   }
 
-  private fun CodeGenerationIR.writeOperations(context: CodeGenerationContext, irPackageName: String, outputDir: File) {
+  private fun CodeGenerationIR.writeOperations(context: CodeGenerationContext, outputDir: File) {
     operations.map { OperationTypeSpecBuilder(it, fragments) }
         .forEach {
           val packageName = it.operation.filePath.formatPackageName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -25,19 +25,15 @@ class GraphQLCompiler {
         customTypeMap = supportedScalarTypeMapping,
         nullableValueGenerationType = args.nullableValueGenerationType()
     )
-    ir.writeTypeUsed(context, args.outputDir)
-    ir.writeFragments(context, args.outputDir)
-    ir.writeOperations(context, args.outputDir)
+    ir.writeJavaFiles(context, args.outputDir)
   }
 
-  private fun CodeGenerationIR.writeFragments(context: CodeGenerationContext, outputDir: File) {
+  private fun CodeGenerationIR.writeJavaFiles(context: CodeGenerationContext, outputDir: File) {
     fragments.forEach {
       val typeSpec = it.toTypeSpec(context)
       JavaFile.builder(context.fragmentsPackage, typeSpec).build().writeTo(outputDir)
     }
-  }
 
-  private fun CodeGenerationIR.writeTypeUsed(context: CodeGenerationContext, outputDir: File) {
     typesUsed.supportedTypeDeclarations().forEach {
       val typeSpec = it.toTypeSpec(context)
       JavaFile.builder(context.typesPackage, typeSpec).build().writeTo(outputDir)
@@ -47,9 +43,7 @@ class GraphQLCompiler {
       val typeSpec = CustomEnumTypeSpecBuilder(context).build()
       JavaFile.builder(context.typesPackage, typeSpec).build().writeTo(outputDir)
     }
-  }
 
-  private fun CodeGenerationIR.writeOperations(context: CodeGenerationContext, outputDir: File) {
     operations.map { OperationTypeSpecBuilder(it, fragments) }
         .forEach {
           val packageName = it.operation.filePath.formatPackageName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeSpecBuilder.kt
@@ -49,7 +49,7 @@ class SchemaTypeSpecBuilder(
     if (fragments.isNotEmpty()) {
       addMethod(fragmentsAccessorMethodSpec())
       addFields(listOf(fragmentsFieldSpec()))
-      addType(fragmentsTypeSpec(fragments, context.fragmentsPackage))
+      addType(fragmentsTypeSpec(fragments))
     }
     return this
   }
@@ -89,7 +89,7 @@ class SchemaTypeSpecBuilder(
       .build()
 
   /** Returns a generic `Fragments` interface with methods for each of the provided fragments */
-  private fun fragmentsTypeSpec(fragments: List<String>, fragmentsPackage: String): TypeSpec {
+  private fun fragmentsTypeSpec(fragments: List<String>): TypeSpec {
 
     fun TypeSpec.Builder.addFragmentFields(): TypeSpec.Builder {
       return addFields(fragments.map {

--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'java-gradle-plugin'
+clearSkipApolloRuntimeDep()
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -1,6 +1,5 @@
 package com.apollographql.android.gradle.unit
 
-import com.apollographql.android.VersionKt
 import com.apollographql.android.gradle.*
 import com.moowork.gradle.node.NodePlugin
 import org.gradle.testfixtures.ProjectBuilder

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -108,7 +108,7 @@ class ApolloAndroidPluginSpec extends Specification {
     assert (project.extensions.findByType(ApolloExtension.class)) != null
   }
 
-  def "adds apollo-runtime dependency"() {
+  def "adds apollo-runtime dependency if not skipped and not found in compile dep list"() {
     given:
     def project = ProjectBuilder.builder().build()
     ApolloPluginTestHelper.setupDefaultAndroidProject(project)
@@ -118,9 +118,27 @@ class ApolloAndroidPluginSpec extends Specification {
     project.evaluate()
 
     then:
-    def apolloApi = project.configurations.getByName("compile").dependencies.find {
+    def apolloRuntime = project.configurations.getByName("compile").dependencies.find {
       it.group == "com.apollographql.android" && it.name == "runtime"
     }
-    assert apolloApi != null
+    assert apolloRuntime != null
+  }
+
+  def "doesn't add apollo-runtime dependency if skip property is set" () {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
+
+    project.beforeEvaluate {
+      System.setProperty("apollographql.skipRuntimeDep", "true")
+    }
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    def compileDepSet = project.configurations.getByName("compile").dependencies
+    assert compileDepSet.isEmpty()
   }
 }

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
-skipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'
@@ -40,10 +39,4 @@ dependencies {
 
 apollo {
   customTypeMapping['Date'] = "java.util.Date"
-}
-
-// This prevents the plugin from adding the snapshot version of
-// apollo-runtime dependencies to the dependencies set
-def skipApolloRuntimeDep() {
-  System.setProperty("apollographql.skipRuntimeDep", "true")
 }

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
+skipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'
@@ -24,7 +25,6 @@ android {
     ignore 'InvalidPackage', 'GoogleAppIndexingWarning', 'AllowBackup'
   }
 }
-
 dependencies {
   compile project(':apollo-api')
   compile project(':apollo-runtime')

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -32,8 +32,6 @@ android {
 }
 
 dependencies {
-  compile dep.jsr305
-  compile dep.supportAnnotations
   compile dep.okHttp
   compile dep.moshi
 
@@ -43,7 +41,6 @@ dependencies {
   testCompile dep.truth
   testCompile dep.mockWebServer
   testCompile dep.okhttpTestSupport
-  testCompile dep.mockito
 
   androidTestCompile dep.truth
   androidTestCompile (dep.testRunner) {

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+clearSkipApolloRuntimeDep()
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion

--- a/apollo-rxsupport/build.gradle
+++ b/apollo-rxsupport/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
+clearSkipApolloRuntimeDep()
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion

--- a/apollo-rxsupport/build.gradle
+++ b/apollo-rxsupport/build.gradle
@@ -40,7 +40,6 @@ dependencies {
   testCompile dep.truth
   testCompile dep.mockWebServer
   testCompile dep.okhttpTestSupport
-  testCompile dep.mockito
 
   androidTestCompile dep.truth
   androidTestCompile(dep.testRunner) {

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -4,6 +4,7 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
+clearSkipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -28,7 +28,6 @@ android {
 dependencies {
   compile dep.appcompat
   compile dep.okhttpLoggingInterceptor
-  compile dep.apolloRuntime
 
   testCompile dep.junit
 }

--- a/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
+++ b/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
@@ -47,8 +47,8 @@ public class MainActivity extends AppCompatActivity {
 
       }
 
-      @Override public void onFailure(@Nonnull Exception e) {
-        Log.e(TAG, e.getMessage(), e);
+      @Override public void onFailure(@Nonnull Throwable t) {
+        Log.e(TAG, t.getMessage(), t);
       }
     });
   }

--- a/build.gradle
+++ b/build.gradle
@@ -44,12 +44,16 @@ subprojects {
       }
     }
   }
-  // This prevents the plugin from adding the snapshot version of
-  // apollo-runtime dependencies to the dependencies set
-  // Once set, this property should to be cleared for other modules
-  if (project.name.equals('apollo-integration')) {
-    System.setProperty("apollographql.skipRuntimeDep", "true")
-  } else {
+}
+
+// This prevents the plugin from adding the snapshot version of
+// apollo-runtime dependencies to the dependencies set
+def skipApolloRuntimeDep() {
+  System.setProperty("apollographql.skipRuntimeDep", "true")
+}
+// Clears the skipRuntimeDep property for other modules
+def clearSkipApolloRuntimeDep() {
+  if (System.getProperty("apollographql.skipRuntimeDep") != null) {
     System.clearProperty("apollographql.skipRuntimeDep")
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,12 @@ subprojects {
       }
     }
   }
+  // This prevents the plugin from adding the snapshot version of
+  // apollo-runtime dependencies to the dependencies set
+  // Once set, this property should to be cleared for other modules
+  if (project.name.equals('apollo-integration')) {
+    System.setProperty("apollographql.skipRuntimeDep", "true")
+  } else {
+    System.clearProperty("apollographql.skipRuntimeDep")
+  }
 }

--- a/gradle/testFixturesDeps.gradle
+++ b/gradle/testFixturesDeps.gradle
@@ -5,7 +5,6 @@ ext.supportDeps = [
 ]
 
 ext.apolloRuntimeCompileDeps = [
-    dep.jsr305,
     dep.supportAnnotations,
     dep.okHttp,
     dep.moshi


### PR DESCRIPTION
Removes some unused variables in GraphQLCompiler, unused dependencies in `apollo-runtime`.

Added a test case for the plugin adding `apollo-runtime` dependency flow

Clear the `skipRuntimeDep` system property for other modules (If apollo-integration sets that, it would persist within the other modules that run after apollo-integration (such as apollo-sample))

Fixed method signature change in sample and removed unneeded runtime dependency (since the plugin adds that now).