### PR TITLE
Plugin config option to generate accessor methods 

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -23,8 +23,8 @@ class GraphQLCompiler {
         fragmentsPackage = fragmentsPackage,
         typesPackage = typesPackage,
         customTypeMap = supportedScalarTypeMapping,
-        nullableValueGenerationType = args.nullableValueGenerationType()
-    )
+        nullableValueGenerationType = args.nullableValueGenerationType(),
+        generateAccessors = args.generateAccessors)
     ir.writeTypeUsed(context, args.outputDir)
     ir.writeFragments(context, args.outputDir)
     ir.writeOperations(context, irPackageName, args.outputDir)
@@ -84,7 +84,8 @@ class GraphQLCompiler {
       val outputDir: File,
       val customTypeMap: Map<String, String>,
       val useOptional: Boolean,
-      val useGuava: Boolean) {
+      val useGuava: Boolean,
+      val generateAccessors: Boolean) {
     fun nullableValueGenerationType(): NullableValueGenerationType {
       return if (useOptional) {
         if (useGuava) NullableValueGenerationType.GUAVA_OPTIONAL else NullableValueGenerationType.APOLLO_OPTIONAL

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeSpecBuilder.kt
@@ -35,19 +35,22 @@ class SchemaTypeSpecBuilder(
   }
 
   private fun TypeSpec.Builder.addFields(fields: List<Field>): TypeSpec.Builder {
-    val fieldSpecs = fields.map {
-      it.fieldSpec(context)
+    addFields(fields
+        .map { it.fieldSpec(context, !context.generateAccessors) }
+        .map { it.overrideType(innerTypeNameOverrideMap) })
+    if (context.generateAccessors) {
+      addMethods(fields
+          .map { it.accessorMethodSpec(context) }
+          .map { it.overrideReturnType(innerTypeNameOverrideMap) })
     }
-    val methodSpecs = fields.map {
-      it.accessorMethodSpec(context)
-    }
-    return addFields(fieldSpecs.map { it.overrideType(innerTypeNameOverrideMap) })
-        .addMethods(methodSpecs.map { it.overrideReturnType(innerTypeNameOverrideMap) })
+    return this
   }
 
   private fun TypeSpec.Builder.addInnerFragmentTypes(fragments: List<String>): TypeSpec.Builder {
     if (fragments.isNotEmpty()) {
-      addMethod(fragmentsAccessorMethodSpec())
+      if (context.generateAccessors) {
+        addMethod(fragmentsAccessorMethodSpec())
+      }
       addFields(listOf(fragmentsFieldSpec()))
       addType(fragmentsTypeSpec(fragments, context.fragmentsPackage))
     }
@@ -63,15 +66,19 @@ class SchemaTypeSpecBuilder(
   }
 
   private fun TypeSpec.Builder.addInlineFragments(fragments: List<InlineFragment>): TypeSpec.Builder {
-    val reservedTypeNames = context.reservedTypeNames + typeName + fields.filter(Field::isNonScalar).map(
-        Field::normalizedName)
+    val reservedTypeNames = context.reservedTypeNames + typeName +
+        fields.filter(Field::isNonScalar).map(Field::normalizedName)
     val uniqueTypeNameMap = buildUniqueTypeNameMap(reservedTypeNames)
-    val typeSpecs = fragments.map { it.toTypeSpec(context.copy(reservedTypeNames = reservedTypeNames)) }
-    val methodSpecs = fragments.map { it.accessorMethodSpec(context).overrideReturnType(uniqueTypeNameMap) }
-    val fieldSpecs = fragments.map { it.fieldSpec(context).overrideType(uniqueTypeNameMap) }
-    return addTypes(typeSpecs)
-        .addMethods(methodSpecs)
-        .addFields(fieldSpecs)
+
+    addTypes(fragments.map { it.toTypeSpec(context.copy(reservedTypeNames = reservedTypeNames)) })
+    addFields(fragments.map { it.fieldSpec(context, !context.generateAccessors).overrideType(uniqueTypeNameMap) })
+
+    if (context.generateAccessors) {
+      addMethods(fragments
+          .map { it.accessorMethodSpec(context).overrideReturnType(uniqueTypeNameMap) })
+    }
+
+    return this
   }
 
   private fun fragmentsAccessorMethodSpec(): MethodSpec {
@@ -84,8 +91,9 @@ class SchemaTypeSpecBuilder(
   }
 
   private fun fragmentsFieldSpec(): FieldSpec = FieldSpec
-      .builder(ClassName.get("", FRAGMENTS_TYPE_NAME.capitalize()), FRAGMENTS_TYPE_NAME.decapitalize())
-      .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+      .builder(ClassName.get("", FRAGMENTS_TYPE_NAME.capitalize()).annotated(Annotations.NONNULL),
+          FRAGMENTS_TYPE_NAME.decapitalize())
+      .addModifiers(if (context.generateAccessors) Modifier.PRIVATE else Modifier.PUBLIC, Modifier.FINAL)
       .build()
 
   /** Returns a generic `Fragments` interface with methods for each of the provided fragments */
@@ -95,19 +103,22 @@ class SchemaTypeSpecBuilder(
       return addFields(fragments.map {
         FieldSpec.builder(JavaTypeResolver(context, context.fragmentsPackage).resolve(it.capitalize()),
             it.decapitalize())
-            .addModifiers(Modifier.PRIVATE)
+            .addModifiers(if (context.generateAccessors) Modifier.PRIVATE else Modifier.PUBLIC, Modifier.FINAL)
             .build()
       })
     }
 
     fun TypeSpec.Builder.addFragmentAccessorMethods(): TypeSpec.Builder {
-      return addMethods(fragments.map {
-        MethodSpec.methodBuilder(it.decapitalize())
-            .returns(JavaTypeResolver(context, context.fragmentsPackage).resolve(it.capitalize()))
-            .addModifiers(Modifier.PUBLIC)
-            .addStatement("return this.\$L", it.decapitalize())
-            .build()
-      })
+      if (context.generateAccessors) {
+        addMethods(fragments.map {
+          MethodSpec.methodBuilder(it.decapitalize())
+              .returns(JavaTypeResolver(context, context.fragmentsPackage).resolve(it.capitalize()))
+              .addModifiers(Modifier.PUBLIC)
+              .addStatement("return this.\$L", it.decapitalize())
+              .build()
+        })
+      }
+      return this
     }
 
     val mapper = FragmentsResponseMapperBuilder(fragments, context).build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/CodeGenerationContext.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/CodeGenerationContext.kt
@@ -8,5 +8,6 @@ data class CodeGenerationContext(
     val fragmentsPackage: String = "",
     val typesPackage: String = "",
     val customTypeMap: Map<String, String>,
-    val nullableValueGenerationType: NullableValueGenerationType
+    val nullableValueGenerationType: NullableValueGenerationType,
+    val generateAccessors: Boolean
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Field.kt
@@ -30,9 +30,9 @@ data class Field(
         .build()
   }
 
-  fun fieldSpec(context: CodeGenerationContext): FieldSpec =
+  fun fieldSpec(context: CodeGenerationContext, publicModifier: Boolean = false): FieldSpec =
       FieldSpec.builder(toTypeName(methodResponseType(), context), responseName)
-          .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+          .addModifiers(if (publicModifier) Modifier.PUBLIC else Modifier.PRIVATE, Modifier.FINAL)
           .build()
 
   fun argumentCodeBlock(): CodeBlock {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/InlineFragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/InlineFragment.kt
@@ -24,9 +24,9 @@ data class InlineFragment(
         .build()
   }
 
-  fun fieldSpec(context: CodeGenerationContext): FieldSpec =
+  fun fieldSpec(context: CodeGenerationContext, publicModifier:Boolean = false): FieldSpec =
       FieldSpec.builder(typeName(context), interfaceName().decapitalize())
-          .addModifiers(Modifier.PRIVATE)
+          .addModifiers(if (publicModifier) Modifier.PUBLIC else Modifier.PRIVATE, Modifier.FINAL)
           .build()
 
   private fun interfaceName() = "$INTERFACE_PREFIX${typeCondition.capitalize()}"

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -179,9 +179,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
         }
 
         public static class Node {
-          private final Fragments fragments;
+          private final @Nonnull Fragments fragments;
 
-          public Node(Fragments fragments) {
+          public Node(@Nonnull Fragments fragments) {
             this.fragments = fragments;
           }
 
@@ -217,7 +217,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
           }
 
           public static class Fragments {
-            private Optional<StarshipFragment> starshipFragment;
+            private final Optional<StarshipFragment> starshipFragment;
 
             public Fragments(@Nullable StarshipFragment starshipFragment) {
               this.starshipFragment = Optional.fromNullable(starshipFragment);

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -173,9 +173,9 @@ public class StarshipFragment {
       }
 
       public static class Node {
-        private final Fragments fragments;
+        private final @Nonnull Fragments fragments;
 
-        public Node(Fragments fragments) {
+        public Node(@Nonnull Fragments fragments) {
           this.fragments = fragments;
         }
 
@@ -211,7 +211,7 @@ public class StarshipFragment {
         }
 
         public static class Fragments {
-          private Optional<PilotFragment> pilotFragment;
+          private final Optional<PilotFragment> pilotFragment;
 
           public Fragments(@Nullable PilotFragment pilotFragment) {
             this.pilotFragment = Optional.fromNullable(pilotFragment);

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -101,9 +101,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private final @Nonnull List<Episode> appearsIn;
 
-      private final Fragments fragments;
+      private final @Nonnull Fragments fragments;
 
-      public Hero(@Nonnull String name, @Nonnull List<Episode> appearsIn, Fragments fragments) {
+      public Hero(@Nonnull String name, @Nonnull List<Episode> appearsIn,
+          @Nonnull Fragments fragments) {
         this.name = name;
         this.appearsIn = appearsIn;
         this.fragments = fragments;
@@ -157,7 +158,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
 
       public static class Fragments {
-        private Optional<HeroDetails> heroDetails;
+        private final Optional<HeroDetails> heroDetails;
 
         public Fragments(@Nullable HeroDetails heroDetails) {
           this.heroDetails = Optional.fromNullable(heroDetails);

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -112,9 +112,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class R2 {
-      private final Fragments fragments;
+      private final @Nonnull Fragments fragments;
 
-      public R2(Fragments fragments) {
+      public R2(@Nonnull Fragments fragments) {
         this.fragments = fragments;
       }
 
@@ -150,9 +150,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
 
       public static class Fragments {
-        private Optional<HumanDetails> humanDetails;
+        private final Optional<HumanDetails> humanDetails;
 
-        private Optional<DroidDetails> droidDetails;
+        private final Optional<DroidDetails> droidDetails;
 
         public Fragments(@Nullable HumanDetails humanDetails, @Nullable DroidDetails droidDetails) {
           this.humanDetails = Optional.fromNullable(humanDetails);
@@ -241,9 +241,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Luke {
-      private final Fragments fragments;
+      private final @Nonnull Fragments fragments;
 
-      public Luke(Fragments fragments) {
+      public Luke(@Nonnull Fragments fragments) {
         this.fragments = fragments;
       }
 
@@ -279,9 +279,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
 
       public static class Fragments {
-        private Optional<HumanDetails> humanDetails;
+        private final Optional<HumanDetails> humanDetails;
 
-        private Optional<DroidDetails> droidDetails;
+        private final Optional<DroidDetails> droidDetails;
 
         public Fragments(@Nullable HumanDetails humanDetails, @Nullable DroidDetails droidDetails) {
           this.humanDetails = Optional.fromNullable(humanDetails);

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -111,9 +111,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public static class Hero {
       private final @Nonnull String name;
 
-      private Optional<AsHuman> asHuman;
+      private final Optional<AsHuman> asHuman;
 
-      private Optional<AsDroid> asDroid;
+      private final Optional<AsDroid> asDroid;
 
       public Hero(@Nonnull String name, @Nullable AsHuman asHuman, @Nullable AsDroid asDroid) {
         this.name = name;

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -161,9 +161,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public static class Hero {
       private final @Nonnull String name;
 
-      private Optional<AsHuman> asHuman;
+      private final Optional<AsHuman> asHuman;
 
-      private Optional<AsDroid> asDroid;
+      private final Optional<AsDroid> asDroid;
 
       public Hero(@Nonnull String name, @Nullable AsHuman asHuman, @Nullable AsDroid asDroid) {
         this.name = name;
@@ -270,7 +270,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         public static class Friend {
           private final @Nonnull String name;
 
-          private Optional<AsHuman1> asHuman;
+          private final Optional<AsHuman1> asHuman;
 
           public Friend(@Nonnull String name, @Nullable AsHuman1 asHuman) {
             this.name = name;
@@ -482,7 +482,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         public static class Friend {
           private final @Nonnull String name;
 
-          private Optional<AsHuman> asHuman;
+          private final Optional<AsHuman> asHuman;
 
           public Friend(@Nonnull String name, @Nullable AsHuman asHuman) {
             this.name = name;

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.graphql
@@ -1,0 +1,23 @@
+query TestQuery {
+  hero {
+    name
+    ...HeroDetails
+    appearsIn
+  }
+}
+
+fragment HeroDetails on Character {
+  name
+  friendsConnection {
+    totalCount
+    edges {
+      node {
+        name
+      }
+    }
+  }
+  ... on Droid {
+    name
+    primaryFunction
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -1,4 +1,4 @@
-package com.example.fragment_friends_connection;
+package com.example.no_accessors;
 
 import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
@@ -7,11 +7,13 @@ import com.apollographql.android.api.graphql.Query;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
 import com.apollographql.android.api.graphql.ResponseReader;
 import com.apollographql.android.api.graphql.internal.Optional;
-import com.example.fragment_friends_connection.fragment.HeroDetails;
+import com.example.no_accessors.fragment.HeroDetails;
+import com.example.no_accessors.type.Episode;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,7 +23,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
+      + "    name\n"
       + "    ...HeroDetails\n"
+      + "    appearsIn\n"
       + "  }\n"
       + "}";
 
@@ -55,14 +59,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   public static class Data implements Operation.Data {
-    private final Optional<Hero> hero;
+    public final Optional<Hero> hero;
 
     public Data(@Nullable Hero hero) {
       this.hero = Optional.fromNullable(hero);
-    }
-
-    public Optional<Hero> hero() {
-      return this.hero;
     }
 
     @Override
@@ -93,19 +93,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Hero {
-      private final @Nonnull Fragments fragments;
+      public final @Nonnull String name;
 
-      public Hero(@Nonnull Fragments fragments) {
+      public final @Nonnull List<Episode> appearsIn;
+
+      public final @Nonnull Fragments fragments;
+
+      public Hero(@Nonnull String name, @Nonnull List<Episode> appearsIn,
+          @Nonnull Fragments fragments) {
+        this.name = name;
+        this.appearsIn = appearsIn;
         this.fragments = fragments;
-      }
-
-      public @Nonnull Fragments fragments() {
-        return this.fragments;
       }
 
       @Override
       public String toString() {
         return "Hero{"
+          + "name=" + name + ", "
+          + "appearsIn=" + appearsIn + ", "
           + "fragments=" + fragments
           + "}";
       }
@@ -117,7 +122,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         if (o instanceof Hero) {
           Hero that = (Hero) o;
-          return ((this.fragments == null) ? (that.fragments == null) : this.fragments.equals(that.fragments));
+          return ((this.name == null) ? (that.name == null) : this.name.equals(that.name))
+           && ((this.appearsIn == null) ? (that.appearsIn == null) : this.appearsIn.equals(that.appearsIn))
+           && ((this.fragments == null) ? (that.fragments == null) : this.fragments.equals(that.fragments));
         }
         return false;
       }
@@ -126,19 +133,19 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       public int hashCode() {
         int h = 1;
         h *= 1000003;
+        h ^= (name == null) ? 0 : name.hashCode();
+        h *= 1000003;
+        h ^= (appearsIn == null) ? 0 : appearsIn.hashCode();
+        h *= 1000003;
         h ^= (fragments == null) ? 0 : fragments.hashCode();
         return h;
       }
 
       public static class Fragments {
-        private final Optional<HeroDetails> heroDetails;
+        public final Optional<HeroDetails> heroDetails;
 
         public Fragments(@Nullable HeroDetails heroDetails) {
           this.heroDetails = Optional.fromNullable(heroDetails);
-        }
-
-        public Optional<HeroDetails> heroDetails() {
-          return this.heroDetails;
         }
 
         @Override
@@ -187,6 +194,12 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
 
         final Field[] fields = {
+          Field.forString("name", "name", null, false),
+          Field.forList("appearsIn", "appearsIn", null, false, new Field.ListReader<Episode>() {
+            @Override public Episode read(final Field.ListItemReader reader) throws IOException {
+              return Episode.valueOf(reader.readString());
+            }
+          }),
           Field.forConditionalType("__typename", "__typename", new Field.ConditionalTypeReader<Fragments>() {
             @Override
             public Fragments read(String conditionalType, ResponseReader reader) throws
@@ -198,8 +211,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
         @Override
         public Hero map(ResponseReader reader) throws IOException {
-          final Fragments fragments = reader.read(fields[0]);
-          return new Hero(fragments);
+          final String name = reader.read(fields[0]);
+          final List<Episode> appearsIn = reader.read(fields[1]);
+          final Fragments fragments = reader.read(fields[2]);
+          return new Hero(name, appearsIn, fragments);
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.json
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.json
@@ -1,0 +1,174 @@
+{
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/no_accessors/TestQuery.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "appearsIn",
+							"fieldName": "appearsIn",
+							"type": "[Episode]!"
+						}
+					],
+					"fragmentSpreads": [
+						"HeroDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			]
+		}
+	],
+	"fragments": [
+		{
+			"filePath": "src/test/graphql/com/example/no_accessors/TestQuery.graphql",
+			"fragmentName": "HeroDetails",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
+			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
+			"fields": [
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!"
+				},
+				{
+					"responseName": "friendsConnection",
+					"fieldName": "friendsConnection",
+					"type": "FriendsConnection!",
+					"fields": [
+						{
+							"responseName": "totalCount",
+							"fieldName": "totalCount",
+							"type": "Int"
+						},
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[FriendsEdge]",
+							"fields": [
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Character",
+									"fields": [
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!"
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [
+				{
+					"typeCondition": "Droid",
+					"possibleTypes": [
+						"Droid"
+					],
+					"fields": [
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!"
+						},
+						{
+							"responseName": "friendsConnection",
+							"fieldName": "friendsConnection",
+							"type": "FriendsConnection!",
+							"fields": [
+								{
+									"responseName": "totalCount",
+									"fieldName": "totalCount",
+									"type": "Int"
+								},
+								{
+									"responseName": "edges",
+									"fieldName": "edges",
+									"type": "[FriendsEdge]",
+									"fields": [
+										{
+											"responseName": "node",
+											"fieldName": "node",
+											"type": "Character",
+											"fields": [
+												{
+													"responseName": "name",
+													"fieldName": "name",
+													"type": "String!"
+												}
+											],
+											"fragmentSpreads": [],
+											"inlineFragments": []
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						},
+						{
+							"responseName": "primaryFunction",
+							"fieldName": "primaryFunction",
+							"type": "String"
+						}
+					],
+					"fragmentSpreads": []
+				}
+			],
+			"fragmentsReferenced": []
+		}
+	],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977."
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980."
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983."
+				}
+			]
+		}
+	]
+}

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
@@ -1,4 +1,4 @@
-package com.example.fragment_with_inline_fragment.fragment;
+package com.example.no_accessors.fragment;
 
 import com.apollographql.android.api.graphql.Field;
 import com.apollographql.android.api.graphql.ResponseFieldMapper;
@@ -41,29 +41,17 @@ public class HeroDetails {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
 
-  private final @Nonnull String name;
+  public final @Nonnull String name;
 
-  private final @Nonnull FriendsConnection friendsConnection;
+  public final @Nonnull FriendsConnection friendsConnection;
 
-  private final Optional<AsDroid> asDroid;
+  public final Optional<AsDroid> asDroid;
 
   public HeroDetails(@Nonnull String name, @Nonnull FriendsConnection friendsConnection,
       @Nullable AsDroid asDroid) {
     this.name = name;
     this.friendsConnection = friendsConnection;
     this.asDroid = Optional.fromNullable(asDroid);
-  }
-
-  public @Nonnull String name() {
-    return this.name;
-  }
-
-  public @Nonnull FriendsConnection friendsConnection() {
-    return this.friendsConnection;
-  }
-
-  public Optional<AsDroid> asDroid() {
-    return this.asDroid;
   }
 
   @Override
@@ -102,21 +90,13 @@ public class HeroDetails {
   }
 
   public static class FriendsConnection {
-    private final Optional<Integer> totalCount;
+    public final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    public final Optional<List<Edge>> edges;
 
     public FriendsConnection(@Nullable Integer totalCount, @Nullable List<Edge> edges) {
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
-    }
-
-    public Optional<Integer> totalCount() {
-      return this.totalCount;
-    }
-
-    public Optional<List<Edge>> edges() {
-      return this.edges;
     }
 
     @Override
@@ -151,14 +131,10 @@ public class HeroDetails {
     }
 
     public static class Edge {
-      private final Optional<Node> node;
+      public final Optional<Node> node;
 
       public Edge(@Nullable Node node) {
         this.node = Optional.fromNullable(node);
-      }
-
-      public Optional<Node> node() {
-        return this.node;
       }
 
       @Override
@@ -189,14 +165,10 @@ public class HeroDetails {
       }
 
       public static class Node {
-        private final @Nonnull String name;
+        public final @Nonnull String name;
 
         public Node(@Nonnull String name) {
           this.name = name;
-        }
-
-        public @Nonnull String name() {
-          return this.name;
         }
 
         @Override
@@ -280,29 +252,17 @@ public class HeroDetails {
   }
 
   public static class AsDroid {
-    private final @Nonnull String name;
+    public final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection1 friendsConnection;
+    public final @Nonnull FriendsConnection1 friendsConnection;
 
-    private final Optional<String> primaryFunction;
+    public final Optional<String> primaryFunction;
 
     public AsDroid(@Nonnull String name, @Nonnull FriendsConnection1 friendsConnection,
         @Nullable String primaryFunction) {
       this.name = name;
       this.friendsConnection = friendsConnection;
       this.primaryFunction = Optional.fromNullable(primaryFunction);
-    }
-
-    public @Nonnull String name() {
-      return this.name;
-    }
-
-    public @Nonnull FriendsConnection1 friendsConnection() {
-      return this.friendsConnection;
-    }
-
-    public Optional<String> primaryFunction() {
-      return this.primaryFunction;
     }
 
     @Override
@@ -341,21 +301,13 @@ public class HeroDetails {
     }
 
     public static class FriendsConnection1 {
-      private final Optional<Integer> totalCount;
+      public final Optional<Integer> totalCount;
 
-      private final Optional<List<Edge>> edges;
+      public final Optional<List<Edge>> edges;
 
       public FriendsConnection1(@Nullable Integer totalCount, @Nullable List<Edge> edges) {
         this.totalCount = Optional.fromNullable(totalCount);
         this.edges = Optional.fromNullable(edges);
-      }
-
-      public Optional<Integer> totalCount() {
-        return this.totalCount;
-      }
-
-      public Optional<List<Edge>> edges() {
-        return this.edges;
       }
 
       @Override
@@ -390,14 +342,10 @@ public class HeroDetails {
       }
 
       public static class Edge {
-        private final Optional<Node> node;
+        public final Optional<Node> node;
 
         public Edge(@Nullable Node node) {
           this.node = Optional.fromNullable(node);
-        }
-
-        public Optional<Node> node() {
-          return this.node;
         }
 
         @Override
@@ -428,14 +376,10 @@ public class HeroDetails {
         }
 
         public static class Node {
-          private final @Nonnull String name;
+          public final @Nonnull String name;
 
           public Node(@Nonnull String name) {
             this.name = name;
-          }
-
-          public @Nonnull String name() {
-            return this.name;
           }
 
           @Override

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/type/Episode.java
@@ -1,0 +1,24 @@
+package com.example.no_accessors.type;
+
+import javax.annotation.Generated;
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+@Generated("Apollo GraphQL")
+public enum Episode {
+  /**
+   * Star Wars Episode IV: A New Hope, released in 1977.
+   */
+  NEWHOPE,
+
+  /**
+   * Star Wars Episode V: The Empire Strikes Back, released in 1980.
+   */
+  EMPIRE,
+
+  /**
+   * Star Wars Episode VI: Return of the Jedi, released in 1983.
+   */
+  JEDI
+}

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -93,9 +93,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Hero {
-      private final Fragments fragments;
+      private final @Nonnull Fragments fragments;
 
-      public Hero(Fragments fragments) {
+      public Hero(@Nonnull Fragments fragments) {
         this.fragments = fragments;
       }
 
@@ -131,7 +131,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
 
       public static class Fragments {
-        private Optional<HeroDetails> heroDetails;
+        private final Optional<HeroDetails> heroDetails;
 
         public Fragments(@Nullable HeroDetails heroDetails) {
           this.heroDetails = Optional.fromNullable(heroDetails);

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -101,9 +101,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public static class Hero {
       private final @Nonnull String name;
 
-      private Optional<AsHuman> asHuman;
+      private final Optional<AsHuman> asHuman;
 
-      private Optional<AsDroid> asDroid;
+      private final Optional<AsDroid> asDroid;
 
       public Hero(@Nonnull String name, @Nullable AsHuman asHuman, @Nullable AsDroid asDroid) {
         this.name = name;

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -116,7 +116,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
       private final Optional<List<Friend>> friends;
 
-      private Optional<AsHuman> asHuman;
+      private final Optional<AsHuman> asHuman;
 
       public HeroDetailQuery1(@Nonnull String name, @Nullable List<Friend> friends,
           @Nullable AsHuman asHuman) {
@@ -346,9 +346,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
           }
 
           public static class Friend2 {
-            private final Fragments fragments;
+            private final @Nonnull Fragments fragments;
 
-            public Friend2(Fragments fragments) {
+            public Friend2(@Nonnull Fragments fragments) {
               this.fragments = fragments;
             }
 
@@ -384,7 +384,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
             }
 
             public static class Fragments {
-              private Optional<HeroDetails> heroDetails;
+              private final Optional<HeroDetails> heroDetails;
 
               public Fragments(@Nullable HeroDetails heroDetails) {
                 this.heroDetails = Optional.fromNullable(heroDetails);

--- a/apollo-compiler/src/test/kotlin/com/apollographql/android/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/android/compiler/JavaTypeResolverTest.kt
@@ -14,7 +14,8 @@ class JavaTypeResolverTest {
       fragmentsPackage = "",
       typesPackage = "",
       customTypeMap = emptyMap(),
-      nullableValueGenerationType = NullableValueGenerationType.APOLLO_OPTIONAL)
+      nullableValueGenerationType = NullableValueGenerationType.APOLLO_OPTIONAL,
+      generateAccessors = true)
   private val defaultResolver = JavaTypeResolver(defaultContext, packageName)
 
   @Test

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -105,7 +105,7 @@ class ApolloPlugin implements Plugin<Project> {
                                boolean hasGuava) {
     ApolloIRGenTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
     ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name, project.apollo.customTypeMapping,
-        project.apollo.generateOptional, hasGuava)
+        project.apollo.generateOptional, hasGuava, project.apollo.generateAccessors)
     variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir)
     apolloIRGenTask.dependsOn(variantIRTask)
     apolloClassGenTask.dependsOn(variantClassTask)
@@ -116,7 +116,7 @@ class ApolloPlugin implements Plugin<Project> {
 
     ApolloIRGenTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
     ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name, project.apollo.customTypeMapping,
-        project.apollo.generateOptional, hasGuava)
+        project.apollo.generateOptional, hasGuava, project.apollo.generateAccessors)
     apolloIRGenTask.dependsOn(sourceSetIRTask)
     apolloClassGenTask.dependsOn(sourceSetClassTask)
 
@@ -151,7 +151,8 @@ class ApolloPlugin implements Plugin<Project> {
   }
 
   private ApolloClassGenTask createApolloClassGenTask(String name, Map<String, String> customTypeMapping,
-                                                      boolean generateOptional, boolean hasGuava) {
+                                                      boolean generateOptional, boolean hasGuava,
+                                                      boolean generateAccessors) {
     String taskName = String.format(ApolloClassGenTask.NAME, name.capitalize())
     ApolloClassGenTask task = project.tasks.create(taskName, ApolloClassGenTask) {
       group = TASK_GROUP
@@ -160,7 +161,7 @@ class ApolloPlugin implements Plugin<Project> {
       source = project.tasks.findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())).outputDir
       include "**${File.separatorChar}*API.json"
     }
-    task.init(name, customTypeMapping, generateOptional, hasGuava)
+    task.init(name, customTypeMapping, generateOptional, hasGuava, generateAccessors)
     return task
   }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
@@ -81,7 +81,7 @@ public class ApolloClassGenTask extends SourceTask {
     this.useOptional = useOptional;
   }
 
-  public boolean isGenerateAccessors() {
+  public boolean shouldGenerateAccessors() {
     return generateAccessors;
   }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
@@ -23,13 +23,16 @@ public class ApolloClassGenTask extends SourceTask {
   @Internal private Map<String, String> customTypeMapping;
   @Internal boolean useOptional;
   @Internal boolean hasGuavaDep;
+  @Internal boolean generateAccessors;
   @OutputDirectory private File outputDir;
 
-  public void init(String buildVariant, Map<String, String> typeMapping, boolean generateOptional, boolean hasGuava) {
+  public void init(String buildVariant, Map<String, String> typeMapping, boolean generateOptional, boolean hasGuava,
+      boolean accessors) {
     variant = buildVariant;
     customTypeMapping = typeMapping;
     useOptional = generateOptional;
     hasGuavaDep = hasGuava;
+    generateAccessors = accessors;
     outputDir = new File(getProject().getBuildDir() + "/" + Joiner.on(File.separator).join(GraphQLCompiler.Companion
         .getOUTPUT_DIRECTORY()));
   }
@@ -40,7 +43,7 @@ public class ApolloClassGenTask extends SourceTask {
       @Override
       public void execute(InputFileDetails inputFileDetails) {
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFileDetails.getFile(), outputDir,
-            customTypeMapping, useOptional, hasGuavaDep);
+            customTypeMapping, useOptional, hasGuavaDep, generateAccessors);
         new GraphQLCompiler().write(args);
       }
     });
@@ -76,5 +79,13 @@ public class ApolloClassGenTask extends SourceTask {
 
   public void setUseOptional(boolean useOptional) {
     this.useOptional = useOptional;
+  }
+
+  public boolean isGenerateAccessors() {
+    return generateAccessors;
+  }
+
+  public void setGenerateAccessors(boolean generateAccessors) {
+    this.generateAccessors = generateAccessors;
   }
 }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloExtension.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloExtension.java
@@ -9,6 +9,7 @@ public class ApolloExtension {
   static final String NAME = "apollo";
   private Map<String, String> customTypeMapping = new LinkedHashMap<>();
   private boolean generateOptional = false;
+  private boolean generateAccessors = true;
 
   public Map<String, String> getCustomTypeMapping() {
     return customTypeMapping;
@@ -24,6 +25,14 @@ public class ApolloExtension {
 
   public void setGenerateOptional(boolean generateOptional) {
     this.generateOptional = generateOptional;
+  }
+
+  public boolean isGenerateAccessors() {
+    return generateAccessors;
+  }
+
+  public void setGenerateAccessors(boolean generateAccessors) {
+    this.generateAccessors = generateAccessors;
   }
 
   public void setCustomTypeMapping(Closure closure) {

--- a/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/impl/RealResponseReader.java
@@ -9,6 +9,7 @@ import com.apollographql.android.api.graphql.ScalarType;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -174,7 +175,7 @@ import java.util.Map;
         result.add(item);
       }
       readerShadow.didParseList(values);
-      return result;
+      return Collections.unmodifiableList(result);
     }
   }
 
@@ -196,7 +197,7 @@ import java.util.Map;
         result.add(item);
       }
       readerShadow.didParseList(values);
-      return result;
+      return Collections.unmodifiableList(result);
     }
   }
 

--- a/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
+++ b/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
@@ -47,8 +47,8 @@ public class MainActivity extends AppCompatActivity {
 
       }
 
-      @Override public void onFailure(@Nonnull Exception e) {
-        Log.e(TAG, e.getMessage(), e);
+      @Override public void onFailure(@Nonnull Throwable t) {
+        Log.e(TAG, t.getMessage(), t);
       }
     });
   }


### PR DESCRIPTION
Closes #332 

Adds gradle configuration option to generate accessor methods.

By default it set to `true`.
https://github.com/apollographql/apollo-android/pull/352/files#diff-b04637123f448c4d6ce43973170b8ab0

Fixes couple issues with missing `Nonnull` annotations
https://github.com/apollographql/apollo-android/pull/352/files#diff-0a57476f4fa471ab6621dbf28e9ff5cd

Makes `List` in models be immutable
https://github.com/apollographql/apollo-android/pull/352/files#diff-537e62e5f38dfdafae746f4f0cd114a1

Examples:
https://github.com/apollographql/apollo-android/pull/352/files#diff-9d649787d30729102b2e44b96102b22b
https://github.com/apollographql/apollo-android/pull/352/files#diff-bc1759fd8b2ecbc12c0c279ca4b91843