### PR TITLE
Small fixes

### DIFF
--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -33,6 +33,7 @@ android {
 }
 
 dependencies {
+  compile dep.jsr305
   compile dep.okHttp
   compile dep.moshi
 

--- a/apollo-rxsupport/build.gradle
+++ b/apollo-rxsupport/build.gradle
@@ -33,6 +33,7 @@ android {
 }
 
 dependencies {
+  compile dep.jsr305
   compile dep.rxjava
   provided project(":apollo-runtime")
   provided project(":apollo-api")

--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -29,6 +29,12 @@ public final class RxApollo {
 
   @Nonnull
   public static <T> Observable<T> from(@Nonnull final ApolloWatcher<T> watcher) {
+    return from(watcher, Emitter.BackpressureMode.LATEST);
+  }
+
+  @Nonnull public static <T> Observable<T> from(@Nonnull final ApolloWatcher<T> watcher,
+      @Nonnull Emitter.BackpressureMode backpressureMode) {
+    checkNotNull(backpressureMode, "backpressureMode == null");
     checkNotNull(watcher, "watcher == null");
     return Observable.fromEmitter(new Action1<Emitter<T>>() {
       @Override public void call(final Emitter<T> emitter) {
@@ -48,7 +54,7 @@ public final class RxApollo {
           }
         });
       }
-    }, Emitter.BackpressureMode.LATEST);
+    }, backpressureMode);
   }
 
   @Nonnull public static <T> Single<T> from(@Nonnull final ApolloCall<T> call) {

--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -36,7 +36,7 @@ public final class RxApollo {
       @Nonnull Emitter.BackpressureMode backpressureMode) {
     checkNotNull(backpressureMode, "backpressureMode == null");
     checkNotNull(watcher, "watcher == null");
-    return Observable.fromEmitter(new Action1<Emitter<T>>() {
+    return Observable.create(new Action1<Emitter<T>>() {
       @Override public void call(final Emitter<T> emitter) {
         emitter.setCancellation(new Cancellable() {
           @Override public void cancel() throws Exception {

--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -3,6 +3,7 @@ package com.apollographql.android.rx;
 
 import com.apollographql.android.ApolloCall;
 import com.apollographql.android.ApolloWatcher;
+import com.apollographql.android.Cancelable;
 import com.apollographql.android.api.graphql.Response;
 
 import java.io.IOException;
@@ -12,10 +13,12 @@ import javax.annotation.Nonnull;
 import rx.Emitter;
 import rx.Observable;
 import rx.Single;
-import rx.SingleEmitter;
+import rx.SingleSubscriber;
 import rx.exceptions.Exceptions;
+import rx.functions.Action0;
 import rx.functions.Action1;
 import rx.functions.Cancellable;
+import rx.subscriptions.Subscriptions;
 
 import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
@@ -26,7 +29,7 @@ public final class RxApollo {
 
   @Nonnull
   public static <T> Observable<T> from(@Nonnull final ApolloWatcher<T> watcher) {
-    checkNotNull(watcher);
+    checkNotNull(watcher, "watcher == null");
     return Observable.fromEmitter(new Action1<Emitter<T>>() {
       @Override public void call(final Emitter<T> emitter) {
         emitter.setCancellation(new Cancellable() {
@@ -49,23 +52,30 @@ public final class RxApollo {
   }
 
   @Nonnull public static <T> Single<T> from(@Nonnull final ApolloCall<T> call) {
-    checkNotNull(call);
-    return Single.fromEmitter(new Action1<SingleEmitter<T>>() {
-      @Override public void call(SingleEmitter<T> emitter) {
-        emitter.setCancellation(new Cancellable() {
-          @Override public void cancel() throws Exception {
-            call.cancel();
-          }
-        });
-
+    checkNotNull(call, "call == null");
+    return Single.create(new Single.OnSubscribe<T>() {
+      @Override public void call(SingleSubscriber<? super T> subscriber) {
+        cancelOnSingleUnsubscribe(subscriber, call);
         try {
           Response<T> response = call.execute();
-          emitter.onSuccess(response.data());
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onSuccess(response.data());
+          }
         } catch (IOException e) {
           Exceptions.throwIfFatal(e);
-          emitter.onError(e);
+          if (!subscriber.isUnsubscribed()) {
+            subscriber.onError(e);
+          }
         }
       }
     });
+  }
+
+  private static <T> void cancelOnSingleUnsubscribe(SingleSubscriber<? super T> subscriber, final Cancelable toCancel) {
+    subscriber.add(Subscriptions.create(new Action0() {
+      @Override public void call() {
+        toCancel.cancel();
+      }
+    }));
   }
 }

--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -3,20 +3,19 @@ package com.apollographql.android.rx;
 
 import com.apollographql.android.ApolloCall;
 import com.apollographql.android.ApolloWatcher;
-import com.apollographql.android.Cancelable;
 import com.apollographql.android.api.graphql.Response;
 
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
+import rx.Emitter;
 import rx.Observable;
 import rx.Single;
-import rx.SingleSubscriber;
-import rx.Subscriber;
+import rx.SingleEmitter;
 import rx.exceptions.Exceptions;
-import rx.functions.Action0;
-import rx.subscriptions.Subscriptions;
+import rx.functions.Action1;
+import rx.functions.Cancellable;
 
 import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
@@ -26,65 +25,47 @@ public final class RxApollo {
   }
 
   @Nonnull
-  public static <T> Observable<T> from(@Nonnull
-  final ApolloWatcher<T> watcher) {
+  public static <T> Observable<T> from(@Nonnull final ApolloWatcher<T> watcher) {
     checkNotNull(watcher);
-    return Observable.create(new Observable.OnSubscribe<T>() {
-      @Override public void call(final Subscriber<? super T> subscriber) {
-        cancelOnUnsubscribe(subscriber, watcher);
+    return Observable.fromEmitter(new Action1<Emitter<T>>() {
+      @Override public void call(final Emitter<T> emitter) {
+        emitter.setCancellation(new Cancellable() {
+          @Override public void cancel() throws Exception {
+            watcher.cancel();
+          }
+        });
         watcher.enqueueAndWatch(new ApolloCall.Callback<T>() {
           @Override public void onResponse(@Nonnull Response<T> response) {
-            if (!subscriber.isUnsubscribed()) {
-              subscriber.onNext(response.data());
-            }
+            emitter.onNext(response.data());
           }
 
           @Override public void onFailure(@Nonnull Throwable e) {
             Exceptions.throwIfFatal(e);
-            if (!subscriber.isUnsubscribed()) {
-              subscriber.onError(e);
-            }
+            emitter.onError(e);
+          }
+        });
+      }
+    }, Emitter.BackpressureMode.LATEST);
+  }
+
+  @Nonnull public static <T> Single<T> from(@Nonnull final ApolloCall<T> call) {
+    checkNotNull(call);
+    return Single.fromEmitter(new Action1<SingleEmitter<T>>() {
+      @Override public void call(SingleEmitter<T> emitter) {
+        emitter.setCancellation(new Cancellable() {
+          @Override public void cancel() throws Exception {
+            call.cancel();
           }
         });
 
-      }
-    });
-  }
-
-  @Nonnull public static <T> Single<T> from(@Nonnull
-  final ApolloCall<T> call) {
-    checkNotNull(call);
-    return Single.create(new Single.OnSubscribe<T>() {
-      @Override public void call(SingleSubscriber<? super T> subscriber) {
-        cancelOnSingleUnsubscribe(subscriber, call);
         try {
           Response<T> response = call.execute();
-          if (!subscriber.isUnsubscribed()) {
-            subscriber.onSuccess(response.data());
-          }
+          emitter.onSuccess(response.data());
         } catch (IOException e) {
           Exceptions.throwIfFatal(e);
-          if (!subscriber.isUnsubscribed()) {
-            subscriber.onError(e);
-          }
+          emitter.onError(e);
         }
       }
     });
-  }
-
-  private static <T> void cancelOnUnsubscribe(Subscriber<? super T> subscriber, final Cancelable toCancel) {
-    subscriber.add(Subscriptions.create(new Action0() {
-      @Override public void call() {
-        toCancel.cancel();
-      }
-    }));
-  }
-
-  private static <T> void cancelOnSingleUnsubscribe(SingleSubscriber<? super T> subscriber, final Cancelable toCancel) {
-    subscriber.add(Subscriptions.create(new Action0() {
-      @Override public void call() {
-        toCancel.cancel();
-      }
-    }));
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,7 +24,7 @@ ext.dep = [
     compiletesting          : 'com.google.testing.compile:compile-testing:0.10',
     javaPoet                : 'com.squareup:javapoet:1.8.0',
     moshi                   : 'com.squareup.moshi:moshi:1.4.0',
-    rxjava                  : 'io.reactivex:rxjava:1.2.3',
+    rxjava                  : 'io.reactivex:rxjava:1.2.9',
     rxjava2                 : 'io.reactivex.rxjava2:rxjava:2.0.5',
     rxandroid               : 'io.reactivex.rxjava2:rxandroid:2.0.1',
     jsr305                  : 'com.google.code.findbugs:jsr305:3.0.1',


### PR DESCRIPTION
- Add Jsr305 dep back to runtime
- Fix semantics of converting async calls to Rx

Couple sources for RxJav suggest avoid of using Single/Observer.create