### PR TITLE
Use Observable.fromEmitter instead of Observable.create

### DIFF
--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -10,12 +10,15 @@ import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
+import rx.Emitter;
+import rx.Emitter.BackpressureMode;
 import rx.Observable;
 import rx.Single;
 import rx.SingleSubscriber;
-import rx.Subscriber;
 import rx.exceptions.Exceptions;
 import rx.functions.Action0;
+import rx.functions.Action1;
+import rx.functions.Cancellable;
 import rx.subscriptions.Subscriptions;
 
 import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
@@ -29,26 +32,22 @@ public final class RxApollo {
   public static <T> Observable<T> from(@Nonnull
   final ApolloWatcher<T> watcher) {
     checkNotNull(watcher);
-    return Observable.create(new Observable.OnSubscribe<T>() {
-      @Override public void call(final Subscriber<? super T> subscriber) {
-        cancelOnUnsubscribe(subscriber, watcher);
+    return Observable.fromEmitter(new Action1<Emitter<T>>() {
+      @Override
+      public void call(final Emitter<T> emitter) {
+        cancelOnUnsubscribe(emitter, watcher);
         watcher.enqueueAndWatch(new ApolloCall.Callback<T>() {
           @Override public void onResponse(@Nonnull Response<T> response) {
-            if (!subscriber.isUnsubscribed()) {
-              subscriber.onNext(response.data());
-            }
+            emitter.onNext(response.data());
           }
 
           @Override public void onFailure(@Nonnull Throwable e) {
             Exceptions.throwIfFatal(e);
-            if (!subscriber.isUnsubscribed()) {
-              subscriber.onError(e);
-            }
+            emitter.onError(e);
           }
         });
-
       }
-    });
+    }, BackpressureMode.BUFFER);
   }
 
   @Nonnull public static <T> Single<T> from(@Nonnull
@@ -72,12 +71,13 @@ public final class RxApollo {
     });
   }
 
-  private static <T> void cancelOnUnsubscribe(Subscriber<? super T> subscriber, final Cancelable toCancel) {
-    subscriber.add(Subscriptions.create(new Action0() {
-      @Override public void call() {
+  private static <T> void cancelOnUnsubscribe(Emitter<T> emitter, final Cancelable toCancel) {
+    emitter.setCancellation(new Cancellable() {
+      @Override
+      public void cancel() throws Exception {
         toCancel.cancel();
       }
-    }));
+    });
   }
 
   private static <T> void cancelOnSingleUnsubscribe(SingleSubscriber<? super T> subscriber, final Cancelable toCancel) {


### PR DESCRIPTION
The `Observable.create(OnSubscribe)` method that is being used to create an `Observable` does not handle backpressure properly. As a matter of fact, since RxJava 1.2.7, the `Observable.create` method that is being used by `RxApollo` is deprecated and is now called `unsafeCreate` for this very reason. See [here](https://github.com/ReactiveX/RxJava/releases/tag/v1.2.7) 

To fix this without updating to the latest version of RxJava 1.x, it is recommended to use `fromEmitter`. This safely wraps async callbacks to return an `Observable` while handling backpressure for us. 