### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ notifications:
 
 sudo: false
 
+before_cache:
+    - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+
 cache:
   directories:
     - ${TRAVIS_BUILD_DIR}/gradle/caches/

--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,14 @@ def clearSkipApolloRuntimeDep() {
     System.clearProperty("apollographql.skipRuntimeDep")
   }
 }
+
+if (System.env.TRAVIS == 'true') {
+  // attempt to reduce memory overhead of the tests running on travis
+  tasks.withType(GroovyCompile) {
+    groovyOptions.fork = false
+  }
+  tasks.withType(Test) {
+    jvmArgs '-Xmx512m'
+    maxParallelForks = 2
+  }
+}


### PR DESCRIPTION
First commit, clears the cached artifacts after the build.


Second commit attempts to fix the builds that succeed but are killed by travis due to memory usage (I'm assuming it's because of the `GradleRunner` tests). It reduces the number of JVMs that Gradle forks and increases the max heap size for the tests. 
(I'll revert the second commit if that doesn't lead to a fix)
