### PR TITLE
Regenerate if apollo extension changes

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloClassGenTask.java
@@ -3,9 +3,9 @@ package com.apollographql.android.gradle;
 import com.google.common.base.Joiner;
 
 import com.apollographql.android.compiler.GraphQLCompiler;
-import com.apollographql.android.compiler.NullableValueGenerationType;
 
 import org.gradle.api.Action;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
@@ -20,10 +20,10 @@ public class ApolloClassGenTask extends SourceTask {
   static final String NAME = "generate%sApolloClasses";
 
   @Internal private String variant;
-  @Internal private Map<String, String> customTypeMapping;
-  @Internal boolean useOptional;
-  @Internal boolean hasGuavaDep;
-  @Internal boolean generateAccessors;
+  @Input private Map<String, String> customTypeMapping;
+  @Input private boolean useOptional;
+  @Input private boolean hasGuavaDep;
+  @Input private boolean generateAccessors;
   @OutputDirectory private File outputDir;
 
   public void init(String buildVariant, Map<String, String> typeMapping, boolean generateOptional, boolean hasGuava,

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/ApolloPluginTestHelper.groovy
@@ -114,4 +114,8 @@ class ApolloPluginTestHelper {
     def localProperties = new File(destDir, "local.properties")
     localProperties.write("sdk.dir=${androidHome()}")
   }
+
+  static def replaceTextInFile(source, Closure replaceText){
+    source.write(replaceText(source.text))
+  }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -1,11 +1,13 @@
 package com.apollographql.android.gradle.integration
 
-import com.apollographql.android.gradle.ApolloPluginTestHelper
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static com.apollographql.android.gradle.ApolloPluginTestHelper.*
+import static org.apache.commons.io.FileUtils.copyFile
 
 /**
  * The ordering of the tests in this file matters, cleanup only happens after all feature
@@ -38,8 +40,17 @@ class BasicAndroidSpec extends Specification {
     // Java classes generated successfully
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/Films.java").isFile()
-    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/fragment/SpeciesInformation.java").isFile()
+
+    // verify that the custom type generated was Object.class because no customType mapping was specified
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").getText('UTF-8').contains(
+        "return Object.class;")
+
+    // Optional is not added to the generated classes
+    assert !new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").getText(
+        'UTF-8').contains(
+        "import com.apollographql.android.api.graphql.internal.Optional;")
   }
 
   def "installApolloCodegenTask is up to date if no changes occur to node_modules and package.json"() {
@@ -83,8 +94,77 @@ class BasicAndroidSpec extends Specification {
     result.task(":installApolloCodegen").outcome == TaskOutcome.SUCCESS
   }
 
-  def "instrumentation tests run successfully"() {
-    // TODO: run `connectedCheck` task on an emulator and have android instrumentation tests under testProject
+  // ApolloExtension tests
+  def "generateApolloClasses is up to date if inputs and apollo extension don't change"() {
+    setup: "a testProject with a previous build"
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err)).build()
+
+    then:
+    result.task(":generateApolloClasses").outcome == TaskOutcome.UP_TO_DATE
+  }
+
+  def "adding a custom type to the build script re-generates the CustomType class"() {
+    setup: "a testProject with a previous build and an apollo extension appended"
+    new File("$testProjectDir/build.gradle") << "apollo { customTypeMapping { DateTime = \"java.util.Date\" } }"
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err)).build()
+
+    then:
+    // modifying the customTypeMapping should cause the task to be out of date
+    // and the task should run again
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").getText('UTF-8').contains(
+        "return Date.class;")
+  }
+
+  def "changing the value of a customTypeMapping key regenerates the CustomType class with the new key"() {
+    setup: "a testProject with a previous build and a modified apollo extension"
+    replaceTextInFile(new File("$testProjectDir/build.gradle")) {
+      it.replace("java.util.Date", "java.util.Currency")
+    }
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err)).build()
+
+    then:
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/type/CustomType.java").getText('UTF-8').contains(
+        "return Currency.class;")
+  }
+
+  def "adding generateOptional in Apollo Extension generates classes with apollographql Optional"() {
+    setup: "a testProject with a previous build and a modified build script"
+    replaceTextInFile(new File("$testProjectDir/build.gradle")) {
+      it.replace("apollo { ", "apollo { generateOptional = true \n")
+    }
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err)).build()
+
+    then:
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+    assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").getText(
+        'UTF-8').contains("import com.apollographql.android.api.graphql.internal.Optional;")
   }
 
   def cleanupSpec() {
@@ -92,11 +172,10 @@ class BasicAndroidSpec extends Specification {
   }
 
   private static File setupBasicAndroidProject() {
-    def destDir = ApolloPluginTestHelper.createTempTestDirectory("basic")
-    ApolloPluginTestHelper.prepareProjectTestDir(destDir, ApolloPluginTestHelper.ProjectType.Android, "basic",
-        "basic")
+    def destDir = createTempTestDirectory("basic")
+    prepareProjectTestDir(destDir, ProjectType.Android, "basic", "basic")
     String schemaFilesFixtures = "src/test/testProject/android/schemaFilesFixtures"
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/oldswapi.json"), new File("$destDir/src/main/graphql/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/oldswapi.json"), new File("$destDir/src/main/graphql/schema.json"))
     return destDir
   }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -128,7 +128,7 @@ class BasicAndroidSpec extends Specification {
         "return Date.class;")
   }
 
-  def "changing the value of a customTypeMapping key regenerates the CustomType class with the new key"() {
+  def "changing the class for a customTypeMapping key regenerates with the new class"() {
     setup: "a testProject with a previous build and a modified apollo extension"
     replaceTextInFile(new File("$testProjectDir/build.gradle")) {
       it.replace("java.util.Date", "java.util.Currency")

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/FlavoredMultiSchemaSpec.groovy
@@ -1,11 +1,13 @@
 package com.apollographql.android.gradle.integration
 
-import com.apollographql.android.gradle.ApolloPluginTestHelper
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
 import spock.lang.Specification
+
+import static com.apollographql.android.gradle.ApolloPluginTestHelper.*
+import static org.apache.commons.io.FileUtils.copyFile
 
 
 class FlavoredMultiSchemaSpec extends Specification {
@@ -128,16 +130,14 @@ class FlavoredMultiSchemaSpec extends Specification {
   }
 
   private static File setupFlavoredAndroidProject() {
-    def destDir = ApolloPluginTestHelper.createTempTestDirectory("flavoredWithMultipleSchemas")
-    ApolloPluginTestHelper.prepareProjectTestDir(destDir, ApolloPluginTestHelper.ProjectType.Android,
-        "flavoredWithMultipleSchemas",
-        "flavored")
+    def destDir = createTempTestDirectory("flavoredWithMultipleSchemas")
+    prepareProjectTestDir(destDir, ProjectType.Android, "flavoredWithMultipleSchemas", "flavored")
     String schemaFilesFixtures = "src/test/testProject/android/schemaFilesFixtures"
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/invalidSchema.json"), new File("$destDir/src/main/graphql/com/githunt/api/schema.json"))
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/frontpage.json"), new File("$destDir/src/main/graphql/com/frontpage/api/schema.json"))
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/githunt.json"), new File("$destDir/src/demoDebug/graphql/com/githunt/api/schema.json"))
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/starwars.json"), new File("$destDir/src/demoDebug/graphql/com/starwars/api/schema.json"))
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/starwars.json"), new File("$destDir/src/release/graphql/com/starwars/api/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/invalidSchema.json"), new File("$destDir/src/main/graphql/com/githunt/api/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/frontpage.json"), new File("$destDir/src/main/graphql/com/frontpage/api/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/githunt.json"), new File("$destDir/src/demoDebug/graphql/com/githunt/api/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/starwars.json"), new File("$destDir/src/demoDebug/graphql/com/starwars/api/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/starwars.json"), new File("$destDir/src/release/graphql/com/starwars/api/schema.json"))
     return destDir
   }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/LibraryProjectAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/LibraryProjectAndroidSpec.groovy
@@ -7,6 +7,10 @@ import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Shared
 import spock.lang.Specification
 
+import static com.apollographql.android.gradle.ApolloPluginTestHelper.createTempTestDirectory
+import static com.apollographql.android.gradle.ApolloPluginTestHelper.prepareProjectTestDir
+import static org.apache.commons.io.FileUtils.copyFile
+
 class LibraryProjectAndroidSpec extends Specification {
   @Shared File testProjectDir
 
@@ -32,11 +36,10 @@ class LibraryProjectAndroidSpec extends Specification {
   }
 
   private static File setupAndroidLibraryProject() {
-    def destDir = ApolloPluginTestHelper.createTempTestDirectory("libraryProject")
-    ApolloPluginTestHelper.prepareProjectTestDir(destDir, ApolloPluginTestHelper.ProjectType.Android, "basic",
-        "libraryProject")
+    def destDir = createTempTestDirectory("libraryProject")
+    prepareProjectTestDir(destDir, ApolloPluginTestHelper.ProjectType.Android, "basic", "libraryProject")
     String schemaFilesFixtures = "src/test/testProject/android/schemaFilesFixtures"
-    FileUtils.copyFile(new File(schemaFilesFixtures + "/oldswapi.json"), new File("$destDir/src/main/graphql/schema.json"))
+    copyFile(new File(schemaFilesFixtures + "/oldswapi.json"), new File("$destDir/src/main/graphql/schema.json"))
     return destDir
   }
 }

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -47,9 +47,3 @@ dependencies {
   compile supportDeps
   compile apolloApiCompileDeps
 }
-
-apollo {
-  customTypeMapping {
-    DateTime = "java.util.Date"
-  }
-}


### PR DESCRIPTION
Closes #175 


The generated classes were considered up-to-date even if the options in apollo extensions change. 

Annotating them with `@Input` fixes this issue.