### PR TITLE
Add NamedCountDownLatch with ability to throw exception on TimeOut

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nonnull;
 
@@ -35,6 +35,7 @@ public class ApolloWatcherTest {
   private ApolloClient apolloClient;
   private MockWebServer server;
   private CacheStore cacheStore;
+  private static final int TIME_OUT_SECONDS = 3;
 
   @Before public void setUp() {
     server = new MockWebServer();
@@ -57,9 +58,9 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherUpdated_SameQuery_DifferentResults() throws IOException, InterruptedException {
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+  public void testQueryWatcherUpdated_SameQuery_DifferentResults() throws IOException, InterruptedException, TimeoutException {
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
@@ -84,17 +85,18 @@ public class ApolloWatcherTest {
           }
         });
 
-    firstResponseLatch.await();
-    //Another newer call gets updated information
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+
+    // Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
-    secondResponseLatch.await();
+    secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
-  public void testQueryWatcherNotUpdated_SameQuery_SameResults() throws IOException, InterruptedException {
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+  public void testQueryWatcherNotUpdated_SameQuery_SameResults() throws IOException, InterruptedException, TimeoutException {
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
@@ -118,16 +120,19 @@ public class ApolloWatcherTest {
           }
         });
 
-    firstResponseLatch.await();
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
-    secondResponseLatch.await(3, TimeUnit.SECONDS); //Wait 3 seconds to make sure no double callback
+
+    // Wait 3 seconds to make sure no double callback.
+    // Successful if timeout _is_ reached
+    secondResponseLatch.await(3, TimeUnit.SECONDS);
   }
 
   @Test
-  public void testQueryWatcherUpdated_DifferentQuery_DifferentResults() throws IOException, InterruptedException {
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+  public void testQueryWatcherUpdated_DifferentQuery_DifferentResults() throws IOException, InterruptedException, TimeoutException {
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
@@ -152,18 +157,18 @@ public class ApolloWatcherTest {
           }
         });
 
-    firstResponseLatch.await();
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
     apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
-    secondResponseLatch.await();
+    secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
-  public void testQueryWatcherNotUpdated_DifferentQueries() throws IOException, InterruptedException {
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+  public void testQueryWatcherNotUpdated_DifferentQueries() throws IOException, InterruptedException, TimeoutException {
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
@@ -187,21 +192,24 @@ public class ApolloWatcherTest {
           }
         });
 
-    firstResponseLatch.await();
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
     apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
-    secondResponseLatch.await(3, TimeUnit.SECONDS); //Wait 3 seconds to make sure no double callback
+
+    // Wait 3 seconds to make sure no double callback.
+    // Successful if timeout _is_ reached
+    secondResponseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
-  public void rewatchCacheControl() throws IOException, InterruptedException {
+  public void rewatchCacheControl() throws IOException, InterruptedException, TimeoutException {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
     ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
     watcher.refetchCacheControl(CacheControl.NETWORK_ONLY) //Force network instead of CACHE_FIRST default
         .enqueueAndWatch(
@@ -223,19 +231,19 @@ public class ApolloWatcherTest {
               }
             });
 
-    firstResponseLatch.await();
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     //Another newer call gets updated information -- need to queue up two network responses
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
 
     //To verify that the updated response comes from server use a different name change
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
-    secondResponseLatch.await();
+    secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   @Test
-  public void testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() throws IOException, InterruptedException {
-    final CountDownLatch cacheWarmUpLatch = new CountDownLatch(1);
+  public void testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() throws IOException, InterruptedException, TimeoutException {
+    final NamedCountDownLatch cacheWarmUpLatch = new NamedCountDownLatch("cacheWarmUpLatch", 1);
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     apolloClient.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
@@ -248,12 +256,12 @@ public class ApolloWatcherTest {
         cacheWarmUpLatch.countDown();
       }
     });
-    cacheWarmUpLatch.await();
+    cacheWarmUpLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
 
     //Cache is now "warm" with response data
 
-    final CountDownLatch firstResponseLatch = new CountDownLatch(1);
-    final CountDownLatch secondResponseLatch = new CountDownLatch(2);
+    final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
+    final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
     ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query)
         .cacheControl(CacheControl.CACHE_ONLY)
@@ -277,12 +285,12 @@ public class ApolloWatcherTest {
           }
         });
 
-    firstResponseLatch.await();
+    firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     //Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
-    secondResponseLatch.await();
+    secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/ApolloWatcherTest.java
@@ -58,7 +58,8 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherUpdated_SameQuery_DifferentResults() throws IOException, InterruptedException, TimeoutException {
+  public void testQueryWatcherUpdated_SameQuery_DifferentResults() throws IOException, InterruptedException,
+      TimeoutException {
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
@@ -94,7 +95,8 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherNotUpdated_SameQuery_SameResults() throws IOException, InterruptedException, TimeoutException {
+  public void testQueryWatcherNotUpdated_SameQuery_SameResults() throws IOException, InterruptedException,
+      TimeoutException {
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
@@ -130,7 +132,8 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherUpdated_DifferentQuery_DifferentResults() throws IOException, InterruptedException, TimeoutException {
+  public void testQueryWatcherUpdated_DifferentQuery_DifferentResults() throws IOException, InterruptedException,
+      TimeoutException {
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
@@ -166,7 +169,8 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherNotUpdated_DifferentQueries() throws IOException, InterruptedException, TimeoutException {
+  public void testQueryWatcherNotUpdated_DifferentQueries() throws IOException, InterruptedException,
+      TimeoutException {
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
@@ -242,7 +246,8 @@ public class ApolloWatcherTest {
   }
 
   @Test
-  public void testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() throws IOException, InterruptedException, TimeoutException {
+  public void testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() throws IOException, InterruptedException,
+      TimeoutException {
     final NamedCountDownLatch cacheWarmUpLatch = new NamedCountDownLatch("cacheWarmUpLatch", 1);
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/IntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
@@ -41,6 +41,8 @@ public class IntegrationTest {
 
   private ApolloClient apolloClient;
   private CustomTypeAdapter<Date> dateCustomTypeAdapter;
+
+  private static final long TIME_OUT_SECONDS = 3;
 
   @Rule public final MockWebServer server = new MockWebServer();
 
@@ -166,7 +168,7 @@ public class IntegrationTest {
 
   @Test public void allPlanetQueryAsync() throws Exception {
     server.enqueue(mockResponse("/HttpCacheTestAllPlanets.json"));
-    final CountDownLatch latch = new CountDownLatch(1);
+    final NamedCountDownLatch latch = new NamedCountDownLatch("latch", 1);
     apolloClient.newCall(new AllPlanets()).enqueue(new ApolloCall.Callback<AllPlanets.Data>() {
       @Override public void onResponse(@Nonnull Response<AllPlanets.Data> response) {
         assertThat(response.isSuccessful()).isTrue();
@@ -179,7 +181,7 @@ public class IntegrationTest {
         Assert.fail("expected success");
       }
     });
-    latch.await();
+    latch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/NamedCountDownLatch.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/NamedCountDownLatch.java
@@ -1,0 +1,37 @@
+package com.apollographql.android.impl;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * {@link java.util.concurrent.CountDownLatch} with an associated name for debugging
+ */
+public class NamedCountDownLatch extends CountDownLatch {
+
+  private String name;
+
+  /**
+   * Constructs a {@code CountDownLatch} initialized with the given count.
+   *
+   * @param count the number of times {@link #countDown} must be invoked before threads can pass through {@link #await}
+   * @throws IllegalArgumentException if {@code count} is negative
+   */
+  public NamedCountDownLatch(String name, int count) {
+    super(count);
+    this.name = name;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public void awaitOrThrowWithTimeout(long timeout, TimeUnit timeUnit)
+      throws InterruptedException, TimeoutException {
+    this.await(timeout, timeUnit);
+    if (this.getCount() != 0) {
+      throw new TimeoutException("Time expired before latch, " + this.name() + "count went to zero.");
+    }
+  }
+
+}

--- a/apollo-integration/src/test/java/com/apollographql/android/impl/NamedCountDownLatch.java
+++ b/apollo-integration/src/test/java/com/apollographql/android/impl/NamedCountDownLatch.java
@@ -26,6 +26,10 @@ public class NamedCountDownLatch extends CountDownLatch {
     return name;
   }
 
+  /**
+   * Waits until latch countdown goes to zero. If timeout expires before latch count has gone to zero,
+   * then a {@link TimeoutException} will be thrown.
+   */
   public void awaitOrThrowWithTimeout(long timeout, TimeUnit timeUnit)
       throws InterruptedException, TimeoutException {
     this.await(timeout, timeUnit);


### PR DESCRIPTION
- In the event some of our async tests fail -- (not all count down latches decremented properly) instead of not terminating, we should wait some reasonable amount of time (here, 3 seconds) and then throw an exception.