### PR TITLE
Handle missing record in SqlStore

### DIFF
--- a/apollo-runtime/src/androidTest/java/com/apollographql/android/cache/normalized/sql/SqlStoreTest.java
+++ b/apollo-runtime/src/androidTest/java/com/apollographql/android/cache/normalized/sql/SqlStoreTest.java
@@ -67,6 +67,12 @@ public class SqlStoreTest {
     assertThat(record.get().key()).isEqualTo(QUERY_ROOT_KEY);
   }
 
+  @Test
+  public void testRecordSelection_recordNotPresent() {
+    Record record = sqlStore.loadRecord(STANDARD_KEY);
+    assertThat(record).isNull();
+  }
+
   private long createRecord(String key) {
     return sqlStore.createRecord(key, FIELDS);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
@@ -59,8 +59,7 @@ public final class LruCacheStore extends CacheStore {
             // get(key, callable) requires non-null. If null, an exception should be
             //thrown, which will be converted to null in the catch clause.
             if (record == null) {
-              throw new ExecutionException(
-                  new IOException(String.format("Record{id=%s} not present in secondary cache", key)));
+              throw new IOException(String.format("Record{id=%s} not present in secondary cache", key));
             }
             return record;
           }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
@@ -7,7 +7,6 @@ import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.cache.CacheBuilder;
 import com.nytimes.android.external.cache.Weigher;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
@@ -10,7 +10,6 @@ import com.nytimes.android.external.cache.Weigher;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -63,7 +62,7 @@ public final class LruCacheStore extends CacheStore {
             return record;
           }
         });
-      } catch (ExecutionException e) {
+      } catch (Exception e) {
         return null;
       }
     }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/lru/LruCacheStore.java
@@ -59,7 +59,7 @@ public final class LruCacheStore extends CacheStore {
             // get(key, callable) requires non-null. If null, an exception should be
             //thrown, which will be converted to null in the catch clause.
             if (record == null) {
-              throw new IOException(String.format("Record{id=%s} not present in secondary cache", key));
+              throw new Exception(String.format("Record{key=%s} not present in secondary cache", key));
             }
             return record;
           }

--- a/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/sql/SqlStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/android/cache/normalized/sql/SqlStore.java
@@ -48,7 +48,7 @@ public final class SqlStore extends CacheStore {
   }
 
   @Nullable public Record loadRecord(String key) {
-    return selectRecordForKey(key).get();
+    return selectRecordForKey(key).orNull();
   }
 
   @Nonnull public Set<String> merge(Record apolloRecord) {
@@ -97,7 +97,9 @@ public final class SqlStore extends CacheStore {
     Cursor cursor = database.query(TABLE_RECORDS,
         allColumns, ApolloSqlHelper.COLUMN_KEY + " = ?", new String[]{key},
         null, null, null);
-    cursor.moveToFirst();
+    if (cursor == null || !cursor.moveToFirst()) {
+      return Optional.absent();
+    }
     try {
       return Optional.of(cursorToRecord(cursor));
     } catch (IOException exception) {

--- a/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
@@ -74,6 +74,13 @@ public class LruCacheStoreTest {
   }
 
   @Test
+  public void testLoadNotPresent() {
+    LruCacheStore lruCacheStore = new LruCacheStore(EvictionPolicy.builder().maxSizeBytes(10 * 1024).build());
+    final Record record = lruCacheStore.loadRecord("key1");
+    assertThat(record).isNull();
+  }
+
+  @Test
   public void testEviction() {
     LruCacheStore lruCacheStore = new LruCacheStore(EvictionPolicy.builder().maxSizeBytes(2000).build());
 

--- a/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
@@ -195,6 +195,14 @@ public class LruCacheStoreTest {
     assertThat(secondaryCacheStore.loadRecords(keys).size()).isEqualTo(3);
   }
 
+  @Test
+  public void testDualCache_recordNotPresent() {
+    LruCacheStore secondaryCacheStore = new LruCacheStore(EvictionPolicy.NO_EVICTION);
+    LruCacheStore primaryCacheStore = new LruCacheStore(EvictionPolicy.NO_EVICTION, secondaryCacheStore);
+
+    assertThat(primaryCacheStore.loadRecord("not_present_id")).isNull();
+  }
+
   private void assertTestRecordPresentAndAccurate(Record testRecord, CacheStore store) {
     final Record cacheRecord1 = store.loadRecord(testRecord.key());
     assertThat(cacheRecord1.key()).isEqualTo(testRecord.key());

--- a/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/android/cache/normalized/lru/LruCacheStoreTest.java
@@ -74,7 +74,7 @@ public class LruCacheStoreTest {
   }
 
   @Test
-  public void testLoadNotPresent() {
+  public void testLoad_recordNotPresent() {
     LruCacheStore lruCacheStore = new LruCacheStore(EvictionPolicy.builder().maxSizeBytes(10 * 1024).build());
     final Record record = lruCacheStore.loadRecord("key1");
     assertThat(record).isNull();


### PR DESCRIPTION
closes https://github.com/apollographql/apollo-android/issues/364

SqlStore was throwing an sql exception when trying to load a missing record. Added check on the cursor. Also, fixed another bug using `Optional` when SqlStore returns `absent`.

I should have caught this in my last PR -- but this time tested on local fork in sandbox application, and the dual memcache sql cache is working