### PR TITLE
Refactor api package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:compileDebugUnitTestJavaWithJavac -x :apollo-integration:compileReleaseUnitTestJavaWithJavac -x :apollo-integration:compileDebugJavaWithJavac -x :apollo-integration:compileReleaseJavaWithJavac --stacktrace
+  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:compileDebugUnitTestJavaWithJavac -x :apollo-integration:compileReleaseUnitTestJavaWithJavac -x :apollo-integration:compileDebugJavaWithJavac -x :apollo-integration:compileReleaseJavaWithJavac -Dapollographql.skipRuntimeDep=true -x apollo-gradle-plugin:test --stacktrace
 
 before_script:
   - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:compileDebugUnitTestJavaWithJavac -x :apollo-integration:compileReleaseUnitTestJavaWithJavac --stacktrace
+  - ./gradlew clean build connectedCheck -x checkstyleTest -x :apollo-integration:compileDebugUnitTestJavaWithJavac -x :apollo-integration:compileReleaseUnitTestJavaWithJavac -x :apollo-integration:compileDebugJavaWithJavac -x :apollo-integration:compileReleaseJavaWithJavac --stacktrace
 
 before_script:
   - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Field.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Field.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/FragmentResponseFieldMapper.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/FragmentResponseFieldMapper.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.io.IOException;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Mutation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Mutation.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 public interface Mutation<D extends Operation.Data, T, V extends Operation.Variables> extends Operation<D, T, V> {
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.util.Collections;
 import java.util.Map;

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Query.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Query.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 /** TODO */
 public interface Query<D extends Operation.Data, T, V extends Operation.Variables> extends Operation<D, T, V> {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.util.Collections;
 import java.util.List;

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseFieldMapper.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseFieldMapper.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.io.IOException;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 import java.io.IOException;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarType.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarType.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql;
+package com.apollographql.apollo.api;
 
 public interface ScalarType {
   String typeName();

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 /**
  * Implementation of an {@link Optional} not containing a reference.
  */
@@ -49,13 +51,13 @@ final class Absent<T> extends Optional<T> {
 
   @Override
   public T or(T defaultValue) {
-    return Utils.checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
+    return checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
   }
 
   @SuppressWarnings("unchecked") // safe covariant cast
   @Override
   public Optional<T> or(Optional<? extends T> secondChoice) {
-    return (Optional<T>) Utils.checkNotNull(secondChoice);
+    return (Optional<T>) checkNotNull(secondChoice);
   }
 
   @Override
@@ -66,7 +68,7 @@ final class Absent<T> extends Optional<T> {
 
   @Override
   public <V> Optional<V> transform(Function<? super T, V> function) {
-    Utils.checkNotNull(function);
+    checkNotNull(function);
     return Optional.absent();
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package com.apollographql.android.api.graphql.internal;
+package com.apollographql.apollo.api.internal;
 
 
 import java.util.Collections;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
 /**
  * Implementation of an {@link Optional} not containing a reference.
@@ -51,13 +49,13 @@ final class Absent<T> extends Optional<T> {
 
   @Override
   public T or(T defaultValue) {
-    return checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
+    return Utils.checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
   }
 
   @SuppressWarnings("unchecked") // safe covariant cast
   @Override
   public Optional<T> or(Optional<? extends T> secondChoice) {
-    return (Optional<T>) checkNotNull(secondChoice);
+    return (Optional<T>) Utils.checkNotNull(secondChoice);
   }
 
   @Override
@@ -68,7 +66,7 @@ final class Absent<T> extends Optional<T> {
 
   @Override
   public <V> Optional<V> transform(Function<? super T, V> function) {
-    checkNotNull(function);
+    Utils.checkNotNull(function);
     return Optional.absent();
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Function.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Function.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql.internal;
+package com.apollographql.apollo.api.internal;
 
 import javax.annotation.Nonnull;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Functions.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Functions.java
@@ -1,9 +1,7 @@
-package com.apollographql.android.api.graphql.internal;
+package com.apollographql.apollo.api.internal;
 
 
 import javax.annotation.Nullable;
-
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
 public class Functions {
   /**
@@ -48,7 +46,7 @@ public class Functions {
 
     @Override
     public String apply(Object o) {
-      checkNotNull(o); // eager for GWT.
+      Utils.checkNotNull(o); // eager for GWT.
       return o.toString();
     }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Functions.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Functions.java
@@ -3,6 +3,8 @@ package com.apollographql.apollo.api.internal;
 
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 public class Functions {
   /**
    * Returns the identity function.
@@ -46,7 +48,7 @@ public class Functions {
 
     @Override
     public String apply(Object o) {
-      Utils.checkNotNull(o); // eager for GWT.
+      checkNotNull(o); // eager for GWT.
       return o.toString();
     }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 
 /**
  * An immutable object that may contain a non-null reference to another object. Each instance of this type either
@@ -91,7 +93,7 @@ public abstract class Optional<T> implements Serializable {
    * @throws NullPointerException if {@code reference} is null
    */
   public static <T> Optional<T> of(T reference) {
-    return new Present<T>(Utils.checkNotNull(reference));
+    return new Present<T>(checkNotNull(reference));
   }
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.apollographql.android.api.graphql.internal;
+package com.apollographql.apollo.api.internal;
 
 
 import java.io.Serializable;
@@ -22,8 +22,6 @@ import java.util.Set;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
-
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
 
 /**
@@ -93,7 +91,7 @@ public abstract class Optional<T> implements Serializable {
    * @throws NullPointerException if {@code reference} is null
    */
   public static <T> Optional<T> of(T reference) {
-    return new Present<T>(checkNotNull(reference));
+    return new Present<T>(Utils.checkNotNull(reference));
   }
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 /**
  * Implementation of an {@link Optional} containing a reference.
  */
@@ -42,17 +44,17 @@ final class Present<T> extends Optional<T> {
   }
 
   @Override public T or(T defaultValue) {
-    Utils.checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
+    checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
     return reference;
   }
 
   @Override public Optional<T> or(Optional<? extends T> secondChoice) {
-    Utils.checkNotNull(secondChoice);
+    checkNotNull(secondChoice);
     return this;
   }
 
   @Override public <V> Optional<V> transform(Function<? super T, V> function) {
-    return new Present<V>(Utils.checkNotNull(function.apply(reference),
+    return new Present<V>(checkNotNull(function.apply(reference),
         "the Function passed to Optional.transform() must not return null."));
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package com.apollographql.android.api.graphql.internal;
+package com.apollographql.apollo.api.internal;
 
 
 import java.util.Collections;
 import java.util.Set;
 
 import javax.annotation.Nullable;
-
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
 
 /**
  * Implementation of an {@link Optional} containing a reference.
@@ -44,17 +42,17 @@ final class Present<T> extends Optional<T> {
   }
 
   @Override public T or(T defaultValue) {
-    checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
+    Utils.checkNotNull(defaultValue, "use Optional.orNull() instead of Optional.or(null)");
     return reference;
   }
 
   @Override public Optional<T> or(Optional<? extends T> secondChoice) {
-    checkNotNull(secondChoice);
+    Utils.checkNotNull(secondChoice);
     return this;
   }
 
   @Override public <V> Optional<V> transform(Function<? super T, V> function) {
-    return new Present<V>(checkNotNull(function.apply(reference),
+    return new Present<V>(Utils.checkNotNull(function.apply(reference),
         "the Function passed to Optional.transform() must not return null."));
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/UnmodifiableMapBuilder.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/UnmodifiableMapBuilder.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql.util;
+package com.apollographql.apollo.api.internal;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Utils.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Utils.java
@@ -1,4 +1,4 @@
-package com.apollographql.android.api.graphql.util;
+package com.apollographql.apollo.api.internal;
 
 import java.util.Set;
 

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
@@ -1,6 +1,8 @@
 package com.apollographql.android.api.graphql;
 
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 
 import org.junit.Test;
 
@@ -19,7 +21,7 @@ public class CacheKeyForFieldTest {
 
   @Test
   public void testFieldWithNoArguments() {
-    Field field = Field.forString("hero", "hero", null, false);
+    com.apollographql.apollo.api.Field field = Field.forString("hero", "hero", null, false);
     Operation.Variables variables = new Operation.Variables() {
       @Nonnull @Override public Map<String, Object> valueMap() {
         return super.valueMap();

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/CacheKeyForFieldTest.java
@@ -21,7 +21,7 @@ public class CacheKeyForFieldTest {
 
   @Test
   public void testFieldWithNoArguments() {
-    com.apollographql.apollo.api.Field field = Field.forString("hero", "hero", null, false);
+    Field field = Field.forString("hero", "hero", null, false);
     Operation.Variables variables = new Operation.Variables() {
       @Nonnull @Override public Map<String, Object> valueMap() {
         return super.valueMap();

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/internal/OptionalTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/internal/OptionalTest.java
@@ -19,6 +19,10 @@ package com.apollographql.android.api.graphql.internal;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
+import com.apollographql.apollo.api.internal.Function;
+import com.apollographql.apollo.api.internal.Functions;
+import com.apollographql.apollo.api.internal.Optional;
+
 import org.junit.Test;
 
 import java.util.Collections;
@@ -173,7 +177,7 @@ public final class OptionalTest {
       Optional<String> unused =
           Optional.of("a")
               .transform(
-                  new Function<String, String>() {
+                  new com.apollographql.apollo.api.internal.Function<String, String>() {
                     @Override
                     public String apply(String input) {
                       return null;

--- a/apollo-api/src/test/java/com/apollographql/android/api/graphql/internal/OptionalTest.java
+++ b/apollo-api/src/test/java/com/apollographql/android/api/graphql/internal/OptionalTest.java
@@ -177,7 +177,7 @@ public final class OptionalTest {
       Optional<String> unused =
           Optional.of("a")
               .transform(
-                  new com.apollographql.apollo.api.internal.Function<String, String>() {
+                  new Function<String, String>() {
                     @Override
                     public String apply(String input) {
                       return null;

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ClassNames.kt
@@ -1,12 +1,12 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.Mutation
-import com.apollographql.android.api.graphql.Operation
-import com.apollographql.android.api.graphql.Query
-import com.apollographql.android.api.graphql.ResponseReader
-import com.apollographql.android.api.graphql.internal.Optional
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder
-import com.apollographql.android.api.graphql.util.Utils
+import com.apollographql.apollo.api.Mutation
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.internal.Optional
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder
+import com.apollographql.apollo.api.internal.Utils
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/CustomEnumTypeSpecBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.ScalarType
+import com.apollographql.apollo.api.ScalarType
 import com.apollographql.android.compiler.ir.CodeGenerationContext
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/FragmentsResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/FragmentsResponseMapperBuilder.kt
@@ -1,7 +1,7 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper
-import com.apollographql.android.api.graphql.ResponseReader
+import com.apollographql.apollo.api.FragmentResponseFieldMapper
+import com.apollographql.apollo.api.ResponseReader
 import com.apollographql.android.compiler.ir.CodeGenerationContext
 import com.apollographql.android.compiler.ir.Fragment
 import com.squareup.javapoet.*
@@ -104,7 +104,8 @@ class FragmentsResponseMapperBuilder(
           }
 
   companion object {
-    private val API_RESPONSE_FIELD_MAPPER_TYPE = ClassName.get(FragmentResponseFieldMapper::class.java)
+    private val API_RESPONSE_FIELD_MAPPER_TYPE = ClassName.get(
+        FragmentResponseFieldMapper::class.java)
     private val RESPONSE_FIELD_MAPPER_TYPE = ParameterizedTypeName.get(API_RESPONSE_FIELD_MAPPER_TYPE,
         SchemaTypeSpecBuilder.FRAGMENTS_TYPE.withoutAnnotations())
     private val CONDITIONAL_TYPE_VAR = "conditionalType"

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.ResponseFieldMapper
+import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.android.compiler.ir.*
 import com.squareup.javapoet.*
 import javax.lang.model.element.Modifier

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/SchemaTypeResponseMapperBuilder.kt
@@ -1,7 +1,7 @@
 package com.apollographql.android.compiler
 
-import com.apollographql.android.api.graphql.ResponseFieldMapper
-import com.apollographql.android.api.graphql.ResponseReader
+import com.apollographql.apollo.api.ResponseFieldMapper
+import com.apollographql.apollo.api.ResponseReader
 import com.apollographql.android.compiler.ir.CodeGenerationContext
 import com.apollographql.android.compiler.ir.Field
 import com.apollographql.android.compiler.ir.InlineFragment
@@ -68,7 +68,7 @@ class SchemaTypeResponseMapperBuilder(
   }
 
   private fun fieldArray(fields: List<Field>) =
-      FieldSpec.builder(Array<com.apollographql.android.api.graphql.Field>::class.java, FIELDS_VAR)
+      FieldSpec.builder(Array<com.apollographql.apollo.api.Field>::class.java, FIELDS_VAR)
           .addModifiers(Modifier.FINAL)
           .initializer(CodeBlock.builder()
               .add("{\n")
@@ -361,16 +361,16 @@ class SchemaTypeResponseMapperBuilder(
     private val READER_PARAM = ParameterSpec.builder(ResponseReader::class.java, READER_VAR).build()
     private val SCALAR_TYPES = listOf(ClassNames.STRING, TypeName.INT, TypeName.INT.box(), TypeName.LONG,
         TypeName.LONG.box(), TypeName.DOUBLE, TypeName.DOUBLE.box(), TypeName.BOOLEAN, TypeName.BOOLEAN.box())
-    private val API_RESPONSE_FIELD_TYPE = ClassName.get(com.apollographql.android.api.graphql.Field::class.java)
+    private val API_RESPONSE_FIELD_TYPE = ClassName.get(com.apollographql.apollo.api.Field::class.java)
     private val API_RESPONSE_FIELD_OBJECT_READER_TYPE = ClassName.get(
-        com.apollographql.android.api.graphql.Field.ObjectReader::class.java)
+        com.apollographql.apollo.api.Field.ObjectReader::class.java)
     private val API_RESPONSE_FIELD_LIST_READER_TYPE = ClassName.get(
-        com.apollographql.android.api.graphql.Field.ListReader::class.java)
+        com.apollographql.apollo.api.Field.ListReader::class.java)
     private val API_RESPONSE_FIELD_LIST_ITEM_READER_TYPE = ClassName.get(
-        com.apollographql.android.api.graphql.Field.ListItemReader::class.java)
+        com.apollographql.apollo.api.Field.ListItemReader::class.java)
     private val API_RESPONSE_FIELD_MAPPER_TYPE = ClassName.get(ResponseFieldMapper::class.java)
     private val API_RESPONSE_FIELD_CONDITIONAL_TYPE_READER_TYPE = ClassName.get(
-        com.apollographql.android.api.graphql.Field.ConditionalTypeReader::class.java)
+        com.apollographql.apollo.api.Field.ConditionalTypeReader::class.java)
 
     private fun normalizeGraphQlType(type: String) =
         type.removeSuffix("!").removeSurrounding(prefix = "[", suffix = "]").removeSuffix("!")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/ir/Operation.kt
@@ -1,6 +1,6 @@
 package com.apollographql.android.compiler.ir
 
-import com.apollographql.android.api.graphql.Operation
+import com.apollographql.apollo.api.Operation
 import com.apollographql.android.compiler.SchemaTypeSpecBuilder
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.arguments_complex;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_complex.type.Episode;
 import java.io.IOException;
 import java.lang.Double;

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.arguments_simple;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_simple.type.Episode;
 import java.io.IOException;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.custom_scalar_type;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.custom_scalar_type.type.CustomType;
 import java.io.IOException;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
@@ -1,6 +1,6 @@
 package com.example.custom_scalar_type.type;
 
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
 import java.lang.Override;
 import java.lang.String;

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.directives;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.enum_type;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.enum_type.type.Episode;
 import java.io.IOException;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.fragment_friends_connection;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_friends_connection.fragment.HeroDetails;
 import java.io.IOException;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -1,9 +1,9 @@
 package com.example.fragment_friends_connection.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -1,13 +1,13 @@
 package com.example.fragment_in_fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.fragment_in_fragment.fragment.PilotFragment;
 import com.example.fragment_in_fragment.fragment.StarshipFragment;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -1,9 +1,9 @@
 package com.example.fragment_in_fragment.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -1,10 +1,10 @@
 package com.example.fragment_in_fragment.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.fragment_with_inline_fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
 import com.example.fragment_with_inline_fragment.type.Episode;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -1,9 +1,9 @@
 package com.example.fragment_with_inline_fragment.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.fragments_with_type_condition;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragments_with_type_condition.fragment.DroidDetails;
 import com.example.fragments_with_type_condition.fragment.HumanDetails;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
@@ -1,9 +1,9 @@
 package com.example.fragments_with_type_condition.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
@@ -1,9 +1,9 @@
 package com.example.fragments_with_type_condition.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.hero_details;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -1,10 +1,10 @@
 package com.example.hero_details_guava;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
 import com.google.common.base.Optional;
 import java.io.IOException;
 import java.lang.Integer;

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -1,10 +1,10 @@
 package com.example.hero_details_nullable;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.hero_name;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.inline_fragments_with_friends;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.inline_fragments_with_friends.type.Episode;
 import java.io.IOException;
 import java.lang.Double;

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -1,13 +1,13 @@
 package com.example.input_object_type;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Mutation;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
-import com.apollographql.android.api.graphql.util.Utils;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Mutation;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.input_object_type.type.Episode;
 import com.example.input_object_type.type.ReviewInput;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.nested_conditional_inline;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.nested_conditional_inline.type.Episode;
 import java.io.IOException;
 import java.lang.Double;

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.no_accessors;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.no_accessors.fragment.HeroDetails;
 import com.example.no_accessors.type.Episode;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
@@ -1,9 +1,9 @@
 package com.example.no_accessors.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.scalar_types;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.simple_fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.simple_fragment.fragment.HeroDetails;
 import java.io.IOException;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
@@ -1,8 +1,8 @@
 package com.example.simple_fragment.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -1,11 +1,11 @@
 package com.example.simple_inline_fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
 import java.lang.Object;

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.two_heroes;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -1,12 +1,12 @@
 package com.example.two_heroes_unique;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.android.api.graphql.util.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -1,12 +1,12 @@
 package com.example.unique_type_name;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.FragmentResponseFieldMapper;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import com.example.unique_type_name.fragment.HeroDetails;
 import com.example.unique_type_name.type.Episode;
 import java.io.IOException;

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -1,9 +1,9 @@
 package com.example.unique_type_name.fragment;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -65,8 +65,7 @@ class ApolloPlugin implements Plugin<Project> {
               "apollo-runtime version ${apolloRuntimeDep.version} isn't compatible with the apollo-gradle-plugin version ${VersionKt.VERSION}")
         }
         if (System.getProperty("apollographql.skipRuntimeDep") != "true" && apolloRuntimeDep == null) {
-          //TODO https://github.com/apollographql/apollo-android/issues/374
-//          compileDepSet.add(project.dependencies.create("$APOLLO_DEP_GROUP:$RUNTIME_DEP_NAME:$VersionKt.VERSION"))
+          compileDepSet.add(project.dependencies.create("$APOLLO_DEP_GROUP:$RUNTIME_DEP_NAME:$VersionKt.VERSION"))
         }
       }
 

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -24,7 +24,7 @@ import javax.inject.Inject
 class ApolloPlugin implements Plugin<Project> {
   private static final String NODE_VERSION = "6.7.0"
   public static final String TASK_GROUP = "apollo"
-  private static final String APOLLO_DEP_GROUP = "com.apollographql"
+  private static final String APOLLO_DEP_GROUP = "com.apollographql.apollo"
   private static final String RUNTIME_DEP_NAME = "apollo-runtime"
 
   private Project project

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -50,7 +50,7 @@ class BasicAndroidSpec extends Specification {
     // Optional is not added to the generated classes
     assert !new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").getText(
         'UTF-8').contains(
-        "import com.apollographql.android.api.graphql.internal.Optional;")
+        "import com.apollographql.apollo.api.internal.Optional;")
   }
 
   def "installApolloCodegenTask is up to date if no changes occur to node_modules and package.json"() {
@@ -164,7 +164,7 @@ class BasicAndroidSpec extends Specification {
     result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetails.java").getText(
-        'UTF-8').contains("import com.apollographql.android.api.graphql.internal.Optional;")
+        'UTF-8').contains("import com.apollographql.apollo.api.internal.Optional;")
   }
 
   def cleanupSpec() {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/AsyncNormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/AsyncNormalizedCacheTestCase.java
@@ -4,7 +4,7 @@ import com.google.common.base.Strings;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CacheTest.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo;
 
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.http.DiskLruCacheStore;
 import com.apollographql.apollo.internal.cache.http.HttpCache;
 import com.apollographql.apollo.cache.http.HttpCacheControl;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -4,11 +4,11 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
 
-import com.apollographql.android.api.graphql.Error;
-import com.apollographql.android.api.graphql.Response;
 import com.apollographql.android.impl.httpcache.AllFilms;
 import com.apollographql.android.impl.httpcache.AllPlanets;
 import com.apollographql.android.impl.httpcache.type.CustomType;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Response;
 
 import org.junit.Assert;
 import org.junit.Before;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.CacheReference;

--- a/apollo-runtime/src/androidTest/java/com/apollographql/apollo/cache/normalized/sql/SqlStoreTest.java
+++ b/apollo-runtime/src/androidTest/java/com/apollographql/apollo/cache/normalized/sql/SqlStoreTest.java
@@ -3,11 +3,8 @@ package com.apollographql.apollo.cache.normalized.sql;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
-import com.apollographql.android.api.graphql.internal.Optional;
-import com.apollographql.apollo.cache.normalized.sql.FieldsAdapter;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.Record;
-import com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper;
-import com.apollographql.apollo.cache.normalized.sql.SqlStore;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -1,8 +1,8 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.internal.util.Cancelable;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
 import com.apollographql.apollo.cache.http.HttpCacheControl;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -1,9 +1,9 @@
 package com.apollographql.apollo;
 
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.http.EvictionStrategy;
 import com.apollographql.apollo.internal.RealApolloCall;
 import com.apollographql.apollo.internal.RealApolloPrefetch;
@@ -37,7 +37,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ApolloClient implements ApolloCall.Factory {
   public static Builder builder() {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/Logger.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/Logger.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo;
 
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.internal.Optional;
 
 import javax.annotation.Nonnull;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/CacheKey.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/CacheKey.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo.cache.normalized;
 
 import javax.annotation.Nonnull;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class CacheKey {
   public static final CacheKey NO_KEY = new CacheKey("");

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/CacheKeyResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/CacheKeyResolver.java
@@ -1,8 +1,8 @@
 package com.apollographql.apollo.cache.normalized;
 
-import com.apollographql.android.api.graphql.Mutation;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Query;
+import com.apollographql.apollo.api.Mutation;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
 
 import java.util.Map;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/EvictionPolicy.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/EvictionPolicy.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.cache.normalized.lru;
 
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.internal.Optional;
 
 import java.util.concurrent.TimeUnit;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruCacheStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruCacheStore.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.cache.normalized.lru;
 
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.CacheStore;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.nytimes.android.external.cache.Cache;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlStore.java
@@ -4,7 +4,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.CacheStore;
 import com.apollographql.apollo.cache.normalized.Record;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -1,8 +1,8 @@
 package com.apollographql.apollo.interceptor;
 
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.Record;
 
 import java.io.IOException;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -4,10 +4,10 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.CustomTypeAdapter;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.internal.cache.http.HttpCache;
 import com.apollographql.apollo.cache.http.HttpCacheControl;
 import com.apollographql.apollo.internal.cache.normalized.Cache;
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 @SuppressWarnings("WeakerAccess") public final class RealApolloCall<T> implements ApolloCall<T> {
   final Operation operation;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal;
 
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.ApolloPrefetch;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloWatcher.java
@@ -2,8 +2,8 @@ package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloWatcher;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.util.Utils;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.cache.normalized.Cache;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/CacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/CacheInterceptor.java
@@ -8,7 +8,7 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 final class CacheInterceptor implements Interceptor {
   private final HttpCache cache;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/HttpCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/HttpCache.java
@@ -15,7 +15,7 @@ import okhttp3.Response;
 import okio.ForwardingSource;
 import okio.Source;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 @SuppressWarnings("WeakerAccess") public final class HttpCache {
   public static final String CACHE_KEY_HEADER = "APOLLO-CACHE-KEY";

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/ResponseBodyProxy.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/http/ResponseBodyProxy.java
@@ -17,7 +17,7 @@ import okio.Okio;
 import okio.Source;
 import okio.Timeout;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static okhttp3.internal.Util.closeQuietly;
 import static okhttp3.internal.Util.discard;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealCache.java
@@ -17,7 +17,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class RealCache implements Cache, ReadableCache, WriteableCache {
   private final CacheStore cacheStore;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.internal.cache.normalized;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.CacheReference;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.internal.field;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.cache.normalized.CacheReference;
 import com.apollographql.apollo.internal.cache.normalized.ReadableCache;
 import com.apollographql.apollo.cache.normalized.Record;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.field;
 
-import com.apollographql.android.api.graphql.Field;
+import com.apollographql.apollo.api.Field;
 
 public interface FieldValueResolver<R> {
   <T> T valueFor(R recordSet, Field field);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.field;
 
-import com.apollographql.android.api.graphql.Field;
+import com.apollographql.apollo.api.Field;
 
 import java.util.Map;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -1,9 +1,9 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.internal.cache.normalized.Cache;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ApolloCacheInterceptor implements ApolloInterceptor {
   private final Cache cache;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
@@ -1,9 +1,9 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.cache.http.HttpCacheControl;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/HttpResponseBodyParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/HttpResponseBodyParser.java
@@ -1,10 +1,10 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.android.api.graphql.Error;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.Response;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/RealApolloInterceptorChain.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/RealApolloInterceptorChain.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 
@@ -11,7 +11,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.annotation.Nonnull;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class RealApolloInterceptorChain implements ApolloInterceptorChain {
   private final Operation operation;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
@@ -1,9 +1,9 @@
 package com.apollographql.apollo.internal.reader;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.android.api.graphql.ScalarType;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.internal.field.FieldValueResolver;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/ResponseReaderShadow.java
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.internal.reader;
 
-import com.apollographql.android.api.graphql.Field;
-import com.apollographql.android.api.graphql.Operation;
+import com.apollographql.apollo.api.Field;
+import com.apollographql.apollo.api.Operation;
 
 import java.util.List;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/util/ApolloLogger.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/util/ApolloLogger.java
@@ -1,12 +1,12 @@
 package com.apollographql.apollo.internal.util;
 
 import com.apollographql.apollo.Logger;
-import com.apollographql.android.api.graphql.internal.Optional;
+import com.apollographql.apollo.api.internal.Optional;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ApolloLogger {
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/InterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/InterceptorTest.java
@@ -1,10 +1,8 @@
 package com.apollographql.apollo;
 
-import com.apollographql.android.api.graphql.Query;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
-import com.apollographql.apollo.ApolloClient;
-import com.apollographql.apollo.HttpException;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/CacheControlTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/CacheControlTest.java
@@ -1,12 +1,11 @@
 package com.apollographql.apollo.internal;
 
-import com.apollographql.android.api.graphql.Operation;
-import com.apollographql.android.api.graphql.ResponseFieldMapper;
-import com.apollographql.android.api.graphql.ResponseReader;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.cache.http.HttpCacheControl;
 import com.apollographql.apollo.cache.normalized.CacheControl;
-import com.apollographql.apollo.internal.RealApolloCall;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com.apollographql.android.rx/RxApollo.java
@@ -4,7 +4,7 @@ package com.apollographql.android.rx;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloWatcher;
 import com.apollographql.apollo.internal.util.Cancelable;
-import com.apollographql.android.api.graphql.Response;
+import com.apollographql.apollo.api.Response;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import rx.functions.Action1;
 import rx.functions.Cancellable;
 import rx.subscriptions.Subscriptions;
 
-import static com.apollographql.android.api.graphql.util.Utils.checkNotNull;
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class RxApollo {
 

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -27,6 +27,8 @@ android {
 }
 
 dependencies {
+  compile dep.jsr305
+  compile dep.apolloRuntime
   compile dep.appcompat
   compile dep.okhttpLoggingInterceptor
 

--- a/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
+++ b/apollo-sample/src/main/java/com/example/apollographql/sample/MainActivity.java
@@ -5,7 +5,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.TextView;
 
-import com.apollographql.android.ApolloCall;
+import com.apollographql.apollo.ApolloCall;
 import com.apollographql.android.api.graphql.Response;
 import com.example.FeedQuery;
 import com.example.type.FeedType;

--- a/apollo-sample/src/main/java/com/example/apollographql/sample/SampleApplication.java
+++ b/apollo-sample/src/main/java/com/example/apollographql/sample/SampleApplication.java
@@ -2,8 +2,8 @@ package com.example.apollographql.sample;
 
 import android.app.Application;
 
-import com.apollographql.android.ApolloCall;
-import com.apollographql.android.impl.ApolloClient;
+import com.apollographql.apollo.ApolloCall;
+import com.apollographql.apollo.ApolloClient;
 
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-GROUP=com.apollographql
+GROUP=com.apollographql.apollo
 VERSION_NAME=0.2.3-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    apolloVersion: '0.2.2-SNAPSHOT',
+    apolloVersion: '0.2.3-SNAPSHOT',
     cacheVersion: '2.0.2',
     okHttpVersion: '3.6.0',
     kotlinVersion: '1.0.6',
@@ -18,8 +18,8 @@ ext.androidConfig = [
 
 ext.dep = [
     androidPlugin           : 'com.android.tools.build:gradle:2.3.0',
-    apolloPlugin            : "com.apollographql.android:gradle-plugin:$versions.apolloVersion",
-    apolloRuntime           : "com.apollographql.android:runtime:$versions.apolloVersion",
+    apolloPlugin            : "com.apollographql:gradle-plugin:$versions.apolloVersion",
+    apolloRuntime           : "com.apollographql:apollo-runtime:$versions.apolloVersion",
     supportAnnotations      : 'com.android.support:support-annotations:25.1.0',
     compiletesting          : 'com.google.testing.compile:compile-testing:0.10',
     cache                   : "com.nytimes.android:cache:$versions.cacheVersion",


### PR DESCRIPTION
This PR:
- rename `com.apollographql.android.api.graphql` to `com.apollographql.apollo.api`
- ~enable back plugin tests~
- ~enable back auto add dep to apollo-runtime module in gradle plugin~
- bump apollo version to 0.2.3