### PR TITLE
ApolloPrefetch should extend Cancellable interface

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
@@ -1,19 +1,19 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.internal.util.Cancelable;
+
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public interface ApolloPrefetch {
+public interface ApolloPrefetch extends Cancelable {
 
   void execute() throws IOException;
 
   @Nonnull ApolloPrefetch enqueue(@Nullable Callback callback);
 
   ApolloPrefetch clone();
-
-  void cancel();
 
   interface Callback {
     void onSuccess();


### PR DESCRIPTION
Addresses #383 

No need to have a cancel() method in the ApolloPrefetch interface as a Cancellable interface already exists, and ApolloPrefetch can simply extend this interface.