### PR TITLE
move node_modules and package.json to be under the build directory

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -1,9 +1,9 @@
 package com.apollographql.android.gradle;
 
-import com.google.common.collect.Lists;
-
 import java.io.File;
 import java.io.IOException;
+
+import okio.Okio;
 
 import org.gradle.api.Task;
 import org.gradle.api.logging.LogLevel;
@@ -11,16 +11,17 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputDirectory;
 
 import com.apollographql.android.compiler.GraphQLCompiler;
-import com.moowork.gradle.node.npm.NpmTask;
-import com.squareup.moshi.JsonWriter;
-import com.squareup.moshi.JsonAdapter;
-import com.squareup.moshi.Moshi;
 
-import okio.Okio;
+import com.google.common.collect.Lists;
+
+import com.moowork.gradle.node.npm.NpmTask;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.JsonWriter;
+import com.squareup.moshi.Moshi;
 
 public class ApolloCodeGenInstallTask extends NpmTask {
   static final String NAME = "installApolloCodegen";
-  private static final String INSTALL_DIR = "node_modules/apollo-codegen";
+  private static final String INSTALL_DIR =  "apollo-codegen/node_modules/apollo-codegen";
 
   @OutputDirectory private File installDir;
 
@@ -28,9 +29,13 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     // TODO: set to const when ApolloPlugin is in java
     setGroup("apollo");
     setDescription("Runs npm install for apollo-codegen");
-    installDir = getProject().file(INSTALL_DIR);
+    installDir = new File(getProject().getBuildDir(), INSTALL_DIR);
+    installDir.mkdirs();
 
-    final File apolloPackageFile = getProject().file("package.json");
+    File workingDir = new File(getProject().getBuildDir(), "apollo-codegen");
+    setWorkingDir(workingDir);
+
+    final File apolloPackageFile = new File(workingDir, "package.json");
     final boolean isSameCodegenVersion = isSameApolloCodegenVersion(getApolloVersion());
 
     if (!isSameCodegenVersion) {
@@ -56,10 +61,10 @@ public class ApolloCodeGenInstallTask extends NpmTask {
   /**
    * Returns the locally install apollo-codegen version as found in the package.json file.
    *
-   * @return null if node_modules/apollo-codegen/package.json wasn't found, version otherwise
+   * @return null if build/apollo-codegen/node_modules/apollo-codegen/package.json wasn't found, version otherwise
    */
   private String getApolloVersion() {
-    File packageFile = getProject().file(INSTALL_DIR + "/package.json");
+    File packageFile = new File(getProject().getBuildDir(), INSTALL_DIR + "/package.json");
     if (!packageFile.isFile()) {
       return null;
     }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloIRGenTask.java
@@ -29,7 +29,7 @@ import com.google.common.collect.Lists;
 import com.moowork.gradle.node.task.NodeTask;
 
 public class ApolloIRGenTask extends NodeTask {
-  private static final String APOLLO_CODEGEN = "node_modules/apollo-codegen/lib/cli.js";
+  private static final String APOLLO_CODEGEN = "apollo-codegen/node_modules/apollo-codegen/lib/cli.js";
   static final String NAME = "generate%sApolloIR";
 
   @Internal private String variant;
@@ -46,7 +46,7 @@ public class ApolloIRGenTask extends NodeTask {
 
   @Override
   public void exec() {
-    File apolloScript = getProject().file(APOLLO_CODEGEN);
+    File apolloScript = new File(getProject().getBuildDir(), APOLLO_CODEGEN);
     if (!apolloScript.isFile()) {
       throw new GradleException("Apollo-codegen was not found in node_modules. Please run the installApolloCodegen task.");
     }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -1,5 +1,6 @@
 package com.apollographql.android.gradle.integration
 
+import com.apollographql.android.compiler.GraphQLCompiler
 import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -68,7 +69,7 @@ class BasicAndroidSpec extends Specification {
 
   def "installApolloCodegenTask gets outdated if node_modules directory is altered"() {
     setup: "a testProject with a deleted node_modules directory"
-    FileUtils.deleteDirectory(new File(testProjectDir, "node_modules"))
+    FileUtils.deleteDirectory(new File(testProjectDir, "build/apollo-codegen/node_modules"))
 
     when:
     def result = GradleRunner.create().withProjectDir(testProjectDir)
@@ -80,9 +81,13 @@ class BasicAndroidSpec extends Specification {
     result.task(":installApolloCodegen").outcome == TaskOutcome.SUCCESS
   }
 
-  def "installApolloCodegenTask gets outdated if package.json is altered"() {
-    setup: "a testProject with a deleted package.json directory"
-    FileUtils.deleteDirectory(new File(testProjectDir, "node_modules"))
+  def "installApolloCodegenTask gets outdated if apollo-codegen version is different"() {
+    setup: "a testProject with a different apollo-codegen version as indicated in the package.json file"
+
+    replaceTextInFile(new File(testProjectDir, "build/apollo-codegen/node_modules/apollo-codegen/package.json")) {
+      it.replace("\"version\": \"$GraphQLCompiler.APOLLOCODEGEN_VERSION\"", "\"version\": \"0.10.1\"")
+    }
+    new File(testProjectDir, "build/apollo-codegen/package.json") << "\n"
 
     when:
     def result = GradleRunner.create().withProjectDir(testProjectDir)

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/integration/BasicAndroidSpec.groovy
@@ -87,7 +87,6 @@ class BasicAndroidSpec extends Specification {
     replaceTextInFile(new File(testProjectDir, "build/apollo-codegen/node_modules/apollo-codegen/package.json")) {
       it.replace("\"version\": \"$GraphQLCompiler.APOLLOCODEGEN_VERSION\"", "\"version\": \"0.10.1\"")
     }
-    new File(testProjectDir, "build/apollo-codegen/package.json") << "\n"
 
     when:
     def result = GradleRunner.create().withProjectDir(testProjectDir)

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -108,22 +108,21 @@ class ApolloAndroidPluginSpec extends Specification {
     assert (project.extensions.findByType(ApolloExtension.class)) != null
   }
 
-  //TODO https://github.com/apollographql/apollo-android/issues/374
-//  def "adds apollo-runtime dependency if not skipped and not found in compile dep list"() {
-//    given:
-//    def project = ProjectBuilder.builder().build()
-//    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
-//
-//    when:
-//    ApolloPluginTestHelper.applyApolloPlugin(project)
-//    project.evaluate()
-//
-//    then:
-//    def apolloRuntime = project.configurations.getByName("compile").dependencies.find {
-//      it.group == "com.apollographql.android" && it.name == "runtime"
-//    }
-//    assert apolloRuntime != null
-//  }
+  def "adds apollo-runtime dependency if not skipped and not found in compile dep list"() {
+    given:
+    def project = ProjectBuilder.builder().build()
+    ApolloPluginTestHelper.setupDefaultAndroidProject(project)
+
+    when:
+    ApolloPluginTestHelper.applyApolloPlugin(project)
+    project.evaluate()
+
+    then:
+    def apolloRuntime = project.configurations.getByName("compile").dependencies.find {
+      it.group == "com.apollographql.apollo" && it.name == "apollo-runtime"
+    }
+    assert apolloRuntime != null
+  }
 
   def "doesn't add apollo-runtime dependency if skip property is set" () {
     given:

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/android/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
@@ -37,7 +37,7 @@ class ApolloCodeGenInstallTaskSpec extends Specification {
     task.dependsOn.contains("nodeSetup")
   }
 
-  def "task creates a package.json file in project root"() {
+  def "task creates a package.json file under build/apollo-codegen"() {
     setup:
     def project = ProjectBuilder.builder().build()
     ApolloPluginTestHelper.setupDefaultAndroidProject(project)
@@ -47,7 +47,7 @@ class ApolloCodeGenInstallTaskSpec extends Specification {
     project.evaluate()
 
     then:
-    File packageFile = project.file("package.json")
+    File packageFile = new File(project.buildDir, "apollo-codegen/package.json")
     assert packageFile.isFile()
     def input = new JsonSlurper().parseText(packageFile.text)
     assert input.name == "apollo-android"


### PR DESCRIPTION
closes #380.

Those are now generated under: `build/apollo-codegen/package.json` and `build/apollo-codegen/node_modules/..`
 