### PR TITLE
Misc Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Apollo-Android is a GraphQL compliant client that generates Java models from sta
 
 ## Adding Apollo to your Project
 
-The latest Gradle plugin version is 0.2.2.
+The latest Gradle plugin version is 0.3.0.
 
 To use this plugin, add the dependency to your project's build.gradle file:
 
@@ -15,11 +15,9 @@ To use this plugin, add the dependency to your project's build.gradle file:
 buildscript {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
     }
     dependencies {
-        
-        classpath 'com.apollographql.android:gradle-plugin:0.2.2'
+        classpath 'com.apollographql.apollo:gradle-plugin:0.3.0'
     }
 }
 ```
@@ -33,8 +31,7 @@ buildscript {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
   }
   dependencies {
-    
-    classpath 'com.apollographql.apollo:gradle-plugin:0.3.0'
+    classpath 'com.apollographql.apollo:gradle-plugin:0.3.1-SNAPSHOT'
   }
 }
 ```

--- a/apollo-android-support/build.gradle
+++ b/apollo-android-support/build.gradle
@@ -5,7 +5,6 @@ buildscript {
 }
 
 apply plugin: 'com.android.library'
-clearSkipApolloRuntimeDep()
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion

--- a/apollo-api/build.gradle
+++ b/apollo-api/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-compiler/build.gradle
+++ b/apollo-compiler/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'kotlin'
-clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_6
 sourceCompatibility = JavaVersion.VERSION_1_6

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/GraphQLCompiler.kt
@@ -63,7 +63,7 @@ class GraphQLCompiler {
   companion object {
     const val FILE_EXTENSION = "graphql"
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
-    const val APOLLOCODEGEN_VERSION = "0.10.9"
+    const val APOLLOCODEGEN_VERSION = "0.10.10"
   }
 
   data class Arguments(

--- a/apollo-compiler/src/test/graphql/apollo-codegen.properties
+++ b/apollo-compiler/src/test/graphql/apollo-codegen.properties
@@ -1,1 +1,1 @@
-apollo-codegen version=0.10.9
+apollo-codegen version=0.10.10

--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'java-gradle-plugin'
-clearSkipApolloRuntimeDep()
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
-skipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-rx2support/build.gradle
+++ b/apollo-rx2support/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-rxsupport/build.gradle
+++ b/apollo-rxsupport/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-clearSkipApolloRuntimeDep()
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     classpath dep.apolloPlugin
   }
 }
-clearSkipApolloRuntimeDep()
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.apollographql.android'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ subprojects {
   buildscript {
     repositories {
       jcenter()
-      maven { url "https://jitpack.io" }
       maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
@@ -14,7 +13,6 @@ subprojects {
   }
   repositories {
     jcenter()
-    maven { url "https://jitpack.io" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
   }
 
@@ -43,17 +41,5 @@ subprojects {
         check.dependsOn('checkstyle')
       }
     }
-  }
-}
-
-// This prevents the plugin from adding the snapshot version of
-// apollo-runtime dependencies to the dependencies set
-def skipApolloRuntimeDep() {
-  System.setProperty("apollographql.skipRuntimeDep", "true")
-}
-// Clears the skipRuntimeDep property for other modules
-def clearSkipApolloRuntimeDep() {
-  if (System.getProperty("apollographql.skipRuntimeDep") != null) {
-    System.clearProperty("apollographql.skipRuntimeDep")
   }
 }


### PR DESCRIPTION
Bump apollo-codegen version, update README for v0.3 release.

Also, removes the unnecessary `skipApolloRuntimeDep` method since project dependencies
are included in the resolved compile dependency sets and so the apollo-integration module will use the project version of `apollo-runtime` (verified that locally).