### PR TITLE
Add guide for supporting Kotlin developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ apply plugin: 'com.apollographql.android'
 
 The Android Plugin must be applied before the Apollo plugin
 
+### Kotlin
+
+If using Apollo in your Kotlin project, make sure to apply the Apollo plugin before your Kotlin plugins within your app module's `build.gradle`:
+
+```
+apply plugin: 'com.apollographql.android'
+// Kotlin plugins
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+...
+```
+
 ## Generate Code using Apollo
 
 Follow these steps:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ If using Apollo in your Kotlin project, make sure to apply the Apollo plugin bef
 
 ```
 apply plugin: 'com.apollographql.android'
-// Kotlin plugins
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 ...


### PR DESCRIPTION
The order of plugins is essential to getting Apollo working with Kotlin, and is often missed when getting started. Adding this guide snippet will help fix that issue.