### PR TITLE
ApolloWatcherTest- cancel watcher at end of each test

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -13,7 +13,6 @@ import com.apollographql.apollo.exception.ApolloException;
 
 import junit.framework.Assert;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +34,7 @@ public class ApolloWatcherTest {
   private MockWebServer server;
   private static final int TIME_OUT_SECONDS = 5;
 
-  @Before public void setUp() throws IOException {
+  @Before public void setUp() {
     server = new MockWebServer();
     OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
 
@@ -52,10 +51,6 @@ public class ApolloWatcherTest {
           }
         })
         .build();
-  }
-
-  @After public void tearDown() throws IOException {
-    server.shutdown();
   }
 
   @Test

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -93,6 +93,7 @@ public class ApolloWatcherTest {
     // Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
   }
@@ -124,6 +125,7 @@ public class ApolloWatcherTest {
         });
 
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
@@ -165,6 +167,7 @@ public class ApolloWatcherTest {
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
     apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
+
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
   }
@@ -243,6 +246,7 @@ public class ApolloWatcherTest {
     // -- this is for the refetch
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
   }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.exception.ApolloException;
 
 import junit.framework.Assert;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,6 +52,13 @@ public class ApolloWatcherTest {
           }
         })
         .build();
+  }
+
+  @After public void tearDown() {
+    try {
+      server.shutdown();
+    } catch (IOException ignored) {
+    }
   }
 
   @Test

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -9,7 +9,6 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
-import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.exception.ApolloException;
 
 import junit.framework.Assert;
@@ -34,13 +33,11 @@ import static com.google.common.truth.Truth.assertThat;
 public class ApolloWatcherTest {
   private ApolloClient apolloClient;
   private MockWebServer server;
-  private NormalizedCache normalizedCache;
-  private static final int TIME_OUT_SECONDS = 3;
+  private static final int TIME_OUT_SECONDS = 5;
 
-  @Before public void setUp() {
+  @Before public void setUp() throws IOException {
     server = new MockWebServer();
     OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
-    normalizedCache = new InMemoryNormalizedCache();
 
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
@@ -55,15 +52,10 @@ public class ApolloWatcherTest {
           }
         })
         .build();
-
-    normalizedCache = apolloClient.apolloStore().normalizedCache();
   }
 
-  @After public void tearDown() {
-    try {
-      server.shutdown();
-    } catch (IOException ignored) {
-    }
+  @After public void tearDown() throws IOException {
+    server.shutdown();
   }
 
   @Test
@@ -90,8 +82,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 
@@ -101,6 +91,7 @@ public class ApolloWatcherTest {
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
@@ -126,8 +117,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 
@@ -138,6 +127,7 @@ public class ApolloWatcherTest {
     // Wait 3 seconds to make sure no double callback.
     // Successful if timeout _is_ reached
     secondResponseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
@@ -164,8 +154,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 
@@ -175,6 +163,7 @@ public class ApolloWatcherTest {
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
     apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
@@ -200,8 +189,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 
@@ -214,10 +201,11 @@ public class ApolloWatcherTest {
     // Wait 3 seconds to make sure no double callback.
     // Successful if timeout _is_ reached
     secondResponseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
-  public void rewatchCacheControl() throws IOException, InterruptedException, TimeoutException {
+  public void testRefetchCacheControl() throws IOException, InterruptedException, TimeoutException {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
@@ -232,26 +220,28 @@ public class ApolloWatcherTest {
                   assertThat(response.data().hero().name()).isEqualTo("R2-D2");
                 } else if (secondResponseLatch.getCount() == 1) {
                   assertThat(response.data().hero().name()).isEqualTo("ArTwo");
+                } else {
+                  Assert.fail("Unknown hero name: " + response.data().hero().name());
                 }
                 firstResponseLatch.countDown();
                 secondResponseLatch.countDown();
               }
 
               @Override public void onFailure(@Nonnull ApolloException e) {
-                Assert.fail(e.getMessage());
-                firstResponseLatch.countDown();
-                secondResponseLatch.countDown();
+                Assert.fail(e.getCause().getMessage());
               }
             });
 
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
-    //Another newer call gets updated information -- need to queue up two network responses
+    //A different call gets updated information.
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
 
     //To verify that the updated response comes from server use a different name change
+    // -- this is for the refetch
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"));
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
@@ -294,8 +284,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 
@@ -305,6 +293,7 @@ public class ApolloWatcherTest {
     apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
+    watcher.cancel();
   }
 
   @Test
@@ -331,8 +320,6 @@ public class ApolloWatcherTest {
 
           @Override public void onFailure(@Nonnull ApolloException e) {
             Assert.fail(e.getMessage());
-            firstResponseLatch.countDown();
-            secondResponseLatch.countDown();
           }
         });
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -33,10 +33,11 @@ import static com.google.common.truth.Truth.assertThat;
 public class ApolloWatcherTest {
   private ApolloClient apolloClient;
   private MockWebServer server;
-  private static final int TIME_OUT_SECONDS = 5;
+  private static final int TIME_OUT_SECONDS = 3;
 
-  @Before public void setUp() {
+  @Before public void setUp() throws IOException {
     server = new MockWebServer();
+    server.start();
     OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
 
     apolloClient = ApolloClient.builder()

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NamedCountDownLatch.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NamedCountDownLatch.java
@@ -32,8 +32,7 @@ public class NamedCountDownLatch extends CountDownLatch {
    */
   public void awaitOrThrowWithTimeout(long timeout, TimeUnit timeUnit)
       throws InterruptedException, TimeoutException {
-    this.await(timeout, timeUnit);
-    if (this.getCount() != 0) {
+    if (!this.await(timeout, timeUnit)) {
       throw new TimeoutException("Time expired before latch, " + this.name() + "count went to zero.");
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloWatcher.java
@@ -67,8 +67,8 @@ final class RealApolloWatcher<T> implements ApolloWatcher<T> {
   }
 
   private void refetch() {
-    activeCall.cancel();
     apolloStore.unsubscribe(recordChangeSubscriber);
+    activeCall.cancel();
     activeCall = activeCall.clone().cacheControl(refetchCacheControl);
     activeCall.enqueue(callbackProxy(this.callback));
   }
@@ -80,9 +80,9 @@ final class RealApolloWatcher<T> implements ApolloWatcher<T> {
           return;
         }
 
-        sourceCallback.onResponse(response);
         dependentKeys = response.dependentKeys();
         apolloStore.subscribe(recordChangeSubscriber);
+        sourceCallback.onResponse(response);
       }
 
       @Override public void onFailure(@Nonnull ApolloException e) {


### PR DESCRIPTION
We saw an ApolloWatcherTest spuriously fail on CI. I could not get it fail locally, but trying a few things to make the tests more stable

- Bump timeout to 5 seconds
- Cancel watcher at end of each test
- Remove countdown on errors -- we already timeout if a latch does not countdown
- Some style fixes