### PR TITLE
add a schema introspection task

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloCodeGenInstallTask.java
@@ -24,18 +24,17 @@ public class ApolloCodeGenInstallTask extends NpmTask {
   private static final String INSTALL_DIR =  "apollo-codegen/node_modules/apollo-codegen";
 
   @OutputDirectory private File installDir;
-
+  private File apolloPackageFile;
+  
   public ApolloCodeGenInstallTask() {
     // TODO: set to const when ApolloPlugin is in java
     setGroup("apollo");
     setDescription("Runs npm install for apollo-codegen");
-    installDir = new File(getProject().getBuildDir(), INSTALL_DIR);
-    installDir.mkdirs();
-
+    installDir = getProject().file(getProject().getBuildDir() + "/" + INSTALL_DIR);
     File workingDir = new File(getProject().getBuildDir(), "apollo-codegen");
     setWorkingDir(workingDir);
+    apolloPackageFile = getProject().file(workingDir + "/package.json");
 
-    final File apolloPackageFile = new File(workingDir, "package.json");
     final boolean isSameCodegenVersion = isSameApolloCodegenVersion(getApolloVersion());
 
     if (!isSameCodegenVersion) {
@@ -46,15 +45,18 @@ public class ApolloCodeGenInstallTask extends NpmTask {
         return apolloPackageFile.isFile() && isSameCodegenVersion;
       }
     });
+  }
 
+  @Override
+  public void exec() {
     if (!apolloPackageFile.isFile()) {
       writePackageFile(apolloPackageFile);
     }
     setArgs(Lists.newArrayList("install", "apollo-codegen@" + GraphQLCompiler.APOLLOCODEGEN_VERSION, "--save",
         "--save-exact"));
     getLogging().captureStandardOutput(LogLevel.INFO);
+    super.exec();
   }
-
   private static class PackageJson {
     String version;
   }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloIRGenTask.java
@@ -29,7 +29,8 @@ import com.google.common.collect.Lists;
 import com.moowork.gradle.node.task.NodeTask;
 
 public class ApolloIRGenTask extends NodeTask {
-  private static final String APOLLO_CODEGEN = "apollo-codegen/node_modules/apollo-codegen/lib/cli.js";
+  static final String APOLLO_CODEGEN_EXEC_FILE = "lib/cli.js";
+  private static final String APOLLO_CODEGEN = "apollo-codegen/node_modules/apollo-codegen/" + APOLLO_CODEGEN_EXEC_FILE;
   static final String NAME = "generate%sApolloIR";
 
   @Internal private String variant;

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloSchemaIntrospectionTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloSchemaIntrospectionTask.java
@@ -4,21 +4,25 @@ import com.google.common.collect.Lists;
 
 import com.moowork.gradle.node.task.NodeTask;
 
+import org.gradle.api.internal.tasks.options.Option;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ApolloSchemaIntrospectionTask extends NodeTask{
-  // URL for the GraphQL server, also supports a local query file
+  @Option(option = "url", description = "URL for the GraphQL server, also supports a local query file")
   private String url;
-  // Output path for the GraphQL schema file relative to the project root
+  @Option(option = "output", description = "Output path for the GraphQL schema file relative to the project root")
   private String output;
-  // Additional header to send to the server
-  private String header;
-  // Allows "insecure" SSL connection to the server
+  @Option(option = "headers", description = "Additional Headers to send to the server")
+  private List<String> headers;
+  @Option(option = "insecure", description = "Allows \"insecure\" SSL connection to the server")
   private boolean insecure;
 
   public ApolloSchemaIntrospectionTask() {
     dependsOn(ApolloCodeGenInstallTask.NAME);
+    headers = new ArrayList<>();
   }
 
   @Override
@@ -33,9 +37,11 @@ public class ApolloSchemaIntrospectionTask extends NodeTask{
     List<String> args = Lists.newArrayList("introspect-schema", url, "--output", getProject().file(output)
         .getAbsolutePath());
 
-    if (!Utils.isNullOrEmpty(header)) {
-      args.add("--header");
-      args.add(header);
+    if (!headers.isEmpty()) {
+      for(String h : headers) {
+        args.add("--header");
+        args.add(h);
+      }
     }
 
     if (insecure) {
@@ -55,8 +61,8 @@ public class ApolloSchemaIntrospectionTask extends NodeTask{
     this.output = output;
   }
 
-  public void setHeader(String header) {
-    this.header = header;
+  public void setHeaders(List<String> header) {
+    this.headers = header;
   }
 
   public void setInsecure(boolean inSecure) {

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloSchemaIntrospectionTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/ApolloSchemaIntrospectionTask.java
@@ -1,0 +1,65 @@
+package com.apollographql.android.gradle;
+
+import com.google.common.collect.Lists;
+
+import com.moowork.gradle.node.task.NodeTask;
+
+import java.io.File;
+import java.util.List;
+
+public class ApolloSchemaIntrospectionTask extends NodeTask{
+  // URL for the GraphQL server, also supports a local query file
+  private String url;
+  // Output path for the GraphQL schema file relative to the project root
+  private String output;
+  // Additional header to send to the server
+  private String header;
+  // Allows "insecure" SSL connection to the server
+  private boolean insecure;
+
+  public ApolloSchemaIntrospectionTask() {
+    dependsOn(ApolloCodeGenInstallTask.NAME);
+  }
+
+  @Override
+  public void exec() {
+    if (Utils.isNullOrEmpty(url) || Utils.isNullOrEmpty(output)) {
+      throw new IllegalArgumentException("Schema URL and output path can't be empty");
+    }
+
+    setScript(new File(getProject().getTasks().getByPath(ApolloCodeGenInstallTask.NAME).getOutputs().getFiles()
+        .getAsPath(), ApolloIRGenTask.APOLLO_CODEGEN_EXEC_FILE));
+
+    List<String> args = Lists.newArrayList("introspect-schema", url, "--output", getProject().file(output)
+        .getAbsolutePath());
+
+    if (!Utils.isNullOrEmpty(header)) {
+      args.add("--header");
+      args.add(header);
+    }
+
+    if (insecure) {
+      args.add("--insecure");
+      args.add("true");
+    }
+
+    setArgs(args);
+    super.exec();
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public void setOutput(String output) {
+    this.output = output;
+  }
+
+  public void setHeader(String header) {
+    this.header = header;
+  }
+
+  public void setInsecure(boolean inSecure) {
+    this.insecure = inSecure;
+  }
+}

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/Utils.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/android/gradle/Utils.java
@@ -3,11 +3,15 @@ package com.apollographql.android.gradle;
 import java.io.File;
 
 public class Utils {
-  public static String capitalize(String s) {
+  static String capitalize(String s) {
     return s.substring(0, 1).toUpperCase() + s.substring(1);
   }
 
-  public static void deleteDirectory(File directory) {
+  static boolean isNullOrEmpty(String s) {
+    return s == null || s.length() == 0;
+  }
+
+  static void deleteDirectory(File directory) {
     if (directory.exists()){
       File[] files = directory.listFiles();
       if (files != null){


### PR DESCRIPTION
This task uses apollo-codegen to introspect a schema from a GraphQL server using `apollo-codegen introspect-schema`.


Usage, add the following to the build file:

```
task introspectSchema(type: com.apollographql.android.gradle.ApolloSchemaIntrospectionTask) {
  url = "http://api.githunt.com/graphql"
  output = "src/main/graphql/schema.json"
}
```
And run `gradle introspectSchema`

Closes #91.