### PR TITLE
add apollo-plugin tasks to the androidTest source sets

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/android/gradle/ApolloPlugin.groovy
@@ -91,6 +91,9 @@ class ApolloPlugin implements Plugin<Project> {
       getVariants().all { v ->
         addVariantTasks(v, apolloIRGenTask, apolloClassGenTask, v.sourceSets)
       }
+      project.android.testVariants.each { tv ->
+        addVariantTasks(tv, apolloIRGenTask, apolloClassGenTask, tv.sourceSets)
+      }
     } else {
       getSourceSets().all { sourceSet ->
         addSourceSetTasks(sourceSet, apolloIRGenTask, apolloClassGenTask)
@@ -179,5 +182,4 @@ class ApolloPlugin implements Plugin<Project> {
     return project.android.hasProperty(
         'libraryVariants') ? project.android.libraryVariants : project.android.applicationVariants
   }
-
 }


### PR DESCRIPTION
Small change to add the plugin tasks to the androidTest source sets. 

This allows for writing android tests against test-specific queries and making use of the models generated by Apollo for those.

Closes #95.