### PR TITLE
Don't allow request to proceed from network/cache if fields missing

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -191,14 +191,12 @@ public class IntegrationTest {
     latch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
-  @Test public void dataEmpty() throws Exception {
+  @Test(expected = ApolloException.class) public void dataEmpty() throws Exception {
     MockResponse mockResponse = mockResponse("ResponseDataEmpty.json");
     server.enqueue(mockResponse);
 
     ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
-    Response<HeroName.Data> body = call.execute();
-    assertThat(body.data()).isNotNull();
-    assertThat(body.hasErrors()).isFalse();
+    call.execute();
   }
 
   @Test public void dataNull() throws Exception {
@@ -209,6 +207,14 @@ public class IntegrationTest {
     Response<HeroName.Data> body = call.execute();
     assertThat(body.data()).isNull();
     assertThat(body.hasErrors()).isFalse();
+  }
+
+  @Test(expected = ApolloException.class) public void fieldMissing() throws Exception {
+    MockResponse mockResponse = mockResponse("ResponseDataMissing.json");
+    server.enqueue(mockResponse);
+
+    ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
+    call.execute();
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -75,6 +75,14 @@ public class NormalizedCacheTestCase {
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
   }
 
+
+  @Test
+  public void episodeHeroNameCacheMiss() throws IOException, ApolloException {
+    EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
+    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    assertThat(body.data()).isNull();
+  }
+
   @Test public void heroAndFriendsNameResponse() throws IOException, ApolloException {
     server.enqueue(mockResponse("HeroAndFriendsNameResponse.json"));
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -296,8 +296,7 @@ public class NormalizedCacheTestCase {
     assertThat(characterData).isNull();
   }
 
-  @Test
-  public void testIndependentQueriesGoToNetworkWhenCacheMiss() throws IOException, ApolloException {
+  @Test public void independentQueriesGoToNetworkWhenCacheMiss() throws IOException, ApolloException {
     server.enqueue(mockResponse("HeroNameResponse.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
@@ -311,9 +310,7 @@ public class NormalizedCacheTestCase {
     assertThat(allPlanetsResponse.data().allPlanets()).isNotNull();
   }
 
-
-  @Test
-  public void testCacheOnlyMissReturnNullData() throws IOException, ApolloException {
+  @Test public void cacheOnlyMissReturnsNullData() throws IOException, ApolloException {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.data()).isNull();
@@ -322,14 +319,12 @@ public class NormalizedCacheTestCase {
   @Test public void cacheResponseWithNullableFields() throws IOException, ApolloException {
     server.enqueue(mockResponse("AllPlanetsNullableField.json"));
     AllPlanets query = new AllPlanets();
-    Response<AllPlanets.Data> body =
-        apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    Response<AllPlanets.Data> body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     assertThat(body).isNotNull();
     assertThat(body.hasErrors()).isFalse();
 
-    body =
-        apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body).isNotNull();
     assertThat(body.hasErrors()).isFalse();
   }

--- a/apollo-integration/src/test/resources/AllPlanetsNullableField.json
+++ b/apollo-integration/src/test/resources/AllPlanetsNullableField.json
@@ -1,0 +1,1073 @@
+{
+  "data": {
+    "allPlanets": {
+      "__typename": "PlanetsConnection",
+      "planets": [
+        {
+          "__typename": "Planet",
+          "name": "Tatooine",
+          "climates": [
+            "arid"
+          ],
+          "surfaceWater": 1,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 5,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Alderaan",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 40,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 2,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Yavin IV",
+          "climates": [
+            "temperate",
+            "tropical"
+          ],
+          "surfaceWater": 8,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Hoth",
+          "climates": [
+            "frozen"
+          ],
+          "surfaceWater": 100,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Dagobah",
+          "climates": [
+            "murky"
+          ],
+          "surfaceWater": 8,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 3,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Bespin",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 0,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Endor",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 8,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Naboo",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 12,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 4,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Coruscant",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 4,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Kamino",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 100,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Geonosis",
+          "climates": [
+            "temperate",
+            "arid"
+          ],
+          "surfaceWater": 5,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Utapau",
+          "climates": [
+            "temperate",
+            "arid",
+            "windy"
+          ],
+          "surfaceWater": 0.9,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Mustafar",
+          "climates": [
+            "hot"
+          ],
+          "surfaceWater": 0,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Kashyyyk",
+          "climates": [
+            "tropical"
+          ],
+          "surfaceWater": 60,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Polis Massa",
+          "climates": [
+            "artificial temperate"
+          ],
+          "surfaceWater": 0,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Mygeeto",
+          "climates": [
+            "frigid"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Felucia",
+          "climates": [
+            "hot",
+            "humid"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Cato Neimoidia",
+          "climates": [
+            "temperate",
+            "moist"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Saleucami",
+          "climates": [
+            "hot"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Stewjon",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Eriadu",
+          "climates": [
+            "polluted"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Corellia",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 70,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Rodia",
+          "climates": [
+            "hot"
+          ],
+          "surfaceWater": 60,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Nal Hutta",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Dantooine",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Bestine IV",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 98,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Ord Mantell",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 10,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "unknown",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Trandosha",
+          "climates": [
+            "arid"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Socorro",
+          "climates": [
+            "arid"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Mon Cala",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 100,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Chandrila",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 40,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Sullust",
+          "climates": [
+            "superheated"
+          ],
+          "surfaceWater": 5,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Toydaria",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Malastare",
+          "climates": [
+            "arid",
+            "temperate",
+            "tropical"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Dathomir",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Ryloth",
+          "climates": [
+            "temperate",
+            "arid",
+            "subartic"
+          ],
+          "surfaceWater": 5,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Aleen Minor",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Vulpter",
+          "climates": [
+            "temperate",
+            "artic"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Troiken",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Tund",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Haruun Kal",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Cerea",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 20,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Glee Anselm",
+          "climates": [
+            "tropical",
+            "temperate"
+          ],
+          "surfaceWater": 80,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Iridonia",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Tholoth",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Iktotch",
+          "climates": [
+            "arid",
+            "rocky",
+            "windy"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Quermia",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Dorin",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Champala",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Mirial",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Serenno",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Concord Dawn",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Zolan",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Ojom",
+          "climates": [
+            "frigid"
+          ],
+          "surfaceWater": 100,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Skako",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Muunilinst",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 25,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Shili",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Kalee",
+          "climates": [
+            "arid",
+            "temperate",
+            "tropical"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        },
+        {
+          "__typename": "Planet",
+          "name": "Umbara",
+          "climates": [
+            "unknown"
+          ],
+          "surfaceWater": null,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/apollo-integration/src/test/resources/ResponseDataMissing.json
+++ b/apollo-integration/src/test/resources/ResponseDataMissing.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Droid"
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -67,6 +67,10 @@ public final class Record {
     return fields.get(fieldKey);
   }
 
+  public boolean hasField(String fieldKey) {
+    return fields.containsKey(fieldKey);
+  }
+
   public String key() {
     return key;
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -25,10 +25,11 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
   private SimpleStack<List<String>> pathStack;
   private SimpleStack<Record> recordStack;
   private SimpleStack<Object> valueStack;
-  private Set<String> dependentKeys;
   private List<String> path;
   private Record.Builder currentRecordBuilder;
-  private RecordSet recordSet;
+
+  private RecordSet recordSet = new RecordSet();
+  private Set<String> dependentKeys = Collections.emptySet();
 
   public Collection<Record> records() {
     return recordSet.allRecords();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
@@ -2,6 +2,8 @@ package com.apollographql.apollo.internal.field;
 
 import com.apollographql.apollo.api.Field;
 
+import java.io.IOException;
+
 public interface FieldValueResolver<R> {
-  <T> T valueFor(R recordSet, Field field);
+  <T> T valueFor(R recordSet, Field field) throws IOException;
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
@@ -2,11 +2,15 @@ package com.apollographql.apollo.internal.field;
 
 import com.apollographql.apollo.api.Field;
 
+import java.io.IOException;
 import java.util.Map;
 
 public final class MapFieldValueResolver implements FieldValueResolver<Map<String, Object>> {
 
-  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Map<String, Object> map, Field field) {
+  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Map<String, Object> map, Field field) throws IOException {
+    if (!map.containsKey(field.responseName())) {
+      throw new IOException("Missing value: " + field.responseName());
+    }
     return (T) map.get(field.responseName());
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/MapFieldValueResolver.java
@@ -7,7 +7,8 @@ import java.util.Map;
 
 public final class MapFieldValueResolver implements FieldValueResolver<Map<String, Object>> {
 
-  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Map<String, Object> map, Field field) throws IOException {
+  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Map<String, Object> map, Field field)
+      throws IOException {
     if (!map.containsKey(field.responseName())) {
       throw new IOException("Missing value: " + field.responseName());
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/ResponseJsonStreamReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/ResponseJsonStreamReader.java
@@ -146,6 +146,7 @@ public class ResponseJsonStreamReader {
       String name = streamReader.nextName();
       if (streamReader.isNextNull()) {
         streamReader.skipNext();
+        result.put(name, null);
       } else if (streamReader.isNextObject()) {
         result.put(name, readObject(streamReader));
       } else if (streamReader.isNextList()) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
@@ -204,7 +204,7 @@ import java.util.Map;
     }
   }
 
-  @SuppressWarnings("unchecked") private <T> T readCustomType(Field.CustomTypeField field) {
+  @SuppressWarnings("unchecked") private <T> T readCustomType(Field.CustomTypeField field) throws IOException {
     Object value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -195,7 +195,7 @@ public class ResponseReaderTest {
     checkReadFields(recordSet, successField, classCastExceptionField, responseObject1);
   }
 
-  @Test public void optionalFields() throws Exception {
+  @Test public void optionalFieldsIOException() throws Exception {
     List<Field> fields = asList(
         Field.forString("stringField", "stringField", null, true),
         Field.forInt("intField", "intField", null, true),
@@ -224,11 +224,16 @@ public class ResponseReaderTest {
 
     RealResponseReader<Map<String, Object>> responseReader = responseReader(Collections.<String, Object>emptyMap());
     for (Field field : fields) {
-      assertThat(responseReader.read(field)).isNull();
+      try {
+        responseReader.read(field);
+        fail("expected IOException for field: " + field);
+      } catch (IOException expected) {
+        //expected
+      }
     }
   }
 
-  @Test public void mandatoryFieldsNpe() throws Exception {
+  @Test public void mandatoryFieldsIOException() throws Exception {
     List<Field> fields = asList(
         Field.forString("stringField", "stringField", null, false),
         Field.forInt("intField", "intField", null, false),
@@ -260,7 +265,7 @@ public class ResponseReaderTest {
       try {
         responseReader.read(field);
         fail("expected NullPointerException for field: " + field);
-      } catch (NullPointerException expected) {
+      } catch (IOException expected) {
         //expected
       }
     }


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/466

There is currently a bug where if a request has all `@nullable` fields and has never been executed before, and is executed with CACHE_FIRST, we will resolve null from cache and never go to network.

Per the graphql spec, requested fields should never be missing -- only null. Additionally, we should respect this in the cache, and store null when the server returns null.

As this is part of the GQL spec, if the server returns missing fields, we should throw an exception.

If there are missing fields when reading from the cache, this is a cache miss. This is an important case because if all the objects in a query are nullable, the cache needs to be able to differentiate between valid nullability, and nullability because a request has never been executed.