### PR TITLE
Prepare for query re-fetching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2 -x apollo-gradle-plugin:test -x apollo-integration:build
+  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2 -x apollo-gradle-plugin:test -x apollo-integration:build -x apollo-integration:connectedCheck
   - .buildscript/integration_tests_composite.sh
 
 before_script:

--- a/apollo-android-support/src/androidTest/java/com/apollographql/apollo/ApolloCallbackTest.java
+++ b/apollo-android-support/src/androidTest/java/com/apollographql/apollo/ApolloCallbackTest.java
@@ -50,7 +50,7 @@ public class ApolloCallbackTest {
     final AtomicBoolean invoked = new AtomicBoolean();
     final Handler callbackHandler = mockCallbackHandler(invoked);
     server.enqueue(new MockResponse().setResponseCode(401).setBody("Unauthorized request!"));
-    apolloClient.newCall(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
+    apolloClient.query(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected onHttpError");
       }
@@ -71,7 +71,7 @@ public class ApolloCallbackTest {
     final CountDownLatch countDownLatch = new CountDownLatch(1);
     final AtomicBoolean invoked = new AtomicBoolean();
     final Handler callbackHandler = mockCallbackHandler(invoked);
-    apolloClient.newCall(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
+    apolloClient.query(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected onNetworkError");
       }
@@ -93,7 +93,7 @@ public class ApolloCallbackTest {
     final AtomicBoolean invoked = new AtomicBoolean();
     final Handler callbackHandler = mockCallbackHandler(invoked);
     server.enqueue(new MockResponse().setResponseCode(200).setBody("nonsense"));
-    apolloClient.newCall(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
+    apolloClient.query(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected onParseError");
       }
@@ -127,7 +127,7 @@ public class ApolloCallbackTest {
         "    }" +
         "  ]" +
         "}"));
-    apolloClient.newCall(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
+    apolloClient.query(EMPTY_QUERY).enqueue(ApolloCallback.wrap(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         countDownLatch.countDown();
       }

--- a/apollo-android-support/src/androidTest/java/com/apollographql/apollo/TestUtils.java
+++ b/apollo-android-support/src/androidTest/java/com/apollographql/apollo/TestUtils.java
@@ -2,6 +2,7 @@ package com.apollographql.apollo;
 
 import android.os.Looper;
 
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -9,6 +10,8 @@ import com.apollographql.apollo.api.ResponseReader;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Handler;
+
+import javax.annotation.Nonnull;
 
 public final class TestUtils {
   public static final Query EMPTY_QUERY = new Query() {
@@ -30,6 +33,10 @@ public final class TestUtils {
 
     @Override public Object wrapData(Data data) {
       return data;
+    }
+
+    @Nonnull @Override public OperationName name() {
+      return null;
     }
   };
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -31,6 +31,13 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
   T wrapData(D data);
 
   /**
+   * Returns GraphQL operation name.
+   *
+   * @return {@link OperationName} operation name
+   */
+  @Nonnull OperationName name();
+
+  /**
    * Abstraction for data returned by the server in response to this operation.
    */
   interface Data {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/OperationName.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/OperationName.java
@@ -1,0 +1,13 @@
+package com.apollographql.apollo.api;
+
+/**
+ * GraphQL operation name.
+ */
+public interface OperationName {
+  /**
+   * Returns operation name.
+   *
+   * @return operation name
+   */
+  String name();
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/android/compiler/OperationTypeSpecBuilder.kt
@@ -2,6 +2,7 @@ package com.apollographql.android.compiler
 
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.android.compiler.ir.*
+import com.apollographql.apollo.api.OperationName
 import com.squareup.javapoet.*
 import javax.lang.model.element.Modifier
 
@@ -26,6 +27,7 @@ class OperationTypeSpecBuilder(
         .addResponseFieldMapperMethod()
         .addBuilder(context)
         .addType(operation.toTypeSpec(newContext))
+        .addOperationName()
         .build()
         .flatten(excludeTypeNames = listOf(Util.MAPPER_TYPE_NAME, SchemaTypeSpecBuilder.FRAGMENTS_TYPE_NAME))
   }
@@ -179,6 +181,35 @@ class OperationTypeSpecBuilder(
         ClassName.get("", "$OPERATION_TYPE_NAME.Variables")
       else
         ClassNames.GRAPHQL_OPERATION_VARIABLES
+
+  private fun TypeSpec.Builder.addOperationName(): TypeSpec.Builder {
+    fun operationNameTypeSpec() = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(OperationName::class.java)
+        .addMethod(MethodSpec.methodBuilder("name")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .returns(java.lang.String::class.java)
+            .addStatement("return \$S", operation.operationName)
+            .build())
+        .build()
+
+    fun TypeSpec.Builder.addOperationNameField(): TypeSpec.Builder =
+        addField(FieldSpec.builder(OperationName::class.java, "OPERATION_NAME", Modifier.PRIVATE, Modifier.STATIC,
+            Modifier.FINAL)
+            .initializer("\$L", operationNameTypeSpec())
+            .build())
+
+    fun TypeSpec.Builder.addOperationNameAccessor(): TypeSpec.Builder =
+        addMethod(MethodSpec.methodBuilder("name")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .returns(OperationName::class.java)
+            .addStatement("return \$L", "OPERATION_NAME")
+            .build())
+
+    return addOperationNameField()
+        .addOperationNameAccessor()
+  }
 
   companion object {
     private val OPERATION_DEFINITION_FIELD_NAME = "OPERATION_DEFINITION"

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.arguments_complex;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -32,6 +33,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final TestQuery.Variables variables;
 
   public TestQuery(@Nullable Episode episode, int stars, double greenValue) {
@@ -60,6 +68,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static final class Variables extends Operation.Variables {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.arguments_simple;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -29,6 +30,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "}";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
 
   private final TestQuery.Variables variables;
 
@@ -58,6 +66,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static final class Variables extends Operation.Variables {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.custom_scalar_type;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -33,6 +34,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -57,6 +65,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.directives;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -24,6 +25,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "}";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
 
   private final Operation.Variables variables;
 
@@ -49,6 +57,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.enum_type;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -29,6 +30,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -53,6 +61,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.fragment_friends_connection;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -28,6 +29,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
    + HeroDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -52,6 +60,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -3,6 +3,7 @@ package com.example.fragment_in_fragment;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -38,6 +39,13 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
    + StarshipFragment.FRAGMENT_DEFINITION + "\n"
    + PilotFragment.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "AllStarships";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public AllStarships() {
@@ -62,6 +70,11 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
   @Override
   public ResponseFieldMapper<AllStarships.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.fragment_with_inline_fragment;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -32,6 +33,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
    + HeroDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -56,6 +64,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.fragments_with_type_condition;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -36,6 +37,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
    + HumanDetails.FRAGMENT_DEFINITION + "\n"
    + DroidDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -60,6 +68,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.hero_details;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -38,6 +39,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -62,6 +70,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.hero_details_guava;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -38,6 +39,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -62,6 +70,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.hero_details_nullable;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -37,6 +38,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -61,6 +69,11 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.hero_name;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -24,6 +25,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "}";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
 
   private final Operation.Variables variables;
 
@@ -49,6 +57,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.inline_fragments_with_friends;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -44,6 +45,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -68,6 +76,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.input_object_type;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.internal.Optional;
@@ -34,6 +35,13 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final TestQuery.Variables variables;
 
   public TestQuery(@Nonnull Episode ep, @Nonnull ReviewInput review) {
@@ -64,6 +72,11 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static final class Variables extends Operation.Variables {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.nested_conditional_inline;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -54,6 +55,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final TestQuery.Variables variables;
 
   public TestQuery(@Nullable Episode episode) {
@@ -82,6 +90,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static final class Variables extends Operation.Variables {

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.no_accessors;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -32,6 +33,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
    + HeroDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -56,6 +64,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.scalar_types;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -23,6 +24,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String OPERATION_DEFINITION = "";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
 
   private final Operation.Variables variables;
 
@@ -48,6 +56,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -3,6 +3,7 @@ package com.example.simple_fragment;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -28,6 +29,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
    + HeroDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -52,6 +60,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.simple_inline_fragment;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -34,6 +35,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -58,6 +66,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.two_heroes_unique;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -31,6 +32,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -55,6 +63,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -2,6 +2,7 @@ package com.example.two_heroes_with_friends;
 
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -55,6 +56,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public TestQuery() {
@@ -79,6 +87,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -3,6 +3,7 @@ package com.example.unique_type_name;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
@@ -47,6 +48,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
    + HeroDetails.FRAGMENT_DEFINITION;
 
+  private static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "HeroDetailQuery";
+    }
+  };
+
   private final Operation.Variables variables;
 
   public HeroDetailQuery() {
@@ -71,6 +79,11 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
   @Override
   public ResponseFieldMapper<HeroDetailQuery.Data> responseFieldMapper() {
     return new Data.Mapper();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
   }
 
   public static class Data implements Operation.Data {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -45,7 +45,7 @@ public class ApolloCallTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     mockWebServer.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.newCall(query);
+    ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.query(query);
 
     apolloCall.cancel();
 
@@ -77,7 +77,7 @@ public class ApolloCallTest {
         .setBodyDelay(TIME_OUT_SECONDS, TimeUnit.SECONDS));
 
     final AtomicReference<ApolloException> errorRef = new AtomicReference<>();
-    ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.newCall(query);
+    ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.query(query);
     apolloCall.enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
         responseLatch.countDown();
@@ -105,7 +105,7 @@ public class ApolloCallTest {
         .setBodyDelay(TIME_OUT_SECONDS, TimeUnit.SECONDS));
 
     final AtomicReference<ApolloException> errorRef = new AtomicReference<>();
-    final ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.newCall(query);
+    final ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.query(query);
     new Thread(new Runnable() {
       @Override public void run() {
         try {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -91,7 +91,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    Response<EpisodeHeroName.Data> actualResponse = client.newCall(query).execute();
+    Response<EpisodeHeroName.Data> actualResponse = client.query(query).execute();
 
     assertThat(expectedResponse.parsedResponse.get()).isEqualTo(actualResponse);
   }
@@ -127,7 +127,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    client.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+    client.query(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
         assertThat(expectedResponse.parsedResponse.get()).isEqualTo(response);
         responseLatch.countDown();
@@ -169,7 +169,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    Response<EpisodeHeroName.Data> actualResponse = client.newCall(query).execute();
+    Response<EpisodeHeroName.Data> actualResponse = client.query(query).execute();
 
     assertThat(rewrittenResponse.parsedResponse.get()).isEqualTo(actualResponse);
   }
@@ -211,7 +211,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    client.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+    client.query(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
         assertThat(rewrittenResponse.parsedResponse.get()).isEqualTo(response);
         responseLatch.countDown();
@@ -251,7 +251,7 @@ public class ApolloInterceptorTest {
     client = createApolloClient(interceptor);
 
     try {
-      client.newCall(query).execute();
+      client.query(query).execute();
     } catch (Exception e) {
       assertThat(e.getMessage()).isEqualTo("ApolloException");
       assertThat(e).isInstanceOf(ApolloException.class);
@@ -286,7 +286,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    client.newCall(query)
+    client.query(query)
         .enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
 
@@ -326,7 +326,7 @@ public class ApolloInterceptorTest {
     client = createApolloClient(interceptor);
 
     try {
-      client.newCall(query).execute();
+      client.query(query).execute();
     } catch (Exception e) {
       assertThat(e.getMessage()).isEqualTo("RuntimeException");
       assertThat(e).isInstanceOf(RuntimeException.class);
@@ -370,7 +370,7 @@ public class ApolloInterceptorTest {
         .build();
 
     client
-        .newCall(query)
+        .query(query)
         .enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
 
@@ -408,7 +408,7 @@ public class ApolloInterceptorTest {
     client = createApolloClient(interceptor);
 
     try {
-      client.newCall(query).execute();
+      client.query(query).execute();
       Assert.fail();
     } catch (Exception e) {
       assertThat(e).isInstanceOf(NullPointerException.class);
@@ -449,7 +449,7 @@ public class ApolloInterceptorTest {
         .dispatcher(new ExceptionHandlingExecutor(null, NullPointerException.class, latch))
         .build();
 
-    client.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+    client.query(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
 
       }
@@ -489,7 +489,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    Response<EpisodeHeroName.Data> actualResponse = client.newCall(query).execute();
+    Response<EpisodeHeroName.Data> actualResponse = client.query(query).execute();
     assertThat(actualResponse.data().hero().name()).isEqualTo("Artoo");
   }
 
@@ -540,7 +540,7 @@ public class ApolloInterceptorTest {
         .addApplicationInterceptor(secondInterceptor)
         .build();
 
-    Response<EpisodeHeroName.Data> actualResponse = client.newCall(query).execute();
+    Response<EpisodeHeroName.Data> actualResponse = client.query(query).execute();
     assertThat(expectedResponse.parsedResponse.get()).isEqualTo(actualResponse);
   }
 
@@ -574,7 +574,7 @@ public class ApolloInterceptorTest {
 
     client = createApolloClient(interceptor);
 
-    ApolloCall<EpisodeHeroName.Data> apolloCall = client.newCall(query);
+    ApolloCall<EpisodeHeroName.Data> apolloCall = client.query(query);
 
     apolloCall.enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -161,7 +161,7 @@ public class ApolloPrefetchTest {
     enqueueResponse("HttpCacheTestAllPlanets.json");
     apolloClient.prefetch(new AllPlanets()).execute();
     checkCachedResponse("HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets())
+    assertThat(apolloClient.query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS)).execute()
         .hasErrors()).isFalse();
   }
@@ -175,7 +175,7 @@ public class ApolloPrefetchTest {
     enqueueResponse("HttpCacheTestAllPlanets.json");
     apolloClient.prefetch(new AllPlanets()).execute();
     enqueueResponse("HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
   }
 
   @Test public void prefetchFileSystemWriteFailure() throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -5,8 +5,6 @@ import com.apollographql.android.impl.normalizer.HeroAndFriendsNamesWithIDs;
 import com.apollographql.android.impl.normalizer.type.Episode;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.CacheControl;
-import com.apollographql.apollo.cache.normalized.CacheKey;
-import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy;
 import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory;
 import com.apollographql.apollo.exception.ApolloException;
@@ -62,7 +60,7 @@ public class ApolloWatcherTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
     watcher.enqueueAndWatch(
         new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
@@ -84,7 +82,7 @@ public class ApolloWatcherTest {
 
     // Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
   }
@@ -98,7 +96,7 @@ public class ApolloWatcherTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
     watcher.enqueueAndWatch(
         new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
@@ -118,7 +116,7 @@ public class ApolloWatcherTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
 
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     // Wait 3 seconds to make sure no double callback.
     // Successful if timeout _is_ reached
@@ -135,7 +133,7 @@ public class ApolloWatcherTest {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
     watcher.enqueueAndWatch(
         new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
@@ -157,7 +155,7 @@ public class ApolloWatcherTest {
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
-    apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
@@ -172,7 +170,7 @@ public class ApolloWatcherTest {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
     watcher.enqueueAndWatch(
         new ApolloCall.Callback<EpisodeHeroName.Data>() {
           @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
@@ -193,7 +191,7 @@ public class ApolloWatcherTest {
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
-    apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     // Wait 3 seconds to make sure no double callback.
     // Successful if timeout _is_ reached
@@ -208,7 +206,7 @@ public class ApolloWatcherTest {
 
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
     watcher.refetchCacheControl(CacheControl.NETWORK_ONLY) //Force network instead of CACHE_FIRST default
         .enqueueAndWatch(
             new ApolloCall.Callback<EpisodeHeroName.Data>() {
@@ -236,7 +234,7 @@ public class ApolloWatcherTest {
     //To verify that the updated response comes from server use a different name change
     // -- this is for the refetch
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
@@ -248,7 +246,7 @@ public class ApolloWatcherTest {
     final NamedCountDownLatch cacheWarmUpLatch = new NamedCountDownLatch("cacheWarmUpLatch", 1);
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
-    apolloClient.newCall(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
+    apolloClient.query(query).enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
       @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
         cacheWarmUpLatch.countDown();
       }
@@ -265,7 +263,7 @@ public class ApolloWatcherTest {
     final NamedCountDownLatch firstResponseLatch = new NamedCountDownLatch("firstResponseLatch", 1);
     final NamedCountDownLatch secondResponseLatch = new NamedCountDownLatch("secondResponseLatch", 2);
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query)
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query)
         .cacheControl(CacheControl.CACHE_ONLY)
         .watcher();
     watcher.enqueueAndWatch(
@@ -288,7 +286,7 @@ public class ApolloWatcherTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     //Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     watcher.cancel();
@@ -303,7 +301,7 @@ public class ApolloWatcherTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     watcher.enqueueAndWatch(
         new ApolloCall.Callback<EpisodeHeroName.Data>() {
@@ -325,7 +323,7 @@ public class ApolloWatcherTest {
 
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
     watcher.cancel();
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     //Wait for 3 seconds to check that callback is not called twice.
     //Test is successful if timeout is reached.

--- a/apollo-integration/src/test/java/com/apollographql/apollo/AsyncNormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/AsyncNormalizedCacheTestCase.java
@@ -56,7 +56,7 @@ public class AsyncNormalizedCacheTestCase {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
     server.enqueue(mockResponse("HeroNameResponse.json"));
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
     for (int i = 0; i < 500; i++) {
@@ -65,7 +65,7 @@ public class AsyncNormalizedCacheTestCase {
 
     final CountDownLatch latch = new CountDownLatch(1000);
     for (int i = 0; i < 1000; i++) {
-      apolloClient.newCall(query).cacheControl(i % 2 == 0 ? CacheControl.NETWORK_FIRST : CacheControl.CACHE_ONLY)
+      apolloClient.query(query).cacheControl(i % 2 == 0 ? CacheControl.NETWORK_FIRST : CacheControl.CACHE_ONLY)
           .enqueue(new ApolloCall.Callback<EpisodeHeroName.Data>() {
             @Override public void onResponse(@Nonnull Response<EpisodeHeroName.Data> response) {
               assertThat(response.hasErrors()).isFalse();

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
@@ -77,7 +77,7 @@ public class CacheHeadersTest {
 
     server.enqueue(mockResponse("HeroAndFriendsNameResponse.json"));
     CacheHeaders cacheHeaders = CacheHeaders.builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "true").build();
-    apolloClient.newCall(new HeroAndFriendsNames(Episode.NEWHOPE))
+    apolloClient.query(new HeroAndFriendsNames(Episode.NEWHOPE))
         .cacheHeaders(cacheHeaders)
         .execute();
   }
@@ -117,7 +117,7 @@ public class CacheHeadersTest {
 
     server.enqueue(mockResponse("HeroAndFriendsNameResponse.json"));
 
-    apolloClient.newCall(new HeroAndFriendsNames(Episode.NEWHOPE)).execute();
+    apolloClient.query(new HeroAndFriendsNames(Episode.NEWHOPE)).execute();
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -99,7 +99,7 @@ public class HttpCacheTest {
     server.enqueue(mockResponse);
 
     try {
-      Response<AllPlanets.Data> body = apolloClient.newCall(new AllPlanets())
+      Response<AllPlanets.Data> body = apolloClient.query(new AllPlanets())
           .httpCachePolicy(HttpCachePolicy.NETWORK_ONLY).execute();
       assertThat(body.hasErrors()).isFalse();
       fail("expected ApolloException");
@@ -111,21 +111,21 @@ public class HttpCacheTest {
 
   @Test public void cacheDefault() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
   }
 
   @Test public void cacheSeveralResponses() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     enqueueResponse("/HttpCacheTestDroidDetails.json");
-    assertThat(apolloClient.newCall(new DroidDetails()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new DroidDetails()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestDroidDetails.json");
 
     enqueueResponse("/HttpCacheTestAllFilms.json");
-    assertThat(apolloClient.newCall(new AllFilms()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllFilms()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllFilms.json");
   }
 
@@ -137,13 +137,13 @@ public class HttpCacheTest {
         .okHttpClient(okHttpClient)
         .build();
 
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkNoCachedResponse();
   }
 
   @Test public void networkOnly() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
+    assertThat(apolloClient.query(new AllPlanets()).httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
         .execute().hasErrors()).isFalse();
     assertThat(server.getRequestCount()).isEqualTo(1);
     assertThat(lastHttResponse.networkResponse()).isNotNull();
@@ -153,7 +153,7 @@ public class HttpCacheTest {
 
   @Test public void networkOnly_responseWithGraphError_noCached() throws Exception {
     enqueueResponse("/ResponseError.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
+    assertThat(apolloClient.query(new AllPlanets()).httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
         .execute().hasErrors()).isTrue();
     assertThat(server.getRequestCount()).isEqualTo(1);
     assertThat(lastHttResponse.networkResponse()).isNotNull();
@@ -163,12 +163,12 @@ public class HttpCacheTest {
 
   @Test public void cacheOnlyHit() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.takeRequest()).isNotNull();
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS))
         .execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
@@ -180,20 +180,20 @@ public class HttpCacheTest {
   @Test(expected = ApolloHttpException.class) public void cacheOnlyMiss() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS))
         .execute();
   }
 
   @Test public void cacheNonStale() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.takeRequest()).isNotNull();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_FIRST.expireAfter(2, TimeUnit.SECONDS))
         .execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
@@ -203,13 +203,13 @@ public class HttpCacheTest {
 
   @Test public void cacheStale() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
 
     Thread.sleep(TimeUnit.SECONDS.toMillis(3));
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
     assertThat(lastHttResponse.networkResponse()).isNotNull();
     assertThat(lastHttResponse.cacheResponse()).isNull();
@@ -218,14 +218,14 @@ public class HttpCacheTest {
 
   @Test public void cacheStaleBeforeNetwork() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
 
     Thread.sleep(TimeUnit.SECONDS.toMillis(3));
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.NETWORK_FIRST)
         .execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
@@ -236,14 +236,14 @@ public class HttpCacheTest {
 
   @Test public void cacheStaleBeforeNetworkError() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
 
     Thread.sleep(TimeUnit.SECONDS.toMillis(3));
 
     server.enqueue(new MockResponse().setResponseCode(504).setBody(""));
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.NETWORK_FIRST)
         .execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
@@ -254,14 +254,14 @@ public class HttpCacheTest {
 
   @Test public void cacheUpdate() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(1);
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     Thread.sleep(TimeUnit.SECONDS.toMillis(3));
 
     enqueueResponse("/HttpCacheTestAllPlanets2.json");
-    apolloClient.newCall(new AllPlanets()).execute();
+    apolloClient.query(new AllPlanets()).execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
     checkCachedResponse("/HttpCacheTestAllPlanets2.json");
     assertThat(lastHttResponse.networkResponse()).isNotNull();
@@ -269,7 +269,7 @@ public class HttpCacheTest {
 
     enqueueResponse("/HttpCacheTestAllPlanets2.json");
     apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_FIRST.expireAfter(2, TimeUnit.SECONDS))
         .execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
@@ -281,7 +281,7 @@ public class HttpCacheTest {
   @Test public void fileSystemUnavailable() throws IOException, ApolloException {
     cacheStore.delegate = new DiskLruHttpCacheStore(new NoFileSystem(), new File("/cache/"), Integer.MAX_VALUE);
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkNoCachedResponse();
   }
 
@@ -291,12 +291,12 @@ public class HttpCacheTest {
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     faultyCacheStore.failStrategy(FaultyHttpCacheStore.FailStrategy.FAIL_HEADER_WRITE);
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkNoCachedResponse();
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     faultyCacheStore.failStrategy(FaultyHttpCacheStore.FailStrategy.FAIL_BODY_WRITE);
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkNoCachedResponse();
   }
 
@@ -305,12 +305,12 @@ public class HttpCacheTest {
     cacheStore.delegate = faultyCacheStore;
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     faultyCacheStore.failStrategy(FaultyHttpCacheStore.FailStrategy.FAIL_HEADER_READ);
-    assertThat(apolloClient.newCall(new AllPlanets()).httpCachePolicy(HttpCachePolicy.CACHE_FIRST.expireAfter(2, TimeUnit.SECONDS))
+    assertThat(apolloClient.query(new AllPlanets()).httpCachePolicy(HttpCachePolicy.CACHE_FIRST.expireAfter(2, TimeUnit.SECONDS))
         .execute().hasErrors()).isFalse();
     assertThat(server.getRequestCount()).isEqualTo(2);
 
@@ -318,7 +318,7 @@ public class HttpCacheTest {
     faultyCacheStore.failStrategy(FaultyHttpCacheStore.FailStrategy.FAIL_BODY_READ);
     try {
       apolloClient
-          .newCall(new AllPlanets())
+          .query(new AllPlanets())
           .httpCachePolicy(HttpCachePolicy.CACHE_FIRST.expireAfter(2, TimeUnit.SECONDS))
           .execute();
       fail("expected exception");
@@ -330,18 +330,18 @@ public class HttpCacheTest {
   @Test public void expireAfterRead() throws IOException, ApolloException {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
 
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     assertThat(apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS).expireAfterRead())
         .execute().hasErrors()).isFalse();
     checkNoCachedResponse();
 
     try {
       apolloClient
-          .newCall(new AllPlanets())
+          .query(new AllPlanets())
           .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS))
           .execute();
       fail("exception expected");
@@ -349,32 +349,32 @@ public class HttpCacheTest {
     }
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
   }
 
   @Test public void cacheNetworkError() throws IOException, ApolloException {
     server.enqueue(new MockResponse().setResponseCode(504).setBody(""));
     try {
-      apolloClient.newCall(new AllPlanets()).execute();
+      apolloClient.query(new AllPlanets()).execute();
       fail("exception expected");
     } catch (Exception expected) {
     }
     checkNoCachedResponse();
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     checkCachedResponse("/HttpCacheTestAllPlanets.json");
 
     assertThat(apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS))
         .execute().hasErrors()).isFalse();
   }
 
   @Test public void networkFirst() throws Exception {
     enqueueResponse("/HttpCacheTestAllPlanets.json");
-    assertThat(apolloClient.newCall(new AllPlanets()).execute().hasErrors()).isFalse();
+    assertThat(apolloClient.query(new AllPlanets()).execute().hasErrors()).isFalse();
     assertThat(server.getRequestCount()).isEqualTo(1);
     assertThat(lastHttResponse.networkResponse()).isNotNull();
     assertThat(lastHttResponse.cacheResponse()).isNull();
@@ -382,7 +382,7 @@ public class HttpCacheTest {
 
     enqueueResponse("/HttpCacheTestAllPlanets.json");
     assertThat(apolloClient
-        .newCall(new AllPlanets())
+        .query(new AllPlanets())
         .httpCachePolicy(HttpCachePolicy.NETWORK_FIRST.expireAfter(2, TimeUnit.SECONDS))
         .execute().hasErrors()).isFalse();
     assertThat(server.getRequestCount()).isEqualTo(2);

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -79,7 +79,7 @@ public class IntegrationTest {
   @SuppressWarnings("ConstantConditions") @Test public void allPlanetQuery() throws Exception {
     server.enqueue(mockResponse("HttpCacheTestAllPlanets.json"));
 
-    Response<AllPlanets.Data> body = apolloClient.newCall(new AllPlanets()).execute();
+    Response<AllPlanets.Data> body = apolloClient.query(new AllPlanets()).execute();
     assertThat(body.hasErrors()).isFalse();
 
     assertThat(server.takeRequest().getBody().readString(Charsets.UTF_8))
@@ -143,7 +143,7 @@ public class IntegrationTest {
 
   @Test public void errorResponse() throws Exception {
     server.enqueue(mockResponse("ResponseError.json"));
-    Response<AllPlanets.Data> body = apolloClient.newCall(new AllPlanets()).execute();
+    Response<AllPlanets.Data> body = apolloClient.query(new AllPlanets()).execute();
     assertThat(body.hasErrors()).isTrue();
     //noinspection ConstantConditions
     assertThat(body.errors()).containsExactly(new Error(
@@ -154,7 +154,7 @@ public class IntegrationTest {
   @Test public void allFilmsWithDate() throws Exception {
     server.enqueue(mockResponse("HttpCacheTestAllFilms.json"));
 
-    Response<AllFilms.Data> body = apolloClient.newCall(new AllFilms()).execute();
+    Response<AllFilms.Data> body = apolloClient.query(new AllFilms()).execute();
     assertThat(body.hasErrors()).isFalse();
 
 
@@ -176,7 +176,7 @@ public class IntegrationTest {
   @Test public void allPlanetQueryAsync() throws Exception {
     server.enqueue(mockResponse("HttpCacheTestAllPlanets.json"));
     final NamedCountDownLatch latch = new NamedCountDownLatch("latch", 1);
-    apolloClient.newCall(new AllPlanets()).enqueue(new ApolloCall.Callback<AllPlanets.Data>() {
+    apolloClient.query(new AllPlanets()).enqueue(new ApolloCall.Callback<AllPlanets.Data>() {
       @Override public void onResponse(@Nonnull Response<AllPlanets.Data> response) {
         assertThat(response.hasErrors()).isFalse();
         assertThat(response.data().allPlanets().planets().size()).isEqualTo(60);
@@ -195,7 +195,7 @@ public class IntegrationTest {
     MockResponse mockResponse = mockResponse("ResponseDataEmpty.json");
     server.enqueue(mockResponse);
 
-    ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
+    ApolloCall<HeroName.Data> call = apolloClient.query(new HeroName());
     call.execute();
   }
 
@@ -203,7 +203,7 @@ public class IntegrationTest {
     MockResponse mockResponse = mockResponse("ResponseDataNull.json");
     server.enqueue(mockResponse);
 
-    ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
+    ApolloCall<HeroName.Data> call = apolloClient.query(new HeroName());
     Response<HeroName.Data> body = call.execute();
     assertThat(body.data()).isNull();
     assertThat(body.hasErrors()).isFalse();
@@ -213,7 +213,7 @@ public class IntegrationTest {
     MockResponse mockResponse = mockResponse("ResponseDataMissing.json");
     server.enqueue(mockResponse);
 
-    ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
+    ApolloCall<HeroName.Data> call = apolloClient.query(new HeroName());
     call.execute();
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -68,10 +68,10 @@ public class NormalizedCacheTestCase {
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
   }
@@ -81,10 +81,10 @@ public class NormalizedCacheTestCase {
 
     HeroAndFriendsNames query = HeroAndFriendsNames.builder().episode(Episode.JEDI).build();
 
-    Response<HeroAndFriendsNames.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroAndFriendsNames.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
     assertThat(body.data().hero().friends()).hasSize(3);
@@ -98,10 +98,10 @@ public class NormalizedCacheTestCase {
 
     HeroAndFriendsNamesWithIDs query = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
-    Response<HeroAndFriendsNamesWithIDs.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroAndFriendsNamesWithIDs.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().id()).isEqualTo("2001");
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
@@ -120,10 +120,10 @@ public class NormalizedCacheTestCase {
     HeroAndFriendsNamesWithIDForParentOnly query = HeroAndFriendsNamesWithIDForParentOnly.builder()
         .episode(Episode.NEWHOPE).build();
 
-    Response<HeroAndFriendsNamesWithIDForParentOnly.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroAndFriendsNamesWithIDForParentOnly.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().id()).isEqualTo("2001");
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
@@ -138,10 +138,10 @@ public class NormalizedCacheTestCase {
 
     HeroAppearsIn query = new HeroAppearsIn();
 
-    Response<HeroAppearsIn.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroAppearsIn.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().appearsIn()).hasSize(3);
     assertThat(body.data().hero().appearsIn().get(0).name()).isEqualTo("NEWHOPE");
@@ -154,10 +154,10 @@ public class NormalizedCacheTestCase {
 
     HeroParentTypeDependentField query = HeroParentTypeDependentField.builder().episode(Episode.NEWHOPE).build();
 
-    Response<HeroParentTypeDependentField.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroParentTypeDependentField.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
     assertThat(body.data().hero().asDroid().name()).isEqualTo("R2-D2");
@@ -172,20 +172,20 @@ public class NormalizedCacheTestCase {
 
     HeroTypeDependentAliasedField query = HeroTypeDependentAliasedField.builder().episode(Episode.NEWHOPE).build();
 
-    Response<HeroTypeDependentAliasedField.Data> body = apolloClient.newCall(query).execute();
+    Response<HeroTypeDependentAliasedField.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().asHuman()).isNull();
     assertThat(body.data().hero().asDroid().property()).isEqualTo("Astromech");
 
     server.enqueue(mockResponse("HeroTypeDependentAliasedFieldResponseHuman.json"));
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().asDroid()).isNull();
     assertThat(body.data().hero().asHuman().property()).isEqualTo("Tatooine");
@@ -196,10 +196,10 @@ public class NormalizedCacheTestCase {
 
     SameHeroTwice query = new SameHeroTwice();
 
-    Response<SameHeroTwice.Data> body = apolloClient.newCall(query).execute();
+    Response<SameHeroTwice.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
     assertThat(body.data().r2().appearsIn()).hasSize(3);
@@ -213,10 +213,10 @@ public class NormalizedCacheTestCase {
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_FIRST).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_FIRST).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
   }
@@ -226,10 +226,10 @@ public class NormalizedCacheTestCase {
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
   }
@@ -239,17 +239,17 @@ public class NormalizedCacheTestCase {
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
     server.enqueue(mockResponse("HeroNameResponse.json"));
-    body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_FIRST).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.NETWORK_FIRST).execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
 
     server.enqueue(new MockResponse().setResponseCode(504).setBody(""));
-    body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_FIRST).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.NETWORK_FIRST).execute();
     assertThat(server.getRequestCount()).isEqualTo(3);
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
@@ -260,11 +260,11 @@ public class NormalizedCacheTestCase {
 
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
 
     server.enqueue(mockResponse("HeroNameResponse.json"));
-    body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     assertThat(server.getRequestCount()).isEqualTo(2);
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data().hero().name()).isEqualTo("R2-D2");
@@ -273,10 +273,10 @@ public class NormalizedCacheTestCase {
   @Test public void masterDetailSuccess() throws Exception {
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
     HeroAndFriendsNamesWithIDs query = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     CharacterNameById character = CharacterNameById.builder().id("1002").build();
-    CharacterNameById.Data characterData = apolloClient.newCall(character).cacheControl(CacheControl.CACHE_ONLY)
+    CharacterNameById.Data characterData = apolloClient.query(character).cacheControl(CacheControl.CACHE_ONLY)
         .execute().data();
 
     assertThat(characterData).isNotNull();
@@ -287,10 +287,10 @@ public class NormalizedCacheTestCase {
   @Test public void masterDetailFailIncomplete() throws Exception {
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
     HeroAndFriendsNamesWithIDs query = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     CharacterDetails character = CharacterDetails.builder().id("1002").build();
-    CharacterDetails.Data characterData = apolloClient.newCall(character).cacheControl(CacheControl.CACHE_ONLY)
+    CharacterDetails.Data characterData = apolloClient.query(character).cacheControl(CacheControl.CACHE_ONLY)
         .execute().data();
 
     assertThat(characterData).isNull();
@@ -299,32 +299,32 @@ public class NormalizedCacheTestCase {
   @Test public void independentQueriesGoToNetworkWhenCacheMiss() throws IOException, ApolloException {
     server.enqueue(mockResponse("HeroNameResponse.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).execute();
     assertThat(body.hasErrors()).isFalse();
     assertThat(body.data()).isNotNull();
 
     server.enqueue(mockResponse("AllPlanetsNullableField.json"));
     AllPlanets allPlanetsQuery = new AllPlanets();
-    final Response<AllPlanets.Data> allPlanetsResponse = apolloClient.newCall(allPlanetsQuery).execute();
+    final Response<AllPlanets.Data> allPlanetsResponse = apolloClient.query(allPlanetsQuery).execute();
     assertThat(allPlanetsResponse.hasErrors()).isFalse();
     assertThat(allPlanetsResponse.data().allPlanets()).isNotNull();
   }
 
   @Test public void cacheOnlyMissReturnsNullData() throws IOException, ApolloException {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
-    Response<EpisodeHeroName.Data> body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    Response<EpisodeHeroName.Data> body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body.data()).isNull();
   }
 
   @Test public void cacheResponseWithNullableFields() throws IOException, ApolloException {
     server.enqueue(mockResponse("AllPlanetsNullableField.json"));
     AllPlanets query = new AllPlanets();
-    Response<AllPlanets.Data> body = apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    Response<AllPlanets.Data> body = apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     assertThat(body).isNotNull();
     assertThat(body.hasErrors()).isFalse();
 
-    body = apolloClient.newCall(query).cacheControl(CacheControl.CACHE_ONLY).execute();
+    body = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute();
     assertThat(body).isNotNull();
     assertThat(body.hasErrors()).isFalse();
   }
@@ -333,7 +333,7 @@ public class NormalizedCacheTestCase {
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
 
     HeroAndFriendsNamesWithIDs query = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
-    apolloClient.newCall(query).execute();
+    apolloClient.query(query).execute();
 
     HeroAndFriendsNamesWithIDs.Data data = apolloClient.apolloStore().read(query);
     assertThat(data.hero().id()).isEqualTo("2001");
@@ -351,7 +351,7 @@ public class NormalizedCacheTestCase {
     server.enqueue(mockResponse("HeroAndFriendsWithFragmentResponse.json"));
 
     HeroAndFriendsNamesWithIDs query = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
-    apolloClient.newCall(query).execute();
+    apolloClient.query(query).execute();
 
     HeroWithFriendsFragment heroWithFriendsFragment = apolloClient.apolloStore().read(
         new HeroWithFriendsFragment.Mapper(), CacheKey.from("2001"), Operation.EMPTY_VARIABLES);

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
@@ -70,7 +70,7 @@ public class ResponseNormalizationTest {
     MockResponse mockResponse = mockResponse("HeroNameResponse.json");
     server.enqueue(mockResponse);
 
-    ApolloCall<HeroName.Data> call = apolloClient.newCall(new HeroName());
+    ApolloCall<HeroName.Data> call = apolloClient.query(new HeroName());
     Response<HeroName.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -88,7 +88,7 @@ public class ResponseNormalizationTest {
     server.enqueue(mockResponse);
 
     final EpisodeHeroName query = EpisodeHeroName.builder().episode(JEDI).build();
-    ApolloCall<EpisodeHeroName.Data> call = apolloClient.newCall(query);
+    ApolloCall<EpisodeHeroName.Data> call = apolloClient.query(query);
     Response<EpisodeHeroName.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -108,7 +108,7 @@ public class ResponseNormalizationTest {
 
     final HeroAppearsIn heroAppearsInQuery = new HeroAppearsIn();
 
-    ApolloCall<HeroAppearsIn.Data> call = apolloClient.newCall(heroAppearsInQuery);
+    ApolloCall<HeroAppearsIn.Data> call = apolloClient.query(heroAppearsInQuery);
     Response<HeroAppearsIn.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -126,7 +126,7 @@ public class ResponseNormalizationTest {
     server.enqueue(mockResponse);
     final HeroAndFriendsNames heroAndFriendsNameQuery = HeroAndFriendsNames.builder().episode(JEDI).build();
 
-    ApolloCall<HeroAndFriendsNames.Data> call = apolloClient.newCall(heroAndFriendsNameQuery);
+    ApolloCall<HeroAndFriendsNames.Data> call = apolloClient.query(heroAndFriendsNameQuery);
     Response<HeroAndFriendsNames.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -153,7 +153,7 @@ public class ResponseNormalizationTest {
     server.enqueue(mockResponse);
     final HeroAndFriendsNamesWithIDs heroAndFriendsWithIdsQuery = HeroAndFriendsNamesWithIDs.builder().episode(JEDI).build();
 
-    ApolloCall<HeroAndFriendsNamesWithIDs.Data> call = apolloClient.newCall(heroAndFriendsWithIdsQuery);
+    ApolloCall<HeroAndFriendsNamesWithIDs.Data> call = apolloClient.query(heroAndFriendsWithIdsQuery);
     Response<HeroAndFriendsNamesWithIDs.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -181,7 +181,7 @@ public class ResponseNormalizationTest {
     final HeroAndFriendsNamesWithIDForParentOnly heroAndFriendsWithIdsQuery = HeroAndFriendsNamesWithIDForParentOnly
         .builder().episode(JEDI).build();
 
-    ApolloCall<HeroAndFriendsNamesWithIDForParentOnly.Data> call = apolloClient.newCall(heroAndFriendsWithIdsQuery);
+    ApolloCall<HeroAndFriendsNamesWithIDForParentOnly.Data> call = apolloClient.query(heroAndFriendsWithIdsQuery);
     Response<HeroAndFriendsNamesWithIDForParentOnly.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -209,7 +209,7 @@ public class ResponseNormalizationTest {
 
     final SameHeroTwice sameHeroTwiceQuery = new SameHeroTwice();
 
-    ApolloCall<SameHeroTwice.Data> call = apolloClient.newCall(sameHeroTwiceQuery);
+    ApolloCall<SameHeroTwice.Data> call = apolloClient.query(sameHeroTwiceQuery);
     Response<SameHeroTwice.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -229,7 +229,7 @@ public class ResponseNormalizationTest {
 
     final HeroTypeDependentAliasedField aliasedQuery = HeroTypeDependentAliasedField.builder().episode(JEDI).build();
 
-    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.newCall(aliasedQuery);
+    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.query(aliasedQuery);
     Response<HeroTypeDependentAliasedField.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -248,7 +248,7 @@ public class ResponseNormalizationTest {
 
     final HeroTypeDependentAliasedField aliasedQuery = HeroTypeDependentAliasedField.builder().episode(EMPIRE).build();
 
-    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.newCall(aliasedQuery);
+    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.query(aliasedQuery);
     Response<HeroTypeDependentAliasedField.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -267,7 +267,7 @@ public class ResponseNormalizationTest {
 
     final HeroTypeDependentAliasedField aliasedQuery = HeroTypeDependentAliasedField.builder().episode(EMPIRE).build();
 
-    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.newCall(aliasedQuery);
+    ApolloCall<HeroTypeDependentAliasedField.Data> call = apolloClient.query(aliasedQuery);
     Response<HeroTypeDependentAliasedField.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -285,7 +285,7 @@ public class ResponseNormalizationTest {
     server.enqueue(mockResponse);
     final HeroParentTypeDependentField aliasedQuery = HeroParentTypeDependentField.builder().episode(JEDI).build();
 
-    ApolloCall<HeroParentTypeDependentField.Data> call = apolloClient.newCall(aliasedQuery);
+    ApolloCall<HeroParentTypeDependentField.Data> call = apolloClient.query(aliasedQuery);
     Response<HeroParentTypeDependentField.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 
@@ -307,7 +307,7 @@ public class ResponseNormalizationTest {
     server.enqueue(mockResponse);
     final HeroParentTypeDependentField aliasedQuery = HeroParentTypeDependentField.builder().episode(EMPIRE).build();
 
-    ApolloCall<HeroParentTypeDependentField.Data> call = apolloClient.newCall(aliasedQuery);
+    ApolloCall<HeroParentTypeDependentField.Data> call = apolloClient.query(aliasedQuery);
     Response<HeroParentTypeDependentField.Data> body = call.execute();
     assertThat(body.hasErrors()).isFalse();
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/Rx2ApolloTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/Rx2ApolloTest.java
@@ -65,7 +65,7 @@ public class Rx2ApolloTest {
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
 
     EpisodeHeroName.Data data = Rx2Apollo
-        .from(apolloClient.newCall(query))
+        .from(apolloClient.query(query))
         .test()
         .await()
         .assertNoErrors()
@@ -85,7 +85,7 @@ public class Rx2ApolloTest {
     TestObserver<Response<EpisodeHeroName.Data>> testObserver = new TestObserver<>();
 
     Disposable disposable = Rx2Apollo
-        .from(apolloClient.newCall(query))
+        .from(apolloClient.query(query))
         .delay(5, TimeUnit.SECONDS)
         .subscribeWith(testObserver);
 
@@ -135,7 +135,7 @@ public class Rx2ApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     Rx2Apollo
         .from(watcher)
@@ -168,7 +168,7 @@ public class Rx2ApolloTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     //Another newer call gets updated information
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_CHANGE));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
@@ -181,7 +181,7 @@ public class Rx2ApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     Rx2Apollo
         .from(watcher)
@@ -213,7 +213,7 @@ public class Rx2ApolloTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
 
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     secondResponseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
@@ -227,7 +227,7 @@ public class Rx2ApolloTest {
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     Rx2Apollo
         .from(watcher)
@@ -261,7 +261,7 @@ public class Rx2ApolloTest {
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     mockWebServer.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
-    apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
@@ -274,7 +274,7 @@ public class Rx2ApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     Disposable disposable = Rx2Apollo
         .from(watcher)
@@ -307,7 +307,7 @@ public class Rx2ApolloTest {
 
     mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_CHANGE));
     disposable.dispose();
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
 
     secondResponseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/RxApolloTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/RxApolloTest.java
@@ -61,7 +61,7 @@ public class RxApolloTest {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
     Response<EpisodeHeroName.Data> response = RxApollo
-        .from(apolloClient.newCall(query))
+        .from(apolloClient.query(query))
         .test()
         .awaitTerminalEvent()
         .assertNoErrors()
@@ -75,7 +75,7 @@ public class RxApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloCall<EpisodeHeroName.Data> call = apolloClient.newCall(query);
+    ApolloCall<EpisodeHeroName.Data> call = apolloClient.query(query);
     TestSubscriber<Response<EpisodeHeroName.Data>> subscriber = new TestSubscriber<>();
     Subscription subscription = RxApollo
         .from(call)
@@ -127,7 +127,7 @@ public class RxApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     RxApollo.from(watcher).subscribe(new Observer<Response<EpisodeHeroName.Data>>() {
       @Override public void onCompleted() {
@@ -153,7 +153,7 @@ public class RxApolloTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
     //Another newer call gets updated information
     server.enqueue(mockResponse("EpisodeHeroNameResponseNameChange.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 
@@ -165,7 +165,7 @@ public class RxApolloTest {
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     RxApollo.from(watcher).subscribe(new Observer<Response<EpisodeHeroName.Data>>() {
       @Override public void onCompleted() {
@@ -190,7 +190,7 @@ public class RxApolloTest {
     firstResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
 
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
-    apolloClient.newCall(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
+    apolloClient.query(query).cacheControl(CacheControl.NETWORK_ONLY).enqueue(null);
 
     // Wait 3 seconds to make sure no double callback.
     // Successful if timeout _is_ reached
@@ -206,7 +206,7 @@ public class RxApolloTest {
     server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"));
     EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-    ApolloWatcher<EpisodeHeroName.Data> watcher = apolloClient.newCall(query).watcher();
+    ApolloQueryWatcher<EpisodeHeroName.Data> watcher = apolloClient.query(query).watcher();
 
     RxApollo.from(watcher).subscribe(new Observer<Response<EpisodeHeroName.Data>>() {
       @Override public void onCompleted() {
@@ -234,7 +234,7 @@ public class RxApolloTest {
     HeroAndFriendsNamesWithIDs friendsQuery = HeroAndFriendsNamesWithIDs.builder().episode(Episode.NEWHOPE).build();
 
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"));
-    apolloClient.newCall(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
+    apolloClient.query(friendsQuery).cacheControl(CacheControl.NETWORK_ONLY).execute();
     secondResponseLatch.awaitOrThrowWithTimeout(TIME_OUT_SECONDS, TimeUnit.SECONDS);
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -1,10 +1,8 @@
 package com.apollographql.apollo;
 
-import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.CacheHeaders;
-import com.apollographql.apollo.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.exception.ApolloCanceledException;
 import com.apollographql.apollo.exception.ApolloException;
@@ -42,19 +40,6 @@ public interface ApolloCall<T> extends Cancelable {
    * @throws IllegalStateException when the call has already been executed
    */
   void enqueue(@Nullable Callback<T> callback);
-
-  /**
-   * Returns a watcher to watch the changes made by this call to the normalized cache store.
-   */
-  @Nonnull ApolloWatcher<T> watcher();
-
-  /**
-   * Sets the http cache policy for response/request cache.
-   *
-   * @param httpCachePolicy {@link HttpCachePolicy.Policy} to set
-   * @return The ApolloCall object with the provided {@link HttpCachePolicy.Policy}
-   */
-  @Nonnull ApolloCall<T> httpCachePolicy(@Nonnull HttpCachePolicy.Policy httpCachePolicy);
 
   /**
    * Sets the {@link CacheControl} strategy for an ApolloCall object.
@@ -130,19 +115,5 @@ public interface ApolloCall<T> extends Cancelable {
     public void onCanceledError(@Nonnull ApolloCanceledException e) {
       onFailure(e);
     }
-  }
-
-  /**
-   * Factory for creating ApolloCall object.
-   */
-  interface Factory {
-    /**
-     * Creates the ApolloCall by wrapping the operation object inside.
-     *
-     * @param operation the operation which needs to be performed
-     * @return The ApolloCall object with the wrapped operation object
-     */
-    <D extends Operation.Data, T, V extends Operation.Variables> ApolloCall<T> newCall(
-        @Nonnull Operation<D, T, V> operation);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -1,6 +1,9 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Optional;
@@ -25,6 +28,7 @@ import com.squareup.moshi.Moshi;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +62,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
  *
  * <p>See the {@link ApolloClient.Builder} class for configuring the ApolloClient.
  */
-public final class ApolloClient implements ApolloCall.Factory, ApolloPrefetch.Factory {
+public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutationCall.Factory, ApolloPrefetch.Factory {
 
   public static Builder builder() {
     return new Builder();
@@ -93,23 +97,15 @@ public final class ApolloClient implements ApolloCall.Factory, ApolloPrefetch.Fa
     this.applicationInterceptors = builder.applicationInterceptors;
   }
 
-  /**
-   * Prepares the {@link ApolloCall} request which will be executed at some point in the future.
-   */
   @Override
-  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloCall<T> newCall(
-      @Nonnull Operation<D, T, V> operation) {
-    ResponseFieldMapper responseFieldMapper;
-    synchronized (responseFieldMapperPool) {
-      responseFieldMapper = responseFieldMapperPool.get(operation.getClass());
-      if (responseFieldMapper == null) {
-        responseFieldMapper = operation.responseFieldMapper();
-        responseFieldMapperPool.put(operation.getClass(), responseFieldMapper);
-      }
-    }
-    return new RealApolloCall<T>(operation, serverUrl, httpCallFactory, httpCache, defaultHttpCachePolicy, moshi,
-        responseFieldMapper, customTypeAdapters, apolloStore, defaultCacheControl, defaultCacheHeaders,
-        dispatcher, logger, applicationInterceptors);
+  public <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
+      @Nonnull Mutation<D, T, V> mutation) {
+    return newCall(mutation);
+  }
+
+  @Override
+  public <D extends Query.Data, T, V extends Query.Variables> ApolloQueryCall<T> query(@Nonnull Query<D, T, V> query) {
+    return newCall(query);
   }
 
   /**
@@ -155,6 +151,26 @@ public final class ApolloClient implements ApolloCall.Factory, ApolloPrefetch.Fa
     } else {
       return null;
     }
+  }
+
+  private <D extends Operation.Data, T, V extends Operation.Variables> RealApolloCall<T> newCall(
+      @Nonnull Operation<D, T, V> operation) {
+    ResponseFieldMapper responseFieldMapper = responseFieldMapper(operation);
+    return new RealApolloCall<T>(operation, serverUrl, httpCallFactory, httpCache, defaultHttpCachePolicy, moshi,
+        responseFieldMapper, customTypeAdapters, apolloStore, defaultCacheControl, defaultCacheHeaders,
+        dispatcher, logger, applicationInterceptors, Collections.<OperationName>emptyList());
+  }
+
+  private ResponseFieldMapper responseFieldMapper(Operation operation) {
+    ResponseFieldMapper responseFieldMapper;
+    synchronized (responseFieldMapperPool) {
+      responseFieldMapper = responseFieldMapperPool.get(operation.getClass());
+      if (responseFieldMapper == null) {
+        responseFieldMapper = operation.responseFieldMapper();
+        responseFieldMapperPool.put(operation.getClass(), responseFieldMapper);
+      }
+    }
+    return responseFieldMapper;
   }
 
   @SuppressWarnings("WeakerAccess") public static class Builder {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -300,7 +300,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
-     * Set the default {@link HttpCachePolicy.Policy} cache policy.
+     * Sets the http cache policy to be used as default for all GraphQL {@link Query} operations. Will be ignored for
+     * any {@link Mutation} operations. By default http cache policy is set to {@link HttpCachePolicy#NETWORK_ONLY}.
      *
      * @return The {@link Builder} object to be used for chaining method calls
      */

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -1,0 +1,44 @@
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.api.Mutation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.cache.normalized.CacheControl;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A call prepared to execute GraphQL mutation operation.
+ */
+public interface ApolloMutationCall<T> extends ApolloCall<T> {
+
+  /**
+   * <p>Sets a list of GraphQL query names to be re-fetched once this mutation completed.</p>
+   * In order to get queries to be re-fetched you must obtain {@link ApolloQueryWatcher} from provided list of
+   * queries before running this mutation.
+   *
+   * @param operationNames array of {@link OperationName} query names to be re-fetched
+   * @return {@link ApolloMutationCall} that will trigger re-fetching provided queries
+   */
+  @Nonnull ApolloMutationCall<T> refetchQueries(@Nonnull OperationName... operationNames);
+
+  @Nonnull @Override ApolloMutationCall<T> cacheControl(@Nonnull CacheControl cacheControl);
+
+  @Nonnull @Override ApolloMutationCall<T> cacheHeaders(@Nonnull CacheHeaders cacheHeaders);
+
+  @Nonnull @Override ApolloMutationCall<T> clone();
+
+  /**
+   * Factory for creating {@link ApolloMutationCall} calls.
+   */
+  interface Factory {
+    /**
+     * Creates and prepares a new {@link ApolloMutationCall} call.
+     *
+     * @param query the operation which needs to be performed
+     * @return prepared {@link ApolloQueryCall} call to be executed at some point in the future
+     */
+    <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
+        @Nonnull Mutation<D, T, V> mutation);
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -3,7 +3,6 @@ package com.apollographql.apollo;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.cache.CacheHeaders;
-import com.apollographql.apollo.cache.normalized.CacheControl;
 
 import javax.annotation.Nonnull;
 
@@ -22,8 +21,6 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    */
   @Nonnull ApolloMutationCall<T> refetchQueries(@Nonnull OperationName... operationNames);
 
-  @Nonnull @Override ApolloMutationCall<T> cacheControl(@Nonnull CacheControl cacheControl);
-
   @Nonnull @Override ApolloMutationCall<T> cacheHeaders(@Nonnull CacheHeaders cacheHeaders);
 
   @Nonnull @Override ApolloMutationCall<T> clone();
@@ -35,8 +32,8 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
     /**
      * Creates and prepares a new {@link ApolloMutationCall} call.
      *
-     * @param query the operation which needs to be performed
-     * @return prepared {@link ApolloQueryCall} call to be executed at some point in the future
+     * @param mutation the mutation which needs to be performed
+     * @return prepared {@link ApolloMutationCall} call to be executed at some point in the future
      */
     <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
         @Nonnull Mutation<D, T, V> mutation);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -1,0 +1,49 @@
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.cache.http.HttpCachePolicy;
+import com.apollographql.apollo.cache.normalized.CacheControl;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A call prepared to execute GraphQL query operation.
+ */
+public interface ApolloQueryCall<T> extends ApolloCall<T> {
+  /**
+   * Returns a watcher to watch the changes to the normalized cache records this query depends on or when mutation call
+   * triggers to re-fetch this query after it completes via {@link ApolloMutationCall#refetchQueries(OperationName...)}
+   *
+   * @return {@link ApolloQueryWatcher}
+   */
+  @Nonnull ApolloQueryWatcher<T> watcher();
+
+  /**
+   * Sets the http cache policy for response/request cache.
+   *
+   * @param httpCachePolicy {@link HttpCachePolicy.Policy} to set
+   * @return {@link ApolloQueryCall} with the provided {@link HttpCachePolicy.Policy}
+   */
+  @Nonnull ApolloQueryCall<T> httpCachePolicy(@Nonnull HttpCachePolicy.Policy httpCachePolicy);
+
+  @Nonnull @Override ApolloQueryCall<T> cacheControl(@Nonnull CacheControl cacheControl);
+
+  @Nonnull @Override ApolloQueryCall<T> cacheHeaders(@Nonnull CacheHeaders cacheHeaders);
+
+  @Nonnull @Override ApolloQueryCall<T> clone();
+
+  /**
+   * Factory for creating {@link ApolloQueryCall} calls.
+   */
+  interface Factory {
+    /**
+     * Creates and prepares a new {@link ApolloQueryCall} call.
+     *
+     * @param query the operation which needs to be performed
+     * @return prepared {@link ApolloQueryCall} call to be executed at some point in the future
+     */
+    <D extends Query.Data, T, V extends Query.Variables> ApolloQueryCall<T> query(@Nonnull Query<D, T, V> query);
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
@@ -6,7 +6,7 @@ import com.apollographql.apollo.cache.normalized.CacheControl;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public interface ApolloWatcher<T> extends Cancelable {
+public interface ApolloQueryWatcher<T> extends Cancelable {
 
   void enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback);
 
@@ -14,6 +14,6 @@ public interface ApolloWatcher<T> extends Cancelable {
    * @param cacheControl The {@link CacheControl} to use when the call is refetched due to a field changing in the
    *                     cache.
    */
-  @Nonnull ApolloWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl);
+  @Nonnull ApolloQueryWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl);
 
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.ApolloQueryCall;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ScalarType;
@@ -202,14 +203,14 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
   private ApolloInterceptorChain prepareInterceptorChain(Operation operation) {
     List<ApolloInterceptor> interceptors = new ArrayList<>();
+    HttpCachePolicy.Policy httpCachePolicy = operation instanceof Query ? this.httpCachePolicy : null;
 
     interceptors.addAll(applicationInterceptors);
     interceptors.add(new ApolloCacheInterceptor(apolloStore, cacheControl, cacheHeaders, responseFieldMapper,
         customTypeAdapters, dispatcher, logger));
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
         customTypeAdapters, logger));
-    interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false, moshi,
-        logger));
+    interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false, moshi, logger));
 
     return new RealApolloInterceptorChain(operation, interceptors);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloCall;
-import com.apollographql.apollo.ApolloWatcher;
+import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.cache.normalized.ApolloStore;
@@ -18,7 +18,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-final class RealApolloWatcher<T> implements ApolloWatcher<T> {
+final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private RealApolloCall<T> activeCall;
   @Nullable private ApolloCall.Callback<T> callback = null;
   private CacheControl refetchCacheControl = CacheControl.CACHE_FIRST;
@@ -34,7 +34,7 @@ final class RealApolloWatcher<T> implements ApolloWatcher<T> {
     }
   };
 
-  RealApolloWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore) {
+  RealApolloQueryWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore) {
     activeCall = originalCall;
     this.apolloStore = apolloStore;
   }
@@ -48,7 +48,7 @@ final class RealApolloWatcher<T> implements ApolloWatcher<T> {
     activeCall.enqueue(callbackProxy(this.callback));
   }
 
-  @Nonnull @Override public RealApolloWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl) {
+  @Nonnull @Override public RealApolloQueryWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl) {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed");
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -1,5 +1,6 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
@@ -58,6 +59,10 @@ import static junit.framework.Assert.fail;
         };
       }
 
+      @Nonnull @Override public OperationName name() {
+        return null;
+      }
+
       @Override public Object wrapData(Data data) {
         return data;
       }
@@ -67,7 +72,7 @@ import static junit.framework.Assert.fail;
   @Test public void httpException() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(401).setBody("Unauthorized request!"));
     try {
-      apolloClient.newCall(emptyQuery).execute();
+      apolloClient.query(emptyQuery).execute();
       fail("Expected ApolloHttpException");
     } catch (ApolloHttpException e) {
       assertThat(e.code()).isEqualTo(401);
@@ -79,7 +84,7 @@ import static junit.framework.Assert.fail;
 
   @Test public void httpExceptionAsync() throws Exception {
     server.enqueue(new MockResponse().setResponseCode(401).setBody("Unauthorized request!"));
-    apolloClient.newCall(emptyQuery).enqueue(new ApolloCall.Callback() {
+    apolloClient.query(emptyQuery).enqueue(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected ApolloHttpException");
       }
@@ -112,7 +117,7 @@ import static junit.framework.Assert.fail;
 
   @Test public void testTimeoutException() throws Exception {
     try {
-      apolloClient.newCall(emptyQuery).execute();
+      apolloClient.query(emptyQuery).execute();
       fail("Expected ApolloNetworkException");
     } catch (ApolloNetworkException e) {
       assertThat(e.getMessage()).isEqualTo("Failed to execute http call");
@@ -121,7 +126,7 @@ import static junit.framework.Assert.fail;
   }
 
   @Test public void testTimeoutExceptionAsync() throws Exception {
-    apolloClient.newCall(emptyQuery).enqueue(new ApolloCall.Callback() {
+    apolloClient.query(emptyQuery).enqueue(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected ApolloNetworkException");
       }
@@ -153,7 +158,7 @@ import static junit.framework.Assert.fail;
   @Test public void testParseException() throws Exception {
     server.enqueue(new MockResponse().setBody("Noise"));
     try {
-      apolloClient.newCall(emptyQuery).execute();
+      apolloClient.query(emptyQuery).execute();
       fail("Expected ApolloParseException");
     } catch (ApolloParseException e) {
       assertThat(e.getMessage()).isEqualTo("Failed to parse http response");
@@ -163,7 +168,7 @@ import static junit.framework.Assert.fail;
 
   @Test public void testParseExceptionAsync() throws Exception {
     server.enqueue(new MockResponse().setBody("Noise"));
-    apolloClient.newCall(emptyQuery).enqueue(new ApolloCall.Callback() {
+    apolloClient.query(emptyQuery).enqueue(new ApolloCall.Callback() {
       @Override public void onResponse(@Nonnull Response response) {
         fail("Expected ApolloParseException");
       }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/CacheControlTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/CacheControlTest.java
@@ -1,7 +1,8 @@
 package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloClient;
-import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
@@ -12,18 +13,44 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
 
 import okhttp3.OkHttpClient;
 
 import static com.google.common.truth.Truth.assertThat;
 
 public class CacheControlTest {
-
   private OkHttpClient okHttpClient;
+  private Query emptyQuery;
 
   @Before public void setUp() {
     okHttpClient = new OkHttpClient.Builder().build();
+    emptyQuery = new Query() {
+      @Override public String queryDocument() {
+        return "";
+      }
+
+      @Override public Variables variables() {
+        return EMPTY_VARIABLES;
+      }
+
+      @Override public ResponseFieldMapper<Data> responseFieldMapper() {
+        return new ResponseFieldMapper<Data>() {
+          @Override public Data map(ResponseReader responseReader) throws IOException {
+            return null;
+          }
+        };
+      }
+
+      @Nonnull @Override public OperationName name() {
+        return null;
+      }
+
+      @Override public Object wrapData(Data data) {
+        return data;
+      }
+    };
   }
 
   @Test public void setDefaultCachePolicy() {
@@ -34,29 +61,7 @@ public class CacheControlTest {
         .defaultCacheControl(CacheControl.NETWORK_ONLY)
         .build();
 
-    RealApolloCall realApolloCall = (RealApolloCall) apolloClient.newCall(
-        new Operation<Operation.Data, Object, Operation.Variables>() {
-          @Override public String queryDocument() {
-            return null;
-          }
-
-          @Override public Variables variables() {
-            return null;
-          }
-
-          @Override public ResponseFieldMapper<Data> responseFieldMapper() {
-            return new ResponseFieldMapper<Data>() {
-              @Override public Data map(ResponseReader responseReader) throws IOException {
-                return null;
-              }
-            };
-          }
-
-          @Override public Object wrapData(Data data) {
-            return null;
-          }
-        });
-
+    RealApolloCall realApolloCall = (RealApolloCall) apolloClient.query(emptyQuery);
     assertThat(realApolloCall.httpCachePolicy.fetchStrategy).isEqualTo(HttpCacheFetchStrategy.CACHE_ONLY);
     assertThat(realApolloCall.cacheControl).isEqualTo(CacheControl.NETWORK_ONLY);
   }
@@ -67,29 +72,7 @@ public class CacheControlTest {
         .okHttpClient(okHttpClient)
         .build();
 
-    RealApolloCall realApolloCall = (RealApolloCall) apolloClient.newCall(
-        new Operation<Operation.Data, Object, Operation.Variables>() {
-          @Override public String queryDocument() {
-            return null;
-          }
-
-          @Override public Variables variables() {
-            return null;
-          }
-
-          @Override public ResponseFieldMapper<Data> responseFieldMapper() {
-            return new ResponseFieldMapper<Data>() {
-              @Override public Data map(ResponseReader responseReader) throws IOException {
-                return null;
-              }
-            };
-          }
-
-          @Override public Object wrapData(Data data) {
-            return null;
-          }
-        });
-
+    RealApolloCall realApolloCall = (RealApolloCall) apolloClient.query(emptyQuery);
     assertThat(realApolloCall.httpCachePolicy.fetchStrategy).isEqualTo(HttpCacheFetchStrategy.NETWORK_ONLY);
     assertThat(realApolloCall.cacheControl).isEqualTo(CacheControl.CACHE_FIRST);
   }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -3,6 +3,7 @@ package com.apollographql.apollo.internal.reader;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ScalarType;
@@ -330,6 +331,10 @@ public class ResponseReaderTest {
 
     @Override public Object wrapData(Data data) {
       throw new UnsupportedOperationException();
+    }
+
+    @Nonnull @Override public OperationName name() {
+      return null;
     }
   };
 

--- a/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo.rx2;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloPrefetch;
-import com.apollographql.apollo.ApolloWatcher;
+import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.internal.util.Cancelable;
@@ -34,14 +34,14 @@ public class Rx2Apollo {
   }
 
   /**
-   * Converts an {@link ApolloWatcher} to an asynchronous Observable.
+   * Converts an {@link ApolloQueryWatcher} to an asynchronous Observable.
    *
    * @param watcher the ApolloWatcher to convert.
    * @param <T>     the value type
    * @return the converted Observable
    * @throws NullPointerException if watcher == null
    */
-  public static <T> Observable<Response<T>> from(@Nonnull final ApolloWatcher<T> watcher) {
+  public static <T> Observable<Response<T>> from(@Nonnull final ApolloQueryWatcher<T> watcher) {
     checkNotNull(watcher, "watcher == null");
     return Observable.create(new ObservableOnSubscribe<Response<T>>() {
       @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {

--- a/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -36,7 +36,7 @@ public class Rx2Apollo {
   /**
    * Converts an {@link ApolloQueryWatcher} to an asynchronous Observable.
    *
-   * @param watcher the ApolloWatcher to convert.
+   * @param watcher the ApolloQueryWatcher to convert.
    * @param <T>     the value type
    * @return the converted Observable
    * @throws NullPointerException if watcher == null

--- a/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -38,7 +38,7 @@ public final class RxApollo {
    * Converts an {@link ApolloQueryWatcher} into an Observable. Honors the back pressure from downstream with the back
    * pressure strategy {@link rx.Emitter.BackpressureMode#LATEST}.
    *
-   * @param watcher the ApolloWatcher to convert
+   * @param watcher the ApolloQueryWatcher to convert
    * @param <T>     the value type
    * @return the converted Observable
    */
@@ -50,7 +50,7 @@ public final class RxApollo {
   /**
    * Converts an {@link ApolloQueryWatcher} into an Observable.
    *
-   * @param watcher          the ApolloWatcher to convert
+   * @param watcher          the ApolloQueryWatcher to convert
    * @param backpressureMode the back pressure strategy to apply to the observable source.
    * @param <T>              the value type
    * @return the converted Observable

--- a/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -3,7 +3,7 @@ package com.apollographql.apollo.rx;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloPrefetch;
-import com.apollographql.apollo.ApolloWatcher;
+import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.internal.util.Cancelable;
@@ -35,7 +35,7 @@ public final class RxApollo {
   }
 
   /**
-   * Converts an {@link ApolloWatcher} into an Observable. Honors the back pressure from downstream with the back
+   * Converts an {@link ApolloQueryWatcher} into an Observable. Honors the back pressure from downstream with the back
    * pressure strategy {@link rx.Emitter.BackpressureMode#LATEST}.
    *
    * @param watcher the ApolloWatcher to convert
@@ -43,19 +43,19 @@ public final class RxApollo {
    * @return the converted Observable
    */
   @Nonnull
-  public static <T> Observable<Response<T>> from(@Nonnull final ApolloWatcher<T> watcher) {
+  public static <T> Observable<Response<T>> from(@Nonnull final ApolloQueryWatcher<T> watcher) {
     return from(watcher, Emitter.BackpressureMode.LATEST);
   }
 
   /**
-   * Converts an {@link ApolloWatcher} into an Observable.
+   * Converts an {@link ApolloQueryWatcher} into an Observable.
    *
    * @param watcher          the ApolloWatcher to convert
    * @param backpressureMode the back pressure strategy to apply to the observable source.
    * @param <T>              the value type
    * @return the converted Observable
    */
-  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloWatcher<T> watcher,
+  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloQueryWatcher<T> watcher,
       @Nonnull Emitter.BackpressureMode backpressureMode) {
     checkNotNull(backpressureMode, "backpressureMode == null");
     checkNotNull(watcher, "watcher == null");


### PR DESCRIPTION
Introduce separate interfaces for query and mutation calls.
Generate OperationName type for operations to be used as identifier for refetching.

Part of #452 