### PR TITLE
Add custom GraphQL error attributes

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
@@ -1,20 +1,28 @@
 package com.apollographql.apollo.api;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Represents an error response returned from the GraphQL server
  */
-public class Error {
+public final class Error {
   private final String message;
-  @Nullable private final List<Location> locations;
+  private final List<Location> locations;
+  private final Map<String, Object> customAttributes;
 
-  public Error(String message, @Nullable List<Location> locations) {
+  public Error(String message, @Nullable List<Location> locations, @Nullable Map<String, Object> customAttributes) {
     this.message = message;
-    this.locations = locations;
+    this.locations = locations != null ? unmodifiableList(locations) : Collections.<Location>emptyList();
+    this.customAttributes = customAttributes != null ? unmodifiableMap(customAttributes)
+        : Collections.<String, Object>emptyMap();
   }
 
   /**
@@ -27,35 +35,41 @@ public class Error {
   /**
    * Returns the location of the error in the GraphQL operation.
    */
-  @Nullable public List<Location> locations() {
-    return locations != null ? new ArrayList<>(locations) : null;
+  @Nonnull public List<Location> locations() {
+    return locations;
+  }
+
+  /**
+   * Returns custom attributes associated with this error
+   */
+  @Nonnull public Map<String, Object> customAttributes() {
+    return customAttributes;
   }
 
   @Override public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (!(o instanceof Error)) return false;
 
-    Error that = (Error) o;
+    Error error = (Error) o;
 
-    //noinspection SimplifiableIfStatement
-    if (message != null ? !message.equals(that.message) : that.message != null) return false;
-    return locations != null ? locations.equals(that.locations) : that.locations == null;
+    if (message != null ? !message.equals(error.message) : error.message != null) return false;
+    if (!locations.equals(error.locations)) return false;
+    return customAttributes.equals(error.customAttributes);
   }
 
   @Override public int hashCode() {
     int result = message != null ? message.hashCode() : 0;
-    result = 31 * result + (locations != null ? locations.hashCode() : 0);
+    result = 31 * result + locations.hashCode();
+    result = 31 * result + customAttributes.hashCode();
     return result;
   }
 
   @Override public String toString() {
-    return "Error{"
-        + "message='"
-        + message
-        + '\''
-        + ", locations="
-        + locations
-        + '}';
+    return "Error{" +
+        "message='" + message + '\'' +
+        ", locations=" + locations +
+        ", customAttributes=" + customAttributes +
+        '}';
   }
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Error.java
@@ -65,11 +65,11 @@ public final class Error {
   }
 
   @Override public String toString() {
-    return "Error{" +
-        "message='" + message + '\'' +
-        ", locations=" + locations +
-        ", customAttributes=" + customAttributes +
-        '}';
+    return "Error{"
+        + "message='" + message + '\''
+        + ", locations=" + locations
+        + ", customAttributes=" + customAttributes
+        + '}';
   }
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -7,22 +7,26 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+
 /** Represents either a successful or failed response received from the GraphQL server. */
-public class Response<T> {
+public final class Response<T> {
   private final Operation operation;
   private final T data;
   private final List<Error> errors;
   private Set<String> dependentKeys;
 
-  public Response(Operation operation) {
-    this(operation, null, null, null);
+  public static <T> Response.Builder<T> builder(@Nonnull final Operation operation) {
+    return new Builder<>(operation);
   }
 
-  public Response(Operation operation, T data, List<Error> errors, Set<String> dependentKeys) {
-    this.operation = operation;
-    this.data = data;
-    this.errors = errors != null ? errors : Collections.<Error>emptyList();
-    this.dependentKeys = dependentKeys != null ? dependentKeys : Collections.<String>emptySet();
+  Response(Builder<T> builder) {
+    operation = checkNotNull(builder.operation, "operation == null");
+    data = builder.data;
+    errors = builder.errors != null ? unmodifiableList(builder.errors) : Collections.<Error>emptyList();
+    dependentKeys = builder.dependentKeys != null ? unmodifiableSet(builder.dependentKeys) : Collections.<String>emptySet();
   }
 
   public Operation operation() {
@@ -43,5 +47,35 @@ public class Response<T> {
 
   public boolean hasErrors() {
     return !errors.isEmpty();
+  }
+
+  public static final class Builder<T> {
+    private final Operation operation;
+    private T data;
+    private List<Error> errors;
+    private Set<String> dependentKeys;
+
+    Builder(@Nonnull final Operation operation) {
+      this.operation = checkNotNull(operation, "operation == null");
+    }
+
+    public Builder<T> data(T data) {
+      this.data = data;
+      return this;
+    }
+
+    public Builder<T> errors(@Nullable List<Error> errors) {
+      this.errors = errors;
+      return this;
+    }
+
+    public Builder<T> dependentKeys(@Nullable Set<String> dependentKeys) {
+      this.dependentKeys = dependentKeys;
+      return this;
+    }
+
+    public Response<T> build() {
+      return new Response<>(this);
+    }
   }
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -26,7 +26,8 @@ public final class Response<T> {
     operation = checkNotNull(builder.operation, "operation == null");
     data = builder.data;
     errors = builder.errors != null ? unmodifiableList(builder.errors) : Collections.<Error>emptyList();
-    dependentKeys = builder.dependentKeys != null ? unmodifiableSet(builder.dependentKeys) : Collections.<String>emptySet();
+    dependentKeys = builder.dependentKeys != null ? unmodifiableSet(builder.dependentKeys)
+        : Collections.<String>emptySet();
   }
 
   public Operation operation() {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorChainTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorChainTest.java
@@ -336,7 +336,7 @@ public class ApolloInterceptorChainTest {
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build();
 
-    Response<EpisodeHeroName.Data> apolloResponse = new Response<>(query);
+    Response<EpisodeHeroName.Data> apolloResponse = Response.<EpisodeHeroName.Data>builder(query).build();
 
     return new InterceptorResponse(okHttpResponse,
         apolloResponse, Collections.<Record>emptyList());

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -621,7 +621,7 @@ public class ApolloInterceptorTest {
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build();
 
-    Response<EpisodeHeroName.Data> apolloResponse = new Response<>(query);
+    Response<EpisodeHeroName.Data> apolloResponse = Response.<EpisodeHeroName.Data>builder(query).build();
 
     return new InterceptorResponse(okHttpResponse,
         apolloResponse, Collections.<Record>emptyList());

--- a/apollo-integration/src/test/resources/ResponseErrorWithCustomAttributes.json
+++ b/apollo-integration/src/test/resources/ResponseErrorWithCustomAttributes.json
@@ -1,0 +1,17 @@
+{
+  "errors": [
+    {
+      "message": "Cannot query field \"names\" on type \"Species\".",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "code": 500,
+      "status": "Internal Error",
+      "fatal": true,
+      "path":["query"]
+    }
+  ]
+}

--- a/apollo-integration/src/test/resources/ResponseErrorWithData.json
+++ b/apollo-integration/src/test/resources/ResponseErrorWithData.json
@@ -1,0 +1,19 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Droid",
+      "name": "R2-D2"
+    }
+  },
+  "errors": [
+    {
+      "message": "Cannot query field \"names\" on type \"Species\".",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ]
+    }
+  ]
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapter.java
@@ -46,7 +46,7 @@ public final class RecordFieldAdapter {
   public Map<String, Object> from(BufferedSource bufferedFieldSource) throws IOException {
     final CacheJsonStreamReader cacheJsonStreamReader =
         cacheJsonStreamReader(bufferedSourceJsonReader(bufferedFieldSource));
-    return cacheJsonStreamReader.buffer();
+    return cacheJsonStreamReader.toMap();
   }
 
   public Map<String, Object> from(String jsonFieldSource) throws IOException {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -120,7 +120,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     Response<T> response;
     try {
-      response = interceptorChain.proceed().parsedResponse.or(new Response(operation));
+      response = interceptorChain.proceed().parsedResponse.or(Response.<T>builder(operation).build());
     } catch (Exception e) {
       if (canceled) {
         throw new ApolloCanceledException("Canceled", e);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -83,7 +83,7 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
   @Nonnull @Override public <D extends Operation.Data, T, V extends Operation.Variables> Response<T> read(
       @Nonnull Operation<D, T, V> operation, @Nonnull ResponseFieldMapper<D> responseFieldMapper,
       @Nonnull ResponseNormalizer<Record> responseNormalizer, @Nonnull CacheHeaders cacheHeaders) {
-    return new Response<T>(operation);
+    return Response.<T>builder(operation).build();
   }
 
   @Nullable @Override public <F extends GraphqlFragment> F read(@Nonnull ResponseFieldMapper<F> fieldMapper,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -172,7 +172,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
       @Nonnull @Override public Response<T> execute(ReadableStore cache) {
         Record rootRecord = cache.read(CacheKeyResolver.rootKeyForOperation(operation).key(), cacheHeaders);
         if (rootRecord == null) {
-          return new Response<>(operation);
+          return Response.<T>builder(operation).build();
         }
 
         CacheFieldValueResolver fieldValueResolver = new CacheFieldValueResolver(cache, operation.variables(),
@@ -182,10 +182,13 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
         try {
           responseNormalizer.willResolveRootQuery(operation);
           T data = operation.wrapData(responseFieldMapper.map(responseReader));
-          return new Response<T>(operation, data, null, responseNormalizer.dependentKeys());
+          return Response.<T>builder(operation)
+              .data(data)
+              .dependentKeys(responseNormalizer.dependentKeys())
+              .build();
         } catch (final Exception e) {
           logger.e(e, "Failed to read cached operation data. Operation: %s", operation);
-          return new Response<>(operation);
+          return Response.<T>builder(operation).build();
         }
       }
     });

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/HttpResponseBodyParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/HttpResponseBodyParser.java
@@ -1,18 +1,21 @@
 package com.apollographql.apollo.internal.interceptor;
 
+import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ScalarType;
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
 import com.apollographql.apollo.internal.json.BufferedSourceJsonReader;
-import com.apollographql.apollo.internal.reader.RealResponseReader;
 import com.apollographql.apollo.internal.json.ResponseJsonStreamReader;
+import com.apollographql.apollo.internal.reader.RealResponseReader;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +52,7 @@ final class HttpResponseBodyParser<D extends Operation.Data, W> {
           //noinspection unchecked
           data = (D) responseStreamReader.nextObject(true, new ResponseJsonStreamReader.ObjectReader<Object>() {
             @Override public Object read(ResponseJsonStreamReader reader) throws IOException {
-              Map<String, Object> buffer = reader.buffer();
+              Map<String, Object> buffer = reader.toMap();
               RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(
                   operation.variables(), buffer, new MapFieldValueResolver(), customTypeAdapters,
                   networkResponseNormalizer);
@@ -63,7 +66,11 @@ final class HttpResponseBodyParser<D extends Operation.Data, W> {
         }
       }
       jsonReader.endObject();
-      return new Response<>(operation, operation.wrapData(data), errors, networkResponseNormalizer.dependentKeys());
+      return Response.<W>builder(operation)
+          .data(operation.wrapData(data))
+          .errors(errors)
+          .dependentKeys(networkResponseNormalizer.dependentKeys())
+          .build();
     } finally {
       if (jsonReader != null) {
         jsonReader.close();
@@ -83,42 +90,40 @@ final class HttpResponseBodyParser<D extends Operation.Data, W> {
     });
   }
 
-  private Error readError(ResponseJsonStreamReader reader) throws IOException {
+  @SuppressWarnings("unchecked") private Error readError(ResponseJsonStreamReader reader) throws IOException {
     String message = null;
-    List<Error.Location> locations = null;
-    while (reader.hasNext()) {
-      String name = reader.nextName();
-      if ("message".equals(name)) {
-        message = reader.nextString(false);
-      } else if ("locations".equals(name)) {
-        locations = reader.nextList(true, new ResponseJsonStreamReader.ListReader<Error.Location>() {
-          @Override public Error.Location read(ResponseJsonStreamReader reader) throws IOException {
-            return reader.nextObject(false, new ResponseJsonStreamReader.ObjectReader<Error.Location>() {
-              @Override public Error.Location read(ResponseJsonStreamReader reader) throws IOException {
-                return readErrorLocation(reader);
-              }
-            });
+    final List<Error.Location> locations = new ArrayList<>();
+    final Map<String, Object> customAttributes = new HashMap<>();
+    for (Map.Entry<String, Object> entry : reader.toMap().entrySet()) {
+      if ("message".equals(entry.getKey())) {
+        message = entry.getValue().toString();
+      } else if ("locations".equals(entry.getKey())) {
+        List<Map<String, Object>> locationItems = (List<Map<String, Object>>) entry.getValue();
+        if (locationItems != null) {
+          for (Map<String, Object> item : locationItems) {
+            locations.add(readErrorLocation(item));
           }
-        });
+        }
       } else {
-        reader.skipNext();
+        if (entry.getValue() != null) {
+          customAttributes.put(entry.getKey(), entry.getValue());
+        }
       }
     }
-    return new Error(message, locations);
+    return new Error(message, locations, customAttributes);
   }
 
   @SuppressWarnings("ConstantConditions")
-  private Error.Location readErrorLocation(ResponseJsonStreamReader reader) throws IOException {
+  private Error.Location readErrorLocation(Map<String, Object> data) throws IOException {
     long line = -1;
     long column = -1;
-    while (reader.hasNext()) {
-      String name = reader.nextName();
-      if ("line".equals(name)) {
-        line = reader.nextLong(false);
-      } else if ("column".equals(name)) {
-        column = reader.nextLong(false);
-      } else {
-        reader.skipNext();
+    if (data != null) {
+      for (Map.Entry<String, Object> entry : data.entrySet()) {
+        if ("line".equals(entry.getKey())) {
+          line = ((BigDecimal) entry.getValue()).longValue();
+        } else if ("column".equals(entry.getKey())) {
+          column = ((BigDecimal) entry.getValue()).longValue();
+        }
       }
     }
     return new Error.Location(line, column);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/CacheJsonStreamReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/CacheJsonStreamReader.java
@@ -13,8 +13,8 @@ public final class CacheJsonStreamReader extends ResponseJsonStreamReader {
     super(jsonReader);
   }
 
-  @Override protected Object readScalar(ResponseJsonStreamReader streamReader) throws IOException {
-    Object scalar = super.readScalar(streamReader);
+  @Override public Object nextScalar(boolean optional) throws IOException {
+    Object scalar = super.nextScalar(optional);
     if (scalar instanceof String) {
       String scalarString = (String) scalar;
       if (CacheReference.canDeserialize(scalarString)) {

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
@@ -89,7 +89,7 @@ public class GitHuntEntryDetailActivity extends AppCompatActivity {
 
   private void fetchRepositoryDetails() {
     ApolloCall<EntryDetailQuery.Data> entryDetailQuery = application.apolloClient()
-        .newCall(new EntryDetailQuery(repoFullName))
+        .query(new EntryDetailQuery(repoFullName))
         .cacheControl(CacheControl.CACHE_FIRST);
 
     //Example call using Rx2Support

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
@@ -74,7 +74,7 @@ public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNav
         .type(FeedType.HOT)
         .build();
     githuntFeedCall = application.apolloClient()
-        .newCall(feedQuery)
+        .query(feedQuery)
         .cacheControl(CacheControl.NETWORK_FIRST);
     githuntFeedCall.enqueue(dataCallback);
   }


### PR DESCRIPTION
Some implementations of GraphQL server extends generic Error type and include custom attributes.
One example is https://docs.scaphold.io/errors/ where error can be:
```
{
  "data":{"loginUser":null},
  "errors":[{
    "message":"Could not find a user with that username",
    "locations":[{"line":1,"column":53}],
    "path":["loginUser"],
    "name":"GraphQLError"}
  ]}
```