### PR TITLE
Add re-fetch query watchers

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/QueryRefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/QueryRefetchTest.java
@@ -118,6 +118,7 @@ public class QueryRefetchTest {
     final AtomicReference<Response<ReviewsByEpisode.Data>> empireReviewsWatchResponse = new AtomicReference<>();
     ApolloQueryWatcher<ReviewsByEpisode.Data> queryWatcher = apolloClient.query(new ReviewsByEpisode(Episode.EMPIRE))
         .watcher()
+        .refetchCacheControl(CacheControl.NETWORK_FIRST)
         .enqueueAndWatch(new ApolloCall.Callback<ReviewsByEpisode.Data>() {
           @Override public void onResponse(@Nonnull Response<ReviewsByEpisode.Data> response) {
             countDownMutationLatch.countDown();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -1,5 +1,6 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.CacheHeaders;
@@ -65,6 +66,13 @@ public interface ApolloCall<T> extends Cancelable {
    * @return The cloned ApolloCall object.
    */
   @Nonnull ApolloCall<T> clone();
+
+  /**
+   * Returns GraphQl operation this call executes
+   *
+   * @return {@link Operation}
+   */
+  @Nonnull Operation operation();
 
   /**
    * Communicates responses from a server or offline requests.

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
@@ -54,6 +54,13 @@ public interface ApolloPrefetch extends Cancelable {
   ApolloPrefetch clone();
 
   /**
+   * Returns GraphQl operation this call executes
+   *
+   * @return {@link Operation}
+   */
+  @Nonnull Operation operation();
+
+  /**
    * Communicates responses from the server.
    */
   abstract class Callback {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
@@ -1,14 +1,15 @@
 package com.apollographql.apollo;
 
-import com.apollographql.apollo.internal.util.Cancelable;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.cache.normalized.CacheControl;
+import com.apollographql.apollo.internal.util.Cancelable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public interface ApolloQueryWatcher<T> extends Cancelable {
 
-  void enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback);
+  ApolloQueryWatcher<T> enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback);
 
   /**
    * @param cacheControl The {@link CacheControl} to use when the call is refetched due to a field changing in the
@@ -16,4 +17,15 @@ public interface ApolloQueryWatcher<T> extends Cancelable {
    */
   @Nonnull ApolloQueryWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl);
 
+  /**
+   * Returns GraphQl watched operation.
+   *
+   * @return {@link Operation}
+   */
+  @Nonnull Operation operation();
+
+  /**
+   * Re-fetches watched GraphQl query.
+   */
+  void refetch();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -2,6 +2,7 @@ package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloMutationCall;
 import com.apollographql.apollo.ApolloQueryCall;
+import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
@@ -123,7 +124,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     Response<T> response;
     try {
-      tracker.onSyncCallInProgress(this);
+      tracker.registerCall(this);
       response = interceptorChain.proceed().parsedResponse.or(Response.<T>builder(operation).build());
     } catch (Exception e) {
       if (canceled) {
@@ -132,13 +133,14 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         throw e;
       }
     } finally {
-      tracker.onSyncCallFinished(this);
+      tracker.unregisterCall(this);
     }
 
     if (canceled) {
       throw new ApolloCanceledException("Canceled");
     }
 
+    refetchQueryWatchers();
     if (queryFetcher.isPresent()) {
       queryFetcher.get().refetchSync();
     }
@@ -150,13 +152,12 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     if (!executed.compareAndSet(false, true)) {
       throw new IllegalStateException("Already Executed");
     }
-    AsyncCall asyncCall = new AsyncCall(responseCallback);
-    tracker.onAsyncCallInProgress(asyncCall);
-    interceptorChain.proceedAsync(dispatcher, asyncCall);
+    tracker.registerCall(this);
+    interceptorChain.proceedAsync(dispatcher, interceptorCallbackProxy(responseCallback));
   }
 
   @Nonnull @Override public RealApolloQueryWatcher<T> watcher() {
-    return new RealApolloQueryWatcher<>(clone(), apolloStore);
+    return new RealApolloQueryWatcher<>(clone(), apolloStore, tracker);
   }
 
   @Nonnull @Override public RealApolloCall<T> httpCachePolicy(@Nonnull HttpCachePolicy.Policy httpCachePolicy) {
@@ -210,61 +211,69 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .build();
   }
 
-  final class AsyncCall implements ApolloInterceptor.CallBack {
+  @Nonnull @Override public Operation operation() {
+    return operation;
+  }
 
-    private final Callback<T> responseCallback;
-
-    private AsyncCall(Callback<T> callback) {
-      this.responseCallback = callback;
-    }
-
-    @Override public void onResponse(@Nonnull final ApolloInterceptor.InterceptorResponse response) {
-      try {
-
-        if (responseCallback == null) {
-          return;
+  private void refetchQueryWatchers() {
+    try {
+      for (OperationName operationName : refetchQueryNames) {
+        for (ApolloQueryWatcher queryWatcher : tracker.activeQueryWatchers(operationName)) {
+          queryWatcher.refetch();
         }
-        if (canceled) {
-          responseCallback.onCanceledError(new ApolloCanceledException("Canceled"));
-          return;
-        }
-        if (queryFetcher.isPresent()) {
-          queryFetcher.get().refetchAsync(new QueryFetcher.OnFetchCompleteCallback() {
-            @Override public void onFetchComplete() {
-              //noinspection unchecked
-              responseCallback.onResponse(response.parsedResponse.get());
-            }
-          });
-        } else { //noinspection unchecked
-          responseCallback.onResponse(response.parsedResponse.get());
-        }
-      } finally {
-        tracker.onAsyncCallFinished(this);
       }
+    } catch (Exception e) {
+      logger.e(e, "Failed to re-fetch query watcher");
     }
+  }
 
-    @Override public void onFailure(@Nonnull ApolloException e) {
-      try {
+  private ApolloInterceptor.CallBack interceptorCallbackProxy(final Callback<T> originalCallback) {
+    return new ApolloInterceptor.CallBack() {
+      @Override public void onResponse(@Nonnull final ApolloInterceptor.InterceptorResponse response) {
+        if (originalCallback == null) return;
+        try {
+          if (RealApolloCall.this.canceled) {
+            originalCallback.onCanceledError(new ApolloCanceledException("Canceled"));
+            return;
+          }
 
-        if (responseCallback == null) {
-          return;
+          refetchQueryWatchers();
+
+          if (queryFetcher.isPresent()) {
+            queryFetcher.get().refetchAsync(new QueryFetcher.OnFetchCompleteCallback() {
+              @Override public void onFetchComplete() {
+                //noinspection unchecked
+                originalCallback.onResponse(response.parsedResponse.get());
+              }
+            });
+          } else {
+            //noinspection unchecked
+            originalCallback.onResponse(response.parsedResponse.get());
+          }
+        } finally {
+          tracker.unregisterCall(RealApolloCall.this);
         }
-
-        if (canceled) {
-          responseCallback.onCanceledError(new ApolloCanceledException("Canceled", e));
-        } else if (e instanceof ApolloHttpException) {
-          responseCallback.onHttpError((ApolloHttpException) e);
-        } else if (e instanceof ApolloParseException) {
-          responseCallback.onParseError((ApolloParseException) e);
-        } else if (e instanceof ApolloNetworkException) {
-          responseCallback.onNetworkError((ApolloNetworkException) e);
-        } else {
-          responseCallback.onFailure(e);
-        }
-      } finally {
-        tracker.onAsyncCallFinished(this);
       }
-    }
+
+      @Override public void onFailure(@Nonnull ApolloException e) {
+        if (originalCallback == null) return;
+        try {
+          if (RealApolloCall.this.canceled) {
+            originalCallback.onCanceledError(new ApolloCanceledException("Canceled", e));
+          } else if (e instanceof ApolloHttpException) {
+            originalCallback.onHttpError((ApolloHttpException) e);
+          } else if (e instanceof ApolloParseException) {
+            originalCallback.onParseError((ApolloParseException) e);
+          } else if (e instanceof ApolloNetworkException) {
+            originalCallback.onNetworkError((ApolloNetworkException) e);
+          } else {
+            originalCallback.onFailure(e);
+          }
+        } finally {
+          tracker.unregisterCall(RealApolloCall.this);
+        }
+      }
+    };
   }
 
   public Builder<T> toBuilder() {
@@ -404,7 +413,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     }
 
     public Builder<T> refetchQueryNames(List<OperationName> refetchQueryNames) {
-      this.refetchQueryNames = refetchQueryNames;
+      this.refetchQueryNames = refetchQueryNames != null ? new ArrayList<>(refetchQueryNames)
+          : Collections.<OperationName>emptyList();
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -2,6 +2,7 @@ package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloQueryWatcher;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.cache.normalized.ApolloStore;
@@ -18,14 +19,17 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private RealApolloCall<T> activeCall;
-  @Nullable private ApolloCall.Callback<T> callback = null;
-  private CacheControl refetchCacheControl = CacheControl.CACHE_FIRST;
+  private ApolloCall.Callback<T> callback;
+  private CacheControl refetchCacheControl = CacheControl.NETWORK_FIRST;
   private volatile boolean canceled;
   private boolean executed = false;
   private final ApolloStore apolloStore;
   private Set<String> dependentKeys = Collections.emptySet();
+  private final ApolloCallTracker tracker;
   private final ApolloStore.RecordChangeSubscriber recordChangeSubscriber = new ApolloStore.RecordChangeSubscriber() {
     @Override public void onCacheRecordsChanged(Set<String> changedRecordKeys) {
       if (!Utils.areDisjoint(dependentKeys, changedRecordKeys)) {
@@ -34,44 +38,63 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
     }
   };
 
-  RealApolloQueryWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore) {
-    activeCall = originalCall;
+  RealApolloQueryWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore, ApolloCallTracker tracker) {
+    this.activeCall = originalCall;
     this.apolloStore = apolloStore;
+    this.tracker = tracker;
   }
 
-  @Override public void enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback) {
+  @Override public ApolloQueryWatcher<T> enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback) {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed.");
       executed = true;
     }
     this.callback = callback;
+    tracker.registerQueryWatcher(this);
     activeCall.enqueue(callbackProxy(this.callback));
+    return this;
   }
 
   @Nonnull @Override public RealApolloQueryWatcher<T> refetchCacheControl(@Nonnull CacheControl cacheControl) {
     synchronized (this) {
       if (executed) throw new IllegalStateException("Already Executed");
     }
-    Utils.checkNotNull(cacheControl, "httpCacheControl == null");
+    checkNotNull(cacheControl, "httpCacheControl == null");
     this.refetchCacheControl = cacheControl;
     return this;
   }
 
   @Override public void cancel() {
-    canceled = true;
-    activeCall.cancel();
-    apolloStore.unsubscribe(recordChangeSubscriber);
+    synchronized (this) {
+      canceled = true;
+      try {
+        activeCall.cancel();
+        apolloStore.unsubscribe(recordChangeSubscriber);
+      } finally {
+        tracker.unregisterQueryWatcher(this);
+      }
+    }
   }
 
   @Override public boolean isCanceled() {
     return canceled;
   }
 
-  private void refetch() {
-    apolloStore.unsubscribe(recordChangeSubscriber);
-    activeCall.cancel();
-    activeCall = activeCall.clone().cacheControl(refetchCacheControl);
-    activeCall.enqueue(callbackProxy(this.callback));
+  @Nonnull @Override public Operation operation() {
+    return activeCall.operation();
+  }
+
+  @Override public void refetch() {
+    if (canceled) return;
+
+    synchronized (this) {
+      apolloStore.unsubscribe(recordChangeSubscriber);
+      activeCall.cancel();
+      if (!canceled) {
+        activeCall = activeCall.clone().cacheControl(refetchCacheControl);
+        activeCall.enqueue(callbackProxy(this.callback));
+      }
+    }
   }
 
   private ApolloCall.Callback<T> callbackProxy(final ApolloCall.Callback<T> sourceCallback) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -24,7 +24,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private RealApolloCall<T> activeCall;
   private ApolloCall.Callback<T> callback;
-  private CacheControl refetchCacheControl = CacheControl.NETWORK_FIRST;
+  private CacheControl refetchCacheControl = CacheControl.CACHE_FIRST;
   private volatile boolean canceled;
   private boolean executed = false;
   private final ApolloStore apolloStore;


### PR DESCRIPTION
Re-fetch query watchers after mutation completed
Refactor ApolloTracker.

Closes #452