### PR TITLE
Fix issue parentType.getFields is not a function for apollo-codegen

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -63,7 +63,7 @@ class GraphQLCompiler {
   companion object {
     const val FILE_EXTENSION = "graphql"
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
-    const val APOLLOCODEGEN_VERSION = "0.12.8"
+    const val APOLLOCODEGEN_VERSION = "0.12.10"
   }
 
   data class Arguments(

--- a/apollo-compiler/src/test/graphql/apollo-codegen.properties
+++ b/apollo-compiler/src/test/graphql/apollo-codegen.properties
@@ -1,1 +1,1 @@
-apollo-codegen version=0.12.8
+apollo-codegen version=0.12.10


### PR DESCRIPTION
Closes #521