### PR TITLE
Generate marshaller to serialize operation response data

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -41,6 +41,13 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
    * Abstraction for data returned by the server in response to this operation.
    */
   interface Data {
+
+    /**
+     * Returns marshaller to serialize operation data
+     *
+     * @return {@link ResponseFieldMarshaller} to serialize operation data
+     */
+    ResponseFieldMarshaller marshaller();
   }
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseFieldMarshaller.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseFieldMarshaller.java
@@ -1,0 +1,7 @@
+package com.apollographql.apollo.api;
+
+import java.io.IOException;
+
+public interface ResponseFieldMarshaller {
+  void marshal(ResponseWriter writer) throws IOException;
+}

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
@@ -18,9 +18,9 @@ public interface ResponseReader {
 
   Boolean readBoolean(ResponseField field) throws IOException;
 
-  <T> T readObject(ResponseField field, ResponseReader.ObjectReader<T> objectReader) throws IOException;
+  <T> T readObject(ResponseField field, ObjectReader<T> objectReader) throws IOException;
 
-  <T> List<T> readList(ResponseField field, ResponseReader.ListReader listReader) throws IOException;
+  <T> List<T> readList(ResponseField field, ListReader listReader) throws IOException;
 
   <T> T readCustomType(ResponseField.CustomTypeField field) throws IOException;
 
@@ -53,6 +53,6 @@ public interface ResponseReader {
 
     <T> T readCustomType(ScalarType scalarType) throws IOException;
 
-    <T> T readObject(ResponseReader.ObjectReader<T> objectReader) throws IOException;
+    <T> T readObject(ObjectReader<T> objectReader) throws IOException;
   }
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseWriter.java
@@ -1,0 +1,41 @@
+package com.apollographql.apollo.api;
+
+import java.io.IOException;
+
+public interface ResponseWriter {
+  void writeString(ResponseField field, String value) throws IOException;
+
+  void writeInt(ResponseField field, Integer value) throws IOException;
+
+  void writeLong(ResponseField field, Long value) throws IOException;
+
+  void writeDouble(ResponseField field, Double value) throws IOException;
+
+  void writeBoolean(ResponseField field, Boolean value) throws IOException;
+
+  void writeCustom(ResponseField.CustomTypeField field, Object value) throws IOException;
+
+  void writeObject(ResponseField field, ResponseFieldMarshaller marshaller) throws IOException;
+
+  void writeList(ResponseField field, ListWriter listWriter) throws IOException;
+
+  interface ListWriter {
+    void write(ListItemWriter listItemWriter) throws IOException;
+  }
+
+  interface ListItemWriter {
+    void writeString(String value) throws IOException;
+
+    void writeInt(Integer value) throws IOException;
+
+    void writeLong(Long value) throws IOException;
+
+    void writeDouble(Double value) throws IOException;
+
+    void writeBoolean(Boolean value) throws IOException;
+
+    void writeCustom(ScalarType scalarType, Object value) throws IOException;
+
+    void writeObject(ResponseFieldMarshaller marshaller) throws IOException;
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -29,7 +29,8 @@ class OperationTypeSpecBuilder(
         .addType(operation.toTypeSpec(newContext))
         .addOperationName()
         .build()
-        .flatten(excludeTypeNames = listOf(Util.MAPPER_TYPE_NAME, SchemaTypeSpecBuilder.FRAGMENTS_TYPE_NAME))
+        .flatten(excludeTypeNames = listOf(Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
+            (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName()))
   }
 
   private fun TypeSpec.Builder.addQuerySuperInterface(context: CodeGenerationContext): TypeSpec.Builder {
@@ -123,7 +124,7 @@ class OperationTypeSpecBuilder(
         .addAnnotation(Annotations.OVERRIDE)
         .addModifiers(Modifier.PUBLIC)
         .returns(ParameterizedTypeName.get(ClassName.get(ResponseFieldMapper::class.java), DATA_VAR_TYPE))
-        .addStatement("return new \$L.\$L()", Operation.DATA_TYPE_NAME, Util.MAPPER_TYPE_NAME)
+        .addStatement("return new \$L.\$L()", Operation.DATA_TYPE_NAME, Util.RESPONSE_FIELD_MAPPER_TYPE_NAME)
         .build())
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.compiler
 
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ResponseWriter
 import com.apollographql.apollo.compiler.ir.CodeGenerationContext
 import com.apollographql.apollo.compiler.ir.Field
 import com.squareup.javapoet.*
@@ -12,11 +13,11 @@ import javax.lang.model.element.Modifier
 class ResponseFieldSpec(
     val irField: Field,
     val fieldSpec: FieldSpec,
+    val normalizedFieldSpec: FieldSpec,
     val responseFieldType: ResponseField.Type,
     val typeConditions: List<String> = emptyList(),
     val context: CodeGenerationContext
 ) {
-
   fun factoryCode(): CodeBlock {
     val factoryMethod = FACTORY_METHODS[responseFieldType]!!
     return when (responseFieldType) {
@@ -28,28 +29,47 @@ class ResponseFieldSpec(
     }
   }
 
-  fun readValueCode(fieldsVarName: String, index: Int): CodeBlock {
+  fun readValueCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     return when (responseFieldType) {
       ResponseField.Type.STRING,
       ResponseField.Type.INT,
       ResponseField.Type.LONG,
       ResponseField.Type.DOUBLE,
-      ResponseField.Type.BOOLEAN -> readScalarCode(fieldsVarName, index)
-      ResponseField.Type.CUSTOM -> readCustomCode(fieldsVarName, index)
-      ResponseField.Type.ENUM -> readEnumCode(index, fieldsVarName)
-      ResponseField.Type.OBJECT -> readObjectCode(fieldsVarName, index)
-      ResponseField.Type.SCALAR_LIST -> readScalarListCode(fieldsVarName, index)
-      ResponseField.Type.CUSTOM_LIST -> readCustomListCode(fieldsVarName, index)
-      ResponseField.Type.OBJECT_LIST -> readObjectListCode(fieldsVarName, index)
-      ResponseField.Type.INLINE_FRAGMENT -> readInlineFragmentCode(fieldsVarName, index)
-      ResponseField.Type.FRAGMENT -> readFragmentsCode(fieldsVarName, index)
+      ResponseField.Type.BOOLEAN -> readScalarCode(readerParam, fieldParam)
+      ResponseField.Type.CUSTOM -> readCustomCode(readerParam, fieldParam)
+      ResponseField.Type.ENUM -> readEnumCode(readerParam, fieldParam)
+      ResponseField.Type.OBJECT -> readObjectCode(readerParam, fieldParam)
+      ResponseField.Type.SCALAR_LIST -> readScalarListCode(readerParam, fieldParam)
+      ResponseField.Type.CUSTOM_LIST -> readCustomListCode(readerParam, fieldParam)
+      ResponseField.Type.OBJECT_LIST -> readObjectListCode(readerParam, fieldParam)
+      ResponseField.Type.INLINE_FRAGMENT -> readInlineFragmentCode(readerParam, fieldParam)
+      ResponseField.Type.FRAGMENT -> readFragmentsCode(readerParam, fieldParam)
+    }
+  }
+
+  fun writeValueCode(writerParam: CodeBlock, fieldParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    return when (responseFieldType) {
+      ResponseField.Type.STRING,
+      ResponseField.Type.INT,
+      ResponseField.Type.LONG,
+      ResponseField.Type.DOUBLE,
+      ResponseField.Type.BOOLEAN -> writeScalarCode(writerParam, fieldParam)
+      ResponseField.Type.ENUM -> writeEnumCode(writerParam, fieldParam)
+      ResponseField.Type.CUSTOM -> writeCustomCode(writerParam, fieldParam)
+      ResponseField.Type.OBJECT -> writeObjectCode(writerParam, fieldParam, marshaller)
+      ResponseField.Type.SCALAR_LIST -> writeScalarList(writerParam, fieldParam)
+      ResponseField.Type.CUSTOM_LIST -> writeCustomList(writerParam, fieldParam)
+      ResponseField.Type.OBJECT_LIST -> writeObjectList(writerParam, fieldParam, marshaller)
+      ResponseField.Type.INLINE_FRAGMENT -> writeInlineFragmentCode(writerParam, marshaller)
+      ResponseField.Type.FRAGMENT -> writeFragmentsCode(writerParam, marshaller)
+      else -> CodeBlock.of("")
     }
   }
 
   private fun customTypeFactoryCode(irField: Field, factoryMethod: String): CodeBlock {
     val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
     val customScalarEnumConst = normalizeGraphQlType(irField.type).toUpperCase(Locale.ENGLISH)
-    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L, \$L, \$T.\$L)", RESPONSE_FIELD_TYPE, factoryMethod,
+    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L, \$L, \$T.\$L)", ResponseField::class.java, factoryMethod,
         irField.responseName, irField.fieldName, irField.argumentCodeBlock(), irField.isOptional(), customScalarEnum,
         customScalarEnumConst)
   }
@@ -61,67 +81,67 @@ class ResponseFieldSpec(
         }
         .add(")")
         .build()
-    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L)", RESPONSE_FIELD_TYPE, factoryMethod, irField.responseName,
+    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L)", ResponseField::class.java, factoryMethod, irField.responseName,
         irField.fieldName, typeConditionListCode)
   }
 
   private fun genericFactoryCode(irField: Field, factoryMethod: String): CodeBlock {
-    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L, \$L)", RESPONSE_FIELD_TYPE, factoryMethod, irField.responseName,
+    return CodeBlock.of("\$T.\$L(\$S, \$S, \$L, \$L)", ResponseField::class.java, factoryMethod, irField.responseName,
         irField.fieldName, irField.argumentCodeBlock(), irField.isOptional())
   }
 
-  private fun readEnumCode(index: Int, fieldsVarName: String): CodeBlock {
+  private fun readEnumCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val readValueCode = CodeBlock.builder()
-        .addStatement("final \$T \$L", fieldSpec.type, fieldSpec.name)
+        .addStatement("final \$T \$L", normalizedFieldSpec.type, fieldSpec.name)
         .beginControlFlow("if (\$LStr != null)", fieldSpec.name)
-        .addStatement("\$L = \$T.valueOf(\$LStr)", fieldSpec.name, fieldSpec.type, fieldSpec.name)
+        .addStatement("\$L = \$T.valueOf(\$LStr)", fieldSpec.name, normalizedFieldSpec.type, fieldSpec.name)
         .nextControlFlow("else")
         .addStatement("\$L = null", fieldSpec.name)
         .endControlFlow()
         .build()
     return CodeBlock
         .builder()
-        .addStatement("final \$T \$LStr = \$L.\$L(\$L[\$L])", ClassNames.STRING, fieldSpec.name, READER_VAR,
-            READ_METHODS[ResponseField.Type.STRING], fieldsVarName, index)
+        .addStatement("final \$T \$LStr = \$L.\$L(\$L)", ClassNames.STRING, fieldSpec.name, readerParam,
+            READ_METHODS[ResponseField.Type.STRING], fieldParam)
         .add(readValueCode)
         .build()
   }
 
-  private fun readScalarCode(fieldsVarName: String, index: Int): CodeBlock {
-    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L[\$L]);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], fieldsVarName, index)
+  private fun readScalarCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], fieldParam)
   }
 
-  private fun readCustomCode(fieldsVarName: String, index: Int): CodeBlock {
-    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L[\$L]);\n", fieldSpec.type, fieldSpec.name,
-        READER_VAR, READ_METHODS[responseFieldType],
-        ResponseField.CustomTypeField::class.java, fieldsVarName, index)
+  private fun readCustomCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], ResponseField.CustomTypeField::class.java, fieldParam)
   }
 
-  private fun readObjectCode(fieldsVarName: String, index: Int): CodeBlock {
+  private fun readObjectCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val readerTypeSpec = TypeSpec.anonymousClassBuilder("")
-        .superclass(responseFieldObjectReaderTypeName(fieldSpec.type))
+        .superclass(responseFieldObjectReaderTypeName(normalizedFieldSpec.type))
         .addMethod(MethodSpec
             .methodBuilder("read")
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
-            .returns(fieldSpec.type)
-            .addParameter(READER_PARAM)
-            .addStatement("return \$L.map(\$L)", (fieldSpec.type as ClassName).mapperFieldName(), READER_VAR)
+            .returns(normalizedFieldSpec.type)
+            .addParameter(RESPONSE_READER_PARAM)
+            .addStatement("return \$L.map(\$L)", (normalizedFieldSpec.type as ClassName).mapperFieldName(),
+                RESPONSE_READER_PARAM.name)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], fieldsVarName, index, readerTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], fieldParam, readerTypeSpec)
   }
 
-  private fun readScalarListCode(fieldsVarName: String, index: Int): CodeBlock {
-    val rawFieldType = fieldSpec.type.let { if (it.isList()) it.listParamType() else it }
-    val readMethod = SCALAR_LIST_ITEM_READ_METHODS[rawFieldType] ?: "readString()"
+  private fun readScalarListCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val rawFieldType = with(normalizedFieldSpec.type) { if (isList()) listParamType() else this }
+    val readMethod = SCALAR_LIST_ITEM_READ_METHODS[rawFieldType] ?: "readString"
     val readStatement = if (rawFieldType.isEnum(context)) {
-      CodeBlock.of("return \$T.valueOf(\$L.\$L);\n", rawFieldType, READER_VAR, readMethod)
+      CodeBlock.of("return \$T.valueOf(\$L.\$L());\n", rawFieldType, RESPONSE_LIST_ITEM_READER_PARAM.name, readMethod)
     } else {
-      CodeBlock.of("return \$L.\$L;\n", READER_VAR, readMethod)
+      CodeBlock.of("return \$L.\$L();\n", RESPONSE_LIST_ITEM_READER_PARAM.name, readMethod)
     }
     val readerTypeSpec = TypeSpec.anonymousClassBuilder("")
         .superclass(responseFieldListItemReaderType(rawFieldType))
@@ -131,16 +151,16 @@ class ResponseFieldSpec(
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
             .returns(rawFieldType)
-            .addParameter(RESPONSE_FIELD_LIST_ITEM_READER_PARAM)
+            .addParameter(RESPONSE_LIST_ITEM_READER_PARAM)
             .addCode(readStatement)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], fieldsVarName, index, readerTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], fieldParam, readerTypeSpec)
   }
 
-  private fun readCustomListCode(fieldsVarName: String, index: Int): CodeBlock {
-    val rawFieldType = fieldSpec.type.let { if (it.isList()) it.listParamType() else it }
+  private fun readCustomListCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val rawFieldType = normalizedFieldSpec.type.let { if (it.isList()) it.listParamType() else it }
     val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
     val customScalarEnumConst = normalizeGraphQlType(irField.type).toUpperCase(Locale.ENGLISH)
     val readerTypeSpec = TypeSpec.anonymousClassBuilder("")
@@ -151,16 +171,17 @@ class ResponseFieldSpec(
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
             .returns(rawFieldType)
-            .addParameter(RESPONSE_FIELD_LIST_ITEM_READER_PARAM)
-            .addStatement("return \$L.readCustomType(\$T.\$L)", READER_VAR, customScalarEnum, customScalarEnumConst)
+            .addParameter(RESPONSE_LIST_ITEM_READER_PARAM)
+            .addStatement("return \$L.readCustomType(\$T.\$L)", RESPONSE_LIST_ITEM_READER_PARAM.name, customScalarEnum,
+                customScalarEnumConst)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], fieldsVarName, index, readerTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], fieldParam, readerTypeSpec)
   }
 
-  private fun readObjectListCode(fieldsVarName: String, index: Int): CodeBlock {
-    val rawFieldType = fieldSpec.type.let { if (it.isList()) it.listParamType() else it }
+  private fun readObjectListCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val rawFieldType = normalizedFieldSpec.type.let { if (it.isList()) it.listParamType() else it }
     val objectReaderTypeSpec = TypeSpec.anonymousClassBuilder("")
         .superclass(responseFieldObjectReaderTypeName(rawFieldType))
         .addMethod(MethodSpec
@@ -169,8 +190,9 @@ class ResponseFieldSpec(
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
             .returns(rawFieldType)
-            .addParameter(READER_PARAM)
-            .addStatement("return \$L.map(\$L)", (rawFieldType as ClassName).mapperFieldName(), READER_VAR)
+            .addParameter(RESPONSE_READER_PARAM)
+            .addStatement("return \$L.map(\$L)", (rawFieldType as ClassName).mapperFieldName(),
+                RESPONSE_READER_PARAM.name)
             .build())
         .build()
     val listReaderTypeSpec = TypeSpec.anonymousClassBuilder("")
@@ -181,34 +203,35 @@ class ResponseFieldSpec(
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
             .returns(rawFieldType)
-            .addParameter(RESPONSE_FIELD_LIST_ITEM_READER_PARAM)
-            .addStatement("return \$L.readObject(\$L)", READER_VAR, objectReaderTypeSpec)
+            .addParameter(RESPONSE_LIST_ITEM_READER_PARAM)
+            .addStatement("return \$L.readObject(\$L)", RESPONSE_LIST_ITEM_READER_PARAM.name, objectReaderTypeSpec)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], fieldsVarName, index, listReaderTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L(\$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name, readerParam,
+        READ_METHODS[responseFieldType], fieldParam, listReaderTypeSpec)
   }
 
-  private fun readInlineFragmentCode(fieldsVarName: String, index: Int): CodeBlock {
+  private fun readInlineFragmentCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val readerTypeSpec = TypeSpec.anonymousClassBuilder("")
-        .superclass(conditionalResponseFieldReaderTypeName(fieldSpec.type))
+        .superclass(conditionalResponseFieldReaderTypeName(normalizedFieldSpec.type))
         .addMethod(MethodSpec
             .methodBuilder("read")
             .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Override::class.java)
             .addException(IOException::class.java)
-            .returns(fieldSpec.type)
+            .returns(normalizedFieldSpec.type)
             .addParameter(ParameterSpec.builder(String::class.java, CONDITIONAL_TYPE_VAR).build())
-            .addParameter(READER_PARAM)
-            .addStatement("return \$L.map(\$L)", (fieldSpec.type as ClassName).mapperFieldName(), READER_PARAM.name)
+            .addParameter(RESPONSE_READER_PARAM)
+            .addStatement("return \$L.map(\$L)", (normalizedFieldSpec.type as ClassName).mapperFieldName(),
+                RESPONSE_READER_PARAM.name)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], ResponseField.ConditionalTypeField::class.java,
-        fieldsVarName, index, readerTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name,
+        readerParam, READ_METHODS[responseFieldType], ResponseField.ConditionalTypeField::class.java, fieldParam,
+        readerTypeSpec)
   }
 
-  private fun readFragmentsCode(fieldsVarName: String, index: Int): CodeBlock {
+  private fun readFragmentsCode(readerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val readerTypeSpec = TypeSpec.anonymousClassBuilder("")
         .superclass(conditionalResponseFieldReaderTypeName(FRAGMENTS_CLASS))
         .addMethod(MethodSpec
@@ -218,27 +241,151 @@ class ResponseFieldSpec(
             .addException(IOException::class.java)
             .returns(FRAGMENTS_CLASS)
             .addParameter(ParameterSpec.builder(String::class.java, CONDITIONAL_TYPE_VAR).build())
-            .addParameter(READER_PARAM)
-            .addStatement("return \$L.map(\$L, \$L)", FRAGMENTS_CLASS.mapperFieldName(), READER_PARAM.name,
-                CONDITIONAL_TYPE_VAR)
+            .addParameter(RESPONSE_READER_PARAM)
+            .addStatement("return \$L.map(\$L, \$L)", FRAGMENTS_CLASS.mapperFieldName(),
+                RESPONSE_READER_PARAM.name, CONDITIONAL_TYPE_VAR)
             .build())
         .build()
-    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L[\$L], \$L);\n", fieldSpec.type, fieldSpec.name, READER_VAR,
-        READ_METHODS[responseFieldType], ResponseField.ConditionalTypeField::class.java,
-        fieldsVarName, index, readerTypeSpec)
+    return CodeBlock.of("final \$T \$L = \$L.\$L((\$T) \$L, \$L);\n", normalizedFieldSpec.type, fieldSpec.name,
+        readerParam, READ_METHODS[responseFieldType], ResponseField.ConditionalTypeField::class.java, fieldParam,
+        readerTypeSpec)
+  }
+
+  private fun writeScalarCode(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name)
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType],
+        fieldParam, valueCode)
+  }
+
+  private fun writeEnumCode(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
+      CodeBlock.of("\$L.name()", it)
+    }
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType],
+        fieldParam, valueCode)
+  }
+
+  private fun writeCustomCode(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name)
+    return CodeBlock.of("\$L.\$L((\$T) \$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType],
+        ResponseField.CustomTypeField::class.java, fieldParam, valueCode)
+  }
+
+  private fun writeObjectCode(writerParam: CodeBlock, fieldParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
+      CodeBlock.of("\$L.\$L", it, marshaller)
+    }
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType], fieldParam, valueCode)
+  }
+
+  private fun writeScalarList(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val rawFieldType = with(normalizedFieldSpec.type) { if (isList()) listParamType() else this }
+    val writeMethod = SCALAR_LIST_ITEM_WRITE_METHODS[rawFieldType] ?: "writeString"
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            fieldSpec.type.unwrapOptionalValue(fieldSpec.name, false))
+        .add(
+            if (rawFieldType.isEnum(context)) {
+              CodeBlock.of("\$L.\$L(\$L.name());\n", RESPONSE_LIST_ITEM_WRITER_PARAM.name, writeMethod, "\$item")
+            } else {
+              CodeBlock.of("\$L.\$L(\$L);\n", RESPONSE_LIST_ITEM_WRITER_PARAM.name, writeMethod, "\$item")
+            })
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(ResponseWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addParameter(RESPONSE_LIST_ITEM_WRITER_PARAM)
+            .addException(IOException::class.java)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType], fieldParam, valueCode)
+  }
+
+  private fun writeCustomList(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
+    val rawFieldType = normalizedFieldSpec.type.let { if (it.isList()) it.listParamType() else it }
+    val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
+    val customScalarEnumConst = normalizeGraphQlType(irField.type).toUpperCase(Locale.ENGLISH)
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            fieldSpec.type.unwrapOptionalValue(fieldSpec.name, false))
+        .addStatement("\$L.writeCustom(\$T.\$L, \$L)", RESPONSE_LIST_ITEM_WRITER_PARAM.name,
+            customScalarEnum, customScalarEnumConst, "\$item")
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(ResponseWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addParameter(RESPONSE_LIST_ITEM_WRITER_PARAM)
+            .addException(IOException::class.java)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType], fieldParam, valueCode)
+  }
+
+  private fun writeObjectList(writerParam: CodeBlock, fieldParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    val rawFieldType = with(normalizedFieldSpec.type) { if (isList()) listParamType() else this }
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            fieldSpec.type.unwrapOptionalValue(fieldSpec.name, false))
+        .addStatement("\$L.writeObject(\$L.\$L)", RESPONSE_LIST_ITEM_WRITER_PARAM.name, "\$item", marshaller)
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(ResponseWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addParameter(RESPONSE_LIST_ITEM_WRITER_PARAM)
+            .addException(IOException::class.java)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType], fieldParam, valueCode)
+  }
+
+  private fun writeInlineFragmentCode(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    return CodeBlock.builder()
+        .addStatement("final \$T \$L = \$L", fieldSpec.type.unwrapOptionalType().withoutAnnotations(),
+            "\$${fieldSpec.name}", fieldSpec.type.unwrapOptionalValue(fieldSpec.name))
+        .beginControlFlow("if (\$L != null)", "\$${fieldSpec.name}")
+        .addStatement("\$L.\$L.marshal(\$L)", "\$${fieldSpec.name}", marshaller, writerParam)
+        .endControlFlow()
+        .build()
+  }
+
+  private fun writeFragmentsCode(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    return CodeBlock.of("\$L.\$L.marshal(\$L);\n", fieldSpec.name, marshaller, writerParam)
   }
 
   private fun responseFieldObjectReaderTypeName(type: TypeName) =
-      ParameterizedTypeName.get(RESPONSE_FIELD_OBJECT_READER_TYPE, type)
+      ParameterizedTypeName.get(ClassName.get(ResponseReader.ObjectReader::class.java), type)
 
   private fun conditionalResponseFieldReaderTypeName(type: TypeName) =
-      ParameterizedTypeName.get(RESPONSE_FIELD_CONDITIONAL_TYPE_READER_TYPE, type)
+      ParameterizedTypeName.get(ClassName.get(ResponseReader.ConditionalTypeReader::class.java), type)
 
   private fun responseFieldListItemReaderType(type: TypeName) =
-      ParameterizedTypeName.get(RESPONSE_FIELD_LIST_READER_TYPE, type)
+      ParameterizedTypeName.get(ClassName.get(ResponseReader.ListReader::class.java), type)
 
   companion object {
-    private val RESPONSE_FIELD_TYPE = ClassName.get(ResponseField::class.java)
     private val FACTORY_METHODS = mapOf(
         ResponseField.Type.STRING to "forString",
         ResponseField.Type.INT to "forInt",
@@ -269,25 +416,49 @@ class ResponseFieldSpec(
         ResponseField.Type.FRAGMENT to "readConditional",
         ResponseField.Type.INLINE_FRAGMENT to "readConditional"
     )
-    private val SCALAR_LIST_ITEM_READ_METHODS = mapOf(
-        TypeName.INT to "readInt()",
-        TypeName.INT.box() to "readInt()",
-        TypeName.LONG to "readLong()",
-        TypeName.LONG.box() to "readLong()",
-        TypeName.DOUBLE to "readDouble()",
-        TypeName.DOUBLE.box() to "readDouble()",
-        TypeName.BOOLEAN to "readBoolean()",
-        TypeName.BOOLEAN.box() to "readBoolean()"
+    private val WRITE_METHODS = mapOf(
+        ResponseField.Type.STRING to "writeString",
+        ResponseField.Type.INT to "writeInt",
+        ResponseField.Type.LONG to "writeLong",
+        ResponseField.Type.DOUBLE to "writeDouble",
+        ResponseField.Type.BOOLEAN to "writeBoolean",
+        ResponseField.Type.ENUM to "writeString",
+        ResponseField.Type.CUSTOM to "writeCustom",
+        ResponseField.Type.OBJECT to "writeObject",
+        ResponseField.Type.SCALAR_LIST to "writeList",
+        ResponseField.Type.CUSTOM_LIST to "writeList",
+        ResponseField.Type.OBJECT_LIST to "writeList"
     )
+    private val SCALAR_LIST_ITEM_READ_METHODS = mapOf(
+        ClassNames.STRING to "readString",
+        TypeName.INT to "readInt",
+        TypeName.INT.box() to "readInt",
+        TypeName.LONG to "readLong",
+        TypeName.LONG.box() to "readLong",
+        TypeName.DOUBLE to "readDouble",
+        TypeName.DOUBLE.box() to "readDouble",
+        TypeName.BOOLEAN to "readBoolean",
+        TypeName.BOOLEAN.box() to "readBoolean"
+    )
+    private val SCALAR_LIST_ITEM_WRITE_METHODS = mapOf(
+        ClassNames.STRING to "writeString",
+        TypeName.INT to "writeInt",
+        TypeName.INT.box() to "writeInt",
+        TypeName.LONG to "writeLong",
+        TypeName.LONG.box() to "writeLong",
+        TypeName.DOUBLE to "writeDouble",
+        TypeName.DOUBLE.box() to "writeDouble",
+        TypeName.BOOLEAN to "writeBoolean",
+        TypeName.BOOLEAN.box() to "writeBoolean"
+    )
+    private val RESPONSE_READER_PARAM =
+        ParameterSpec.builder(ResponseReader::class.java, "reader").build()
+    private val RESPONSE_LIST_ITEM_READER_PARAM =
+        ParameterSpec.builder(ResponseReader.ListItemReader::class.java, "reader").build()
+    private val RESPONSE_LIST_ITEM_WRITER_PARAM =
+        ParameterSpec.builder(ResponseWriter.ListItemWriter::class.java, "listItemWriter").build()
+
     private val FRAGMENTS_CLASS = ClassName.get("", "Fragments")
     private val CONDITIONAL_TYPE_VAR = "conditionalType"
-    private val READER_VAR = "reader"
-    private val READER_PARAM = ParameterSpec.builder(ResponseReader::class.java, READER_VAR).build()
-    private val RESPONSE_FIELD_OBJECT_READER_TYPE = ClassName.get(ResponseReader.ObjectReader::class.java)
-    private val RESPONSE_FIELD_LIST_READER_TYPE = ClassName.get(ResponseReader.ListReader::class.java)
-    private val RESPONSE_FIELD_LIST_ITEM_READER_PARAM =
-        ParameterSpec.builder(ResponseReader.ListItemReader::class.java, READER_VAR).build()
-    private val RESPONSE_FIELD_CONDITIONAL_TYPE_READER_TYPE =
-        ClassName.get(ResponseReader.ConditionalTypeReader::class.java)
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -49,7 +49,8 @@ data class Field(
 
   fun fieldSpec(context: CodeGenerationContext, publicModifier: Boolean = false): FieldSpec {
     return FieldSpec.builder(toTypeName(methodResponseType(), context), responseName.escapeJavaReservedWord())
-        .addModifiers(if (publicModifier) Modifier.PUBLIC else Modifier.PRIVATE, Modifier.FINAL)
+        .let { if (publicModifier) it.addModifiers(Modifier.PUBLIC) else it }
+        .addModifiers(Modifier.FINAL)
         .let {
           if (publicModifier && !description.isNullOrBlank()) {
             it.addJavadoc("\$L\n", description)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.compiler.ir
 
 import com.apollographql.apollo.compiler.*
+import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.TypeSpec
@@ -34,7 +35,8 @@ data class Fragment(
           .addFragmentDefinitionField()
           .addTypeConditionField()
           .build()
-          .flatten(excludeTypeNames = listOf(Util.MAPPER_TYPE_NAME, SchemaTypeSpecBuilder.FRAGMENTS_TYPE_NAME))
+          .flatten(excludeTypeNames = listOf(Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
+              (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName()))
 
   fun formatClassName() = fragmentName.capitalize()
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/InlineFragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/InlineFragment.kt
@@ -32,7 +32,8 @@ data class InlineFragment(
 
   fun fieldSpec(context: CodeGenerationContext, publicModifier: Boolean = false): FieldSpec =
       FieldSpec.builder(typeName(context), formatClassName().decapitalize())
-          .addModifiers(if (publicModifier) Modifier.PUBLIC else Modifier.PRIVATE, Modifier.FINAL)
+          .let { if (publicModifier) it.addModifiers(Modifier.PUBLIC) else it }
+          .addModifiers(Modifier.FINAL)
           .build()
 
   fun formatClassName(): String = "$INTERFACE_PREFIX${typeCondition.capitalize()}"

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_complex.type.Episode;
@@ -165,7 +167,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<HeroWithReview> heroWithReview;
+    final Optional<HeroWithReview> heroWithReview;
 
     private volatile String $toString;
 
@@ -179,6 +181,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<HeroWithReview> heroWithReview() {
       return this.heroWithReview;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], heroWithReview.isPresent() ? heroWithReview.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -240,11 +251,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
     private volatile String $toString;
 
@@ -275,6 +286,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Double> height() {
       return this.height;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_simple.type.Episode;
@@ -134,7 +136,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -148,6 +150,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -206,9 +217,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<String> name;
+    final Optional<String> name;
 
     private volatile String $toString;
 
@@ -230,6 +241,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<String> name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name.isPresent() ? name.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.custom_scalar_type.type.CustomType;
 import java.io.IOException;
@@ -90,7 +92,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -104,6 +106,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -167,19 +178,19 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forCustomList("links", "links", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull Date birthDate;
+    final @Nonnull Date birthDate;
 
-    private final @Nonnull List<Date> appearanceDates;
+    final @Nonnull List<Date> appearanceDates;
 
-    private final @Nonnull Object fieldWithUnsupportedType;
+    final @Nonnull Object fieldWithUnsupportedType;
 
-    private final @Nonnull String profileLink;
+    final @Nonnull String profileLink;
 
-    private final @Nonnull List<String> links;
+    final @Nonnull List<String> links;
 
     private volatile String $toString;
 
@@ -243,6 +254,35 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull List<String> links() {
       return this.links;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[2], birthDate);
+          writer.writeList($responseFields[3], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Date $item : appearanceDates) {
+                listItemWriter.writeCustom(CustomType.DATE, $item);
+              }
+            }
+          });
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[4], fieldWithUnsupportedType);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[5], profileLink);
+          writer.writeList($responseFields[6], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (String $item : links) {
+                listItemWriter.writeCustom(CustomType.URL, $item);
+              }
+            }
+          });
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.deprecation.type.Episode;
@@ -121,7 +123,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -135,6 +137,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -194,11 +205,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("deprecated", "deprecated", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull @Deprecated String deprecated;
+    final @Nonnull @Deprecated String deprecated;
 
     private volatile String $toString;
 
@@ -230,6 +241,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull @Deprecated String deprecated() {
       return this.deprecated;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeString($responseFields[2], deprecated);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -82,7 +84,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -96,6 +98,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -154,9 +165,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<String> name;
+    final Optional<String> name;
 
     private volatile String $toString;
 
@@ -178,6 +189,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<String> name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name.isPresent() ? name.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.enum_type.type.Episode;
 import java.io.IOException;
@@ -86,7 +88,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -100,6 +102,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -160,13 +171,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("firstAppearsIn", "firstAppearsIn", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull List<Episode> appearsIn;
+    final @Nonnull List<Episode> appearsIn;
 
-    private final @Nonnull Episode firstAppearsIn;
+    final @Nonnull Episode firstAppearsIn;
 
     private volatile String $toString;
 
@@ -205,6 +216,25 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull Episode firstAppearsIn() {
       return this.firstAppearsIn;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : appearsIn) {
+                listItemWriter.writeString($item.name());
+              }
+            }
+          });
+          writer.writeString($responseFields[3], firstAppearsIn.name());
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_friends_connection.fragment.HeroDetails;
 import java.io.IOException;
@@ -86,7 +88,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -100,6 +102,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -159,7 +170,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -180,6 +191,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -221,7 +242,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      private final @Nonnull HeroDetails heroDetails;
+      final @Nonnull HeroDetails heroDetails;
 
       private volatile String $toString;
 
@@ -235,6 +256,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public @Nonnull HeroDetails heroDetails() {
         return this.heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -3,7 +3,9 @@ package com.example.fragment_friends_connection.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -43,11 +45,11 @@ public class HeroDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
-  private final @Nonnull FriendsConnection friendsConnection;
+  final @Nonnull FriendsConnection friendsConnection;
 
   private volatile String $toString;
 
@@ -78,6 +80,17 @@ public class HeroDetails implements GraphqlFragment {
    */
   public @Nonnull FriendsConnection friendsConnection() {
     return this.friendsConnection;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeObject($responseFields[2], friendsConnection.marshaller());
+      }
+    };
   }
 
   @Override
@@ -146,11 +159,11 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -181,6 +194,24 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -254,9 +285,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -278,6 +309,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -341,9 +382,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -365,6 +406,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.fragment_in_fragment.fragment.PilotFragment;
@@ -98,7 +100,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       .build(), true)
     };
 
-    private final Optional<AllStarships1> allStarships;
+    final Optional<AllStarships1> allStarships;
 
     private volatile String $toString;
 
@@ -112,6 +114,15 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
 
     public Optional<AllStarships1> allStarships() {
       return this.allStarships;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], allStarships.isPresent() ? allStarships.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -170,9 +181,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -194,6 +205,23 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeList($responseFields[1], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -262,9 +290,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -286,6 +314,16 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -349,7 +387,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       ResponseField.forFragment("__typename", "__typename", Arrays.asList("Starship"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -370,6 +408,16 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -411,7 +459,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     }
 
     public static class Fragments {
-      private final @Nonnull StarshipFragment starshipFragment;
+      final @Nonnull StarshipFragment starshipFragment;
 
       private volatile String $toString;
 
@@ -425,6 +473,18 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
 
       public @Nonnull StarshipFragment starshipFragment() {
         return this.starshipFragment;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final StarshipFragment $starshipFragment = starshipFragment;
+            if ($starshipFragment != null) {
+              $starshipFragment.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -3,7 +3,9 @@ package com.example.fragment_in_fragment.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -35,11 +37,11 @@ public class PilotFragment implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Person"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final Optional<String> name;
+  final Optional<String> name;
 
-  private final Optional<Homeworld> homeworld;
+  final Optional<Homeworld> homeworld;
 
   private volatile String $toString;
 
@@ -70,6 +72,17 @@ public class PilotFragment implements GraphqlFragment {
    */
   public Optional<Homeworld> homeworld() {
     return this.homeworld;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name.isPresent() ? name.get() : null);
+        writer.writeObject($responseFields[2], homeworld.isPresent() ? homeworld.get().marshaller() : null);
+      }
+    };
   }
 
   @Override
@@ -137,9 +150,9 @@ public class PilotFragment implements GraphqlFragment {
       ResponseField.forString("name", "name", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<String> name;
+    final Optional<String> name;
 
     private volatile String $toString;
 
@@ -161,6 +174,16 @@ public class PilotFragment implements GraphqlFragment {
      */
     public Optional<String> name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name.isPresent() ? name.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -4,7 +4,9 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -44,13 +46,13 @@ public class StarshipFragment implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Starship"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String id;
+  final @Nonnull String id;
 
-  private final Optional<String> name;
+  final Optional<String> name;
 
-  private final Optional<PilotConnection> pilotConnection;
+  final Optional<PilotConnection> pilotConnection;
 
   private volatile String $toString;
 
@@ -86,6 +88,18 @@ public class StarshipFragment implements GraphqlFragment {
 
   public Optional<PilotConnection> pilotConnection() {
     return this.pilotConnection;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], id);
+        writer.writeString($responseFields[2], name.isPresent() ? name.get() : null);
+        writer.writeObject($responseFields[3], pilotConnection.isPresent() ? pilotConnection.get().marshaller() : null);
+      }
+    };
   }
 
   @Override
@@ -158,9 +172,9 @@ public class StarshipFragment implements GraphqlFragment {
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -182,6 +196,23 @@ public class StarshipFragment implements GraphqlFragment {
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeList($responseFields[1], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -250,9 +281,9 @@ public class StarshipFragment implements GraphqlFragment {
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -274,6 +305,16 @@ public class StarshipFragment implements GraphqlFragment {
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -337,7 +378,7 @@ public class StarshipFragment implements GraphqlFragment {
       ResponseField.forFragment("__typename", "__typename", Arrays.asList("Person"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -358,6 +399,16 @@ public class StarshipFragment implements GraphqlFragment {
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -399,7 +450,7 @@ public class StarshipFragment implements GraphqlFragment {
     }
 
     public static class Fragments {
-      private final @Nonnull PilotFragment pilotFragment;
+      final @Nonnull PilotFragment pilotFragment;
 
       private volatile String $toString;
 
@@ -413,6 +464,18 @@ public class StarshipFragment implements GraphqlFragment {
 
       public @Nonnull PilotFragment pilotFragment() {
         return this.pilotFragment;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final PilotFragment $pilotFragment = pilotFragment;
+            if ($pilotFragment != null) {
+              $pilotFragment.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
 import com.example.fragment_with_inline_fragment.type.Episode;
@@ -90,7 +92,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -104,6 +106,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -165,11 +176,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull List<Episode> appearsIn;
+    final @Nonnull List<Episode> appearsIn;
 
     private final @Nonnull Fragments fragments;
 
@@ -207,6 +218,25 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : appearsIn) {
+                listItemWriter.writeString($item.name());
+              }
+            }
+          });
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -256,7 +286,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      private final @Nonnull HeroDetails heroDetails;
+      final @Nonnull HeroDetails heroDetails;
 
       private volatile String $toString;
 
@@ -270,6 +300,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public @Nonnull HeroDetails heroDetails() {
         return this.heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -3,7 +3,9 @@ package com.example.fragment_with_inline_fragment.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -49,13 +51,13 @@ public class HeroDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
-  private final @Nonnull FriendsConnection friendsConnection;
+  final @Nonnull FriendsConnection friendsConnection;
 
-  private final Optional<AsDroid> asDroid;
+  final Optional<AsDroid> asDroid;
 
   private volatile String $toString;
 
@@ -91,6 +93,21 @@ public class HeroDetails implements GraphqlFragment {
 
   public Optional<AsDroid> asDroid() {
     return this.asDroid;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        final AsDroid $asDroid = asDroid.isPresent() ? asDroid.get() : null;
+        if ($asDroid != null) {
+          $asDroid.marshaller().marshal(writer);
+        }
+      }
+    };
   }
 
   @Override
@@ -171,11 +188,11 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -206,6 +223,24 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -279,9 +314,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -303,6 +338,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -366,9 +411,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -390,6 +435,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override
@@ -448,13 +503,13 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forString("primaryFunction", "primaryFunction", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection1 friendsConnection;
+    final @Nonnull FriendsConnection1 friendsConnection;
 
-    private final Optional<String> primaryFunction;
+    final Optional<String> primaryFunction;
 
     private volatile String $toString;
 
@@ -493,6 +548,18 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<String> primaryFunction() {
       return this.primaryFunction;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+          writer.writeString($responseFields[3], primaryFunction.isPresent() ? primaryFunction.get() : null);
+        }
+      };
     }
 
     @Override
@@ -567,11 +634,11 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge1>> edges;
+    final Optional<List<Edge1>> edges;
 
     private volatile String $toString;
 
@@ -602,6 +669,24 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<List<Edge1>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge1 $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -675,9 +760,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node1> node;
+    final Optional<Node1> node;
 
     private volatile String $toString;
 
@@ -699,6 +784,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<Node1> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -762,9 +857,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -786,6 +881,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragments_with_type_condition.fragment.DroidDetails;
 import com.example.fragments_with_type_condition.fragment.HumanDetails;
@@ -95,9 +97,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("luke", "hero", null, true)
     };
 
-    private final Optional<R2> r2;
+    final Optional<R2> r2;
 
-    private final Optional<Luke> luke;
+    final Optional<Luke> luke;
 
     private volatile String $toString;
 
@@ -116,6 +118,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Luke> luke() {
       return this.luke;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], r2.isPresent() ? r2.get().marshaller() : null);
+          writer.writeObject($responseFields[1], luke.isPresent() ? luke.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -187,7 +199,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -208,6 +220,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -249,9 +271,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      private final @Nonnull HumanDetails humanDetails;
+      final @Nonnull HumanDetails humanDetails;
 
-      private final @Nonnull DroidDetails droidDetails;
+      final @Nonnull DroidDetails droidDetails;
 
       private volatile String $toString;
 
@@ -270,6 +292,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public @Nonnull DroidDetails droidDetails() {
         return this.droidDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HumanDetails $humanDetails = humanDetails;
+            if ($humanDetails != null) {
+              $humanDetails.marshaller().marshal(writer);
+            }
+            final DroidDetails $droidDetails = droidDetails;
+            if ($droidDetails != null) {
+              $droidDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override
@@ -355,7 +393,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -376,6 +414,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -417,9 +465,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      private final @Nonnull HumanDetails humanDetails;
+      final @Nonnull HumanDetails humanDetails;
 
-      private final @Nonnull DroidDetails droidDetails;
+      final @Nonnull DroidDetails droidDetails;
 
       private volatile String $toString;
 
@@ -438,6 +486,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public @Nonnull DroidDetails droidDetails() {
         return this.droidDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HumanDetails $humanDetails = humanDetails;
+            if ($humanDetails != null) {
+              $humanDetails.marshaller().marshal(writer);
+            }
+            final DroidDetails $droidDetails = droidDetails;
+            if ($droidDetails != null) {
+              $droidDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
@@ -3,7 +3,9 @@ package com.example.fragments_with_type_condition.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -32,11 +34,11 @@ public class DroidDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Droid"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
-  private final Optional<String> primaryFunction;
+  final Optional<String> primaryFunction;
 
   private volatile String $toString;
 
@@ -67,6 +69,17 @@ public class DroidDetails implements GraphqlFragment {
    */
   public Optional<String> primaryFunction() {
     return this.primaryFunction;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeString($responseFields[2], primaryFunction.isPresent() ? primaryFunction.get() : null);
+      }
+    };
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
@@ -3,7 +3,9 @@ package com.example.fragments_with_type_condition.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
@@ -33,11 +35,11 @@ public class HumanDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
-  private final Optional<Double> height;
+  final Optional<Double> height;
 
   private volatile String $toString;
 
@@ -67,6 +69,17 @@ public class HumanDetails implements GraphqlFragment {
    */
   public Optional<Double> height() {
     return this.height;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+      }
+    };
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -95,7 +97,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -109,6 +111,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -168,11 +179,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection friendsConnection;
+    final @Nonnull FriendsConnection friendsConnection;
 
     private volatile String $toString;
 
@@ -203,6 +214,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull FriendsConnection friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -272,11 +294,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -307,6 +329,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -380,9 +420,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -404,6 +444,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -467,9 +517,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -491,6 +541,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.google.common.base.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -95,7 +97,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -109,6 +111,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -168,11 +179,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection friendsConnection;
+    final @Nonnull FriendsConnection friendsConnection;
 
     private volatile String $toString;
 
@@ -203,6 +214,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull FriendsConnection friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -272,11 +294,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -307,6 +329,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -380,9 +420,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -404,6 +444,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -467,9 +517,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -491,6 +541,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -95,7 +97,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -109,6 +111,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -168,11 +179,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection friendsConnection;
+    final @Nonnull FriendsConnection friendsConnection;
 
     private volatile String $toString;
 
@@ -203,6 +214,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull FriendsConnection friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -272,11 +294,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -307,6 +329,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -380,9 +420,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -404,6 +444,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -467,9 +517,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -491,6 +541,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -94,7 +96,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final @Nullable Hero hero;
+    final @Nullable Hero hero;
 
     private volatile String $toString;
 
@@ -108,6 +110,15 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
     public @Nullable Hero hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.marshaller());
+        }
+      };
     }
 
     @Override
@@ -167,11 +178,11 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection friendsConnection;
+    final @Nonnull FriendsConnection friendsConnection;
 
     private volatile String $toString;
 
@@ -202,6 +213,17 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
      */
     public @Nonnull FriendsConnection friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -271,11 +293,11 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nullable Integer totalCount;
+    final @Nullable Integer totalCount;
 
-    private final @Nullable List<Edge> edges;
+    final @Nullable List<Edge> edges;
 
     private volatile String $toString;
 
@@ -306,6 +328,24 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
      */
     public @Nullable List<Edge> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount);
+          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          });
+        }
+      };
     }
 
     @Override
@@ -379,9 +419,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nullable Node node;
+    final @Nullable Node node;
 
     private volatile String $toString;
 
@@ -403,6 +443,16 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
      */
     public @Nullable Node node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.marshaller());
+        }
+      };
     }
 
     @Override
@@ -466,9 +516,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -490,6 +540,16 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -82,7 +84,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -96,6 +98,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -154,9 +165,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -178,6 +189,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.inline_fragments_with_friends.type.Episode;
 import java.io.IOException;
@@ -102,7 +104,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -116,6 +118,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -176,13 +187,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<AsHuman> asHuman;
+    final Optional<AsHuman> asHuman;
 
-    private final Optional<AsDroid> asDroid;
+    final Optional<AsDroid> asDroid;
 
     private volatile String $toString;
 
@@ -215,6 +226,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<AsDroid> asDroid() {
       return this.asDroid;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          final AsHuman $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+          final AsDroid $asDroid = asDroid.isPresent() ? asDroid.get() : null;
+          if ($asDroid != null) {
+            $asDroid.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -297,13 +326,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("friends", "friends", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
-    private final Optional<List<Friend>> friends;
+    final Optional<List<Friend>> friends;
 
     private volatile String $toString;
 
@@ -342,6 +371,25 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Friend>> friends() {
       return this.friends;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+          writer.writeList($responseFields[3], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -420,9 +468,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forScalarList("appearsIn", "appearsIn", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull List<Episode> appearsIn;
+    final @Nonnull List<Episode> appearsIn;
 
     private volatile String $toString;
 
@@ -444,6 +492,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull List<Episode> appearsIn() {
       return this.appearsIn;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeList($responseFields[1], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : appearsIn) {
+                listItemWriter.writeString($item.name());
+              }
+            }
+          });
+        }
+      };
     }
 
     @Override
@@ -507,13 +572,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("primaryFunction", "primaryFunction", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<List<Friend1>> friends;
+    final Optional<List<Friend1>> friends;
 
-    private final Optional<String> primaryFunction;
+    final Optional<String> primaryFunction;
 
     private volatile String $toString;
 
@@ -552,6 +617,25 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<String> primaryFunction() {
       return this.primaryFunction;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend1 $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+          writer.writeString($responseFields[3], primaryFunction.isPresent() ? primaryFunction.get() : null);
+        }
+      };
     }
 
     @Override
@@ -630,9 +714,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("id", "id", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String id;
+    final @Nonnull String id;
 
     private volatile String $toString;
 
@@ -654,6 +738,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String id() {
       return this.id;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], id);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
@@ -146,7 +148,7 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
       .build(), true)
     };
 
-    private final Optional<CreateReview> createReview;
+    final Optional<CreateReview> createReview;
 
     private volatile String $toString;
 
@@ -160,6 +162,15 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
 
     public Optional<CreateReview> createReview() {
       return this.createReview;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], createReview.isPresent() ? createReview.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -219,11 +230,11 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
       ResponseField.forString("commentary", "commentary", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final int stars;
+    final int stars;
 
-    private final Optional<String> commentary;
+    final Optional<String> commentary;
 
     private volatile String $toString;
 
@@ -253,6 +264,17 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
      */
     public Optional<String> commentary() {
       return this.commentary;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], stars);
+          writer.writeString($responseFields[2], commentary.isPresent() ? commentary.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.nested_conditional_inline.type.Episode;
@@ -144,7 +146,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -158,6 +160,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -218,13 +229,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<AsHuman> asHuman;
+    final Optional<AsHuman> asHuman;
 
-    private final Optional<AsDroid> asDroid;
+    final Optional<AsDroid> asDroid;
 
     private volatile String $toString;
 
@@ -254,6 +265,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<AsDroid> asDroid() {
       return this.asDroid;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          final AsHuman $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+          final AsDroid $asDroid = asDroid.isPresent() ? asDroid.get() : null;
+          if ($asDroid != null) {
+            $asDroid.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -335,11 +364,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("friends", "friends", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<List<Friend>> friends;
+    final Optional<List<Friend>> friends;
 
     private volatile String $toString;
 
@@ -364,6 +393,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<List<Friend>> friends() {
       return this.friends;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -438,11 +485,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<AsHuman1> asHuman;
+    final Optional<AsHuman1> asHuman;
 
     private volatile String $toString;
 
@@ -466,6 +513,20 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<AsHuman1> asHuman() {
       return this.asHuman;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          final AsHuman1 $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -537,11 +598,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
     private volatile String $toString;
 
@@ -565,6 +626,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Double> height() {
       return this.height;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+        }
+      };
     }
 
     @Override
@@ -627,11 +699,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("friends", "friends", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<List<Friend1>> friends;
+    final Optional<List<Friend1>> friends;
 
     private volatile String $toString;
 
@@ -656,6 +728,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<List<Friend1>> friends() {
       return this.friends;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend1 $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -730,11 +820,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<AsHuman2> asHuman;
+    final Optional<AsHuman2> asHuman;
 
     private volatile String $toString;
 
@@ -758,6 +848,20 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<AsHuman2> asHuman() {
       return this.asHuman;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          final AsHuman2 $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -829,11 +933,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
     private volatile String $toString;
 
@@ -857,6 +961,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Double> height() {
       return this.height;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.no_accessors.fragment.HeroDetails;
 import com.example.no_accessors.type.Episode;
@@ -102,6 +104,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       this.hero = Optional.fromNullable(hero);
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -189,6 +200,25 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       this.fragments = fragments;
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : appearsIn) {
+                listItemWriter.writeString($item.name());
+              }
+            }
+          });
+          fragments.marshaller().marshal(writer);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -246,6 +276,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
         this.heroDetails = heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
@@ -3,7 +3,9 @@ package com.example.no_accessors.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -75,6 +77,21 @@ public class HeroDetails implements GraphqlFragment {
     this.name = name;
     this.friendsConnection = friendsConnection;
     this.asDroid = Optional.fromNullable(asDroid);
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        final AsDroid $asDroid = asDroid.isPresent() ? asDroid.get() : null;
+        if ($asDroid != null) {
+          $asDroid.marshaller().marshal(writer);
+        }
+      }
+    };
   }
 
   @Override
@@ -180,6 +197,24 @@ public class HeroDetails implements GraphqlFragment {
       this.edges = Optional.fromNullable(edges);
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -269,6 +304,16 @@ public class HeroDetails implements GraphqlFragment {
       this.node = Optional.fromNullable(node);
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -346,6 +391,16 @@ public class HeroDetails implements GraphqlFragment {
     public Node(@Nonnull String __typename, @Nonnull String name) {
       this.__typename = __typename;
       this.name = name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override
@@ -433,6 +488,18 @@ public class HeroDetails implements GraphqlFragment {
       this.name = name;
       this.friendsConnection = friendsConnection;
       this.primaryFunction = Optional.fromNullable(primaryFunction);
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+          writer.writeString($responseFields[3], primaryFunction.isPresent() ? primaryFunction.get() : null);
+        }
+      };
     }
 
     @Override
@@ -532,6 +599,24 @@ public class HeroDetails implements GraphqlFragment {
       this.edges = Optional.fromNullable(edges);
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge1 $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -621,6 +706,16 @@ public class HeroDetails implements GraphqlFragment {
       this.node = Optional.fromNullable(node);
     }
 
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
+    }
+
     @Override
     public String toString() {
       if ($toString == null) {
@@ -698,6 +793,16 @@ public class HeroDetails implements GraphqlFragment {
     public Node1(@Nonnull String __typename, @Nonnull String name) {
       this.__typename = __typename;
       this.name = name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Object;
@@ -125,105 +127,105 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("while", "while", null, true)
     };
 
-    private final Optional<String> abstract_;
+    final Optional<String> abstract_;
 
-    private final Optional<String> assert_;
+    final Optional<String> assert_;
 
-    private final Optional<String> boolean_;
+    final Optional<String> boolean_;
 
-    private final Optional<String> break_;
+    final Optional<String> break_;
 
-    private final Optional<String> byte_;
+    final Optional<String> byte_;
 
-    private final Optional<String> case_;
+    final Optional<String> case_;
 
-    private final Optional<String> catch_;
+    final Optional<String> catch_;
 
-    private final Optional<String> char_;
+    final Optional<String> char_;
 
-    private final Optional<String> class_;
+    final Optional<String> class_;
 
-    private final Optional<String> const_;
+    final Optional<String> const_;
 
-    private final Optional<String> continue_;
+    final Optional<String> continue_;
 
-    private final Optional<String> default_;
+    final Optional<String> default_;
 
-    private final Optional<String> do_;
+    final Optional<String> do_;
 
-    private final Optional<String> double_;
+    final Optional<String> double_;
 
-    private final Optional<String> else_;
+    final Optional<String> else_;
 
-    private final Optional<String> enum_;
+    final Optional<String> enum_;
 
-    private final Optional<String> extends_;
+    final Optional<String> extends_;
 
-    private final Optional<String> final_;
+    final Optional<String> final_;
 
-    private final Optional<String> finally_;
+    final Optional<String> finally_;
 
-    private final Optional<String> float_;
+    final Optional<String> float_;
 
-    private final Optional<String> for_;
+    final Optional<String> for_;
 
-    private final Optional<String> goto_;
+    final Optional<String> goto_;
 
-    private final Optional<String> if_;
+    final Optional<String> if_;
 
-    private final Optional<String> implements_;
+    final Optional<String> implements_;
 
-    private final Optional<String> import_;
+    final Optional<String> import_;
 
-    private final Optional<String> instanceof_;
+    final Optional<String> instanceof_;
 
-    private final Optional<String> int_;
+    final Optional<String> int_;
 
-    private final Optional<String> interface_;
+    final Optional<String> interface_;
 
-    private final Optional<String> long_;
+    final Optional<String> long_;
 
-    private final Optional<String> native_;
+    final Optional<String> native_;
 
-    private final Optional<String> new_;
+    final Optional<String> new_;
 
-    private final Optional<String> package_;
+    final Optional<String> package_;
 
-    private final Optional<String> private_;
+    final Optional<String> private_;
 
-    private final Optional<String> protected_;
+    final Optional<String> protected_;
 
-    private final Optional<String> public_;
+    final Optional<String> public_;
 
-    private final Optional<String> return_;
+    final Optional<String> return_;
 
-    private final Optional<String> short_;
+    final Optional<String> short_;
 
-    private final Optional<String> static_;
+    final Optional<String> static_;
 
-    private final Optional<String> strictfp_;
+    final Optional<String> strictfp_;
 
-    private final Optional<String> super_;
+    final Optional<String> super_;
 
-    private final Optional<String> switch_;
+    final Optional<String> switch_;
 
-    private final Optional<String> synchronized_;
+    final Optional<String> synchronized_;
 
-    private final Optional<String> this_;
+    final Optional<String> this_;
 
-    private final Optional<String> throw_;
+    final Optional<String> throw_;
 
-    private final Optional<String> throws_;
+    final Optional<String> throws_;
 
-    private final Optional<String> transient_;
+    final Optional<String> transient_;
 
-    private final Optional<String> try_;
+    final Optional<String> try_;
 
-    private final Optional<String> void_;
+    final Optional<String> void_;
 
-    private final Optional<String> volatile_;
+    final Optional<String> volatile_;
 
-    private final Optional<String> while_;
+    final Optional<String> while_;
 
     private volatile String $toString;
 
@@ -498,6 +500,64 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<String> while_() {
       return this.while_;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], abstract_.isPresent() ? abstract_.get() : null);
+          writer.writeString($responseFields[1], assert_.isPresent() ? assert_.get() : null);
+          writer.writeString($responseFields[2], boolean_.isPresent() ? boolean_.get() : null);
+          writer.writeString($responseFields[3], break_.isPresent() ? break_.get() : null);
+          writer.writeString($responseFields[4], byte_.isPresent() ? byte_.get() : null);
+          writer.writeString($responseFields[5], case_.isPresent() ? case_.get() : null);
+          writer.writeString($responseFields[6], catch_.isPresent() ? catch_.get() : null);
+          writer.writeString($responseFields[7], char_.isPresent() ? char_.get() : null);
+          writer.writeString($responseFields[8], class_.isPresent() ? class_.get() : null);
+          writer.writeString($responseFields[9], const_.isPresent() ? const_.get() : null);
+          writer.writeString($responseFields[10], continue_.isPresent() ? continue_.get() : null);
+          writer.writeString($responseFields[11], default_.isPresent() ? default_.get() : null);
+          writer.writeString($responseFields[12], do_.isPresent() ? do_.get() : null);
+          writer.writeString($responseFields[13], double_.isPresent() ? double_.get() : null);
+          writer.writeString($responseFields[14], else_.isPresent() ? else_.get() : null);
+          writer.writeString($responseFields[15], enum_.isPresent() ? enum_.get() : null);
+          writer.writeString($responseFields[16], extends_.isPresent() ? extends_.get() : null);
+          writer.writeString($responseFields[17], final_.isPresent() ? final_.get() : null);
+          writer.writeString($responseFields[18], finally_.isPresent() ? finally_.get() : null);
+          writer.writeString($responseFields[19], float_.isPresent() ? float_.get() : null);
+          writer.writeString($responseFields[20], for_.isPresent() ? for_.get() : null);
+          writer.writeString($responseFields[21], goto_.isPresent() ? goto_.get() : null);
+          writer.writeString($responseFields[22], if_.isPresent() ? if_.get() : null);
+          writer.writeString($responseFields[23], implements_.isPresent() ? implements_.get() : null);
+          writer.writeString($responseFields[24], import_.isPresent() ? import_.get() : null);
+          writer.writeString($responseFields[25], instanceof_.isPresent() ? instanceof_.get() : null);
+          writer.writeString($responseFields[26], int_.isPresent() ? int_.get() : null);
+          writer.writeString($responseFields[27], interface_.isPresent() ? interface_.get() : null);
+          writer.writeString($responseFields[28], long_.isPresent() ? long_.get() : null);
+          writer.writeString($responseFields[29], native_.isPresent() ? native_.get() : null);
+          writer.writeString($responseFields[30], new_.isPresent() ? new_.get() : null);
+          writer.writeString($responseFields[31], package_.isPresent() ? package_.get() : null);
+          writer.writeString($responseFields[32], private_.isPresent() ? private_.get() : null);
+          writer.writeString($responseFields[33], protected_.isPresent() ? protected_.get() : null);
+          writer.writeString($responseFields[34], public_.isPresent() ? public_.get() : null);
+          writer.writeString($responseFields[35], return_.isPresent() ? return_.get() : null);
+          writer.writeString($responseFields[36], short_.isPresent() ? short_.get() : null);
+          writer.writeString($responseFields[37], static_.isPresent() ? static_.get() : null);
+          writer.writeString($responseFields[38], strictfp_.isPresent() ? strictfp_.get() : null);
+          writer.writeString($responseFields[39], super_.isPresent() ? super_.get() : null);
+          writer.writeString($responseFields[40], switch_.isPresent() ? switch_.get() : null);
+          writer.writeString($responseFields[41], synchronized_.isPresent() ? synchronized_.get() : null);
+          writer.writeString($responseFields[42], this_.isPresent() ? this_.get() : null);
+          writer.writeString($responseFields[43], throw_.isPresent() ? throw_.get() : null);
+          writer.writeString($responseFields[44], throws_.isPresent() ? throws_.get() : null);
+          writer.writeString($responseFields[45], transient_.isPresent() ? transient_.get() : null);
+          writer.writeString($responseFields[46], try_.isPresent() ? try_.get() : null);
+          writer.writeString($responseFields[47], void_.isPresent() ? void_.get() : null);
+          writer.writeString($responseFields[48], volatile_.isPresent() ? volatile_.get() : null);
+          writer.writeString($responseFields[49], while_.isPresent() ? while_.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -91,27 +93,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("graphQlListOfObjects", "graphQlListOfObjects", null, true)
     };
 
-    private final Optional<String> graphQlString;
+    final Optional<String> graphQlString;
 
-    private final Optional<String> graphQlIdNullable;
+    final Optional<String> graphQlIdNullable;
 
-    private final @Nonnull String graphQlIdNonNullable;
+    final @Nonnull String graphQlIdNonNullable;
 
-    private final Optional<Integer> graphQlIntNullable;
+    final Optional<Integer> graphQlIntNullable;
 
-    private final int graphQlIntNonNullable;
+    final int graphQlIntNonNullable;
 
-    private final Optional<Double> graphQlFloatNullable;
+    final Optional<Double> graphQlFloatNullable;
 
-    private final double graphQlFloatNonNullable;
+    final double graphQlFloatNonNullable;
 
-    private final Optional<Boolean> graphQlBooleanNullable;
+    final Optional<Boolean> graphQlBooleanNullable;
 
-    private final boolean graphQlBooleanNonNullable;
+    final boolean graphQlBooleanNonNullable;
 
-    private final Optional<List<Integer>> graphQlListOfInt;
+    final Optional<List<Integer>> graphQlListOfInt;
 
-    private final Optional<List<GraphQlListOfObject>> graphQlListOfObjects;
+    final Optional<List<GraphQlListOfObject>> graphQlListOfObjects;
 
     private volatile String $toString;
 
@@ -180,6 +182,39 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<List<GraphQlListOfObject>> graphQlListOfObjects() {
       return this.graphQlListOfObjects;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], graphQlString.isPresent() ? graphQlString.get() : null);
+          writer.writeString($responseFields[1], graphQlIdNullable.isPresent() ? graphQlIdNullable.get() : null);
+          writer.writeString($responseFields[2], graphQlIdNonNullable);
+          writer.writeInt($responseFields[3], graphQlIntNullable.isPresent() ? graphQlIntNullable.get() : null);
+          writer.writeInt($responseFields[4], graphQlIntNonNullable);
+          writer.writeDouble($responseFields[5], graphQlFloatNullable.isPresent() ? graphQlFloatNullable.get() : null);
+          writer.writeDouble($responseFields[6], graphQlFloatNonNullable);
+          writer.writeBoolean($responseFields[7], graphQlBooleanNullable.isPresent() ? graphQlBooleanNullable.get() : null);
+          writer.writeBoolean($responseFields[8], graphQlBooleanNonNullable);
+          writer.writeList($responseFields[9], graphQlListOfInt.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Integer $item : graphQlListOfInt.get()) {
+                listItemWriter.writeInt($item);
+              }
+            }
+          } : null);
+          writer.writeList($responseFields[10], graphQlListOfObjects.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (GraphQlListOfObject $item : graphQlListOfObjects.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -297,7 +332,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInt("someField", "someField", null, false)
     };
 
-    private final int someField;
+    final int someField;
 
     private volatile String $toString;
 
@@ -311,6 +346,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public int someField() {
       return this.someField;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeInt($responseFields[0], someField);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.simple_fragment.fragment.HeroDetails;
 import java.io.IOException;
@@ -86,7 +88,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -100,6 +102,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -159,7 +170,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -180,6 +191,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -221,7 +242,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      private final @Nonnull HeroDetails heroDetails;
+      final @Nonnull HeroDetails heroDetails;
 
       private volatile String $toString;
 
@@ -235,6 +256,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public @Nonnull HeroDetails heroDetails() {
         return this.heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
@@ -3,7 +3,9 @@ package com.example.simple_fragment.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -28,9 +30,9 @@ public class HeroDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
   private volatile String $toString;
 
@@ -52,6 +54,16 @@ public class HeroDetails implements GraphqlFragment {
    */
   public @Nonnull String name() {
     return this.name;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+      }
+    };
   }
 
   @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
@@ -92,7 +94,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("hero", "hero", null, true)
     };
 
-    private final Optional<Hero> hero;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -106,6 +108,15 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Hero> hero() {
       return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -166,13 +177,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<AsHuman> asHuman;
+    final Optional<AsHuman> asHuman;
 
-    private final Optional<AsDroid> asDroid;
+    final Optional<AsDroid> asDroid;
 
     private volatile String $toString;
 
@@ -205,6 +216,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<AsDroid> asDroid() {
       return this.asDroid;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          final AsHuman $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+          final AsDroid $asDroid = asDroid.isPresent() ? asDroid.get() : null;
+          if ($asDroid != null) {
+            $asDroid.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -286,11 +315,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forDouble("height", "height", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
     private volatile String $toString;
 
@@ -320,6 +349,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Double> height() {
       return this.height;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
+        }
+      };
     }
 
     @Override
@@ -382,11 +422,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("primaryFunction", "primaryFunction", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<String> primaryFunction;
+    final Optional<String> primaryFunction;
 
     private volatile String $toString;
 
@@ -417,6 +457,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<String> primaryFunction() {
       return this.primaryFunction;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeString($responseFields[2], primaryFunction.isPresent() ? primaryFunction.get() : null);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
@@ -91,9 +93,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<R2> r2;
+    final Optional<R2> r2;
 
-    private final Optional<Luke> luke;
+    final Optional<Luke> luke;
 
     private volatile String $toString;
 
@@ -112,6 +114,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Luke> luke() {
       return this.luke;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], r2.isPresent() ? r2.get().marshaller() : null);
+          writer.writeObject($responseFields[1], luke.isPresent() ? luke.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -182,9 +194,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -206,6 +218,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override
@@ -263,11 +285,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String id;
+    final @Nonnull String id;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -297,6 +319,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], id);
+          writer.writeString($responseFields[2], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -5,7 +5,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
@@ -115,9 +117,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       .build(), true)
     };
 
-    private final Optional<R2> r2;
+    final Optional<R2> r2;
 
-    private final Optional<Luke> luke;
+    final Optional<Luke> luke;
 
     private volatile String $toString;
 
@@ -136,6 +138,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Optional<Luke> luke() {
       return this.luke;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], r2.isPresent() ? r2.get().marshaller() : null);
+          writer.writeObject($responseFields[1], luke.isPresent() ? luke.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -207,11 +219,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection friendsConnection;
+    final @Nonnull FriendsConnection friendsConnection;
 
     private volatile String $toString;
 
@@ -242,6 +254,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull FriendsConnection friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -311,11 +334,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -346,6 +369,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -419,9 +460,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -443,6 +484,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -506,9 +557,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -530,6 +581,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override
@@ -588,13 +649,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String id;
+    final @Nonnull String id;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull FriendsConnection1 friendsConnection;
+    final @Nonnull FriendsConnection1 friendsConnection;
 
     private volatile String $toString;
 
@@ -633,6 +694,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull FriendsConnection1 friendsConnection() {
       return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], id);
+          writer.writeString($responseFields[2], name);
+          writer.writeObject($responseFields[3], friendsConnection.marshaller());
+        }
+      };
     }
 
     @Override
@@ -707,11 +780,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge1>> edges;
+    final Optional<List<Edge1>> edges;
 
     private volatile String $toString;
 
@@ -742,6 +815,24 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<List<Edge1>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge1 $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -815,9 +906,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node1> node;
+    final Optional<Node1> node;
 
     private volatile String $toString;
 
@@ -839,6 +930,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public Optional<Node1> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -902,9 +1003,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -926,6 +1027,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -6,7 +6,9 @@ import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.unique_type_name.fragment.HeroDetails;
 import com.example.unique_type_name.type.Episode;
@@ -105,7 +107,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true)
     };
 
-    private final Optional<HeroDetailQuery1> heroDetailQuery;
+    final Optional<HeroDetailQuery1> heroDetailQuery;
 
     private volatile String $toString;
 
@@ -119,6 +121,15 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public Optional<HeroDetailQuery1> heroDetailQuery() {
       return this.heroDetailQuery;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeObject($responseFields[0], heroDetailQuery.isPresent() ? heroDetailQuery.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -179,13 +190,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<List<Friend>> friends;
+    final Optional<List<Friend>> friends;
 
-    private final Optional<AsHuman> asHuman;
+    final Optional<AsHuman> asHuman;
 
     private volatile String $toString;
 
@@ -221,6 +232,28 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public Optional<AsHuman> asHuman() {
       return this.asHuman;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+          final AsHuman $asHuman = asHuman.isPresent() ? asHuman.get() : null;
+          if ($asHuman != null) {
+            $asHuman.marshaller().marshal(writer);
+          }
+        }
+      };
     }
 
     @Override
@@ -306,9 +339,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -330,6 +363,16 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override
@@ -388,13 +431,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       ResponseField.forDouble("height", "height", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final Optional<List<Friend1>> friends;
+    final Optional<List<Friend1>> friends;
 
-    private final Optional<Double> height;
+    final Optional<Double> height;
 
     private volatile String $toString;
 
@@ -433,6 +476,25 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
      */
     public Optional<Double> height() {
       return this.height;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend1 $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+          writer.writeDouble($responseFields[3], height.isPresent() ? height.get() : null);
+        }
+      };
     }
 
     @Override
@@ -513,13 +575,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       ResponseField.forObjectList("friends", "friends", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
-    private final @Nonnull List<Episode> appearsIn;
+    final @Nonnull List<Episode> appearsIn;
 
-    private final Optional<List<Friend2>> friends;
+    final Optional<List<Friend2>> friends;
 
     private volatile String $toString;
 
@@ -558,6 +620,32 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
      */
     public Optional<List<Friend2>> friends() {
       return this.friends;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : appearsIn) {
+                listItemWriter.writeString($item.name());
+              }
+            }
+          });
+          writer.writeList($responseFields[3], friends.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Friend2 $item : friends.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -642,7 +730,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       "Droid"))
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
     private final @Nonnull Fragments fragments;
 
@@ -663,6 +751,16 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public @Nonnull Fragments fragments() {
       return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          fragments.marshaller().marshal(writer);
+        }
+      };
     }
 
     @Override
@@ -704,7 +802,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
 
     public static class Fragments {
-      private final @Nonnull HeroDetails heroDetails;
+      final @Nonnull HeroDetails heroDetails;
 
       private volatile String $toString;
 
@@ -718,6 +816,18 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
       public @Nonnull HeroDetails heroDetails() {
         return this.heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) throws IOException {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
       }
 
       @Override

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -3,7 +3,9 @@ package com.example.unique_type_name.fragment;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
@@ -43,11 +45,11 @@ public class HeroDetails implements GraphqlFragment {
 
   public static final List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
 
-  private final @Nonnull String __typename;
+  final @Nonnull String __typename;
 
-  private final @Nonnull String name;
+  final @Nonnull String name;
 
-  private final @Nonnull FriendsConnection friendsConnection;
+  final @Nonnull FriendsConnection friendsConnection;
 
   private volatile String $toString;
 
@@ -78,6 +80,17 @@ public class HeroDetails implements GraphqlFragment {
    */
   public @Nonnull FriendsConnection friendsConnection() {
     return this.friendsConnection;
+  }
+
+  public ResponseFieldMarshaller marshaller() {
+    return new ResponseFieldMarshaller() {
+      @Override
+      public void marshal(ResponseWriter writer) throws IOException {
+        writer.writeString($responseFields[0], __typename);
+        writer.writeString($responseFields[1], name);
+        writer.writeObject($responseFields[2], friendsConnection.marshaller());
+      }
+    };
   }
 
   @Override
@@ -146,11 +159,11 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObjectList("edges", "edges", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Integer> totalCount;
+    final Optional<Integer> totalCount;
 
-    private final Optional<List<Edge>> edges;
+    final Optional<List<Edge>> edges;
 
     private volatile String $toString;
 
@@ -181,6 +194,24 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<List<Edge>> edges() {
       return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? new ResponseWriter.ListWriter() {
+            @Override
+            public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Edge $item : edges.get()) {
+                listItemWriter.writeObject($item.marshaller());
+              }
+            }
+          } : null);
+        }
+      };
     }
 
     @Override
@@ -254,9 +285,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forObject("node", "node", null, true)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final Optional<Node> node;
+    final Optional<Node> node;
 
     private volatile String $toString;
 
@@ -278,6 +309,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public Optional<Node> node() {
       return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
     }
 
     @Override
@@ -341,9 +382,9 @@ public class HeroDetails implements GraphqlFragment {
       ResponseField.forString("name", "name", null, false)
     };
 
-    private final @Nonnull String __typename;
+    final @Nonnull String __typename;
 
-    private final @Nonnull String name;
+    final @Nonnull String name;
 
     private volatile String $toString;
 
@@ -365,6 +406,16 @@ public class HeroDetails implements GraphqlFragment {
      */
     public @Nonnull String name() {
       return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) throws IOException {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
     }
 
     @Override


### PR DESCRIPTION
Introduce `ResponseFieldMarshaller` and `ResponseWriter` interfaces
Generate `marshaller` function that returns `ResponseFieldMarshaller` to serialize response data
Update test fixtures

This PR has a lot of changes to compiler part, but take a look at the generated result:
https://github.com/apollographql/apollo-android/pull/534/files#diff-55d8ffdc36cc3c481ac2a90cbed7247e
https://github.com/apollographql/apollo-android/pull/534/files#diff-988687da010965f3832fb8c9216ff862
https://github.com/apollographql/apollo-android/pull/534/files#diff-7ba973c3c506dccfc4e89e39e3a011bc

Part of #467