### PR TITLE
Write GraphQL operation data to the store

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -255,7 +255,11 @@ fun TypeName.unwrapOptionalValue(valueVarName: String, checkPresent: Boolean = t
     }
   } else {
     val valueCode = CodeBlock.of("\$L", valueVarName)
-    transformation?.invoke(valueCode) ?: valueCode
+    if (annotations.contains(Annotations.NULLABLE) && checkPresent && transformation != null) {
+      CodeBlock.of("\$L != null ? \$L : null", valueVarName, transformation.invoke(valueCode))
+    } else {
+      transformation?.invoke(valueCode) ?: valueCode
+    }
   }
 }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -116,7 +116,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       return new ResponseFieldMarshaller() {
         @Override
         public void marshal(ResponseWriter writer) throws IOException {
-          writer.writeObject($responseFields[0], hero.marshaller());
+          writer.writeObject($responseFields[0], hero != null ? hero.marshaller() : null);
         }
       };
     }
@@ -336,14 +336,14 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
         public void marshal(ResponseWriter writer) throws IOException {
           writer.writeString($responseFields[0], __typename);
           writer.writeInt($responseFields[1], totalCount);
-          writer.writeList($responseFields[2], new ResponseWriter.ListWriter() {
+          writer.writeList($responseFields[2], edges != null ? new ResponseWriter.ListWriter() {
             @Override
             public void write(ResponseWriter.ListItemWriter listItemWriter) throws IOException {
               for (Edge $item : edges) {
                 listItemWriter.writeObject($item.marshaller());
               }
             }
-          });
+          } : null);
         }
       };
     }
@@ -450,7 +450,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
         @Override
         public void marshal(ResponseWriter writer) throws IOException {
           writer.writeString($responseFields[0], __typename);
-          writer.writeObject($responseFields[1], node.marshaller());
+          writer.writeObject($responseFields[1], node != null ? node.marshaller() : null);
         }
       };
     }

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroWithDates.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroWithDates.graphql
@@ -1,0 +1,7 @@
+query EpisodeHeroWithDates($episode: Episode) {
+  hero(episode: $episode) {
+    heroName: name
+    birthDate
+    showUpDates: appearanceDates
+  }
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroWithInlineFragment.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroWithInlineFragment.graphql
@@ -1,0 +1,16 @@
+query EpisodeHeroWithInlineFragment($episode: Episode) {
+  hero(episode: $episode) {
+    name
+    friends {
+      ... on Human {
+        id
+        name
+        height
+      }
+      ... on Droid {
+        name
+        primaryFunction
+      }
+    }
+  }
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/HeroNameWithEnums.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/HeroNameWithEnums.graphql
@@ -1,0 +1,7 @@
+query HeroNameWithEnums {
+  hero {
+    name
+    firstAppearsIn
+    appearsIn
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
@@ -1,0 +1,359 @@
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.cache.normalized.CacheControl;
+import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy;
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory;
+import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.integration.normalizer.EpisodeHeroWithDates;
+import com.apollographql.apollo.integration.normalizer.EpisodeHeroWithInlineFragment;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDs;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsWithFragments;
+import com.apollographql.apollo.integration.normalizer.HeroNameWithEnums;
+import com.apollographql.apollo.integration.normalizer.fragment.HeroWithFriendsFragment;
+import com.apollographql.apollo.integration.normalizer.fragment.HumanWithIdFragment;
+import com.apollographql.apollo.integration.normalizer.type.CustomType;
+import com.apollographql.apollo.integration.normalizer.type.Episode;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static com.apollographql.apollo.integration.normalizer.type.Episode.JEDI;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
+public class ResponseWriteTestCase {
+  private ApolloClient apolloClient;
+  private MockWebServer server;
+  private SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-mm-dd");
+
+  @Before public void setUp() {
+    server = new MockWebServer();
+    OkHttpClient okHttpClient = new OkHttpClient.Builder().build();
+
+    apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .okHttpClient(okHttpClient)
+        .normalizedCache(new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION), new IdFieldCacheKeyResolver())
+        .dispatcher(Utils.immediateExecutorService())
+        .addCustomTypeAdapter(CustomType.DATE, new CustomTypeAdapter<Date>() {
+          @Override public Date decode(String value) {
+            try {
+              return DATE_TIME_FORMAT.parse(value);
+            } catch (ParseException e) {
+              throw new RuntimeException(e);
+            }
+          }
+
+          @Override public String encode(Date value) {
+            return DATE_TIME_FORMAT.format(value);
+          }
+        })
+        .build();
+  }
+
+  @After public void tearDown() {
+    try {
+      server.shutdown();
+    } catch (IOException ignored) {
+    }
+  }
+
+  private MockResponse mockResponse(String fileName) throws IOException, ApolloException {
+    return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
+  }
+
+  @Test
+  public void customType() throws Exception {
+    server.enqueue(mockResponse("EpisodeHeroWithDatesResponse.json"));
+
+    EpisodeHeroWithDates query = EpisodeHeroWithDates.builder().episode(JEDI).build();
+    EpisodeHeroWithDates.Hero hero = apolloClient.query(query).execute().data().hero();
+
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.heroName()).isEqualTo("R2-D2");
+    assertThat(DATE_TIME_FORMAT.format(hero.birthDate())).isEqualTo("1984-04-16");
+    assertThat(hero.showUpDates()).hasSize(3);
+    assertThat(DATE_TIME_FORMAT.format(hero.showUpDates().get(0))).isEqualTo("2017-01-16");
+    assertThat(DATE_TIME_FORMAT.format(hero.showUpDates().get(1))).isEqualTo("2017-02-16");
+    assertThat(DATE_TIME_FORMAT.format(hero.showUpDates().get(2))).isEqualTo("2017-03-16");
+
+    hero = new EpisodeHeroWithDates.Hero(
+        hero.__typename(),
+        "R222-D222",
+        DATE_TIME_FORMAT.parse("1985-04-16"),
+        Collections.<Date>emptyList()
+    );
+    apolloClient.apolloStore().write(query, new EpisodeHeroWithDates.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.heroName()).isEqualTo("R222-D222");
+    assertThat(DATE_TIME_FORMAT.format(hero.birthDate())).isEqualTo("1985-04-16");
+    assertThat(hero.showUpDates()).hasSize(0);
+
+    hero = new EpisodeHeroWithDates.Hero(
+        hero.__typename(),
+        "R22-D22",
+        DATE_TIME_FORMAT.parse("1986-04-16"),
+        asList(
+            DATE_TIME_FORMAT.parse("2017-04-16"),
+            DATE_TIME_FORMAT.parse("2017-05-16")
+        )
+    );
+    apolloClient.apolloStore().write(query, new EpisodeHeroWithDates.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.heroName()).isEqualTo("R22-D22");
+    assertThat(DATE_TIME_FORMAT.format(hero.birthDate())).isEqualTo("1986-04-16");
+    assertThat(hero.showUpDates()).hasSize(2);
+    assertThat(DATE_TIME_FORMAT.format(hero.showUpDates().get(0))).isEqualTo("2017-04-16");
+    assertThat(DATE_TIME_FORMAT.format(hero.showUpDates().get(1))).isEqualTo("2017-05-16");
+  }
+
+  @Test
+  public void enums() throws Exception {
+    server.enqueue(mockResponse("HeroNameWithEnumsResponse.json"));
+
+    HeroNameWithEnums query = new HeroNameWithEnums();
+    HeroNameWithEnums.Hero hero = apolloClient.query(query).execute().data().hero();
+
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R2-D2");
+    assertThat(hero.firstAppearsIn()).isEqualTo(Episode.EMPIRE);
+    assertThat(hero.appearsIn()).hasSize(3);
+    assertThat(hero.appearsIn().get(0)).isEqualTo(Episode.NEWHOPE);
+    assertThat(hero.appearsIn().get(1)).isEqualTo(Episode.EMPIRE);
+    assertThat(hero.appearsIn().get(2)).isEqualTo(Episode.JEDI);
+
+    hero = new HeroNameWithEnums.Hero(
+        hero.__typename(),
+        "R222-D222",
+        Episode.JEDI,
+        Collections.<Episode>emptyList()
+    );
+    apolloClient.apolloStore().write(query, new HeroNameWithEnums.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R222-D222");
+    assertThat(hero.firstAppearsIn()).isEqualTo(Episode.JEDI);
+    assertThat(hero.appearsIn()).hasSize(0);
+
+    hero = new HeroNameWithEnums.Hero(
+        hero.__typename(),
+        "R22-D22",
+        Episode.JEDI,
+        asList(Episode.EMPIRE)
+    );
+    apolloClient.apolloStore().write(query, new HeroNameWithEnums.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R22-D22");
+    assertThat(hero.firstAppearsIn()).isEqualTo(Episode.JEDI);
+    assertThat(hero.appearsIn()).hasSize(1);
+    assertThat(hero.appearsIn().get(0)).isEqualTo(Episode.EMPIRE);
+  }
+
+  @Test
+  public void objects() throws Exception {
+    server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
+
+    HeroAndFriendsNamesWithIDs query = new HeroAndFriendsNamesWithIDs(JEDI);
+    HeroAndFriendsNamesWithIDs.Hero hero = apolloClient.query(query).execute().data().hero();
+
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R2-D2");
+    assertThat(hero.id()).isEqualTo("2001");
+    assertThat(hero.friends()).hasSize(3);
+    assertThat(hero.friends().get(0).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(0).id()).isEqualTo("1000");
+    assertThat(hero.friends().get(0).name()).isEqualTo("Luke Skywalker");
+    assertThat(hero.friends().get(1).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(1).id()).isEqualTo("1002");
+    assertThat(hero.friends().get(1).name()).isEqualTo("Han Solo");
+    assertThat(hero.friends().get(2).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(2).id()).isEqualTo("1003");
+    assertThat(hero.friends().get(2).name()).isEqualTo("Leia Organa");
+
+    hero = new HeroAndFriendsNamesWithIDs.Hero(
+        hero.__typename(),
+        hero.id(),
+        "R222-D222",
+        null
+    );
+    apolloClient.apolloStore().write(query, new HeroAndFriendsNamesWithIDs.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R222-D222");
+    assertThat(hero.id()).isEqualTo("2001");
+    assertThat(hero.friends()).isNull();
+
+    HeroAndFriendsNamesWithIDs.Friend friend = new HeroAndFriendsNamesWithIDs.Friend(
+        "Human",
+        "1002",
+        "Han Soloooo"
+    );
+    hero = new HeroAndFriendsNamesWithIDs.Hero(
+        hero.__typename(),
+        hero.id(),
+        "R222-D222",
+        singletonList(friend)
+    );
+    apolloClient.apolloStore().write(query, new HeroAndFriendsNamesWithIDs.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R222-D222");
+    assertThat(hero.id()).isEqualTo("2001");
+    assertThat(hero.friends()).hasSize(1);
+    assertThat(hero.friends().get(0).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(0).id()).isEqualTo("1002");
+    assertThat(hero.friends().get(0).name()).isEqualTo("Han Soloooo");
+  }
+
+  @Test
+  public void operation_with_fragments() throws Exception {
+    server.enqueue(mockResponse("HeroAndFriendsWithFragmentResponse.json"));
+
+    HeroAndFriendsWithFragments query = new HeroAndFriendsWithFragments(Episode.NEWHOPE);
+    HeroAndFriendsWithFragments.Hero hero = apolloClient.query(query).execute().data().hero();
+
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.fragments().heroWithFriendsFragment().__typename()).isEqualTo("Droid");
+    assertThat(hero.fragments().heroWithFriendsFragment().id()).isEqualTo("2001");
+    assertThat(hero.fragments().heroWithFriendsFragment().name()).isEqualTo("R2-D2");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends()).hasSize(3);
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().__typename()).isEqualTo("Human");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().id()).isEqualTo("1000");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().name()).isEqualTo("Luke Skywalker");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().__typename()).isEqualTo("Human");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().id()).isEqualTo("1002");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().name()).isEqualTo("Han Solo");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(2).fragments().humanWithIdFragment().__typename()).isEqualTo("Human");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(2).fragments().humanWithIdFragment().id()).isEqualTo("1003");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(2).fragments().humanWithIdFragment().name()).isEqualTo("Leia Organa");
+
+    hero = new HeroAndFriendsWithFragments.Hero(
+        hero.__typename(),
+        new HeroAndFriendsWithFragments.Hero.Fragments(
+            new HeroWithFriendsFragment(
+                hero.fragments().heroWithFriendsFragment().__typename(),
+                hero.fragments().heroWithFriendsFragment().id(),
+                "R222-D222",
+                asList(
+                    new HeroWithFriendsFragment.Friend(
+                        "Droid",
+                        new HeroWithFriendsFragment.Friend.Fragments(
+                            new HumanWithIdFragment(
+                                "Human",
+                                "1006",
+                                "SuperMan"
+                            )
+                        )
+                    ),
+                    new HeroWithFriendsFragment.Friend(
+                        "Human",
+                        new HeroWithFriendsFragment.Friend.Fragments(
+                            new HumanWithIdFragment(
+                                "Human",
+                                "1004",
+                                "Beast"
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    );
+    apolloClient.apolloStore().write(query, new HeroAndFriendsWithFragments.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.fragments().heroWithFriendsFragment().__typename()).isEqualTo("Droid");
+    assertThat(hero.fragments().heroWithFriendsFragment().id()).isEqualTo("2001");
+    assertThat(hero.fragments().heroWithFriendsFragment().name()).isEqualTo("R222-D222");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends()).hasSize(2);
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().__typename()).isEqualTo("Human");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().id()).isEqualTo("1006");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(0).fragments().humanWithIdFragment().name()).isEqualTo("SuperMan");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().__typename()).isEqualTo("Human");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().id()).isEqualTo("1004");
+    assertThat(hero.fragments().heroWithFriendsFragment().friends().get(1).fragments().humanWithIdFragment().name()).isEqualTo("Beast");
+  }
+
+  @Test
+  public void operation_with_inline_fragments() throws Exception {
+    server.enqueue(mockResponse("EpisodeHeroWithInlineFragmentResponse.json"));
+
+    EpisodeHeroWithInlineFragment query = new EpisodeHeroWithInlineFragment(Episode.NEWHOPE);
+    EpisodeHeroWithInlineFragment.Hero hero = apolloClient.query(query).execute().data().hero();
+
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R2-D2");
+    assertThat(hero.friends()).hasSize(3);
+    assertThat(hero.friends().get(0).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(0).asHuman().id()).isEqualTo("1000");
+    assertThat(hero.friends().get(0).asHuman().name()).isEqualTo("Luke Skywalker");
+    assertThat(hero.friends().get(0).asHuman().height()).isWithin(1.5);
+    assertThat(hero.friends().get(1).__typename()).isEqualTo("Droid");
+    assertThat(hero.friends().get(1).asDroid().name()).isEqualTo("Android");
+    assertThat(hero.friends().get(1).asDroid().primaryFunction()).isEqualTo("Hunt and destroy iOS devices");
+    assertThat(hero.friends().get(2).__typename()).isEqualTo("Droid");
+    assertThat(hero.friends().get(2).asDroid().name()).isEqualTo("Battle Droid");
+    assertThat(hero.friends().get(2).asDroid().primaryFunction()).isEqualTo("Controlled alternative to human soldiers");
+
+    hero = new EpisodeHeroWithInlineFragment.Hero(
+        hero.__typename(),
+        "R22-D22",
+        asList(
+            new EpisodeHeroWithInlineFragment.Friend(
+                "Human",
+                new EpisodeHeroWithInlineFragment.AsHuman(
+                    "Human",
+                    "1002",
+                    "Han Solo",
+                    2.5
+                ),
+                null
+            ),
+            new EpisodeHeroWithInlineFragment.Friend(
+                "Droid",
+                null,
+                new EpisodeHeroWithInlineFragment.AsDroid(
+                    "Droid",
+                    "RD",
+                    "Entertainment"
+                )
+            )
+        )
+    );
+    apolloClient.apolloStore().write(query, new EpisodeHeroWithInlineFragment.Data(hero));
+
+    hero = apolloClient.query(query).cacheControl(CacheControl.CACHE_ONLY).execute().data().hero();
+    assertThat(hero.__typename()).isEqualTo("Droid");
+    assertThat(hero.name()).isEqualTo("R22-D22");
+    assertThat(hero.friends()).hasSize(2);
+    assertThat(hero.friends().get(0).__typename()).isEqualTo("Human");
+    assertThat(hero.friends().get(0).asHuman().id()).isEqualTo("1002");
+    assertThat(hero.friends().get(0).asHuman().name()).isEqualTo("Han Solo");
+    assertThat(hero.friends().get(0).asHuman().height()).isWithin(2.5);
+    assertThat(hero.friends().get(1).__typename()).isEqualTo("Droid");
+    assertThat(hero.friends().get(1).asDroid().name()).isEqualTo("RD");
+    assertThat(hero.friends().get(1).asDroid().primaryFunction()).isEqualTo("Entertainment");
+  }
+}

--- a/apollo-integration/src/test/resources/EpisodeHeroWithDatesResponse.json
+++ b/apollo-integration/src/test/resources/EpisodeHeroWithDatesResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Droid",
+      "heroName": "R2-D2",
+      "birthDate": "1984-04-16",
+      "showUpDates": [
+        "2017-01-16",
+        "2017-02-16",
+        "2017-03-16"
+      ]
+    }
+  }
+}

--- a/apollo-integration/src/test/resources/EpisodeHeroWithInlineFragmentResponse.json
+++ b/apollo-integration/src/test/resources/EpisodeHeroWithInlineFragmentResponse.json
@@ -1,0 +1,26 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Droid",
+      "name": "R2-D2",
+      "friends": [
+        {
+          "__typename": "Human",
+          "id": "1000",
+          "name": "Luke Skywalker",
+          "height": 1.5
+        },
+        {
+          "__typename": "Droid",
+          "name": "Android",
+          "primaryFunction": "Hunt and destroy iOS devices"
+        },
+        {
+          "__typename": "Droid",
+          "name": "Battle Droid",
+          "primaryFunction": "Controlled alternative to human soldiers"
+        }
+      ]
+    }
+  }
+}

--- a/apollo-integration/src/test/resources/HeroNameWithEnumsResponse.json
+++ b/apollo-integration/src/test/resources/HeroNameWithEnumsResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Droid",
+      "name": "R2-D2",
+      "firstAppearsIn": "EMPIRE",
+      "appearsIn": [
+        "NEWHOPE",
+        "EMPIRE",
+        "JEDI"
+      ]
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
@@ -126,5 +126,17 @@ public interface ApolloStore {
   @Nullable <F extends GraphqlFragment> F read(@Nonnull ResponseFieldMapper<F> fieldMapper, @Nonnull CacheKey cacheKey,
       @Nonnull Operation.Variables variables);
 
+  /**
+   * Write operation to the store.
+   *
+   * @param operation     {@link Operation} response data of which should be written to the store
+   * @param operationData {@link Operation.Data} operation response data to be written to the store
+   * @param <D>           type of GraphQL operation data
+   * @param <T>           type operation cached data will be wrapped with
+   * @param <V>           type of operation variables
+   */
+  <D extends Operation.Data, T, V extends Operation.Variables> void write(@Nonnull Operation<D, T, V> operation,
+      @Nonnull D operationData);
+
   ApolloStore NO_APOLLO_STORE = new NoOpApolloStore();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/CacheResponseWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/CacheResponseWriter.java
@@ -199,7 +199,7 @@ final class CacheResponseWriter implements ResponseWriter {
     final List<Map<String, FieldDescriptor>> fieldDescriptors = new ArrayList();
     final List fieldValues = new ArrayList();
 
-    public ListItemWriter(Operation operation, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+    ListItemWriter(Operation operation, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
       this.operation = operation;
       this.customTypeAdapters = customTypeAdapters;
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/CacheResponseWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/CacheResponseWriter.java
@@ -1,0 +1,270 @@
+package com.apollographql.apollo.internal.cache.normalized;
+
+import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseField;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarType;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.cache.normalized.Record;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class CacheResponseWriter implements ResponseWriter {
+  private final Operation operation;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  final Map<String, FieldDescriptor> fieldDescriptors = new LinkedHashMap<>();
+  final Map<String, Object> fieldValues = new LinkedHashMap<>();
+
+  CacheResponseWriter(Operation operation, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+    this.operation = operation;
+    this.customTypeAdapters = customTypeAdapters;
+  }
+
+  @Override public void writeString(ResponseField field, String value) throws IOException {
+    writeScalarFieldValue(field, value);
+  }
+
+  @Override public void writeInt(ResponseField field, Integer value) throws IOException {
+    writeScalarFieldValue(field, value != null ? BigDecimal.valueOf(value) : null);
+  }
+
+  @Override public void writeLong(ResponseField field, Long value) throws IOException {
+    writeScalarFieldValue(field, value != null ? BigDecimal.valueOf(value) : null);
+  }
+
+  @Override public void writeDouble(ResponseField field, Double value) throws IOException {
+    writeScalarFieldValue(field, value != null ? BigDecimal.valueOf(value) : null);
+  }
+
+  @Override public void writeBoolean(ResponseField field, Boolean value) throws IOException {
+    writeScalarFieldValue(field, value);
+  }
+
+  @Override public void writeCustom(ResponseField.CustomTypeField field, Object value) throws IOException {
+    CustomTypeAdapter typeAdapter = customTypeAdapters.get(field.scalarType());
+    if (typeAdapter == null) {
+      writeScalarFieldValue(field, value);
+    } else {
+      writeScalarFieldValue(field, value != null ? typeAdapter.encode(value) : null);
+    }
+  }
+
+  @Override public void writeObject(ResponseField field, ResponseFieldMarshaller marshaller) throws IOException {
+    checkFieldValue(field, marshaller);
+    if (marshaller == null) {
+      fieldDescriptors.put(field.responseName(), new ObjectFieldDescriptor(field,
+          Collections.<String, FieldDescriptor>emptyMap()));
+      return;
+    }
+
+    CacheResponseWriter nestedResponseWriter = new CacheResponseWriter(operation, customTypeAdapters);
+    marshaller.marshal(nestedResponseWriter);
+
+    fieldDescriptors.put(field.responseName(), new ObjectFieldDescriptor(field, nestedResponseWriter.fieldDescriptors));
+    fieldValues.put(field.responseName(), nestedResponseWriter.fieldValues);
+  }
+
+  @Override public void writeList(ResponseField field, ListWriter listWriter) throws IOException {
+    checkFieldValue(field, listWriter);
+
+    if (listWriter == null) {
+      fieldDescriptors.put(field.responseName(), new ListFieldDescriptor(field,
+          Collections.<Map<String, FieldDescriptor>>emptyList()));
+      return;
+    }
+
+    ListItemWriter listItemWriter = new ListItemWriter(operation, customTypeAdapters);
+    listWriter.write(listItemWriter);
+
+    fieldDescriptors.put(field.responseName(), new ListFieldDescriptor(field, listItemWriter.fieldDescriptors));
+    fieldValues.put(field.responseName(), listItemWriter.fieldValues);
+  }
+
+  public Collection<Record> normalize(ResponseNormalizer<Map<String, Object>> responseNormalizer) {
+    responseNormalizer.willResolveRootQuery(operation);
+    normalize(operation, responseNormalizer, fieldDescriptors, fieldValues);
+    return responseNormalizer.records();
+  }
+
+  private void writeScalarFieldValue(ResponseField field, Object value) {
+    checkFieldValue(field, value);
+    fieldDescriptors.put(field.responseName(), new FieldDescriptor(field));
+    if (value != null) {
+      fieldValues.put(field.responseName(), value);
+    }
+  }
+
+  @SuppressWarnings("unchecked") private void normalize(Operation operation,
+      ResponseNormalizer<Map<String, Object>> responseNormalizer, Map<String, FieldDescriptor> fieldDescriptors,
+      Map<String, Object> fieldValues) {
+    for (String fieldResponseName : fieldDescriptors.keySet()) {
+      FieldDescriptor fieldDescriptor = fieldDescriptors.get(fieldResponseName);
+      Object fieldValue = fieldValues.get(fieldResponseName);
+      responseNormalizer.willResolve(fieldDescriptor.field, operation.variables());
+
+      switch (fieldDescriptor.field.type()) {
+        case OBJECT: {
+          ObjectFieldDescriptor objectFieldDescriptor = (ObjectFieldDescriptor) fieldDescriptor;
+          Map<String, Object> objectFieldValues = (Map<String, Object>) fieldValue;
+          normalizeObjectField(objectFieldDescriptor, objectFieldValues, responseNormalizer);
+          break;
+        }
+
+        case OBJECT_LIST: {
+          ListFieldDescriptor listFieldDescriptor = (ListFieldDescriptor) fieldDescriptor;
+          List<Map<String, Object>> listFieldValues = (List<Map<String, Object>>) fieldValue;
+          normalizeObjectListField(listFieldDescriptor, listFieldValues, responseNormalizer);
+          break;
+        }
+
+        case CUSTOM_LIST:
+        case SCALAR_LIST: {
+          normalizeScalarList((List) fieldValue, responseNormalizer);
+          break;
+        }
+
+        default: {
+          if (fieldValue == null) {
+            responseNormalizer.didResolveNull();
+          } else {
+            responseNormalizer.didResolveScalar(fieldValue);
+          }
+          break;
+        }
+      }
+
+      responseNormalizer.didResolve(fieldDescriptor.field, operation.variables());
+    }
+  }
+
+  private void normalizeObjectField(ObjectFieldDescriptor objectFieldDescriptor, Map<String, Object> objectFieldValues,
+      ResponseNormalizer<Map<String, Object>> responseNormalizer) {
+    responseNormalizer.willResolveObject(objectFieldDescriptor.field, Optional.fromNullable(objectFieldValues));
+    if (objectFieldValues == null) {
+      responseNormalizer.didResolveNull();
+    } else {
+      normalize(operation, responseNormalizer, objectFieldDescriptor.childFields, objectFieldValues);
+    }
+    responseNormalizer.didResolveObject(objectFieldDescriptor.field, Optional.fromNullable(objectFieldValues));
+  }
+
+  private void normalizeObjectListField(ListFieldDescriptor listFieldDescriptor,
+      List<Map<String, Object>> listFieldValues, ResponseNormalizer<Map<String, Object>> responseNormalizer) {
+    if (listFieldValues == null) {
+      responseNormalizer.didResolveNull();
+    } else {
+      for (int i = 0; i < listFieldDescriptor.items.size(); i++) {
+        responseNormalizer.willResolveElement(i);
+        responseNormalizer.willResolveObject(listFieldDescriptor.field, Optional.fromNullable(listFieldValues.get(i)));
+        normalize(operation, responseNormalizer, listFieldDescriptor.items.get(i), listFieldValues.get(i));
+        responseNormalizer.didResolveObject(listFieldDescriptor.field, Optional.fromNullable(listFieldValues.get(i)));
+        responseNormalizer.didResolveElement(i);
+      }
+      responseNormalizer.didResolveList(listFieldValues);
+    }
+  }
+
+  private void normalizeScalarList(List listFieldValues, ResponseNormalizer<Map<String, Object>> responseNormalizer) {
+    if (listFieldValues == null) {
+      responseNormalizer.didResolveNull();
+    } else {
+      for (int i = 0; i < listFieldValues.size(); i++) {
+        responseNormalizer.willResolveElement(i);
+        responseNormalizer.didResolveScalar(listFieldValues.get(i));
+        responseNormalizer.didResolveElement(i);
+      }
+      responseNormalizer.didResolveList(listFieldValues);
+    }
+  }
+
+  private static void checkFieldValue(ResponseField field, Object value) {
+    if (!field.optional() && value == null) {
+      throw new NullPointerException(String.format("Mandatory response field `%s` resolved with null value",
+          field.responseName()));
+    }
+  }
+
+  @SuppressWarnings("unchecked") private static final class ListItemWriter implements ResponseWriter.ListItemWriter {
+    final Operation operation;
+    final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+    final List<Map<String, FieldDescriptor>> fieldDescriptors = new ArrayList();
+    final List fieldValues = new ArrayList();
+
+    public ListItemWriter(Operation operation, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+      this.operation = operation;
+      this.customTypeAdapters = customTypeAdapters;
+    }
+
+    @Override public void writeString(String value) throws IOException {
+      fieldValues.add(value);
+    }
+
+    @Override public void writeInt(Integer value) throws IOException {
+      fieldValues.add(value);
+    }
+
+    @Override public void writeLong(Long value) throws IOException {
+      fieldValues.add(value);
+    }
+
+    @Override public void writeDouble(Double value) throws IOException {
+      fieldValues.add(value);
+    }
+
+    @Override public void writeBoolean(Boolean value) throws IOException {
+      fieldValues.add(value);
+    }
+
+    @Override public void writeCustom(ScalarType scalarType, Object value) throws IOException {
+      CustomTypeAdapter typeAdapter = customTypeAdapters.get(scalarType);
+      if (typeAdapter == null) {
+        fieldValues.add(value);
+      } else {
+        fieldValues.add(typeAdapter.encode(value));
+      }
+    }
+
+    @Override public void writeObject(ResponseFieldMarshaller marshaller) throws IOException {
+      CacheResponseWriter nestedResponseWriter = new CacheResponseWriter(operation, customTypeAdapters);
+      marshaller.marshal(nestedResponseWriter);
+
+      fieldDescriptors.add(nestedResponseWriter.fieldDescriptors);
+      fieldValues.add(nestedResponseWriter.fieldValues);
+    }
+  }
+
+  private static class FieldDescriptor {
+    final ResponseField field;
+
+    FieldDescriptor(ResponseField field) {
+      this.field = field;
+    }
+  }
+
+  private static final class ObjectFieldDescriptor extends FieldDescriptor {
+    final Map<String, FieldDescriptor> childFields;
+
+    ObjectFieldDescriptor(ResponseField field, Map<String, FieldDescriptor> childFields) {
+      super(field);
+      this.childFields = childFields;
+    }
+  }
+
+  private static final class ListFieldDescriptor extends FieldDescriptor {
+    final List<Map<String, FieldDescriptor>> items;
+
+    ListFieldDescriptor(ResponseField field, List<Map<String, FieldDescriptor>> items) {
+      super(field);
+      this.items = items;
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -90,4 +90,8 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
       @Nonnull CacheKey cacheKey, @Nonnull Operation.Variables variables) {
     return null;
   }
+
+  @Override public boolean write(@Nonnull Operation operation, @Nonnull Operation.Data operationData) {
+    return false;
+  }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -91,7 +91,6 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
     return null;
   }
 
-  @Override public boolean write(@Nonnull Operation operation, @Nonnull Operation.Data operationData) {
-    return false;
+  @Override public void write(@Nonnull Operation operation, @Nonnull Operation.Data operationData) {
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -2,10 +2,10 @@ package com.apollographql.apollo.internal.cache.normalized;
 
 
 import com.apollographql.apollo.CustomTypeAdapter;
-import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.GraphqlFragment;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.cache.CacheHeaders;
@@ -155,9 +155,9 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
             fieldValueResolver, customTypeAdapters, ResponseNormalizer.NO_OP_NORMALIZER);
         try {
           return operation.wrapData(responseFieldMapper.map(responseReader));
-        } catch (IOException e) {
+        } catch (final Exception e) {
           logger.e(e, "Failed to read cached operation data. Operation: %s", operation);
-          throw new RuntimeException(e);
+          return null;
         }
       }
     });
@@ -188,9 +188,9 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
               .data(data)
               .dependentKeys(responseNormalizer.dependentKeys())
               .build();
-        } catch (IOException e) {
+        } catch (final Exception e) {
           logger.e(e, "Failed to read cached operation data. Operation: %s", operation);
-          throw new RuntimeException(e);
+          return Response.<T>builder(operation).build();
         }
       }
     });
@@ -217,9 +217,9 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
             customTypeAdapters, ResponseNormalizer.NO_OP_NORMALIZER);
         try {
           return responseFieldMapper.map(responseReader);
-        } catch (final IOException e) {
+        } catch (final Exception e) {
           logger.e(e, "Failed to read cached fragment data");
-          throw new RuntimeException(e);
+          return null;
         }
       }
     });

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -68,11 +68,11 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
     }
   }
 
-  @Override public void didParseScalar(@Nullable Object value) {
+  @Override public void didResolveScalar(@Nullable Object value) {
     valueStack.push(value);
   }
 
-  @Override public void willParseObject(ResponseField field, Optional<R> objectSource) {
+  @Override public void willResolveObject(ResponseField field, Optional<R> objectSource) {
     pathStack.push(path);
 
     CacheKey cacheKey = objectSource.isPresent() ? resolveCacheKey(field, objectSource.get()) : CacheKey.NO_KEY;
@@ -87,7 +87,7 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
     currentRecordBuilder = Record.builder(cacheKeyValue);
   }
 
-  @Override public void didParseObject(ResponseField field, Optional<R> objectSource) {
+  @Override public void didResolveObject(ResponseField field, Optional<R> objectSource) {
     path = pathStack.pop();
     Record completedRecord = currentRecordBuilder.build();
     valueStack.push(new CacheReference(completedRecord.key()));
@@ -96,7 +96,7 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
     currentRecordBuilder = recordStack.pop().toBuilder();
   }
 
-  @Override public void didParseList(List array) {
+  @Override public void didResolveList(List array) {
     List<Object> parsedArray = new ArrayList<>(array.size());
     for (int i = 0, size = array.size(); i < size; i++) {
       parsedArray.add(0, valueStack.pop());
@@ -104,15 +104,15 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
     valueStack.push(parsedArray);
   }
 
-  @Override public void willParseElement(int atIndex) {
+  @Override public void willResolveElement(int atIndex) {
     path.add(Integer.toString(atIndex));
   }
 
-  @Override public void didParseElement(int atIndex) {
+  @Override public void didResolveElement(int atIndex) {
     path.remove(path.size() - 1);
   }
 
-  @Override public void didParseNull() {
+  @Override public void didResolveNull() {
     valueStack.push(null);
   }
 
@@ -140,25 +140,25 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
     @Override public void didResolve(ResponseField field, Operation.Variables variables) {
     }
 
-    @Override public void didParseScalar(Object value) {
+    @Override public void didResolveScalar(Object value) {
     }
 
-    @Override public void willParseObject(ResponseField field, Optional objectSource) {
+    @Override public void willResolveObject(ResponseField field, Optional objectSource) {
     }
 
-    @Override public void didParseObject(ResponseField field, Optional objectSource) {
+    @Override public void didResolveObject(ResponseField field, Optional objectSource) {
     }
 
-    @Override public void didParseList(List array) {
+    @Override public void didResolveList(List array) {
     }
 
-    @Override public void willParseElement(int atIndex) {
+    @Override public void willResolveElement(int atIndex) {
     }
 
-    @Override public void didParseElement(int atIndex) {
+    @Override public void didResolveElement(int atIndex) {
     }
 
-    @Override public void didParseNull() {
+    @Override public void didResolveNull() {
     }
 
     @Override public Collection<Record> records() {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
@@ -51,6 +51,10 @@ public final class CacheFieldValueResolver implements FieldValueResolver<Record>
 
   private List<Record> valueForObjectList(Record record, ResponseField field) throws IOException {
     List<CacheReference> values = fieldValue(record, field);
+    if (values == null) {
+      return null;
+    }
+
     List<Record> result = new ArrayList<>();
     for (CacheReference reference : values) {
       result.add(readableCache.read(reference.key(), cacheHeaders));

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
@@ -37,9 +37,9 @@ import java.util.Map;
     String value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
     }
     didResolve(field);
     return value;
@@ -50,9 +50,9 @@ import java.util.Map;
     BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
     }
     didResolve(field);
     return value != null ? value.intValue() : null;
@@ -63,9 +63,9 @@ import java.util.Map;
     BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
     }
     didResolve(field);
     return value != null ? value.longValue() : null;
@@ -76,9 +76,9 @@ import java.util.Map;
     BigDecimal value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
     }
     didResolve(field);
     return value != null ? value.doubleValue() : null;
@@ -89,9 +89,9 @@ import java.util.Map;
     Boolean value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
     }
     didResolve(field);
     return value;
@@ -103,15 +103,15 @@ import java.util.Map;
     willResolve(field);
     R value = fieldValueResolver.valueFor(recordSet, field);
     checkValue(value, field.optional());
-    readerShadow.willParseObject(field, Optional.fromNullable(value));
+    readerShadow.willResolveObject(field, Optional.fromNullable(value));
     final T parsedValue;
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
       parsedValue = null;
     } else {
       parsedValue = (T) objectReader.read(new RealResponseReader(operationVariables, value, fieldValueResolver,
           customTypeAdapters, readerShadow));
-      readerShadow.didParseObject(field, Optional.fromNullable(value));
+      readerShadow.didResolveObject(field, Optional.fromNullable(value));
     }
     didResolve(field);
     return parsedValue;
@@ -124,18 +124,18 @@ import java.util.Map;
     checkValue(values, field.optional());
     final List<T> result;
     if (values == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
       result = null;
     } else {
       result = new ArrayList<>();
       for (int i = 0; i < values.size(); i++) {
-        readerShadow.willParseElement(i);
+        readerShadow.willResolveElement(i);
         Object value = values.get(i);
         T item = (T) listReader.read(new ListItemReader(field, value));
-        readerShadow.didParseElement(i);
+        readerShadow.didResolveElement(i);
         result.add(item);
       }
-      readerShadow.didParseList(values);
+      readerShadow.didResolveList(values);
     }
     didResolve(field);
     return result != null ? Collections.unmodifiableList(result) : null;
@@ -148,15 +148,15 @@ import java.util.Map;
     checkValue(value, field.optional());
     final T result;
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
       result = null;
     } else {
       CustomTypeAdapter<T> typeAdapter = customTypeAdapters.get(field.scalarType());
       if (typeAdapter == null) {
-        readerShadow.didParseScalar(value);
+        readerShadow.didResolveScalar(value);
         result = (T) value;
       } else {
-        readerShadow.didParseScalar(value);
+        readerShadow.didResolveScalar(value);
         result = typeAdapter.decode(value.toString());
       }
     }
@@ -172,15 +172,15 @@ import java.util.Map;
     checkValue(value, field.optional());
     final T result;
     if (value == null) {
-      readerShadow.didParseNull();
+      readerShadow.didResolveNull();
       didResolve(field);
       result = null;
     } else if (field.type() == ResponseField.Type.INLINE_FRAGMENT && !field.conditionalTypes().contains(value)) {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       didResolve(field);
       result = null;
     } else {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       didResolve(field);
       result = (T) conditionalTypeReader.read(value, this);
     }
@@ -211,27 +211,27 @@ import java.util.Map;
     }
 
     @Override public String readString() throws IOException {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return (String) value;
     }
 
     @Override public Integer readInt() throws IOException {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return ((BigDecimal) value).intValue();
     }
 
     @Override public Long readLong() throws IOException {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return ((BigDecimal) value).longValue();
     }
 
     @Override public Double readDouble() throws IOException {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return ((BigDecimal) value).doubleValue();
     }
 
     @Override public Boolean readBoolean() throws IOException {
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return (Boolean) value;
     }
 
@@ -241,17 +241,17 @@ import java.util.Map;
       if (typeAdapter == null) {
         throw new RuntimeException("Can't resolve custom type adapter for " + scalarType.typeName());
       }
-      readerShadow.didParseScalar(value);
+      readerShadow.didResolveScalar(value);
       return typeAdapter.decode(value.toString());
     }
 
     @SuppressWarnings("unchecked")
     @Override public <T> T readObject(ObjectReader<T> objectReader) throws IOException {
       R value = (R) this.value;
-      readerShadow.willParseObject(field, Optional.fromNullable(value));
+      readerShadow.willResolveObject(field, Optional.fromNullable(value));
       T item = (T) objectReader.read(new RealResponseReader<R>(operationVariables, value, fieldValueResolver,
           customTypeAdapters, readerShadow));
-      readerShadow.didParseObject(field, Optional.fromNullable(value));
+      readerShadow.didResolveObject(field, Optional.fromNullable(value));
       return item;
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/ResponseReaderShadow.java
@@ -14,17 +14,17 @@ public interface ResponseReaderShadow<R> {
 
   void didResolve(ResponseField field, Operation.Variables variables);
 
-  void didParseScalar(Object value);
+  void didResolveScalar(Object value);
 
-  void willParseObject(ResponseField objectField, Optional<R> objectSource);
+  void willResolveObject(ResponseField objectField, Optional<R> objectSource);
 
-  void didParseObject(ResponseField objectField, Optional<R> objectSource);
+  void didResolveObject(ResponseField objectField, Optional<R> objectSource);
 
-  void didParseList(List array);
+  void didResolveList(List array);
 
-  void willParseElement(int atIndex);
+  void willResolveElement(int atIndex);
 
-  void didParseElement(int atIndex);
+  void didResolveElement(int atIndex);
 
-  void didParseNull();
+  void didResolveNull();
 }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -611,29 +611,29 @@ public class ResponseReaderTest {
     @Override public void didResolve(ResponseField field, Operation.Variables variables) {
     }
 
-    @Override public void didParseScalar(Object value) {
+    @Override public void didResolveScalar(Object value) {
     }
 
-    @Override public void willParseObject(ResponseField field, Optional objectSource) {
+    @Override public void willResolveObject(ResponseField field, Optional objectSource) {
     }
 
-    @Override public void didParseObject(ResponseField Field, Optional objectSource) {
+    @Override public void didResolveObject(ResponseField Field, Optional objectSource) {
     }
 
     @Nonnull @Override public CacheKey resolveCacheKey(@Nonnull ResponseField field, @Nonnull Object record) {
       return CacheKey.NO_KEY;
     }
 
-    @Override public void didParseList(List array) {
+    @Override public void didResolveList(List array) {
     }
 
-    @Override public void willParseElement(int atIndex) {
+    @Override public void willResolveElement(int atIndex) {
     }
 
-    @Override public void didParseElement(int atIndex) {
+    @Override public void didResolveElement(int atIndex) {
     }
 
-    @Override public void didParseNull() {
+    @Override public void didResolveNull() {
     }
 
     @Override public Collection<Record> records() {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    apolloVersion                : '0.3.2-SNAPSHOT',
+    apolloVersion                : '0.3.3-SNAPSHOT',
     cacheVersion                 : '2.0.2',
     okHttpVersion                : '3.8.1',
     kotlinVersion                : '1.1.2-3',


### PR DESCRIPTION
- Introduce `CacheResponseWriter` responsible for accumulating field values during response marshaling and generating cache records
- Refactor names of `ResponseReaderShadow` delegate calls
- Fix issue with generating marshaller for nullable fields

Outstanding issues:
- Generate constructor parameters verification to prevent model initialization with null values for non-null fields
- Consider of removing redundant throwing `IOException` declaration for `ResponseReader` and `ResponseWriter`
- Maybe more tests for `CacheResponseWriter`
- Introduce write fragment to the store API

Part of #467