### PR TITLE
Generate verification to ensure nonnull values for model constructor

### DIFF
--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_complex.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -265,7 +266,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public HeroWithReview(@Nonnull String __typename, @Nonnull String name,
         @Nullable Double height) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.height = Optional.fromNullable(height);
     }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -12,6 +12,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_simple.type.Episode;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -228,6 +229,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nullable String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.name = Optional.fromNullable(name);
     }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.custom_scalar_type.type.CustomType;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -201,12 +202,33 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull Date birthDate,
         @Nonnull List<Date> appearanceDates, @Nonnull Object fieldWithUnsupportedType,
         @Nonnull String profileLink, @Nonnull List<String> links) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (birthDate == null) {
+        throw new NullPointerException("birthDate can't be null");
+      }
       this.birthDate = birthDate;
+      if (appearanceDates == null) {
+        throw new NullPointerException("appearanceDates can't be null");
+      }
       this.appearanceDates = appearanceDates;
+      if (fieldWithUnsupportedType == null) {
+        throw new NullPointerException("fieldWithUnsupportedType can't be null");
+      }
       this.fieldWithUnsupportedType = fieldWithUnsupportedType;
+      if (profileLink == null) {
+        throw new NullPointerException("profileLink can't be null");
+      }
       this.profileLink = profileLink;
+      if (links == null) {
+        throw new NullPointerException("links can't be null");
+      }
       this.links = links;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.deprecation.type.Episode;
 import java.io.IOException;
 import java.lang.Deprecated;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -219,8 +220,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull @Deprecated String deprecated) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (deprecated == null) {
+        throw new NullPointerException("deprecated can't be null");
+      }
       this.deprecated = deprecated;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -176,6 +177,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nullable String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.name = Optional.fromNullable(name);
     }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.enum_type.type.Episode;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -187,9 +188,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Episode firstAppearsIn) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (appearsIn == null) {
+        throw new NullPointerException("appearsIn can't be null");
+      }
       this.appearsIn = appearsIn;
+      if (firstAppearsIn == null) {
+        throw new NullPointerException("firstAppearsIn can't be null");
+      }
       this.firstAppearsIn = firstAppearsIn;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -12,6 +12,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_friends_connection.fragment.HeroDetails;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -181,7 +182,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -251,6 +258,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
+        if (heroDetails == null) {
+          throw new NullPointerException("heroDetails can't be null");
+        }
         this.heroDetails = heroDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -59,8 +60,17 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
+    if (friendsConnection == null) {
+      throw new NullPointerException("friendsConnection can't be null");
+    }
     this.friendsConnection = friendsConnection;
   }
 
@@ -173,6 +183,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -296,6 +309,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -393,7 +409,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -14,6 +14,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.fragment_in_fragment.fragment.PilotFragment;
 import com.example.fragment_in_fragment.fragment.StarshipFragment;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -192,6 +193,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public AllStarships1(@Nonnull String __typename, @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.edges = Optional.fromNullable(edges);
     }
@@ -301,6 +305,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -398,7 +405,13 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -468,6 +481,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull StarshipFragment starshipFragment) {
+        if (starshipFragment == null) {
+          throw new NullPointerException("starshipFragment can't be null");
+        }
         this.starshipFragment = starshipFragment;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -51,6 +52,9 @@ public class PilotFragment implements GraphqlFragment {
 
   public PilotFragment(@Nonnull String __typename, @Nullable String name,
       @Nullable Homeworld homeworld) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
     this.name = Optional.fromNullable(name);
     this.homeworld = Optional.fromNullable(homeworld);
@@ -161,6 +165,9 @@ public class PilotFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Homeworld(@Nonnull String __typename, @Nullable String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.name = Optional.fromNullable(name);
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -62,7 +63,13 @@ public class StarshipFragment implements GraphqlFragment {
 
   public StarshipFragment(@Nonnull String __typename, @Nonnull String id, @Nullable String name,
       @Nullable PilotConnection pilotConnection) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (id == null) {
+      throw new NullPointerException("id can't be null");
+    }
     this.id = id;
     this.name = Optional.fromNullable(name);
     this.pilotConnection = Optional.fromNullable(pilotConnection);
@@ -183,6 +190,9 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public PilotConnection(@Nonnull String __typename, @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.edges = Optional.fromNullable(edges);
     }
@@ -292,6 +302,9 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -389,7 +402,13 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -459,6 +478,9 @@ public class StarshipFragment implements GraphqlFragment {
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull PilotFragment pilotFragment) {
+        if (pilotFragment == null) {
+          throw new NullPointerException("pilotFragment can't be null");
+        }
         this.pilotFragment = pilotFragment;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
 import com.example.fragment_with_inline_fragment.type.Episode;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -192,9 +193,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (appearsIn == null) {
+        throw new NullPointerException("appearsIn can't be null");
+      }
       this.appearsIn = appearsIn;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -295,6 +308,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
+        if (heroDetails == null) {
+          throw new NullPointerException("heroDetails can't be null");
+        }
         this.heroDetails = heroDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -67,8 +68,17 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection, @Nullable AsDroid asDroid) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
+    if (friendsConnection == null) {
+      throw new NullPointerException("friendsConnection can't be null");
+    }
     this.friendsConnection = friendsConnection;
     this.asDroid = Optional.fromNullable(asDroid);
   }
@@ -202,6 +212,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -325,6 +338,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -422,7 +438,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 
@@ -519,8 +541,17 @@ public class HeroDetails implements GraphqlFragment {
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection, @Nullable String primaryFunction) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
@@ -648,6 +679,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -771,6 +805,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -868,7 +905,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.example.fragments_with_type_condition.fragment.DroidDetails;
 import com.example.fragments_with_type_condition.fragment.HumanDetails;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -210,7 +211,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public R2(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -282,7 +289,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HumanDetails humanDetails, @Nonnull DroidDetails droidDetails) {
+        if (humanDetails == null) {
+          throw new NullPointerException("humanDetails can't be null");
+        }
         this.humanDetails = humanDetails;
+        if (droidDetails == null) {
+          throw new NullPointerException("droidDetails can't be null");
+        }
         this.droidDetails = droidDetails;
       }
 
@@ -404,7 +417,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Luke(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -476,7 +495,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HumanDetails humanDetails, @Nonnull DroidDetails droidDetails) {
+        if (humanDetails == null) {
+          throw new NullPointerException("humanDetails can't be null");
+        }
         this.humanDetails = humanDetails;
+        if (droidDetails == null) {
+          throw new NullPointerException("droidDetails can't be null");
+        }
         this.droidDetails = droidDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -48,7 +49,13 @@ public class DroidDetails implements GraphqlFragment {
 
   public DroidDetails(@Nonnull String __typename, @Nonnull String name,
       @Nullable String primaryFunction) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
     this.primaryFunction = Optional.fromNullable(primaryFunction);
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -48,7 +49,13 @@ public class HumanDetails implements GraphqlFragment {
   private volatile boolean $hashCodeMemoized;
 
   public HumanDetails(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
     this.height = Optional.fromNullable(height);
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -193,8 +194,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -308,6 +318,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -431,6 +444,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -528,7 +544,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.google.common.base.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -193,8 +194,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -308,6 +318,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -431,6 +444,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -528,7 +544,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -193,8 +194,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -308,6 +318,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.ofNullable(totalCount);
       this.edges = Optional.ofNullable(edges);
@@ -431,6 +444,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.ofNullable(node);
     }
@@ -528,7 +544,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -192,8 +193,17 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -307,6 +317,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = totalCount;
       this.edges = edges;
@@ -430,6 +443,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = node;
     }
@@ -527,7 +543,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -176,7 +177,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -12,6 +12,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.example.inline_fragments_with_friends.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -203,7 +204,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
@@ -342,7 +349,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name, @Nullable Double height,
         @Nullable List<Friend> friends) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.height = Optional.fromNullable(height);
       this.friends = Optional.fromNullable(friends);
@@ -479,7 +492,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull List<Episode> appearsIn) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (appearsIn == null) {
+        throw new NullPointerException("appearsIn can't be null");
+      }
       this.appearsIn = appearsIn;
     }
 
@@ -588,7 +607,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends, @Nullable String primaryFunction) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.friends = Optional.fromNullable(friends);
       this.primaryFunction = Optional.fromNullable(primaryFunction);
@@ -725,7 +750,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend1(@Nonnull String __typename, @Nonnull String id) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (id == null) {
+        throw new NullPointerException("id can't be null");
+      }
       this.id = id;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -15,6 +15,7 @@ import com.example.input_object_type.type.Episode;
 import com.example.input_object_type.type.ReviewInput;
 import java.io.IOException;
 import java.lang.IllegalStateException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -243,6 +244,9 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     private volatile boolean $hashCodeMemoized;
 
     public CreateReview(@Nonnull String __typename, int stars, @Nullable String commentary) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.stars = stars;
       this.commentary = Optional.fromNullable(commentary);

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.nested_conditional_inline.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -245,7 +246,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
@@ -378,7 +385,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend> friends) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.friends = Optional.fromNullable(friends);
     }
@@ -498,7 +511,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman1 asHuman) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.asHuman = Optional.fromNullable(asHuman);
     }
@@ -611,7 +630,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman1(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.height = Optional.fromNullable(height);
     }
@@ -713,7 +738,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.friends = Optional.fromNullable(friends);
     }
@@ -833,7 +864,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend1(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman2 asHuman) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.asHuman = Optional.fromNullable(asHuman);
     }
@@ -946,7 +983,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman2(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.height = Optional.fromNullable(height);
     }

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.example.no_accessors.fragment.HeroDetails;
 import com.example.no_accessors.type.Episode;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -194,9 +195,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (appearsIn == null) {
+        throw new NullPointerException("appearsIn can't be null");
+      }
       this.appearsIn = appearsIn;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -275,6 +288,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
+        if (heroDetails == null) {
+          throw new NullPointerException("heroDetails can't be null");
+        }
         this.heroDetails = heroDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -73,8 +74,17 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection, @Nullable AsDroid asDroid) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
+    if (friendsConnection == null) {
+      throw new NullPointerException("friendsConnection can't be null");
+    }
     this.friendsConnection = friendsConnection;
     this.asDroid = Optional.fromNullable(asDroid);
   }
@@ -192,6 +202,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -300,6 +313,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -389,7 +405,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 
@@ -484,8 +506,17 @@ public class HeroDetails implements GraphqlFragment {
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection, @Nullable String primaryFunction) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
@@ -594,6 +625,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -702,6 +736,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -791,7 +828,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -129,6 +130,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Nullable List<GraphQlListOfObject> graphQlListOfObjects) {
       this.graphQlString = Optional.fromNullable(graphQlString);
       this.graphQlIdNullable = Optional.fromNullable(graphQlIdNullable);
+      if (graphQlIdNonNullable == null) {
+        throw new NullPointerException("graphQlIdNonNullable can't be null");
+      }
       this.graphQlIdNonNullable = graphQlIdNonNullable;
       this.graphQlIntNullable = Optional.fromNullable(graphQlIntNullable);
       this.graphQlIntNonNullable = graphQlIntNonNullable;

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -12,6 +12,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.example.simple_fragment.fragment.HeroDetails;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -181,7 +182,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -251,6 +258,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
+        if (heroDetails == null) {
+          throw new NullPointerException("heroDetails can't be null");
+        }
         this.heroDetails = heroDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -41,7 +42,13 @@ public class HeroDetails implements GraphqlFragment {
   private volatile boolean $hashCodeMemoized;
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -193,7 +194,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
@@ -328,7 +335,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.height = Optional.fromNullable(height);
     }
@@ -436,7 +449,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable String primaryFunction) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -11,6 +11,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -205,7 +206,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public R2(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 
@@ -298,8 +305,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Luke(@Nonnull String __typename, @Nonnull String id, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (id == null) {
+        throw new NullPointerException("id can't be null");
+      }
       this.id = id;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -12,6 +12,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -233,8 +234,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public R2(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -348,6 +358,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -471,6 +484,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -568,7 +584,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 
@@ -665,9 +687,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Luke(@Nonnull String __typename, @Nonnull String id, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (id == null) {
+        throw new NullPointerException("id can't be null");
+      }
       this.id = id;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (friendsConnection == null) {
+        throw new NullPointerException("friendsConnection can't be null");
+      }
       this.friendsConnection = friendsConnection;
     }
 
@@ -794,6 +828,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -917,6 +954,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -1014,7 +1054,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -14,6 +14,7 @@ import com.example.unique_type_name.fragment.HeroDetails;
 import com.example.unique_type_name.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -206,7 +207,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public HeroDetailQuery1(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend> friends, @Nullable AsHuman asHuman) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.friends = Optional.fromNullable(friends);
       this.asHuman = Optional.fromNullable(asHuman);
@@ -350,7 +357,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 
@@ -447,7 +460,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends, @Nullable Double height) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
       this.friends = Optional.fromNullable(friends);
       this.height = Optional.fromNullable(height);
@@ -591,8 +610,17 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public Friend1(@Nonnull String __typename, @Nonnull String name,
         @Nonnull List<Episode> appearsIn, @Nullable List<Friend2> friends) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
+      if (appearsIn == null) {
+        throw new NullPointerException("appearsIn can't be null");
+      }
       this.appearsIn = appearsIn;
       this.friends = Optional.fromNullable(friends);
     }
@@ -741,7 +769,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     private volatile boolean $hashCodeMemoized;
 
     public Friend2(@Nonnull String __typename, @Nonnull Fragments fragments) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (fragments == null) {
+        throw new NullPointerException("fragments can't be null");
+      }
       this.fragments = fragments;
     }
 
@@ -811,6 +845,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
+        if (heroDetails == null) {
+          throw new NullPointerException("heroDetails can't be null");
+        }
         this.heroDetails = heroDetails;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import java.io.IOException;
 import java.lang.Integer;
+import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -59,8 +60,17 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection) {
+    if (__typename == null) {
+      throw new NullPointerException("__typename can't be null");
+    }
     this.__typename = __typename;
+    if (name == null) {
+      throw new NullPointerException("name can't be null");
+    }
     this.name = name;
+    if (friendsConnection == null) {
+      throw new NullPointerException("friendsConnection can't be null");
+    }
     this.friendsConnection = friendsConnection;
   }
 
@@ -173,6 +183,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
@@ -296,6 +309,9 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
       this.node = Optional.fromNullable(node);
     }
@@ -393,7 +409,13 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
+      if (__typename == null) {
+        throw new NullPointerException("__typename can't be null");
+      }
       this.__typename = __typename;
+      if (name == null) {
+        throw new NullPointerException("name can't be null");
+      }
       this.name = name;
     }
 


### PR DESCRIPTION
Because of the fact we allow now user to create instances of generated models we must ensure that null values are not accepted for non-null fields

Part of #467