### PR TITLE
Fix README.md:

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You first need to define the mapping in your build.gradle file. This will tell t
 ```gradle
 apollo {
     customTypeMapping['DateTime'] = "java.util.Date"
-    customTypeMapping['Currency'] = "java.util.BigDecimal"
+    customTypeMapping['Currency'] = "java.math.BigDecimal"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,16 +156,15 @@ You first need to define the mapping in your build.gradle file. This will tell t
 
 ```gradle
 apollo {
-    customTypeMapping {
-        DateTime = "java.util.Date"
-    }
+    customTypeMapping['DateTime'] = "java.util.Date"
+    customTypeMapping['Currency'] = "java.util.BigDecimal"
 }
 ```
 
 Then register your custom adapter:
 
 ```java
-CustomTypeAdapter<Date> dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
+CustomTypeAdapter<Date> customTypeAdapter = new CustomTypeAdapter<Date>() {
     @Override
     public Date decode(String value) {
         try {
@@ -174,16 +173,20 @@ CustomTypeAdapter<Date> dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
             throw new RuntimeException(e);
         }
     }
+
     @Override
     public String encode(Date value) {
         return ISO8601_DATE_FORMAT.format(value);
     }
 };
 
-ApolloConverterFactory apolloConverterFactory = new ApolloConverterFactory.Builder()
-        .withCustomTypeAdapter(CustomType.DATETIME, dateCustomTypeAdapter)
-        .withResponseFieldMappers(ResponseFieldMappers.MAPPERS)
-        .build();
+// use on creating ApolloClient
+ApolloClient.builder()
+    .serverUrl(serverUrl)
+    .okHttpClient(okHttpClient)
+    .normalizedCache(normalizedCacheFactory, cacheKeyResolver)
+    .addCustomTypeAdapter(CustomType.DATETIME, customTypeAdapter)
+    .build();
 ```
 
 ## Support For Cached Responses


### PR DESCRIPTION
1.     customTypeMapping {
           Currency = "java.util.BigDecimal"
       }
 fails with error

 you tried to assign a value to the class 'java.util.Currency'

 Replacement allows to override it
 customTypeMapping['Currency'] = "java.util.BigDecimal"

2. Cannot find ApolloConverterFactory in code, suggested a replacement
ApolloClient.builder().addCustomTypeAdapter(CustomType.DATETIME, customTypeAdapter)