### PR TITLE
Generate operation id and add option to send to server instead of document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 sudo: true
+dist: precise
 
 android:
   components:

--- a/apollo-android-support/src/androidTest/java/com/apollographql/apollo/TestUtils.java
+++ b/apollo-android-support/src/androidTest/java/com/apollographql/apollo/TestUtils.java
@@ -43,6 +43,10 @@ public final class TestUtils {
     @Nonnull @Override public OperationName name() {
       return operationName;
     }
+
+    @Nonnull @Override public String operationId() {
+      return "";
+    }
   };
 
   public static Looper createBackgroundLooper() throws Exception {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -38,6 +38,13 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
   @Nonnull OperationName name();
 
   /**
+   * Returns a unique identifier for this operation.
+   *
+   * @return operation identifier.
+   */
+  @Nonnull String operationId();
+
+  /**
    * Abstraction for data returned by the server in response to this operation.
    */
   interface Data {

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -50,8 +50,15 @@ class UpdateTestIRFilesTask extends DefaultTask {
     if (!schema.exists()) {
       schema = new File('apollo-compiler/src/test/graphql/schema.json')
     }
+
+    def idFileDir = new File("apollo-compiler/build/apollo-codegen/${testDir.name}")
+    idFileDir.mkdirs()
+    def idFile = new File(idFileDir, "id.json")
+
     def apolloCodeGenProcess = """apollo-codegen generate ${queryFile.absoluteFile}
           --add-typename
+          --operation-ids-path ${idFile.toString()}
+          --merge-in-fields-from-fragment-spreads false
           --schema ${schema.absoluteFile}
           --output ${outputFile.absoluteFile}
           --target json""".execute()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -64,7 +64,7 @@ class GraphQLCompiler {
   companion object {
     const val FILE_EXTENSION = "graphql"
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo")
-    const val APOLLOCODEGEN_VERSION = "0.12.10"
+    const val APOLLOCODEGEN_VERSION = "0.15.2"
   }
 
   data class Arguments(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -12,7 +12,9 @@ data class Operation(
     val source: String,
     val fields: List<Field>,
     val filePath: String,
-    val fragmentsReferenced: List<String>
+    val fragmentsReferenced: List<String>,
+    val operationId: String
+
 ) : CodeGenerator {
   override fun toTypeSpec(context: CodeGenerationContext): TypeSpec =
       SchemaTypeSpecBuilder(

--- a/apollo-compiler/src/test/graphql/apollo-codegen.properties
+++ b/apollo-compiler/src/test/graphql/apollo-codegen.properties
@@ -1,1 +1,1 @@
-apollo-codegen version=0.12.10
+apollo-codegen version=0.15.2

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestOperation.json
@@ -86,7 +86,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery($episode: Episode, $stars: Int!, $greenValue: Float!) {\n  heroWithReview(episode: $episode, review: {stars: $stars, favoriteColor: {red: 0, green: $greenValue, blue: 0}}) {\n    __typename\n    name\n    height(unit: FOOT)\n  }\n}",
+			"operationId": "4905a0fccc07f97ecd6d660f5a68d4d49ffedc3f4688b76d17288dec1a1fdf93"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -49,6 +49,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "4905a0fccc07f97ecd6d660f5a68d4d49ffedc3f4688b76d17288dec1a1fdf93";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestOperation.json
@@ -52,7 +52,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery($episode: Episode, $includeName: Boolean!) {\n  hero(episode: $episode) {\n    __typename\n    name @include(if: $includeName)\n  }\n}",
+			"operationId": "125df1054cbcf295890b4747e575075f18f2be2635a6b313ab793d1d91a4d4f2"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -47,6 +47,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "125df1054cbcf295890b4747e575075f18f2be2635a6b313ab793d1d91a4d4f2";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestOperation.json
@@ -73,7 +73,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    birthDate\n    appearanceDates\n    fieldWithUnsupportedType\n    profileLink\n    links\n  }\n}",
+			"operationId": "97c3220729cb6b43bfbb66f24be53a88482515ea92d3ba9783fce882bc58fc53"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -50,6 +50,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "97c3220729cb6b43bfbb66f24be53a88482515ea92d3ba9783fce882bc58fc53";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.json
@@ -55,7 +55,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery($episode: Episode) {\n  hero(episode: $episode) {\n    __typename\n    name\n    deprecated\n  }\n}",
+			"operationId": "c86775f24ab7d183b6c219a6df0eba15f39b9efb6ca5ef235e3142c11b447fcd"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -49,6 +49,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "c86775f24ab7d183b6c219a6df0eba15f39b9efb6ca5ef235e3142c11b447fcd";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestOperation.json
@@ -34,7 +34,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name @include(if: false)\n  }\n}",
+			"operationId": "384c8fb221beb93fcac3079204836dfd77c15c3355f745834564f2d777e8e80d"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -42,6 +42,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "384c8fb221beb93fcac3079204836dfd77c15c3355f745834564f2d777e8e80d";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestOperation.json
@@ -49,7 +49,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    appearsIn\n    firstAppearsIn\n  }\n}",
+			"operationId": "b21e7723eade7c2801671c52c5de16f21ea29cb902dd88d8ebf42c334a07e7c0"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -46,6 +46,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "b21e7723eade7c2801671c52c5de16f21ea29cb902dd88d8ebf42c334a07e7c0";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestOperation.json
@@ -29,7 +29,9 @@
 			],
 			"fragmentsReferenced": [
 				"HeroDetails"
-			]
+			],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
+			"operationId": "04159f026f56177a5ffd90a08c365ebdae5d4775175c48f17bc9d82003e74b84"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -46,6 +46,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "04159f026f56177a5ffd90a08c365ebdae5d4775175c48f17bc9d82003e74b84";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -56,6 +56,11 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
   }
 
   @Override
+  public String operationId() {
+    return "6bc63c6c2eaea4bbf8a55313dbfee24c55d43b654411215b84780cf8f04699f3";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/TestOperation.json
@@ -70,7 +70,9 @@
 			"fragmentsReferenced": [
 				"starshipFragment",
 				"pilotFragment"
-			]
+			],
+			"sourceWithFragments": "query AllStarships {\n  allStarships(first: 7) {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...starshipFragment\n      }\n    }\n  }\n}\nfragment pilotFragment on Person {\n  __typename\n  name\n  homeworld {\n    __typename\n    name\n  }\n}\nfragment starshipFragment on Starship {\n  __typename\n  id\n  name\n  pilotConnection {\n    __typename\n    edges {\n      __typename\n      node {\n        __typename\n        ...pilotFragment\n      }\n    }\n  }\n}",
+			"operationId": "6bc63c6c2eaea4bbf8a55313dbfee24c55d43b654411215b84780cf8f04699f3"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestOperation.json
@@ -45,7 +45,9 @@
 			],
 			"fragmentsReferenced": [
 				"HeroDetails"
-			]
+			],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
+			"operationId": "eb09ddd8f931e755957a2631da5129303c0e13d9c20314c5ae3d2522d636b6e1"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -50,6 +50,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "eb09ddd8f931e755957a2631da5129303c0e13d9c20314c5ae3d2522d636b6e1";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestOperation.json
@@ -50,7 +50,9 @@
 			"fragmentsReferenced": [
 				"HumanDetails",
 				"DroidDetails"
-			]
+			],
+			"sourceWithFragments": "query TestQuery {\n  r2: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n  luke: hero {\n    __typename\n    ...HumanDetails\n    ...DroidDetails\n  }\n}\nfragment DroidDetails on Droid {\n  __typename\n  name\n  primaryFunction\n}\nfragment HumanDetails on Human {\n  __typename\n  name\n  height\n}",
+			"operationId": "185ee12f775bf02624bb5f646f5ed2de3009860b79380264ce4716e65fba947d"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -54,6 +54,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "185ee12f775bf02624bb5f646f5ed2de3009860b79380264ce4716e65fba947d";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
@@ -55,6 +55,11 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
   }
 
   @Override
+  public String operationId() {
+    return "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/TestOperation.json
@@ -100,7 +100,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query HeroDetails {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestOperation.json
@@ -100,7 +100,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -55,6 +55,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestOperation.json
@@ -100,7 +100,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -55,6 +55,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestOperation.json
@@ -100,7 +100,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -54,6 +54,11 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
   }
 
   @Override
+  public String operationId() {
+    return "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
@@ -55,6 +55,11 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
   }
 
   @Override
+  public String operationId() {
+    return "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/TestOperation.json
@@ -100,7 +100,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query HeroDetails {\n  hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestOperation.json
@@ -33,7 +33,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n  }\n}",
+			"operationId": "f28c106dcaca07eb2077c9bcf7c64af9b0aa81f85169af29f7b41808b168e468"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -42,6 +42,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "f28c106dcaca07eb2077c9bcf7c64af9b0aa81f85169af29f7b41808b168e468";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestOperation.json
@@ -144,7 +144,9 @@
 					]
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n      }\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n      friends {\n        __typename\n        id\n      }\n    }\n  }\n}",
+			"operationId": "a730adeac9d8f65ae02cdf7c8785745a5d05071a3f101e0651c62bb5fbe3f2f9"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -62,6 +62,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "a730adeac9d8f65ae02cdf7c8785745a5d05071a3f101e0651c62bb5fbe3f2f9";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
@@ -66,7 +66,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}",
+			"operationId": "557e9010a4f6274a5409cc73de928653c878c931099afa98357c530df729a448"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -53,6 +53,11 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
   }
 
   @Override
+  public String operationId() {
+    return "557e9010a4f6274a5409cc73de928653c878c931099afa98357c530df729a448";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -53,6 +53,11 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
   }
 
   @Override
+  public String operationId() {
+    return "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
@@ -66,7 +66,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}",
+			"operationId": "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -53,6 +53,11 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
   }
 
   @Override
+  public String operationId() {
+    return "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
@@ -66,7 +66,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n  createReview(episode: $ep, review: $review) {\n    __typename\n    stars\n    commentary\n  }\n}",
+			"operationId": "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -72,6 +72,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return null;
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestOperation.json
@@ -45,7 +45,9 @@
 			],
 			"fragmentsReferenced": [
 				"HeroDetails"
-			]
+			],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n  ... on Droid {\n    __typename\n    name\n    primaryFunction\n  }\n}",
+			"operationId": "eb09ddd8f931e755957a2631da5129303c0e13d9c20314c5ae3d2522d636b6e1"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -50,6 +50,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "eb09ddd8f931e755957a2631da5129303c0e13d9c20314c5ae3d2522d636b6e1";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/TestQuery.java
@@ -35,6 +35,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return null;
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -41,6 +41,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return null;
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestOperation.json
@@ -29,7 +29,9 @@
 			],
 			"fragmentsReferenced": [
 				"HeroDetails"
-			]
+			],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    ...HeroDetails\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n}",
+			"operationId": "7824113c9abde76f3c8ffbee5d7065129bc5c47757f34dd5959d5cd16464d014"
 		}
 	],
 	"fragments": [

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -46,6 +46,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "7824113c9abde76f3c8ffbee5d7065129bc5c47757f34dd5959d5cd16464d014";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestOperation.json
@@ -94,7 +94,9 @@
 					]
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    ... on Human {\n      __typename\n      height\n    }\n    ... on Droid {\n      __typename\n      primaryFunction\n    }\n  }\n}",
+			"operationId": "b0f3f33d97a1ff5035984e7472107997adaecc8512a8c63358f594dd01faf007"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -52,6 +52,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "b0f3f33d97a1ff5035984e7472107997adaecc8512a8c63358f594dd01faf007";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestOperation.json
@@ -71,7 +71,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    id\n    name\n  }\n}",
+			"operationId": "922160ff4bcf150d3b4a84e8b4d218dde7ff83f6a98145fc9d5237b54eb89e6d"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -48,6 +48,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "922160ff4bcf150d3b4a84e8b4d218dde7ff83f6a98145fc9d5237b54eb89e6d";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestOperation.json
@@ -205,7 +205,9 @@
 					"inlineFragments": []
 				}
 			],
-			"fragmentsReferenced": []
+			"fragmentsReferenced": [],
+			"sourceWithFragments": "query TestQuery {\n  r2: hero {\n    __typename\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n  luke: hero(episode: EMPIRE) {\n    __typename\n    id\n    name\n    friendsConnection {\n      __typename\n      totalCount\n      edges {\n        __typename\n        node {\n          __typename\n          name\n        }\n      }\n    }\n  }\n}",
+			"operationId": "e8d7fac5e934be8f96520ce424ad3d9a447507405f3e43733873897b8ec27ec6"
 		}
 	],
 	"fragments": [],

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -72,6 +72,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   }
 
   @Override
+  public String operationId() {
+    return "e8d7fac5e934be8f96520ce424ad3d9a447507405f3e43733873897b8ec27ec6";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -65,6 +65,11 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
   }
 
   @Override
+  public String operationId() {
+    return "1bffe51c14b1ef09ab54127a8e231d654eac3570c6106b924e0ac9d351061acb";
+  }
+
+  @Override
   public String queryDocument() {
     return QUERY_DOCUMENT;
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/TestOperation.json
@@ -143,7 +143,9 @@
 			],
 			"fragmentsReferenced": [
 				"HeroDetails"
-			]
+			],
+			"sourceWithFragments": "query HeroDetailQuery {\n  heroDetailQuery {\n    __typename\n    name\n    friends {\n      __typename\n      name\n    }\n    ... on Human {\n      __typename\n      height\n      friends {\n        __typename\n        appearsIn\n        friends {\n          __typename\n          ...HeroDetails\n        }\n      }\n    }\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n  }\n}",
+			"operationId": "1bffe51c14b1ef09ab54127a8e231d654eac3570c6106b924e0ac9d351061acb"
 		}
 	],
 	"fragments": [

--- a/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
+++ b/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
@@ -75,6 +75,10 @@ public class ApolloIdlingResourceTest {
     @Nonnull @Override public OperationName name() {
       return operationName;
     }
+
+    @Nonnull @Override public String operationId() {
+      return "";
+    }
   };
 
   @Before

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
@@ -55,11 +55,14 @@ public class ApolloIRGenTask extends NodeTask {
     for (Map.Entry<String, ApolloCodegenArgs> entry : schemaQueryMap.entrySet()) {
       String irOutput = outputDir.getAbsolutePath() + "/" + getProject().relativePath(entry.getValue().getSchemaFile().getParent());
       new File(irOutput).mkdirs();
-
       List<String> apolloArgs = Lists.newArrayList("generate");
       apolloArgs.addAll(entry.getValue().getQueryFiles());
-      apolloArgs.addAll(Lists.newArrayList("--add-typename", "--schema", entry.getValue().getSchemaFile()
-              .getAbsolutePath(), "--output", irOutput + "/" + Utils.capitalize(variant) + "API.json", "--target", "json"));
+      apolloArgs.addAll(Lists.newArrayList("--add-typename",
+          "--schema", entry.getValue().getSchemaFile().getAbsolutePath(),
+          "--output", irOutput + "/" + Utils.capitalize(variant) + "API.json",
+          "--operation-ids-path", irOutput + "/" + Utils.capitalize(variant) + "OperationIdMap.json",
+          "--merge-in-fields-from-fragment-spreads", "false",
+          "--target", "json"));
       setArgs(apolloArgs);
       super.exec();
     }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -37,6 +37,12 @@ class BasicAndroidSpec extends Specification {
     assert new File(testProjectDir,
         "build/generated/source/apollo/generatedIR/debug/src/main/graphql/DebugAPI.json").isFile()
 
+    // OperationIdMap.json generated successfully
+    assert new File(testProjectDir,
+        "build/generated/source/apollo/generatedIR/release/src/main/graphql/ReleaseOperationIdMap.json").isFile()
+    assert new File(testProjectDir,
+        "build/generated/source/apollo/generatedIR/debug/src/main/graphql/DebugOperationIdMap.json").isFile()
+
     // Java classes generated successfully
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/DroidDetailsQuery.java").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/com/example/FilmsQuery.java").isFile()

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/FlavoredMultiSchemaSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/FlavoredMultiSchemaSpec.groovy
@@ -88,6 +88,13 @@ class FlavoredMultiSchemaSpec extends Specification {
     assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/fullRelease/src/main/graphql/com/frontpage/api/FullReleaseAPI.json").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/fullRelease/src/release/graphql/com/starwars/api/FullReleaseAPI.json").isFile()
 
+    // OperationIdMap.json generated successfully
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoRelease/src/main/graphql/com/frontpage/api/DemoReleaseOperationIdMap.json").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoRelease/src/release/graphql/com/starwars/api/DemoReleaseOperationIdMap.json").isFile()
+
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/fullRelease/src/main/graphql/com/frontpage/api/FullReleaseOperationIdMap.json").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/fullRelease/src/release/graphql/com/starwars/api/FullReleaseOperationIdMap.json").isFile()
+
     // generates java classes for queries under the release source set
     assert new File(testProjectDir, "build/generated/source/apollo/com/starwars/api/starship/StarshipQuery.java").isFile()
     assertDemoDebugGenerationSucces()
@@ -103,6 +110,11 @@ class FlavoredMultiSchemaSpec extends Specification {
     assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/demoDebug/graphql/com/githunt/api/DemoDebugAPI.json").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/demoDebug/graphql/com/starwars/api/DemoDebugAPI.json").isFile()
     assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/main/graphql/com/frontpage/api/DemoDebugAPI.json").isFile()
+
+    // OperationIdMap.json file created
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/demoDebug/graphql/com/githunt/api/DemoDebugOperationIdMap.json").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/demoDebug/graphql/com/starwars/api/DemoDebugOperationIdMap.json").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/generatedIR/demoDebug/src/main/graphql/com/frontpage/api/DemoDebugOperationIdMap.json").isFile()
 
     // Java classes generated successfully
     // For Front Page

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
@@ -47,7 +47,6 @@ class ApolloCodeGenInstallTaskSpec extends Specification {
     project.evaluate()
 
     then:
-    println "files:" + (new File(project.buildDir).listFiles())
     File packageFile = new File(project.buildDir, "apollo-codegen/package.json")
     assert packageFile.isFile()
     def input = new JsonSlurper().parseText(packageFile.text)

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -574,8 +574,6 @@ public class ApolloInterceptorTest {
     final NamedCountDownLatch latch = new NamedCountDownLatch("latch", 1);
 
     EpisodeHeroNameQuery query = createHeroNameQuery();
-    final InterceptorResponse fakeResponse = prepareInterceptorResponse(query);
-
     ApolloInterceptor interceptor = new ApolloInterceptor() {
 
       volatile boolean disposed;
@@ -589,11 +587,7 @@ public class ApolloInterceptorTest {
       @Override
       public void interceptAsync(@Nonnull Operation operation, @Nonnull ApolloInterceptorChain chain,
           @Nonnull ExecutorService dispatcher, @Nonnull FetchOptions fetchOptions, @Nonnull final CallBack callBack) {
-        dispatcher.execute(new Runnable() {
-          @Override public void run() {
-              callBack.onResponse(fakeResponse);
-          }
-        });
+        chain.proceedAsync(dispatcher, fetchOptions, callBack);
       }
 
       @Override public void dispose() {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -568,7 +568,9 @@ public class ApolloInterceptorTest {
   }
 
   @Test
-  public void onApolloCallCanceledAsyncApolloInterceptorIsDisposed() throws ApolloException, TimeoutException, InterruptedException {
+  public void onApolloCallCanceledAsyncApolloInterceptorIsDisposed() throws ApolloException, TimeoutException,
+      InterruptedException, IOException {
+    mockWebServer.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID).setBodyDelay(1, TimeUnit.SECONDS));
     final NamedCountDownLatch latch = new NamedCountDownLatch("latch", 1);
 
     EpisodeHeroNameQuery query = createHeroNameQuery();
@@ -589,9 +591,7 @@ public class ApolloInterceptorTest {
           @Nonnull ExecutorService dispatcher, @Nonnull FetchOptions fetchOptions, @Nonnull final CallBack callBack) {
         dispatcher.execute(new Runnable() {
           @Override public void run() {
-            if (!disposed) {
               callBack.onResponse(fakeResponse);
-            }
           }
         });
       }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -16,6 +16,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -41,6 +44,7 @@ public class ApolloWatcherTest {
 
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
+        .dispatcher(immediateExecutorService())
         .okHttpClient(okHttpClient)
           .logger(new Logger() {
             @Override
@@ -346,5 +350,33 @@ public class ApolloWatcherTest {
 
   private MockResponse mockResponse(String fileName) throws IOException {
     return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
+  }
+
+  private ExecutorService immediateExecutorService() {
+    return new AbstractExecutorService() {
+      @Override public void shutdown() {
+
+      }
+
+      @Override public List<Runnable> shutdownNow() {
+        return null;
+      }
+
+      @Override public boolean isShutdown() {
+        return false;
+      }
+
+      @Override public boolean isTerminated() {
+        return false;
+      }
+
+      @Override public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
+        return false;
+      }
+
+      @Override public void execute(Runnable runnable) {
+        runnable.run();
+      }
+    };
   }
 }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
@@ -1,0 +1,82 @@
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesQuery;
+import com.apollographql.apollo.integration.normalizer.type.Episode;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+public class SendOperationIdentifiersTest {
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  @Test public void sendOperationIdsTrue() throws InterruptedException, ApolloException, IOException {
+    enqueueResponse("/HeroAndFriendsNameResponse.json");
+    final HeroAndFriendsNamesQuery heroAndFriendsNamesQuery = new HeroAndFriendsNamesQuery(Episode.EMPIRE);
+    final String expectedId = heroAndFriendsNamesQuery.operationId();
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    OkHttpClient okHttpClient = new OkHttpClient.Builder()
+        .addInterceptor(new Interceptor() {
+          @Override public okhttp3.Response intercept(Chain chain) throws IOException {
+            if (chain.request().body().toString().contains("id: " + expectedId)) {
+              countDownLatch.countDown();
+            }
+            return chain.proceed(chain.request());
+          }
+        })
+        .build();
+
+    ApolloClient apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .sendOperationIdentifiers(true)
+        .okHttpClient(okHttpClient)
+        .build();
+
+    apolloClient.query(heroAndFriendsNamesQuery).execute();
+    countDownLatch.await(3, TimeUnit.SECONDS);
+  }
+
+  @Test public void doesNotSendOperationIdsWhenFalse() throws InterruptedException, ApolloException, IOException {
+    enqueueResponse("/HeroAndFriendsNameResponse.json");
+    final HeroAndFriendsNamesQuery heroAndFriendsNamesQuery = new HeroAndFriendsNamesQuery(Episode.EMPIRE);
+    final String expectedQueryDocument = heroAndFriendsNamesQuery.queryDocument();
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    OkHttpClient okHttpClient = new OkHttpClient.Builder()
+        .addInterceptor(new Interceptor() {
+          @Override public okhttp3.Response intercept(Chain chain) throws IOException {
+            if (chain.request().body().toString().contains("query: " + expectedQueryDocument)) {
+              countDownLatch.countDown();
+            }
+            return chain.proceed(chain.request());
+          }
+        })
+        .build();
+
+    ApolloClient apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .sendOperationIdentifiers(false)
+        .okHttpClient(okHttpClient)
+        .build();
+
+    apolloClient.query(heroAndFriendsNamesQuery).execute();
+    countDownLatch.await(3, TimeUnit.SECONDS);
+  }
+
+  private void enqueueResponse(String fileName) throws IOException {
+    server.enqueue(mockResponse(fileName));
+  }
+
+  private MockResponse mockResponse(String fileName) throws IOException {
+    return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), fileName), 32);
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -84,6 +84,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   private final ApolloLogger logger;
   private final ApolloCallTracker tracker = new ApolloCallTracker();
   private final List<ApolloInterceptor> applicationInterceptors;
+  private final boolean sendOperationIdentifiers;
 
   private ApolloClient(Builder builder) {
     this.serverUrl = builder.serverUrl;
@@ -98,6 +99,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     this.defaultResponseFetcher = builder.defaultResponseFetcher;
     this.logger = builder.apolloLogger;
     this.applicationInterceptors = builder.applicationInterceptors;
+    this.sendOperationIdentifiers = builder.sendOperationIdentifiers;
   }
 
   @Override
@@ -117,7 +119,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   @Override
   public <D extends Operation.Data, T, V extends Operation.Variables> ApolloPrefetch prefetch(
       @Nonnull Operation<D, T, V> operation) {
-    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, httpCache, moshi, dispatcher, logger, tracker);
+    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory,
+        httpCache, moshi, dispatcher, logger, tracker, sendOperationIdentifiers);
   }
 
   /**
@@ -193,6 +196,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
         .tracker(tracker)
         .refetchQueries(Collections.<Query>emptyList())
         .refetchQueryNames(Collections.<OperationName>emptyList())
+        .sendOperationIdentifiers(sendOperationIdentifiers)
         .build();
   }
 
@@ -214,6 +218,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     HttpCache httpCache;
     ApolloLogger apolloLogger;
     final List<ApolloInterceptor> applicationInterceptors = new ArrayList<>();
+    boolean sendOperationIdentifiers;
 
     private Builder() {
     }
@@ -378,6 +383,17 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
      */
     public Builder addApplicationInterceptor(@Nonnull ApolloInterceptor interceptor) {
       applicationInterceptors.add(interceptor);
+      return this;
+    }
+
+    /**
+     *
+     * @param sendOperationIdentifiers True if ApolloClient should send a operation identifier instead of the operation
+     *                        definition. Default: false.
+     * @return The {@link Builder} object to be used for chaining method calls
+     */
+    public Builder sendOperationIdentifiers(boolean sendOperationIdentifiers) {
+      this.sendOperationIdentifiers = sendOperationIdentifiers;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -36,12 +36,13 @@ import okhttp3.Response;
   final ApolloLogger logger;
   final ApolloCallTracker tracker;
   final ApolloInterceptorChain interceptorChain;
+  final boolean sendOperationIds;
   volatile boolean executed;
   volatile boolean canceled;
 
   public RealApolloPrefetch(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory, HttpCache httpCache,
-      Moshi moshi, ExecutorService dispatcher, ApolloLogger logger, ApolloCallTracker
-      callTracker) {
+      Moshi moshi, ExecutorService dispatcher, ApolloLogger logger, ApolloCallTracker callTracker,
+      boolean sendOperationIds) {
     this.operation = operation;
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
@@ -50,9 +51,10 @@ import okhttp3.Response;
     this.dispatcher = dispatcher;
     this.logger = logger;
     this.tracker = callTracker;
+    this.sendOperationIds = sendOperationIds;
     interceptorChain = new RealApolloInterceptorChain(operation, Collections.<ApolloInterceptor>singletonList(
         new ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, true, moshi,
-            logger)
+            logger, sendOperationIds)
     ));
   }
 
@@ -155,7 +157,8 @@ import okhttp3.Response;
   }
 
   @Override public ApolloPrefetch clone() {
-    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, httpCache, moshi, dispatcher, logger, tracker);
+    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, httpCache, moshi, dispatcher, logger,
+        tracker, sendOperationIds);
   }
 
   @Override public void cancel() {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -15,7 +15,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 
@@ -61,6 +60,10 @@ import static junit.framework.Assert.fail;
 
       @Nonnull @Override public OperationName name() {
         return null;
+      }
+
+      @Nonnull @Override public String operationId() {
+        return "";
       }
 
       @Override public Object wrapData(Data data) {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -42,6 +42,11 @@ import static junit.framework.Assert.fail;
         .build();
 
     emptyQuery = new Query() {
+      OperationName operationName = new OperationName() {
+        @Override public String name() {
+          return "emptyQuery";
+        }
+      };
       @Override public String queryDocument() {
         return "";
       }
@@ -59,7 +64,7 @@ import static junit.framework.Assert.fail;
       }
 
       @Nonnull @Override public OperationName name() {
-        return null;
+        return operationName;
       }
 
       @Nonnull @Override public String operationId() {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
@@ -46,6 +46,10 @@ public class ResponseFetcherTest {
         return null;
       }
 
+      @Nonnull @Override public String operationId() {
+        return "";
+      }
+
       @Override public Object wrapData(Data data) {
         return data;
       }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
@@ -25,7 +25,13 @@ public class ResponseFetcherTest {
 
   @Before public void setUp() {
     okHttpClient = new OkHttpClient.Builder().build();
+
     emptyQuery = new Query() {
+      OperationName operationName = new OperationName() {
+        @Override public String name() {
+          return "emptyQuery";
+        }
+      };
       @Override public String queryDocument() {
         return "";
       }
@@ -43,7 +49,7 @@ public class ResponseFetcherTest {
       }
 
       @Nonnull @Override public OperationName name() {
-        return null;
+        return operationName;
       }
 
       @Nonnull @Override public String operationId() {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
@@ -71,6 +71,10 @@ public class ApolloCallTrackerTest {
     @Nonnull @Override public OperationName name() {
       return operationName;
     }
+
+    @Nonnull @Override public String operationId() {
+      return "";
+    }
   };
 
   private OkHttpClient.Builder okHttpClientBuilder;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -636,6 +636,10 @@ public class ResponseReaderTest {
     @Nonnull @Override public OperationName name() {
       return null;
     }
+
+    @Nonnull @Override public String operationId() {
+      return "";
+    }
   };
 
   @SuppressWarnings("unchecked") private static final ResponseNormalizer NO_OP_NORMALIZER = new ResponseNormalizer() {


### PR DESCRIPTION
- Updates apollo codedgen to 0.15.2 (turns off new fragment spread feature)
- Builds now output a `[Variant]OperationIdMap.json` in the same directory of API.json
Developers can write a script to upload this artifact to the server, so that all the operations in the app can be registered.

closes https://github.com/apollographql/apollo-android/issues/550