### PR TITLE
Null out callback in async operations in Call, Prefetch, and Watcher

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -147,7 +147,7 @@ import okhttp3.Response;
       }
 
       @Override public void onFailure(@Nonnull ApolloException e) {
-        synchronized (RealApolloPrefetch.this){
+        synchronized (RealApolloPrefetch.this) {
           if (!callback.isPresent()) {
             logger.d(e, "onFailure for prefetch of operation: %s. No callback present.", operation.name().name());
             return;


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/560

I played around with weak references, but they seemed a little indeterministic which made testing tough.

- Added more state assertations 
- Because this adds another non-final variable in asyncrhonous code, I added sychronized blocks to the points where the variables are accessed. Because a callback cannot be asserted non-null and called into in one expression, using volatile does not seem sufficient