### PR TITLE
Input field marshaller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 sudo: true
+dist: precise
 
 android:
   components:

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldMarshaller.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldMarshaller.java
@@ -1,0 +1,5 @@
+package com.apollographql.apollo.api;
+
+public interface InputFieldMarshaller {
+  void marshal(InputFieldWriter writer);
+}

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldMarshaller.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldMarshaller.java
@@ -1,5 +1,7 @@
 package com.apollographql.apollo.api;
 
+import java.io.IOException;
+
 public interface InputFieldMarshaller {
-  void marshal(InputFieldWriter writer);
+  void marshal(InputFieldWriter writer) throws IOException;
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
@@ -9,6 +9,8 @@ public interface InputFieldWriter {
 
   void writeInt(@Nonnull String fieldName, Integer value) throws IOException;
 
+  void writeLong(@Nonnull String fieldName, Long value) throws IOException;
+
   void writeDouble(@Nonnull String fieldName, Double value) throws IOException;
 
   void writeBoolean(@Nonnull String fieldName, Boolean value) throws IOException;
@@ -27,6 +29,8 @@ public interface InputFieldWriter {
     void writeString(String value) throws IOException;
 
     void writeInt(Integer value) throws IOException;
+
+    void writeLong(Long value) throws IOException;
 
     void writeDouble(Double value) throws IOException;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
@@ -1,0 +1,39 @@
+package com.apollographql.apollo.api;
+
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+
+public interface InputFieldWriter {
+  void writeString(@Nonnull String fieldName, String value) throws IOException;
+
+  void writeInt(@Nonnull String fieldName, Integer value) throws IOException;
+
+  void writeDouble(@Nonnull String fieldName, Double value) throws IOException;
+
+  void writeBoolean(@Nonnull String fieldName, Boolean value) throws IOException;
+
+  void writeCustom(@Nonnull String fieldName, ScalarType scalarType, Object value) throws IOException;
+
+  void writeObject(@Nonnull String fieldName, InputFieldMarshaller marshaller) throws IOException;
+
+  void writeList(@Nonnull String fieldName, ListWriter listWriter) throws IOException;
+
+  interface ListWriter {
+    void write(@Nonnull ListItemWriter listItemWriter) throws IOException;
+  }
+
+  interface ListItemWriter {
+    void writeString(String value) throws IOException;
+
+    void writeInt(Integer value) throws IOException;
+
+    void writeDouble(Double value) throws IOException;
+
+    void writeBoolean(Boolean value) throws IOException;
+
+    void writeCustom(ScalarType scalarType, Object value) throws IOException;
+
+    void writeObject(InputFieldMarshaller marshaller) throws IOException;
+  }
+}

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -75,6 +75,13 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
     @Nonnull public Map<String, Object> valueMap() {
       return Collections.emptyMap();
     }
+
+    @Nonnull public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override public void marshal(InputFieldWriter writer) {
+        }
+      };
+    }
   }
 
   Variables EMPTY_VARIABLES = new Variables();

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
@@ -1,0 +1,223 @@
+package com.apollographql.apollo.compiler
+
+import com.apollographql.apollo.api.InputFieldWriter
+import com.apollographql.apollo.compiler.ir.CodeGenerationContext
+import com.squareup.javapoet.*
+import java.io.IOException
+import java.util.*
+import javax.lang.model.element.Modifier
+
+class InputFieldSpec(
+    val type: Type,
+    val name: String,
+    val graphQLType: String,
+    val javaType: TypeName,
+    val context: CodeGenerationContext
+) {
+
+  fun writeValueCode(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    return when (type) {
+      Type.STRING,
+      Type.INT,
+      Type.LONG,
+      Type.DOUBLE,
+      Type.BOOLEAN -> writeScalarCode(writerParam)
+      Type.ENUM -> writeEnumCode(writerParam)
+      Type.CUSTOM -> writeCustomCode(writerParam)
+      Type.OBJECT -> writeObjectCode(writerParam, marshaller)
+      Type.SCALAR_LIST -> writeScalarList(writerParam)
+      Type.CUSTOM_LIST -> writeCustomList(writerParam)
+      Type.OBJECT_LIST -> writeObjectList(writerParam, marshaller)
+    }
+  }
+
+  private fun writeScalarCode(writerParam: CodeBlock): CodeBlock {
+    val valueCode = javaType.unwrapOptionalValue(name)
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  private fun writeEnumCode(writerParam: CodeBlock): CodeBlock {
+    val valueCode = javaType.unwrapOptionalValue(name) {
+      CodeBlock.of("\$L.name()", it)
+    }
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  private fun writeCustomCode(writerParam: CodeBlock): CodeBlock {
+    val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
+    val customScalarEnumConst = normalizeGraphQlType(graphQLType).toUpperCase(Locale.ENGLISH)
+    val valueCode = javaType.unwrapOptionalValue(name)
+    return CodeBlock.of("\$L.\$L(\$S, \$L.\$L, \$L);\n", writerParam, WRITE_METHODS[type],
+        name, customScalarEnum, customScalarEnumConst, valueCode)
+  }
+
+  private fun writeObjectCode(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    val valueCode = javaType.unwrapOptionalValue(name) {
+      CodeBlock.of("\$L.\$L", it, marshaller)
+    }
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  private fun writeScalarList(writerParam: CodeBlock): CodeBlock {
+    val rawFieldType = with(javaType) { if (isList()) listParamType() else this }
+    val writeMethod = SCALAR_LIST_ITEM_WRITE_METHODS[rawFieldType] ?: "writeString"
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            javaType.unwrapOptionalValue(name, false))
+        .add(
+            if (rawFieldType.isEnum(context)) {
+              CodeBlock.of("\$L.\$L(\$L.name());\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, "\$item")
+            } else {
+              CodeBlock.of("\$L.\$L(\$L);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, "\$item")
+            })
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(InputFieldWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addException(IOException::class.java)
+            .addParameter(LIST_ITEM_WRITER_PARAM)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = javaType.unwrapOptionalValue(name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  private fun writeCustomList(writerParam: CodeBlock): CodeBlock {
+    val rawFieldType = javaType.let { if (it.isList()) it.listParamType() else it }
+    val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
+    val customScalarEnumConst = normalizeGraphQlType(graphQLType).toUpperCase(Locale.ENGLISH)
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            javaType.unwrapOptionalValue(name, false))
+        .addStatement("\$L.writeCustom(\$T.\$L, \$L)", LIST_ITEM_WRITER_PARAM.name, customScalarEnum,
+            customScalarEnumConst, "\$item")
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(InputFieldWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addParameter(LIST_ITEM_WRITER_PARAM)
+            .addException(IOException::class.java)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = javaType.unwrapOptionalValue(name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  private fun writeObjectList(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
+    val rawFieldType = with(javaType) { if (isList()) listParamType() else this }
+    val writeStatement = CodeBlock.builder()
+        .beginControlFlow("for (\$T \$L : \$L)", rawFieldType, "\$item",
+            javaType.unwrapOptionalValue(name, false))
+        .addStatement("\$L.writeObject(\$L.\$L)", LIST_ITEM_WRITER_PARAM.name, "\$item", marshaller)
+        .endControlFlow()
+        .build()
+    val listWriterType = TypeSpec.anonymousClassBuilder("")
+        .addSuperinterface(InputFieldWriter.ListWriter::class.java)
+        .addMethod(MethodSpec.methodBuilder("write")
+            .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Override::class.java)
+            .addParameter(LIST_ITEM_WRITER_PARAM)
+            .addException(IOException::class.java)
+            .addCode(writeStatement)
+            .build()
+        )
+        .build()
+    val valueCode = javaType.unwrapOptionalValue(name) {
+      CodeBlock.of("\$L", listWriterType)
+    }
+    return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
+  }
+
+  companion object {
+    private val WRITE_METHODS = mapOf(
+        Type.STRING to "writeString",
+        Type.INT to "writeInt",
+        Type.LONG to "writeLong",
+        Type.DOUBLE to "writeDouble",
+        Type.BOOLEAN to "writeBoolean",
+        Type.ENUM to "writeString",
+        Type.CUSTOM to "writeCustom",
+        Type.OBJECT to "writeObject",
+        Type.SCALAR_LIST to "writeList",
+        Type.CUSTOM_LIST to "writeList",
+        Type.OBJECT_LIST to "writeList"
+    )
+    private val SCALAR_LIST_ITEM_WRITE_METHODS = mapOf(
+        ClassNames.STRING to "writeString",
+        TypeName.INT to "writeInt",
+        TypeName.INT.box() to "writeInt",
+        TypeName.LONG to "writeLong",
+        TypeName.LONG.box() to "writeLong",
+        TypeName.DOUBLE to "writeDouble",
+        TypeName.DOUBLE.box() to "writeDouble",
+        TypeName.BOOLEAN to "writeBoolean",
+        TypeName.BOOLEAN.box() to "writeBoolean"
+    )
+    private val LIST_ITEM_WRITER_PARAM =
+        ParameterSpec.builder(InputFieldWriter.ListItemWriter::class.java, "listItemWriter").build()
+
+    fun build(name: String, graphQLType: String, context: CodeGenerationContext): InputFieldSpec {
+      val javaType = JavaTypeResolver(context = context, packageName = "")
+          .resolve(typeName = graphQLType, nullableValueType = NullableValueType.ANNOTATED)
+      val normalizedJavaType = javaType.withoutAnnotations()
+      val type = when {
+        normalizedJavaType.isList() -> {
+          val rawFieldType = normalizedJavaType.let { if (it.isList()) it.listParamType() else it }
+          if (graphQLType.isCustomScalarType(context)) {
+            Type.CUSTOM_LIST
+          } else if (rawFieldType.isScalar(context)) {
+            Type.SCALAR_LIST
+          } else {
+            Type.OBJECT_LIST
+          }
+        }
+        graphQLType.isCustomScalarType(context) -> Type.CUSTOM
+        normalizedJavaType.isScalar(context) -> {
+          when (normalizedJavaType) {
+            TypeName.INT, TypeName.INT.box() -> Type.INT
+            TypeName.LONG, TypeName.LONG.box() -> Type.LONG
+            TypeName.DOUBLE, TypeName.DOUBLE.box() -> Type.DOUBLE
+            TypeName.BOOLEAN, TypeName.BOOLEAN.box() -> Type.BOOLEAN
+            else -> if (normalizedJavaType.isEnum(context)) Type.ENUM else Type.STRING
+          }
+        }
+        else -> Type.OBJECT
+      }
+      return InputFieldSpec(
+          type = type,
+          name = name,
+          graphQLType = graphQLType,
+          javaType = javaType,
+          context = context
+      )
+    }
+  }
+
+  enum class Type {
+    STRING,
+    INT,
+    LONG,
+    DOUBLE,
+    BOOLEAN,
+    ENUM,
+    OBJECT,
+    SCALAR_LIST,
+    CUSTOM_LIST,
+    OBJECT_LIST,
+    CUSTOM,
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
@@ -12,7 +12,7 @@ class JavaTypeResolver(
     private val packageName: String,
     private val deprecated: Boolean = false
 ) {
-  fun resolve(typeName: String, isOptional: Boolean = !typeName.endsWith("!")): TypeName {
+  fun resolve(typeName: String, isOptional: Boolean = !typeName.endsWith("!"), nullableValueType: NullableValueType? = null): TypeName {
     val normalizedTypeName = typeName.removeSuffix("!")
     val isList = normalizedTypeName.startsWith('[') && normalizedTypeName.endsWith(']')
     val customScalarType = context.customTypeMap[normalizedTypeName]
@@ -30,7 +30,7 @@ class JavaTypeResolver(
     return if (javaType.isPrimitive) {
       javaType.let { if (deprecated) it.annotated(Annotations.DEPRECATED) else it }
     } else if (isOptional) {
-      when (context.nullableValueType) {
+      when (nullableValueType ?: context.nullableValueType) {
         NullableValueType.APOLLO_OPTIONAL -> parameterizedOptional(javaType)
         NullableValueType.GUAVA_OPTIONAL -> parameterizedGuavaOptional(javaType)
         NullableValueType.JAVA_OPTIONAL -> parameterizedJavaOptional(javaType)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.compiler.ir
 
 import com.apollographql.apollo.compiler.Annotations
-import com.apollographql.apollo.compiler.InputObjectTypeSpecBuilder
+import com.apollographql.apollo.compiler.InputTypeSpecBuilder
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
@@ -69,7 +69,7 @@ data class TypeDeclaration(
   }
 
   private fun inputObjectToTypeSpec(context: CodeGenerationContext) =
-      InputObjectTypeSpecBuilder(name, fields ?: emptyList(), context).build()
+      InputTypeSpecBuilder(name, fields ?: emptyList(), context).build()
 
   companion object {
     val KIND_INPUT_OBJECT_TYPE: String = "InputObjectType"

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -1,5 +1,7 @@
 package com.example.arguments_complex;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
@@ -11,6 +13,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_complex.type.Episode;
+import java.io.IOException;
 import java.lang.Double;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -110,6 +113,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("episode", episode != null ? episode.name() : null);
+          writer.writeInt("stars", stars);
+          writer.writeDouble("greenValue", greenValue);
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -1,5 +1,7 @@
 package com.example.arguments_simple;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
@@ -11,6 +13,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.arguments_simple.type.Episode;
+import java.io.IOException;
 import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
@@ -100,6 +103,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("episode", episode != null ? episode.name() : null);
+          writer.writeBoolean("includeName", includeName);
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -1,5 +1,7 @@
 package com.example.deprecation;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
@@ -11,6 +13,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.deprecation.type.Episode;
+import java.io.IOException;
 import java.lang.Deprecated;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -94,6 +97,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("episode", episode != null ? episode.name() : null);
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
@@ -133,6 +133,21 @@
 					"description": "for test purpose only",
 					"type": "Episode",
 					"defaultValue": "JEDI"
+				},
+				{
+					"name": "nullableEnum",
+					"description": "for test purpose only",
+					"type": "Episode"
+				},
+				{
+					"name": "listOfCustomScalar",
+					"description": "for test purpose only",
+					"type": "[Date]"
+				},
+				{
+					"name": "listOfEnums",
+					"description": "for test purpose only",
+					"type": "[Episode]"
 				}
 			]
 		},
@@ -158,8 +173,19 @@
 					"description": "Blue color",
 					"type": "Float!",
 					"defaultValue": 1.5
+				},
+				{
+					"name": "enumWithDefaultValue",
+					"description": "for test purpose only",
+					"type": "Episode",
+					"defaultValue": "JEDI"
 				}
 			]
+		},
+		{
+			"kind": "ScalarType",
+			"name": "Date",
+			"description": "The `Date` scalar type represents date format."
 		}
 	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -1,5 +1,7 @@
 package com.example.input_object_type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
@@ -13,6 +15,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.input_object_type.type.Episode;
 import com.example.input_object_type.type.ReviewInput;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -106,6 +109,17 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("ep", ep.name());
+          writer.writeObject("review", review.marshaller());
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
@@ -1,6 +1,10 @@
 package com.example.input_object_type.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.Double;
+import java.lang.Override;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
@@ -12,10 +16,13 @@ public final class ColorInput {
 
   private final double blue;
 
-  ColorInput(int red, @Nullable Double green, double blue) {
+  private final @Nullable Episode enumWithDefaultValue;
+
+  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
+    this.enumWithDefaultValue = enumWithDefaultValue;
   }
 
   /**
@@ -39,8 +46,27 @@ public final class ColorInput {
     return this.blue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode enumWithDefaultValue() {
+    return this.enumWithDefaultValue;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("red", red);
+        writer.writeDouble("green", green);
+        writer.writeDouble("blue", blue);
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -49,6 +75,8 @@ public final class ColorInput {
     private @Nullable Double green = 0.0;
 
     private double blue = 1.5;
+
+    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
 
     Builder() {
     }
@@ -77,8 +105,16 @@ public final class ColorInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
+      this.enumWithDefaultValue = enumWithDefaultValue;
+      return this;
+    }
+
     public ColorInput build() {
-      return new ColorInput(red, green, blue);
+      return new ColorInput(red, green, blue, enumWithDefaultValue);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/CustomType.java
@@ -1,0 +1,23 @@
+package com.example.input_object_type.type;
+
+import com.apollographql.apollo.api.ScalarType;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Date;
+import javax.annotation.Generated;
+
+@Generated("Apollo GraphQL")
+public enum CustomType implements ScalarType {
+  DATE {
+    @Override
+    public String typeName() {
+      return "Date";
+    }
+
+    @Override
+    public Class javaType() {
+      return Date.class;
+    }
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -1,8 +1,14 @@
 package com.example.input_object_type.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Integer;
+import java.lang.Override;
 import java.lang.String;
+import java.util.Date;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,14 +25,24 @@ public final class ReviewInput {
 
   private final @Nullable Episode enumWithDefaultValue;
 
+  private final @Nullable Episode nullableEnum;
+
+  private final @Nullable List<Date> listOfCustomScalar;
+
+  private final @Nullable List<Episode> listOfEnums;
+
   ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
       @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue) {
+      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
+      @Nullable List<Date> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
     this.favoriteColor = favoriteColor;
     this.enumWithDefaultValue = enumWithDefaultValue;
+    this.nullableEnum = nullableEnum;
+    this.listOfCustomScalar = listOfCustomScalar;
+    this.listOfEnums = listOfEnums;
   }
 
   /**
@@ -64,8 +80,59 @@ public final class ReviewInput {
     return this.enumWithDefaultValue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode nullableEnum() {
+    return this.nullableEnum;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Date> listOfCustomScalar() {
+    return this.listOfCustomScalar;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Episode> listOfEnums() {
+    return this.listOfEnums;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("stars", stars);
+        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
+        writer.writeString("commentary", commentary);
+        writer.writeObject("favoriteColor", favoriteColor.marshaller());
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
+        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Date $item : listOfCustomScalar) {
+              listItemWriter.writeCustom(CustomType.DATE, $item);
+            }
+          }
+        } : null);
+        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Episode $item : listOfEnums) {
+              listItemWriter.writeString($item.name());
+            }
+          }
+        } : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -78,6 +145,12 @@ public final class ReviewInput {
     private @Nonnull ColorInput favoriteColor;
 
     private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+
+    private @Nullable Episode nullableEnum;
+
+    private @Nullable List<Date> listOfCustomScalar;
+
+    private @Nullable List<Episode> listOfEnums;
 
     Builder() {
     }
@@ -122,9 +195,33 @@ public final class ReviewInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder nullableEnum(@Nullable Episode nullableEnum) {
+      this.nullableEnum = nullableEnum;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfCustomScalar(@Nullable List<Date> listOfCustomScalar) {
+      this.listOfCustomScalar = listOfCustomScalar;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
+      this.listOfEnums = listOfEnums;
+      return this;
+    }
+
     public ReviewInput build() {
       if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
-      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue);
+      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -1,5 +1,7 @@
 package com.example.mutation_create_review;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
@@ -13,6 +15,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.mutation_create_review.type.Episode;
 import com.example.mutation_create_review.type.ReviewInput;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -106,6 +109,17 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("ep", ep.name());
+          writer.writeObject("review", review.marshaller());
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
@@ -133,6 +133,21 @@
 					"description": "for test purpose only",
 					"type": "Episode",
 					"defaultValue": "JEDI"
+				},
+				{
+					"name": "nullableEnum",
+					"description": "for test purpose only",
+					"type": "Episode"
+				},
+				{
+					"name": "listOfCustomScalar",
+					"description": "for test purpose only",
+					"type": "[Date]"
+				},
+				{
+					"name": "listOfEnums",
+					"description": "for test purpose only",
+					"type": "[Episode]"
 				}
 			]
 		},
@@ -158,8 +173,19 @@
 					"description": "Blue color",
 					"type": "Float!",
 					"defaultValue": 1.5
+				},
+				{
+					"name": "enumWithDefaultValue",
+					"description": "for test purpose only",
+					"type": "Episode",
+					"defaultValue": "JEDI"
 				}
 			]
+		},
+		{
+			"kind": "ScalarType",
+			"name": "Date",
+			"description": "The `Date` scalar type represents date format."
 		}
 	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
@@ -1,6 +1,10 @@
 package com.example.mutation_create_review.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.Double;
+import java.lang.Override;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
@@ -12,10 +16,13 @@ public final class ColorInput {
 
   private final double blue;
 
-  ColorInput(int red, @Nullable Double green, double blue) {
+  private final @Nullable Episode enumWithDefaultValue;
+
+  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
+    this.enumWithDefaultValue = enumWithDefaultValue;
   }
 
   /**
@@ -39,8 +46,27 @@ public final class ColorInput {
     return this.blue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode enumWithDefaultValue() {
+    return this.enumWithDefaultValue;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("red", red);
+        writer.writeDouble("green", green);
+        writer.writeDouble("blue", blue);
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -49,6 +75,8 @@ public final class ColorInput {
     private @Nullable Double green = 0.0;
 
     private double blue = 1.5;
+
+    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
 
     Builder() {
     }
@@ -77,8 +105,16 @@ public final class ColorInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
+      this.enumWithDefaultValue = enumWithDefaultValue;
+      return this;
+    }
+
     public ColorInput build() {
-      return new ColorInput(red, green, blue);
+      return new ColorInput(red, green, blue, enumWithDefaultValue);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.java
@@ -1,0 +1,22 @@
+package com.example.mutation_create_review.type;
+
+import com.apollographql.apollo.api.ScalarType;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.Generated;
+
+@Generated("Apollo GraphQL")
+public enum CustomType implements ScalarType {
+  DATE {
+    @Override
+    public String typeName() {
+      return "Date";
+    }
+
+    @Override
+    public Class javaType() {
+      return Object.class;
+    }
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -1,8 +1,13 @@
 package com.example.mutation_create_review.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Integer;
+import java.lang.Override;
 import java.lang.String;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,14 +24,24 @@ public final class ReviewInput {
 
   private final @Nullable Episode enumWithDefaultValue;
 
+  private final @Nullable Episode nullableEnum;
+
+  private final @Nullable List<Object> listOfCustomScalar;
+
+  private final @Nullable List<Episode> listOfEnums;
+
   ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
       @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue) {
+      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
+      @Nullable List<Object> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
     this.favoriteColor = favoriteColor;
     this.enumWithDefaultValue = enumWithDefaultValue;
+    this.nullableEnum = nullableEnum;
+    this.listOfCustomScalar = listOfCustomScalar;
+    this.listOfEnums = listOfEnums;
   }
 
   /**
@@ -64,8 +79,59 @@ public final class ReviewInput {
     return this.enumWithDefaultValue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode nullableEnum() {
+    return this.nullableEnum;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Object> listOfCustomScalar() {
+    return this.listOfCustomScalar;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Episode> listOfEnums() {
+    return this.listOfEnums;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("stars", stars);
+        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
+        writer.writeString("commentary", commentary);
+        writer.writeObject("favoriteColor", favoriteColor.marshaller());
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
+        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Object $item : listOfCustomScalar) {
+              listItemWriter.writeCustom(CustomType.DATE, $item);
+            }
+          }
+        } : null);
+        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Episode $item : listOfEnums) {
+              listItemWriter.writeString($item.name());
+            }
+          }
+        } : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -78,6 +144,12 @@ public final class ReviewInput {
     private @Nonnull ColorInput favoriteColor;
 
     private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+
+    private @Nullable Episode nullableEnum;
+
+    private @Nullable List<Object> listOfCustomScalar;
+
+    private @Nullable List<Episode> listOfEnums;
 
     Builder() {
     }
@@ -122,9 +194,33 @@ public final class ReviewInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder nullableEnum(@Nullable Episode nullableEnum) {
+      this.nullableEnum = nullableEnum;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfCustomScalar(@Nullable List<Object> listOfCustomScalar) {
+      this.listOfCustomScalar = listOfCustomScalar;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
+      this.listOfEnums = listOfEnums;
+      return this;
+    }
+
     public ReviewInput build() {
       if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
-      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue);
+      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -1,5 +1,7 @@
 package com.example.mutation_create_review_semantic_naming;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
@@ -13,6 +15,7 @@ import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.mutation_create_review_semantic_naming.type.Episode;
 import com.example.mutation_create_review_semantic_naming.type.ReviewInput;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -106,6 +109,17 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("ep", ep.name());
+          writer.writeObject("review", review.marshaller());
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
@@ -133,6 +133,21 @@
 					"description": "for test purpose only",
 					"type": "Episode",
 					"defaultValue": "JEDI"
+				},
+				{
+					"name": "nullableEnum",
+					"description": "for test purpose only",
+					"type": "Episode"
+				},
+				{
+					"name": "listOfCustomScalar",
+					"description": "for test purpose only",
+					"type": "[Date]"
+				},
+				{
+					"name": "listOfEnums",
+					"description": "for test purpose only",
+					"type": "[Episode]"
 				}
 			]
 		},
@@ -158,8 +173,19 @@
 					"description": "Blue color",
 					"type": "Float!",
 					"defaultValue": 1.5
+				},
+				{
+					"name": "enumWithDefaultValue",
+					"description": "for test purpose only",
+					"type": "Episode",
+					"defaultValue": "JEDI"
 				}
 			]
+		},
+		{
+			"kind": "ScalarType",
+			"name": "Date",
+			"description": "The `Date` scalar type represents date format."
 		}
 	]
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
@@ -1,6 +1,10 @@
 package com.example.mutation_create_review_semantic_naming.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.Double;
+import java.lang.Override;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
 
@@ -12,10 +16,13 @@ public final class ColorInput {
 
   private final double blue;
 
-  ColorInput(int red, @Nullable Double green, double blue) {
+  private final @Nullable Episode enumWithDefaultValue;
+
+  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
+    this.enumWithDefaultValue = enumWithDefaultValue;
   }
 
   /**
@@ -39,8 +46,27 @@ public final class ColorInput {
     return this.blue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode enumWithDefaultValue() {
+    return this.enumWithDefaultValue;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("red", red);
+        writer.writeDouble("green", green);
+        writer.writeDouble("blue", blue);
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -49,6 +75,8 @@ public final class ColorInput {
     private @Nullable Double green = 0.0;
 
     private double blue = 1.5;
+
+    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
 
     Builder() {
     }
@@ -77,8 +105,16 @@ public final class ColorInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
+      this.enumWithDefaultValue = enumWithDefaultValue;
+      return this;
+    }
+
     public ColorInput build() {
-      return new ColorInput(red, green, blue);
+      return new ColorInput(red, green, blue, enumWithDefaultValue);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/CustomType.java
@@ -1,0 +1,22 @@
+package com.example.mutation_create_review_semantic_naming.type;
+
+import com.apollographql.apollo.api.ScalarType;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.String;
+import javax.annotation.Generated;
+
+@Generated("Apollo GraphQL")
+public enum CustomType implements ScalarType {
+  DATE {
+    @Override
+    public String typeName() {
+      return "Date";
+    }
+
+    @Override
+    public Class javaType() {
+      return Object.class;
+    }
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -1,8 +1,13 @@
 package com.example.mutation_create_review_semantic_naming.type;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Integer;
+import java.lang.Override;
 import java.lang.String;
+import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -19,14 +24,24 @@ public final class ReviewInput {
 
   private final @Nullable Episode enumWithDefaultValue;
 
+  private final @Nullable Episode nullableEnum;
+
+  private final @Nullable List<Object> listOfCustomScalar;
+
+  private final @Nullable List<Episode> listOfEnums;
+
   ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
       @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue) {
+      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
+      @Nullable List<Object> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
     this.favoriteColor = favoriteColor;
     this.enumWithDefaultValue = enumWithDefaultValue;
+    this.nullableEnum = nullableEnum;
+    this.listOfCustomScalar = listOfCustomScalar;
+    this.listOfEnums = listOfEnums;
   }
 
   /**
@@ -64,8 +79,59 @@ public final class ReviewInput {
     return this.enumWithDefaultValue;
   }
 
+  /**
+   * for test purpose only
+   */
+  public @Nullable Episode nullableEnum() {
+    return this.nullableEnum;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Object> listOfCustomScalar() {
+    return this.listOfCustomScalar;
+  }
+
+  /**
+   * for test purpose only
+   */
+  public @Nullable List<Episode> listOfEnums() {
+    return this.listOfEnums;
+  }
+
   public static Builder builder() {
     return new Builder();
+  }
+
+  public InputFieldMarshaller marshaller() {
+    return new InputFieldMarshaller() {
+      @Override
+      public void marshal(InputFieldWriter writer) throws IOException {
+        writer.writeInt("stars", stars);
+        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
+        writer.writeString("commentary", commentary);
+        writer.writeObject("favoriteColor", favoriteColor.marshaller());
+        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
+        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Object $item : listOfCustomScalar) {
+              listItemWriter.writeCustom(CustomType.DATE, $item);
+            }
+          }
+        } : null);
+        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
+          @Override
+          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+            for (Episode $item : listOfEnums) {
+              listItemWriter.writeString($item.name());
+            }
+          }
+        } : null);
+      }
+    };
   }
 
   public static final class Builder {
@@ -78,6 +144,12 @@ public final class ReviewInput {
     private @Nonnull ColorInput favoriteColor;
 
     private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+
+    private @Nullable Episode nullableEnum;
+
+    private @Nullable List<Object> listOfCustomScalar;
+
+    private @Nullable List<Episode> listOfEnums;
 
     Builder() {
     }
@@ -122,9 +194,33 @@ public final class ReviewInput {
       return this;
     }
 
+    /**
+     * for test purpose only
+     */
+    public Builder nullableEnum(@Nullable Episode nullableEnum) {
+      this.nullableEnum = nullableEnum;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfCustomScalar(@Nullable List<Object> listOfCustomScalar) {
+      this.listOfCustomScalar = listOfCustomScalar;
+      return this;
+    }
+
+    /**
+     * for test purpose only
+     */
+    public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
+      this.listOfEnums = listOfEnums;
+      return this;
+    }
+
     public ReviewInput build() {
       if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
-      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue);
+      return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -1,5 +1,7 @@
 package com.example.nested_conditional_inline;
 
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
@@ -11,6 +13,7 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.example.nested_conditional_inline.type.Episode;
+import java.io.IOException;
 import java.lang.Double;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -117,6 +120,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @Override
     public Map<String, Object> valueMap() {
       return Collections.unmodifiableMap(valueMap);
+    }
+
+    @Override
+    public InputFieldMarshaller marshaller() {
+      return new InputFieldMarshaller() {
+        @Override
+        public void marshal(InputFieldWriter writer) throws IOException {
+          writer.writeString("episode", episode != null ? episode.name() : null);
+        }
+      };
     }
   }
 

--- a/apollo-compiler/src/test/graphql/schema.json
+++ b/apollo-compiler/src/test/graphql/schema.json
@@ -1653,6 +1653,44 @@
                 "ofType": null
               },
               "defaultValue": "JEDI"
+            },
+            {
+              "name": "nullableEnum",
+              "description": "for test purpose only",
+              "type": {
+                "kind": "ENUM",
+                "name": "Episode",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "listOfCustomScalar",
+              "description": "for test purpose only",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Date",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "name": "listOfEnums",
+              "description": "for test purpose only",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "Episode",
+                  "ofType": null
+                }
+              }
             }
           ],
           "interfaces": null,
@@ -1702,6 +1740,16 @@
                 }
               },
               "defaultValue": "1.5"
+            },
+            {
+              "name": "enumWithDefaultValue",
+              "description": "for test purpose only",
+              "type": {
+                "kind": "ENUM",
+                "name": "Episode",
+                "ofType": null
+              },
+              "defaultValue": "JEDI"
             }
           ],
           "interfaces": null,

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -64,7 +64,7 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
       return File("src/test/graphql/com/example/").listFiles()
           .filter { it.isDirectory }
           .map {
-            val customTypeMap = if (it.name == "custom_scalar_type") {
+            val customTypeMap = if (it.name == "custom_scalar_type" || it.name == "input_object_type") {
               mapOf("Date" to "java.util.Date", "URL" to "java.lang.String")
             } else {
               emptyMap()

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -22,6 +22,7 @@ apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 tasks.withType(Checkstyle) {
   exclude '**/BufferedSourceJsonReader.java'
   exclude '**/JsonScope.java'
+  exclude '**/JsonUtf8Writer.java'
 }
 
 javadoc {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
@@ -1,0 +1,144 @@
+package com.apollographql.apollo.internal.json;
+
+import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.api.InputFieldMarshaller;
+import com.apollographql.apollo.api.InputFieldWriter;
+import com.apollographql.apollo.api.ScalarType;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
+public class InputFieldJsonWriter implements InputFieldWriter {
+  private final JsonWriter jsonWriter;
+  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+
+  public InputFieldJsonWriter(JsonWriter jsonWriter, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+    this.jsonWriter = jsonWriter;
+    this.customTypeAdapters = customTypeAdapters;
+  }
+
+  @Override public void writeString(@Nonnull String fieldName, String value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (value != null) {
+      jsonWriter.name(fieldName).value(value);
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  @Override public void writeInt(@Nonnull String fieldName, Integer value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (value != null) {
+      jsonWriter.name(fieldName).value(value);
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  @Override public void writeDouble(@Nonnull String fieldName, Double value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (value != null) {
+      jsonWriter.name(fieldName).value(value);
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  @Override public void writeBoolean(@Nonnull String fieldName, Boolean value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (value != null) {
+      jsonWriter.name(fieldName).value(value);
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  @Override public void writeCustom(@Nonnull String fieldName, ScalarType scalarType, Object value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    CustomTypeAdapter customTypeAdapter = customTypeAdapters.get(scalarType);
+    if (customTypeAdapter != null) {
+      writeString(fieldName, customTypeAdapter.encode(value));
+    } else {
+      writeString(fieldName, value != null ? value.toString() : null);
+    }
+  }
+
+  @Override public void writeObject(@Nonnull String fieldName, InputFieldMarshaller marshaller) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (marshaller != null) {
+      jsonWriter.name(fieldName).beginObject();
+      marshaller.marshal(this);
+      jsonWriter.endObject();
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  @Override public void writeList(@Nonnull String fieldName, ListWriter listWriter) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (listWriter != null) {
+      jsonWriter.name(fieldName).beginArray();
+      listWriter.write(new JsonListItemWriter(jsonWriter, customTypeAdapters));
+      jsonWriter.endArray();
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
+  private static final class JsonListItemWriter implements ListItemWriter {
+    private final JsonWriter jsonWriter;
+    private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+
+    JsonListItemWriter(JsonWriter jsonWriter, Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
+      this.jsonWriter = jsonWriter;
+      this.customTypeAdapters = customTypeAdapters;
+    }
+
+    @Override public void writeString(String value) throws IOException {
+      if (value != null) {
+        jsonWriter.value(value);
+      }
+    }
+
+    @Override public void writeInt(Integer value) throws IOException {
+      if (value != null) {
+        jsonWriter.value(value);
+      }
+    }
+
+    @Override public void writeDouble(Double value) throws IOException {
+      if (value != null) {
+        jsonWriter.value(value);
+      }
+    }
+
+    @Override public void writeBoolean(Boolean value) throws IOException {
+      if (value != null) {
+        jsonWriter.value(value);
+      }
+    }
+
+    @Override public void writeCustom(ScalarType scalarType, Object value) throws IOException {
+      if (value == null) {
+        return;
+      }
+
+      CustomTypeAdapter customTypeAdapter = customTypeAdapters.get(scalarType);
+      if (customTypeAdapter != null) {
+        writeString(customTypeAdapter.encode(value));
+      } else {
+        writeString(value.toString());
+      }
+    }
+
+    @Override public void writeObject(InputFieldMarshaller marshaller) throws IOException {
+      if (marshaller != null) {
+        marshaller.marshal(new InputFieldJsonWriter(jsonWriter, customTypeAdapters));
+      }
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
@@ -39,6 +39,15 @@ public class InputFieldJsonWriter implements InputFieldWriter {
     }
   }
 
+  @Override public void writeLong(@Nonnull String fieldName, Long value) throws IOException {
+    checkNotNull(fieldName, "fieldName == null");
+    if (value != null) {
+      jsonWriter.name(fieldName).value(value);
+    } else {
+      jsonWriter.name(fieldName).nullValue();
+    }
+  }
+
   @Override public void writeDouble(@Nonnull String fieldName, Double value) throws IOException {
     checkNotNull(fieldName, "fieldName == null");
     if (value != null) {
@@ -105,6 +114,12 @@ public class InputFieldJsonWriter implements InputFieldWriter {
     }
 
     @Override public void writeInt(Integer value) throws IOException {
+      if (value != null) {
+        jsonWriter.value(value);
+      }
+    }
+
+    @Override public void writeLong(Long value) throws IOException {
       if (value != null) {
         jsonWriter.value(value);
       }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonUtf8Writer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonUtf8Writer.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.internal.json;
+
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import okio.BufferedSink;
+import okio.Sink;
+
+import static com.apollographql.apollo.internal.json.JsonScope.DANGLING_NAME;
+import static com.apollographql.apollo.internal.json.JsonScope.EMPTY_ARRAY;
+import static com.apollographql.apollo.internal.json.JsonScope.EMPTY_DOCUMENT;
+import static com.apollographql.apollo.internal.json.JsonScope.EMPTY_OBJECT;
+import static com.apollographql.apollo.internal.json.JsonScope.NONEMPTY_ARRAY;
+import static com.apollographql.apollo.internal.json.JsonScope.NONEMPTY_DOCUMENT;
+import static com.apollographql.apollo.internal.json.JsonScope.NONEMPTY_OBJECT;
+
+final class JsonUtf8Writer extends JsonWriter {
+
+  /*
+   * From RFC 7159, "All Unicode characters may be placed within the
+   * quotation marks except for the characters that must be escaped:
+   * quotation mark, reverse solidus, and the control characters
+   * (U+0000 through U+001F)."
+   *
+   * We also escape '\u2028' and '\u2029', which JavaScript interprets as
+   * newline characters. This prevents eval() from failing with a syntax
+   * error. http://code.google.com/p/google-gson/issues/detail?id=341
+   */
+  private static final String[] REPLACEMENT_CHARS;
+  static {
+    REPLACEMENT_CHARS = new String[128];
+    for (int i = 0; i <= 0x1f; i++) {
+      REPLACEMENT_CHARS[i] = String.format("\\u%04x", (int) i);
+    }
+    REPLACEMENT_CHARS['"'] = "\\\"";
+    REPLACEMENT_CHARS['\\'] = "\\\\";
+    REPLACEMENT_CHARS['\t'] = "\\t";
+    REPLACEMENT_CHARS['\b'] = "\\b";
+    REPLACEMENT_CHARS['\n'] = "\\n";
+    REPLACEMENT_CHARS['\r'] = "\\r";
+    REPLACEMENT_CHARS['\f'] = "\\f";
+  }
+
+  /** The output data, containing at most one top-level array or object. */
+  private final BufferedSink sink;
+
+  /** The name/value separator; either ":" or ": ". */
+  private String separator = ":";
+
+  private String deferredName;
+
+  JsonUtf8Writer(BufferedSink sink) {
+    if (sink == null) {
+      throw new NullPointerException("sink == null");
+    }
+    this.sink = sink;
+    pushScope(EMPTY_DOCUMENT);
+  }
+
+  @Override public void setIndent(String indent) {
+    super.setIndent(indent);
+    this.separator = !indent.isEmpty() ? ": " : ":";
+  }
+
+  @Override public JsonWriter beginArray() throws IOException {
+    writeDeferredName();
+    return open(EMPTY_ARRAY, "[");
+  }
+
+  @Override public JsonWriter endArray() throws IOException {
+    return close(EMPTY_ARRAY, NONEMPTY_ARRAY, "]");
+  }
+
+  @Override public JsonWriter beginObject() throws IOException {
+    writeDeferredName();
+    return open(EMPTY_OBJECT, "{");
+  }
+
+  @Override public JsonWriter endObject() throws IOException {
+    promoteValueToName = false;
+    return close(EMPTY_OBJECT, NONEMPTY_OBJECT, "}");
+  }
+
+  /**
+   * Enters a new scope by appending any necessary whitespace and the given
+   * bracket.
+   */
+  private JsonWriter open(int empty, String openBracket) throws IOException {
+    beforeValue();
+    pushScope(empty);
+    pathIndices[stackSize - 1] = 0;
+    sink.writeUtf8(openBracket);
+    return this;
+  }
+
+  /**
+   * Closes the current scope by appending any necessary whitespace and the
+   * given bracket.
+   */
+  private JsonWriter close(int empty, int nonempty, String closeBracket) throws IOException {
+    int context = peekScope();
+    if (context != nonempty && context != empty) {
+      throw new IllegalStateException("Nesting problem.");
+    }
+    if (deferredName != null) {
+      throw new IllegalStateException("Dangling name: " + deferredName);
+    }
+
+    stackSize--;
+    pathNames[stackSize] = null; // Free the last path name so that it can be garbage collected!
+    pathIndices[stackSize - 1]++;
+    if (context == nonempty) {
+      newline();
+    }
+    sink.writeUtf8(closeBracket);
+    return this;
+  }
+
+  @Override public JsonWriter name(String name) throws IOException {
+    if (name == null) {
+      throw new NullPointerException("name == null");
+    }
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    if (deferredName != null) {
+      throw new IllegalStateException("Nesting problem.");
+    }
+    deferredName = name;
+    pathNames[stackSize - 1] = name;
+    promoteValueToName = false;
+    return this;
+  }
+
+  private void writeDeferredName() throws IOException {
+    if (deferredName != null) {
+      beforeName();
+      string(sink, deferredName);
+      deferredName = null;
+    }
+  }
+
+  @Override public JsonWriter value(String value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    if (promoteValueToName) {
+      return name(value);
+    }
+    writeDeferredName();
+    beforeValue();
+    string(sink, value);
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  @Override public JsonWriter nullValue() throws IOException {
+    if (deferredName != null) {
+      if (serializeNulls) {
+        writeDeferredName();
+      } else {
+        deferredName = null;
+        return this; // skip the name and the value
+      }
+    }
+    beforeValue();
+    sink.writeUtf8("null");
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  @Override public JsonWriter value(boolean value) throws IOException {
+    writeDeferredName();
+    beforeValue();
+    sink.writeUtf8(value ? "true" : "false");
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  @Override public JsonWriter value(Boolean value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    return value(value.booleanValue());
+  }
+
+  @Override public JsonWriter value(double value) throws IOException {
+    if (!lenient && (Double.isNaN(value) || Double.isInfinite(value))) {
+      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+    }
+    if (promoteValueToName) {
+      return name(Double.toString(value));
+    }
+    writeDeferredName();
+    beforeValue();
+    sink.writeUtf8(Double.toString(value));
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  @Override public JsonWriter value(long value) throws IOException {
+    if (promoteValueToName) {
+      return name(Long.toString(value));
+    }
+    writeDeferredName();
+    beforeValue();
+    sink.writeUtf8(Long.toString(value));
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  @Override public JsonWriter value(@Nullable Number value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+
+    String string = value.toString();
+    if (!lenient
+        && (string.equals("-Infinity") || string.equals("Infinity") || string.equals("NaN"))) {
+      throw new IllegalArgumentException("Numeric values must be finite, but was " + value);
+    }
+    if (promoteValueToName) {
+      return name(string);
+    }
+    writeDeferredName();
+    beforeValue();
+    sink.writeUtf8(string);
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
+  /**
+   * Ensures all buffered data is written to the underlying {@link Sink}
+   * and flushes that writer.
+   */
+  @Override public void flush() throws IOException {
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    sink.flush();
+  }
+
+  /**
+   * Flushes and closes this writer and the underlying {@link Sink}.
+   *
+   * @throws JsonDataException if the JSON document is incomplete.
+   */
+  @Override public void close() throws IOException {
+    sink.close();
+
+    int size = stackSize;
+    if (size > 1 || size == 1 && scopes[size - 1] != NONEMPTY_DOCUMENT) {
+      throw new IOException("Incomplete document");
+    }
+    stackSize = 0;
+  }
+
+  /**
+   * Writes {@code value} as a string literal to {@code sink}. This wraps the value in double quotes
+   * and escapes those characters that require it.
+   */
+  static void string(BufferedSink sink, String value) throws IOException {
+    String[] replacements = REPLACEMENT_CHARS;
+    sink.writeByte('"');
+    int last = 0;
+    int length = value.length();
+    for (int i = 0; i < length; i++) {
+      char c = value.charAt(i);
+      String replacement;
+      if (c < 128) {
+        replacement = replacements[c];
+        if (replacement == null) {
+          continue;
+        }
+      } else if (c == '\u2028') {
+        replacement = "\\u2028";
+      } else if (c == '\u2029') {
+        replacement = "\\u2029";
+      } else {
+        continue;
+      }
+      if (last < i) {
+        sink.writeUtf8(value, last, i);
+      }
+      sink.writeUtf8(replacement);
+      last = i + 1;
+    }
+    if (last < length) {
+      sink.writeUtf8(value, last, length);
+    }
+    sink.writeByte('"');
+  }
+
+  private void newline() throws IOException {
+    if (indent == null) {
+      return;
+    }
+
+    sink.writeByte('\n');
+    for (int i = 1, size = stackSize; i < size; i++) {
+      sink.writeUtf8(indent);
+    }
+  }
+
+  /**
+   * Inserts any necessary separators and whitespace before a name. Also
+   * adjusts the stack to expect the name's value.
+   */
+  private void beforeName() throws IOException {
+    int context = peekScope();
+    if (context == NONEMPTY_OBJECT) { // first in object
+      sink.writeByte(',');
+    } else if (context != EMPTY_OBJECT) { // not in an object!
+      throw new IllegalStateException("Nesting problem.");
+    }
+    newline();
+    replaceTop(DANGLING_NAME);
+  }
+
+  /**
+   * Inserts any necessary separators and whitespace before a literal value,
+   * inline array, or inline object. Also adjusts the stack to expect either a
+   * closing bracket or another element.
+   */
+  @SuppressWarnings("fallthrough")
+  private void beforeValue() throws IOException {
+    switch (peekScope()) {
+      case NONEMPTY_DOCUMENT:
+        if (!lenient) {
+          throw new IllegalStateException(
+              "JSON must have only one top-level value.");
+        }
+        // fall-through
+      case EMPTY_DOCUMENT: // first in document
+        replaceTop(NONEMPTY_DOCUMENT);
+        break;
+
+      case EMPTY_ARRAY: // first in array
+        replaceTop(NONEMPTY_ARRAY);
+        newline();
+        break;
+
+      case NONEMPTY_ARRAY: // another in array
+        sink.writeByte(',');
+        newline();
+        break;
+
+      case DANGLING_NAME: // value for name
+        sink.writeUtf8(separator);
+        replaceTop(NONEMPTY_OBJECT);
+        break;
+
+      default:
+        throw new IllegalStateException("Nesting problem.");
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonWriter.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) 2010 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.internal.json;
+
+import com.apollographql.apollo.json.JsonDataException;
+
+import java.io.Closeable;
+import java.io.Flushable;
+import java.io.IOException;
+
+import javax.annotation.Nullable;
+
+import okio.BufferedSink;
+
+import static com.apollographql.apollo.internal.json.JsonScope.EMPTY_OBJECT;
+import static com.apollographql.apollo.internal.json.JsonScope.NONEMPTY_OBJECT;
+
+/**
+ * Writes a JSON (<a href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>)
+ * encoded value to a stream, one token at a time. The stream includes both
+ * literal values (strings, numbers, booleans and nulls) as well as the begin
+ * and end delimiters of objects and arrays.
+ *
+ * <h3>Encoding JSON</h3>
+ * To encode your data as JSON, create a new {@code JsonWriter}. Each JSON
+ * document must contain one top-level array or object. Call methods on the
+ * writer as you walk the structure's contents, nesting arrays and objects as
+ * necessary:
+ * <ul>
+ *   <li>To write <strong>arrays</strong>, first call {@link #beginArray()}.
+ *       Write each of the array's elements with the appropriate {@link #value}
+ *       methods or by nesting other arrays and objects. Finally close the array
+ *       using {@link #endArray()}.
+ *   <li>To write <strong>objects</strong>, first call {@link #beginObject()}.
+ *       Write each of the object's properties by alternating calls to
+ *       {@link #name} with the property's value. Write property values with the
+ *       appropriate {@link #value} method or by nesting other objects or arrays.
+ *       Finally close the object using {@link #endObject()}.
+ * </ul>
+ *
+ * <h3>Example</h3>
+ * Suppose we'd like to encode a stream of messages such as the following: <pre> {@code
+ * [
+ *   {
+ *     "id": 912345678901,
+ *     "text": "How do I stream JSON in Java?",
+ *     "geo": null,
+ *     "user": {
+ *       "name": "json_newb",
+ *       "followers_count": 41
+ *      }
+ *   },
+ *   {
+ *     "id": 912345678902,
+ *     "text": "@json_newb just use JsonWriter!",
+ *     "geo": [50.454722, -104.606667],
+ *     "user": {
+ *       "name": "jesse",
+ *       "followers_count": 2
+ *     }
+ *   }
+ * ]}</pre>
+ * This code encodes the above structure: <pre>   {@code
+ *   public void writeJsonStream(BufferedSink sink, List<Message> messages) throws IOException {
+ *     JsonWriter writer = JsonWriter.of(sink);
+ *     writer.setIndent("  ");
+ *     writeMessagesArray(writer, messages);
+ *     writer.close();
+ *   }
+ *
+ *   public void writeMessagesArray(JsonWriter writer, List<Message> messages) throws IOException {
+ *     writer.beginArray();
+ *     for (Message message : messages) {
+ *       writeMessage(writer, message);
+ *     }
+ *     writer.endArray();
+ *   }
+ *
+ *   public void writeMessage(JsonWriter writer, Message message) throws IOException {
+ *     writer.beginObject();
+ *     writer.name("id").value(message.getId());
+ *     writer.name("text").value(message.getText());
+ *     if (message.getGeo() != null) {
+ *       writer.name("geo");
+ *       writeDoublesArray(writer, message.getGeo());
+ *     } else {
+ *       writer.name("geo").nullValue();
+ *     }
+ *     writer.name("user");
+ *     writeUser(writer, message.getUser());
+ *     writer.endObject();
+ *   }
+ *
+ *   public void writeUser(JsonWriter writer, User user) throws IOException {
+ *     writer.beginObject();
+ *     writer.name("name").value(user.getName());
+ *     writer.name("followers_count").value(user.getFollowersCount());
+ *     writer.endObject();
+ *   }
+ *
+ *   public void writeDoublesArray(JsonWriter writer, List<Double> doubles) throws IOException {
+ *     writer.beginArray();
+ *     for (Double value : doubles) {
+ *       writer.value(value);
+ *     }
+ *     writer.endArray();
+ *   }}</pre>
+ *
+ * <p>Each {@code JsonWriter} may be used to write a single JSON stream.
+ * Instances of this class are not thread safe. Calls that would result in a
+ * malformed JSON string will fail with an {@link IllegalStateException}.
+ */
+public abstract class JsonWriter implements Closeable, Flushable {
+  // The nesting stack. Using a manual array rather than an ArrayList saves 20%. This stack permits
+  // up to 32 levels of nesting including the top-level document. Deeper nesting is prone to trigger
+  // StackOverflowErrors.
+  int stackSize = 0;
+  final int[] scopes = new int[32];
+  final String[] pathNames = new String[32];
+  final int[] pathIndices = new int[32];
+
+  /**
+   * A string containing a full set of spaces for a single level of indentation, or null for no
+   * pretty printing.
+   */
+  String indent;
+  boolean lenient;
+  boolean serializeNulls;
+  boolean promoteValueToName;
+
+  /** Returns a new instance that writes UTF-8 encoded JSON to {@code sink}. */
+  public static JsonWriter of(BufferedSink sink) {
+    return new JsonUtf8Writer(sink);
+  }
+
+  JsonWriter() {
+    // Package-private to control subclasses.
+  }
+
+  /** Returns the scope on the top of the stack. */
+  final int peekScope() {
+    if (stackSize == 0) {
+      throw new IllegalStateException("JsonWriter is closed.");
+    }
+    return scopes[stackSize - 1];
+  }
+
+  final void pushScope(int newTop) {
+    if (stackSize == scopes.length) {
+      throw new JsonDataException("Nesting too deep at " + getPath() + ": circular reference?");
+    }
+    scopes[stackSize++] = newTop;
+  }
+
+  /** Replace the value on the top of the stack with the given value. */
+  final void replaceTop(int topOfStack) {
+    scopes[stackSize - 1] = topOfStack;
+  }
+
+  /**
+   * Sets the indentation string to be repeated for each level of indentation
+   * in the encoded document. If {@code indent.isEmpty()} the encoded document
+   * will be compact. Otherwise the encoded document will be more
+   * human-readable.
+   *
+   * @param indent a string containing only whitespace.
+   */
+  public void setIndent(String indent) {
+    this.indent = !indent.isEmpty() ? indent : null;
+  }
+
+  /**
+   * Returns a string containing only whitespace, used for each level of
+   * indentation. If empty, the encoded document will be compact.
+   */
+  public final String getIndent() {
+    return indent != null ? indent : "";
+  }
+
+  /**
+   * Configure this writer to relax its syntax rules. By default, this writer
+   * only emits well-formed JSON as specified by <a
+   * href="http://www.ietf.org/rfc/rfc7159.txt">RFC 7159</a>. Setting the writer
+   * to lenient permits the following:
+   * <ul>
+   *   <li>Top-level values of any type. With strict writing, the top-level
+   *       value must be an object or an array.
+   *   <li>Numbers may be {@linkplain Double#isNaN() NaNs} or {@linkplain
+   *       Double#isInfinite() infinities}.
+   * </ul>
+   */
+  public final void setLenient(boolean lenient) {
+    this.lenient = lenient;
+  }
+
+  /**
+   * Returns true if this writer has relaxed syntax rules.
+   */
+  public final boolean isLenient() {
+    return lenient;
+  }
+
+  /**
+   * Sets whether object members are serialized when their value is null.
+   * This has no impact on array elements. The default is false.
+   */
+  public final void setSerializeNulls(boolean serializeNulls) {
+    this.serializeNulls = serializeNulls;
+  }
+
+  /**
+   * Returns true if object members are serialized when their value is null.
+   * This has no impact on array elements. The default is false.
+   */
+  public final boolean getSerializeNulls() {
+    return serializeNulls;
+  }
+
+  /**
+   * Begins encoding a new array. Each call to this method must be paired with
+   * a call to {@link #endArray}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter beginArray() throws IOException;
+
+  /**
+   * Ends encoding the current array.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter endArray() throws IOException;
+
+  /**
+   * Begins encoding a new object. Each call to this method must be paired
+   * with a call to {@link #endObject}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter beginObject() throws IOException;
+
+  /**
+   * Ends encoding the current object.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter endObject() throws IOException;
+
+  /**
+   * Encodes the property name.
+   *
+   * @param name the name of the forthcoming value. Must not be null.
+   * @return this writer.
+   */
+  public abstract JsonWriter name(String name) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value the literal string value, or null to encode a null literal.
+   * @return this writer.
+   */
+  public abstract JsonWriter value(@Nullable String value) throws IOException;
+
+  /**
+   * Encodes {@code null}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter nullValue() throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter value(boolean value) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter value(@Nullable Boolean value) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value a finite value. May not be {@linkplain Double#isNaN() NaNs} or
+   *     {@linkplain Double#isInfinite() infinities}.
+   * @return this writer.
+   */
+  public abstract JsonWriter value(double value) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @return this writer.
+   */
+  public abstract JsonWriter value(long value) throws IOException;
+
+  /**
+   * Encodes {@code value}.
+   *
+   * @param value a finite value. May not be {@linkplain Double#isNaN() NaNs} or
+   *     {@linkplain Double#isInfinite() infinities}.
+   * @return this writer.
+   */
+  public abstract JsonWriter value(@Nullable Number value) throws IOException;
+
+  /**
+   * Changes the writer to treat the next value as a string name. This is useful for map adapters so
+   * that arbitrary type adapters can use {@link #value} to write a name value.
+   */
+  final void promoteValueToName() throws IOException {
+    int context = peekScope();
+    if (context != NONEMPTY_OBJECT && context != EMPTY_OBJECT) {
+      throw new IllegalStateException("Nesting problem.");
+    }
+    promoteValueToName = true;
+  }
+
+  /**
+   * Returns a <a href="http://goessner.net/articles/JsonPath/">JsonPath</a> to
+   * the current location in the JSON value.
+   */
+  public final String getPath() {
+    return JsonScope.getPath(stackSize, scopes, pathNames, pathIndices);
+  }
+}


### PR DESCRIPTION
This is the part of #572 

The idea is similar to what we have for `ResponseMarshaler`.
- introduce `InputFieldMarshaller` and `InputFieldWriter`  to be used in input object type serialization
- add `marshaller()` code generation for input types
- extract `JsonWriter` and `JsonUtf8Writer` from Moshi to be used later for operation variable serialization
- introduce `InputFieldJsonMarshaller` and `InputFieldJsonWriter` implementations.

Next will be replace Moshi with code generated to serialize operation variables.