### PR TITLE
Model ApolloCall/Query/Fetcher state as FSM

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -3,6 +3,7 @@ package com.apollographql.apollo;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.exception.ApolloCanceledException;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery;
 import com.apollographql.apollo.integration.normalizer.type.Episode;
 
@@ -100,7 +101,8 @@ public class ApolloCallTest {
         .setBodyDelay(TIME_OUT_SECONDS, TimeUnit.SECONDS));
 
     final AtomicReference<ApolloException> errorRef = new AtomicReference<>();
-    final ApolloCall<EpisodeHeroNameQuery.Data> apolloCall = apolloClient.query(query);
+    final ApolloCall<EpisodeHeroNameQuery.Data> apolloCall = apolloClient.query(query)
+        .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
     new Thread(new Runnable() {
       @Override public void run() {
         try {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -76,6 +76,15 @@ public interface ApolloCall<T> extends Cancelable {
   @Nonnull Operation operation();
 
   /**
+   * Cancels this {@link ApolloCall}. If the call has already completed, nothing will happen.
+   * If the call is outgoing, an {@link ApolloCanceledException} will be thrown if the call was started
+   * with {@link #execute()}. If the call was started with {@link #enqueue(Callback)}
+   * the {@link com.apollographql.apollo.ApolloCall.Callback} will be disposed, and will receive no more events. The
+   * call will attempt to abort and release resources, if possible.
+   */
+  @Override void cancel();
+
+  /**
    * Communicates responses from a server or offline requests.
    */
   abstract class Callback<T> {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
@@ -61,6 +61,15 @@ public interface ApolloPrefetch extends Cancelable {
   @Nonnull Operation operation();
 
   /**
+   * Cancels this {@link ApolloPrefetch}. If the call has already completed, nothing will happen.
+   * If the call is outgoing, an {@link ApolloCanceledException} will be thrown if the call was started
+   * with {@link #execute()}. If the call was started with {@link #enqueue(Callback)}
+   * the {@link com.apollographql.apollo.ApolloPrefetch.Callback} will be disposed, and will receive no more events.
+   * The call will attempt to abort and release resources, if possible.
+   */
+  @Override void cancel();
+
+  /**
    * Communicates responses from the server.
    */
   abstract class Callback {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
@@ -28,4 +28,12 @@ public interface ApolloQueryWatcher<T> extends Cancelable {
    * Re-fetches watched GraphQL query.
    */
   void refetch();
+
+  /**
+   * Cancels this {@link ApolloQueryWatcher}. The {@link com.apollographql.apollo.ApolloCall.Callback}
+   * will be disposed, and will receive no more events. Any active operations will attempt to abort and
+   * release resources, if possible.
+   */
+  @Override void cancel();
+
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/CallState.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/CallState.java
@@ -1,0 +1,27 @@
+package com.apollographql.apollo.internal;
+
+enum CallState {
+  IDLE, ACTIVE, TERMINATED, CANCELED;
+
+  static class IllegalStateMessage {
+    private final CallState callState;
+
+    private IllegalStateMessage(CallState callState) {
+      this.callState = callState;
+    }
+
+    static IllegalStateMessage forCurrentState(CallState callState) {
+      return new IllegalStateMessage(callState);
+    }
+
+    String expected(CallState... acceptableStates) {
+      StringBuilder stringBuilder = new StringBuilder("Expected: " + callState.name() + ", but found [");
+      String deliminator = "";
+      for (CallState state : acceptableStates) {
+        stringBuilder.append(deliminator).append(state.name());
+        deliminator = ", ";
+      }
+      return stringBuilder.append("]").toString();
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -124,6 +124,12 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     Response<T> response;
     try {
       response = interceptorChain.proceed(fetchOptions).parsedResponse.or(Response.<T>builder(operation).build());
+    } catch (Exception e) {
+      if (state.get() == CANCELED) {
+        throw new ApolloCanceledException("Call canceled", e);
+      } else {
+        throw e;
+      }
     } finally {
       terminate();
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,6 +44,7 @@ import okhttp3.Call;
 import okhttp3.HttpUrl;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+import static com.apollographql.apollo.internal.CallState.*;
 import static java.util.Collections.emptyList;
 
 @SuppressWarnings("WeakerAccess")
@@ -68,9 +69,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final List<Query> refetchQueries;
   final Optional<QueryReFetcher> queryReFetcher;
   final boolean sendOperationdIdentifiers;
-  final AtomicBoolean executed = new AtomicBoolean();
-  volatile boolean canceled;
-  volatile boolean completed;
+  final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
+  final AtomicReference<Callback<T>> originalCallback = new AtomicReference<>();
 
   public static <T> Builder<T> builder() {
     return new Builder<>();
@@ -117,87 +117,92 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   }
 
   @SuppressWarnings("unchecked") @Nonnull @Override public Response<T> execute() throws ApolloException {
-    if (!executed.compareAndSet(false, true)) {
-      throw new IllegalStateException("Already Executed");
-    }
-
-    if (canceled) {
-      throw new ApolloCanceledException("Canceled");
-    }
-
+    activate(Optional.<Callback<T>>absent());
     Response<T> response;
     try {
-      tracker.registerCall(this);
       response = interceptorChain.proceed(fetchOptions).parsedResponse.or(Response.<T>builder(operation).build());
-    } catch (Exception e) {
-      if (canceled) {
-        throw new ApolloCanceledException("Canceled", e);
-      } else {
-        throw e;
-      }
     } finally {
-      tracker.unregisterCall(this);
+      terminate();
     }
-
-    if (canceled) {
-      throw new ApolloCanceledException("Canceled");
-    }
-
     if (queryReFetcher.isPresent()) {
       queryReFetcher.get().refetch();
     }
-
     return response;
   }
 
   @Override public void enqueue(@Nullable final Callback<T> responseCallback) {
-    if (!executed.compareAndSet(false, true)) {
-      throw new IllegalStateException("Already Executed");
-    }
-    if (canceled) {
+    try {
+      activate(Optional.fromNullable(responseCallback));
+    } catch (ApolloCanceledException e) {
       if (responseCallback != null) {
-        responseCallback.onCanceledError(new ApolloCanceledException("Canceled"));
+        responseCallback.onCanceledError(e);
+      } else {
+        logger.e(e, "Operation: %s was canceled", operation().name().name());
       }
+      return;
     }
-    tracker.registerCall(this);
-    interceptorChain.proceedAsync(dispatcher, fetchOptions, interceptorCallbackProxy(responseCallback));
+    interceptorChain.proceedAsync(dispatcher, fetchOptions, interceptorCallbackProxy());
   }
 
   @Nonnull @Override public RealApolloQueryWatcher<T> watcher() {
-    return new RealApolloQueryWatcher<>(clone(), apolloStore, tracker);
+    return new RealApolloQueryWatcher<>(clone(), apolloStore, logger, tracker);
   }
 
   @Nonnull @Override public RealApolloCall<T> httpCachePolicy(@Nonnull HttpCachePolicy.Policy httpCachePolicy) {
-    if (executed.get()) throw new IllegalStateException("Already Executed");
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .httpCachePolicy(checkNotNull(httpCachePolicy, "httpCachePolicy == null"))
         .build();
   }
 
   @Nonnull @Override public RealApolloCall<T> responseFetcher(@Nonnull ResponseFetcher fetcher) {
-    if (executed.get()) throw new IllegalStateException("Already Executed");
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .responseFetcher(checkNotNull(fetcher, "responseFetcher == null"))
         .build();
   }
 
   @Nonnull @Override public RealApolloCall<T> cacheHeaders(@Nonnull CacheHeaders cacheHeaders) {
-    if (executed.get()) throw new IllegalStateException("Already Executed");
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .cacheHeaders(checkNotNull(cacheHeaders, "cacheHeaders == null"))
         .build();
   }
 
-  @Override public void cancel() {
-    canceled = true;
-    interceptorChain.dispose();
-    if (queryReFetcher.isPresent()) {
-      queryReFetcher.get().cancel();
+  /**
+   * Cancels this {@link RealApolloCall}. If the call has already completed, nothing will happen.
+   * If the call is outgoing, an {@link ApolloCanceledException} will be thrown if the call was started
+   * with {@link #execute()}. If the call was started with {@link #enqueue(Callback)} t
+   * the {@link com.apollographql.apollo.ApolloCall.Callback} will be disposed, and will receive no more events. The
+   * call will attempt to abort and release resources, if possible.
+   */
+  @Override public synchronized void cancel() {
+    switch (state.get()) {
+      case ACTIVE:
+        try {
+          interceptorChain.dispose();
+          if (queryReFetcher.isPresent()) {
+            queryReFetcher.get().cancel();
+          }
+        }
+        finally {
+          tracker.unregisterCall(this);
+          originalCallback.set(null);
+          state.set(CANCELED);
+        }
+        break;
+      case IDLE:
+        state.set(CANCELED);
+        break;
+      case CANCELED:
+      case TERMINATED:
+        // These are not illegal states, but cancelling does nothing
+        break;
     }
   }
 
   @Override public boolean isCanceled() {
-    return canceled;
+    return state.get() == CANCELED;
   }
 
   @Override @Nonnull public RealApolloCall<T> clone() {
@@ -205,14 +210,14 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   }
 
   @Nonnull @Override public ApolloMutationCall<T> refetchQueries(@Nonnull OperationName... operationNames) {
-    if (executed.get()) throw new IllegalStateException("Already Executed");
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .refetchQueryNames(Arrays.asList(checkNotNull(operationNames, "operationNames == null")))
         .build();
   }
 
   @Nonnull @Override public ApolloMutationCall<T> refetchQueries(@Nonnull Query... queries) {
-    if (executed.get()) throw new IllegalStateException("Already Executed");
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .refetchQueries(Arrays.asList(checkNotNull(queries, "queries == null")))
         .build();
@@ -222,57 +227,45 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     return operation;
   }
 
-  private ApolloInterceptor.CallBack interceptorCallbackProxy(final Callback<T> originalCallback) {
+  private ApolloInterceptor.CallBack interceptorCallbackProxy() {
     return new ApolloInterceptor.CallBack() {
       @Override public void onResponse(@Nonnull final ApolloInterceptor.InterceptorResponse response) {
-        if (originalCallback == null) return;
-        if (completed) {
-          throw new IllegalStateException("onResponse called after onCompleted for operation: "
-              + operation.name().name());
-        }
-        if (RealApolloCall.this.canceled) {
+        Optional<Callback<T>> callback = responseCallback();
+        if (!callback.isPresent()) {
+          logger.d("onResponse for operation: %s. No callback present.", operation().name().name());
           return;
         }
         //noinspection unchecked
-        originalCallback.onResponse(response.parsedResponse.get());
+        callback.get().onResponse(response.parsedResponse.get());
       }
 
       @Override public void onFailure(@Nonnull ApolloException e) {
-        if (originalCallback == null) return;
-
-        try {
-          if (RealApolloCall.this.canceled) {
-            logger.w(e, "Call was canceled, but experienced exception.");
-          } else if (e instanceof ApolloHttpException) {
-            originalCallback.onHttpError((ApolloHttpException) e);
-          } else if (e instanceof ApolloParseException) {
-            originalCallback.onParseError((ApolloParseException) e);
-          } else if (e instanceof ApolloNetworkException) {
-            originalCallback.onNetworkError((ApolloNetworkException) e);
-          } else {
-            originalCallback.onFailure(e);
-          }
-        } finally {
-          tracker.unregisterCall(RealApolloCall.this);
+        Optional<Callback<T>> callback = terminate();
+        if (!callback.isPresent()) {
+          logger.d(e, "onFailure for operation: %s. No callback present.", operation().name().name());
+          return;
+        }
+        if (e instanceof ApolloHttpException) {
+          callback.get().onHttpError((ApolloHttpException) e);
+        } else if (e instanceof ApolloParseException) {
+          callback.get().onParseError((ApolloParseException) e);
+        } else if (e instanceof ApolloNetworkException) {
+          callback.get().onNetworkError((ApolloNetworkException) e);
+        } else {
+          callback.get().onFailure(e);
         }
       }
 
       @Override public void onCompleted() {
-        if (originalCallback == null) return;
-        if (completed) {
-          throw new IllegalStateException("onCompleted already called for operation: " + operation.name()
-              .name());
+        Optional<Callback<T>> callback = terminate();
+        if (queryReFetcher.isPresent()) {
+          queryReFetcher.get().refetch();
         }
-        if (RealApolloCall.this.canceled) return;
-        try {
-          if (queryReFetcher.isPresent()) {
-            queryReFetcher.get().refetch();
-          }
-          originalCallback.onCompleted();
-        } finally {
-          tracker.unregisterCall(RealApolloCall.this);
-          completed = true;
+        if (!callback.isPresent()) {
+          logger.d("onCompleted for operation: %s. No callback present.", operation().name().name());
+          return;
         }
+        callback.get().onCompleted();
       }
     };
   }
@@ -296,6 +289,50 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .refetchQueryNames(refetchQueryNames)
         .refetchQueries(refetchQueries)
         .sendOperationIdentifiers(sendOperationdIdentifiers);
+  }
+
+  private synchronized void activate(Optional<Callback<T>> callback) throws ApolloCanceledException {
+    switch (state.get()) {
+      case IDLE:
+        originalCallback.set(callback.orNull());
+        tracker.registerCall(this);
+        break;
+      case CANCELED:
+        throw new ApolloCanceledException("Call is cancelled.");
+      case TERMINATED:
+      case ACTIVE:
+        throw new IllegalStateException("Already Executed");
+    }
+    state.set(ACTIVE);
+  }
+
+  private synchronized Optional<Callback<T>> responseCallback() {
+    switch (state.get()) {
+      case ACTIVE:
+      case CANCELED:
+        return Optional.fromNullable(originalCallback.get());
+      case IDLE:
+      case TERMINATED:
+        throw new IllegalStateException(
+            IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+    }
+    throw new IllegalStateException("Unknown state: " + state.get().name());
+  }
+
+  private synchronized Optional<Callback<T>> terminate() {
+    switch (state.get()) {
+      case ACTIVE:
+        tracker.unregisterCall(this);
+        state.set(TERMINATED);
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case CANCELED:
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case IDLE:
+      case TERMINATED:
+        throw new IllegalStateException(
+            IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+    }
+    throw new IllegalStateException("Unknown state: " + state.get().name());
   }
 
   private ApolloInterceptorChain prepareInterceptorChain(Operation operation) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.cache.http.HttpCache;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.exception.ApolloCanceledException;
 import com.apollographql.apollo.exception.ApolloException;
@@ -20,6 +21,7 @@ import com.apollographql.apollo.internal.util.ApolloLogger;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -27,6 +29,8 @@ import javax.annotation.Nullable;
 import okhttp3.Call;
 import okhttp3.HttpUrl;
 import okhttp3.Response;
+
+import static com.apollographql.apollo.internal.CallState.*;
 
 @SuppressWarnings("WeakerAccess") public final class RealApolloPrefetch implements ApolloPrefetch {
   final Operation operation;
@@ -39,8 +43,8 @@ import okhttp3.Response;
   final ApolloCallTracker tracker;
   final ApolloInterceptorChain interceptorChain;
   final boolean sendOperationIds;
-  volatile boolean executed;
-  volatile boolean canceled;
+  final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
+  final AtomicReference<ApolloPrefetch.Callback> originalCallback = new AtomicReference<>();
 
   public RealApolloPrefetch(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory, HttpCache httpCache,
       Map<ScalarType, CustomTypeAdapter> customTypeAdapters, ExecutorService dispatcher, ApolloLogger logger,
@@ -61,72 +65,54 @@ import okhttp3.Response;
   }
 
   @Override public void execute() throws ApolloException {
-    synchronized (this) {
-      if (executed) throw new IllegalStateException("Already Executed");
-      executed = true;
-    }
-
-    if (canceled) {
-      throw new ApolloCanceledException("Canceled");
-    }
-
+    activate(Optional.<Callback>absent());
     Response httpResponse;
-
     try {
-      tracker.registerPrefetchCall(this);
       httpResponse = interceptorChain.proceed(FetchOptions.NETWORK_ONLY).httpResponse.get();
-    } catch (Exception e) {
-      if (canceled) {
-        throw new ApolloCanceledException("Canceled", e);
-      } else {
-        throw e;
+      if (state.get() == CANCELED) {
+        throw new ApolloCanceledException("Canceled");
       }
     } finally {
-      tracker.unregisterPrefetchCall(this);
+      terminate();
     }
-
     httpResponse.close();
-
-    if (canceled) {
-      throw new ApolloCanceledException("Canceled");
-    }
-
     if (!httpResponse.isSuccessful()) {
       throw new ApolloHttpException(httpResponse);
     }
   }
 
   @Override public void enqueue(@Nullable final Callback responseCallback) {
-    synchronized (this) {
-      if (executed) throw new IllegalStateException("Already Executed");
-      executed = true;
-    }
-    if (canceled) {
+    try {
+      activate(Optional.fromNullable(responseCallback));
+    } catch (ApolloCanceledException e) {
       if (responseCallback != null) {
-        responseCallback.onCanceledError(new ApolloCanceledException("Canceled"));
+        responseCallback.onFailure(e);
+      } else {
+        logger.e(e, "Operation: %s was canceled", operation().name().name());
       }
+      return;
     }
-    tracker.registerPrefetchCall(this);
-    interceptorChain.proceedAsync(dispatcher, FetchOptions.NETWORK_ONLY,
-        interceptorCallbackProxy(responseCallback));
+    interceptorChain.proceedAsync(dispatcher, FetchOptions.NETWORK_ONLY, interceptorCallbackProxy());
   }
 
   @Nonnull @Override public Operation operation() {
     return operation;
   }
 
-  private ApolloInterceptor.CallBack interceptorCallbackProxy(final Callback originalCallback) {
+  private ApolloInterceptor.CallBack interceptorCallbackProxy() {
     return new ApolloInterceptor.CallBack() {
       @Override public void onResponse(@Nonnull ApolloInterceptor.InterceptorResponse response) {
         Response httpResponse = response.httpResponse.get();
         try {
-          if (originalCallback == null) return;
-          if (RealApolloPrefetch.this.canceled) return;
-
+          Optional<Callback> callback = terminate();
+          if (!callback.isPresent()) {
+            logger.d("onResponse for prefetch operation: %s. No callback present.", operation().name().name());
+            return;
+          }
           if (httpResponse.isSuccessful()) {
-            originalCallback.onSuccess();
+            callback.get().onSuccess();
           } else {
-            originalCallback.onHttpError(new ApolloHttpException(httpResponse));
+            callback.get().onHttpError(new ApolloHttpException(httpResponse));
           }
         } finally {
           tracker.unregisterPrefetchCall(RealApolloPrefetch.this);
@@ -135,20 +121,19 @@ import okhttp3.Response;
       }
 
       @Override public void onFailure(@Nonnull ApolloException e) {
-        if (originalCallback == null) return;
-        try {
-          if (canceled) {
-            logger.w(e, "Call was canceled, but experienced exception.");
-          } else if (e instanceof ApolloHttpException) {
-            originalCallback.onHttpError((ApolloHttpException) e);
-          } else if (e instanceof ApolloNetworkException) {
-            originalCallback.onNetworkError((ApolloNetworkException) e);
-          } else {
-            originalCallback.onFailure(e);
+          Optional<Callback> callback = terminate();
+          if (!callback.isPresent()) {
+            logger.e(e," onFailure for prefetch operation: %s. No callback present.", operation().name().name());
+            return;
           }
-        } finally {
-          tracker.unregisterPrefetchCall(RealApolloPrefetch.this);
-        }
+          if (e instanceof ApolloHttpException) {
+            callback.get().onHttpError((ApolloHttpException) e);
+          } else if (e instanceof ApolloNetworkException) {
+            callback.get().onNetworkError((ApolloNetworkException) e);
+          } else {
+            callback.get().onFailure(e);
+          }
+
       }
 
       @Override public void onCompleted() {
@@ -163,12 +148,59 @@ import okhttp3.Response;
         logger, tracker, sendOperationIds);
   }
 
-  @Override public void cancel() {
-    canceled = true;
-    interceptorChain.dispose();
+  @Override public synchronized void cancel() {
+    switch (state.get()) {
+      case ACTIVE:
+        try {
+          interceptorChain.dispose();
+        } finally {
+          tracker.unregisterPrefetchCall(this);
+          originalCallback.set(null);
+          state.set(CANCELED);
+        }
+        break;
+      case IDLE:
+        state.set(CANCELED);
+        break;
+      case CANCELED:
+      case TERMINATED:
+        // These are not illegal states, but cancelling does nothing
+        break;
+    }
   }
 
   @Override public boolean isCanceled() {
-    return canceled;
+    return state.get() == CANCELED;
+  }
+
+  private synchronized void activate(Optional<ApolloPrefetch.Callback> callback) throws ApolloCanceledException {
+    switch (state.get()) {
+      case IDLE:
+        originalCallback.set(callback.orNull());
+        tracker.registerPrefetchCall(this);
+        break;
+      case CANCELED:
+        throw new ApolloCanceledException("Call is cancelled.");
+      case TERMINATED:
+      case ACTIVE:
+        throw new IllegalStateException("Already Executed");
+    }
+    state.set(ACTIVE);
+  }
+
+  private synchronized Optional<ApolloPrefetch.Callback> terminate() {
+    switch (state.get()) {
+      case ACTIVE:
+        tracker.unregisterPrefetchCall(this);
+        state.set(TERMINATED);
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case CANCELED:
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case IDLE:
+      case TERMINATED:
+        throw new IllegalStateException(
+            IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+    }
+    throw new IllegalStateException("Unknown state: " + state.get().name());
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -92,7 +92,6 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
     try {
       activate(Optional.fromNullable(responseCallback));
     } catch (ApolloCanceledException e) {
-      terminate();
       if (responseCallback != null) {
         responseCallback.onFailure(e);
       } else {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -78,8 +78,7 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
       } else {
         throw e;
       }
-    }
-    finally {
+    } finally {
       terminate();
     }
     httpResponse.close();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.cache.normalized.ApolloStore;
 import com.apollographql.apollo.exception.ApolloCanceledException;
@@ -13,23 +14,27 @@ import com.apollographql.apollo.exception.ApolloNetworkException;
 import com.apollographql.apollo.exception.ApolloParseException;
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
+import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+import static com.apollographql.apollo.internal.CallState.ACTIVE;
+import static com.apollographql.apollo.internal.CallState.CANCELED;
+import static com.apollographql.apollo.internal.CallState.IDLE;
+import static com.apollographql.apollo.internal.CallState.TERMINATED;
 
 final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private RealApolloCall<T> activeCall;
-  private ApolloCall.Callback<T> callback;
   private ResponseFetcher refetchResponseFetcher = ApolloResponseFetchers.CACHE_FIRST;
-  private volatile boolean canceled;
-  private boolean executed = false;
   private final ApolloStore apolloStore;
   private Set<String> dependentKeys = Collections.emptySet();
+  private final ApolloLogger logger;
   private final ApolloCallTracker tracker;
   private final ApolloStore.RecordChangeSubscriber recordChangeSubscriber = new ApolloStore.RecordChangeSubscriber() {
     @Override public void onCacheRecordsChanged(Set<String> changedRecordKeys) {
@@ -38,99 +43,163 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
       }
     }
   };
+  private final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
+  private final AtomicReference<ApolloCall.Callback<T>> originalCallback = new AtomicReference<>();
 
-  RealApolloQueryWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore, ApolloCallTracker tracker) {
+  RealApolloQueryWatcher(RealApolloCall<T> originalCall, ApolloStore apolloStore, ApolloLogger logger,
+      ApolloCallTracker tracker) {
     this.activeCall = originalCall;
     this.apolloStore = apolloStore;
+    this.logger = logger;
     this.tracker = tracker;
   }
 
   @Override public ApolloQueryWatcher<T> enqueueAndWatch(@Nullable final ApolloCall.Callback<T> callback) {
-    synchronized (this) {
-      if (executed) throw new IllegalStateException("Already Executed.");
-      executed = true;
+    try {
+      activate(Optional.fromNullable(callback));
+    } catch (ApolloCanceledException e) {
+      if (callback != null) {
+        callback.onCanceledError(e);
+      } else {
+        logger.e(e, "Operation: %s was canceled", operation().name().name());
+      }
+      return this;
     }
-    this.callback = callback;
-    tracker.registerQueryWatcher(this);
-    activeCall.enqueue(callbackProxy(this.callback));
+    activeCall.enqueue(callbackProxy());
     return this;
   }
 
-  @Nonnull @Override public RealApolloQueryWatcher<T> refetchResponseFetcher(@Nonnull ResponseFetcher fetcher) {
-    synchronized (this) {
-      if (executed) throw new IllegalStateException("Already Executed");
-    }
+  @Nonnull
+  @Override public synchronized RealApolloQueryWatcher<T> refetchResponseFetcher(@Nonnull ResponseFetcher fetcher) {
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     checkNotNull(fetcher, "responseFetcher == null");
     this.refetchResponseFetcher = fetcher;
     return this;
   }
 
-  @Override public void cancel() {
-    synchronized (this) {
-      canceled = true;
-      try {
-        activeCall.cancel();
-        apolloStore.unsubscribe(recordChangeSubscriber);
-      } finally {
-        tracker.unregisterQueryWatcher(this);
-      }
+  @Override public synchronized void cancel() {
+    switch (state.get()) {
+      case ACTIVE:
+        try {
+          activeCall.cancel();
+          apolloStore.unsubscribe(recordChangeSubscriber);
+        }
+        finally {
+          tracker.unregisterQueryWatcher(this);
+          originalCallback.set(null);
+          state.set(CANCELED);
+        }
+        break;
+      case IDLE:
+        state.set(CANCELED);
+        break;
+      case CANCELED:
+      case TERMINATED:
+        // These are not illegal states, but cancelling does nothing
+        break;
     }
   }
 
   @Override public boolean isCanceled() {
-    return canceled;
+    return state.get() == CANCELED;
   }
 
   @Nonnull @Override public Operation operation() {
     return activeCall.operation();
   }
 
-  @Override public void refetch() {
-    if (canceled) return;
-
-    synchronized (this) {
-      apolloStore.unsubscribe(recordChangeSubscriber);
-      activeCall.cancel();
-      if (!canceled) {
+  @Override public synchronized void refetch() {
+    switch (state.get()) {
+      case ACTIVE:
+        apolloStore.unsubscribe(recordChangeSubscriber);
+        activeCall.cancel();
         activeCall = activeCall.clone().responseFetcher(refetchResponseFetcher);
-        activeCall.enqueue(callbackProxy(this.callback));
-      }
+        activeCall.enqueue(callbackProxy());
+      case IDLE:
+        throw new IllegalStateException("Cannot refetch a watcher which has not first called enqueueAndWatch.");
+      case CANCELED:
+        throw new IllegalStateException("Cannot refetch a canceled watcher,");
+      case TERMINATED:
+        throw new IllegalStateException("Cannot refetch a watcher which has experienced an error.");
+
     }
+
   }
 
-  private ApolloCall.Callback<T> callbackProxy(final ApolloCall.Callback<T> sourceCallback) {
+  private ApolloCall.Callback<T> callbackProxy() {
     return new ApolloCall.Callback<T>() {
       @Override public void onResponse(@Nonnull Response<T> response) {
-        if (canceled) return;
+        Optional<ApolloCall.Callback<T>> callback = responseCallback();
+        if (!callback.isPresent()) {
+          logger.d("onResponse for watched operation: %s. No callback present.", operation().name().name());
+          return;
+        }
         dependentKeys = response.dependentKeys();
         apolloStore.subscribe(recordChangeSubscriber);
-        sourceCallback.onResponse(response);
-      }
-
-      @Override public void onHttpError(@Nonnull ApolloHttpException e) {
-        if (canceled) return;
-        sourceCallback.onHttpError(e);
-      }
-
-      @Override public void onNetworkError(@Nonnull ApolloNetworkException e) {
-        if (canceled) return;
-        sourceCallback.onNetworkError(e);
-      }
-
-      @Override public void onParseError(@Nonnull ApolloParseException e) {
-        if (canceled) return;
-        sourceCallback.onParseError(e);
-      }
-
-      @Override public void onCanceledError(@Nonnull ApolloCanceledException e) {
-        if (canceled) return;
-        sourceCallback.onCanceledError(e);
+        callback.get().onResponse(response);
       }
 
       @Override public void onFailure(@Nonnull ApolloException e) {
-        if (canceled) return;
-        sourceCallback.onFailure(e);
+        Optional<ApolloCall.Callback<T>> callback = terminate();
+        if (!callback.isPresent()) {
+          logger.d(e, "onFailure for operation: %s. No callback present.", operation().name().name());
+          return;
+        }
+        if (e instanceof ApolloHttpException) {
+          callback.get().onHttpError((ApolloHttpException) e);
+        } else if (e instanceof ApolloParseException) {
+          callback.get().onParseError((ApolloParseException) e);
+        } else if (e instanceof ApolloNetworkException) {
+          callback.get().onNetworkError((ApolloNetworkException) e);
+        } else {
+          callback.get().onFailure(e);
+        }
       }
     };
   }
+
+  private synchronized void activate(Optional<ApolloCall.Callback<T>> callback) throws ApolloCanceledException {
+    switch (state.get()) {
+      case IDLE:
+        originalCallback.set(callback.orNull());
+        tracker.registerQueryWatcher(this);
+        break;
+      case CANCELED:
+        throw new ApolloCanceledException("Call is cancelled.");
+      case TERMINATED:
+      case ACTIVE:
+        throw new IllegalStateException("Already Executed");
+    }
+    state.set(ACTIVE);
+  }
+
+  private synchronized Optional<ApolloCall.Callback<T>> responseCallback() {
+    switch (state.get()) {
+      case ACTIVE:
+      case CANCELED:
+        return Optional.fromNullable(originalCallback.get());
+      case IDLE:
+      case TERMINATED:
+        throw new IllegalStateException(
+            CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+    }
+    throw new IllegalStateException("Unknown state: " + state.get().name());
+  }
+
+  private synchronized Optional<ApolloCall.Callback<T>> terminate() {
+    switch (state.get()) {
+      case ACTIVE:
+        tracker.unregisterQueryWatcher(this);
+        state.set(TERMINATED);
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case CANCELED:
+        return Optional.fromNullable(originalCallback.getAndSet(null));
+      case IDLE:
+      case TERMINATED:
+        throw new IllegalStateException(
+            CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+    }
+    throw new IllegalStateException("Unknown state: " + state.get().name());
+  }
+
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -83,8 +83,7 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
         try {
           activeCall.cancel();
           apolloStore.unsubscribe(recordChangeSubscriber);
-        }
-        finally {
+        } finally {
           tracker.unregisterQueryWatcher(this);
           originalCallback.set(null);
           state.set(CANCELED);
@@ -97,6 +96,8 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
       case TERMINATED:
         // These are not illegal states, but cancelling does nothing
         break;
+      default:
+        throw new IllegalStateException("Unknown state");
     }
   }
 
@@ -121,6 +122,8 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
         throw new IllegalStateException("Cannot refetch a canceled watcher,");
       case TERMINATED:
         throw new IllegalStateException("Cannot refetch a watcher which has experienced an error.");
+      default:
+        throw new IllegalStateException("Unknown state");
 
     }
 
@@ -169,6 +172,8 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
       case TERMINATED:
       case ACTIVE:
         throw new IllegalStateException("Already Executed");
+      default:
+        throw new IllegalStateException("Unknown state");
     }
     state.set(ACTIVE);
   }
@@ -182,8 +187,9 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
       case TERMINATED:
         throw new IllegalStateException(
             CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+      default:
+        throw new IllegalStateException("Unknown state");
     }
-    throw new IllegalStateException("Unknown state: " + state.get().name());
   }
 
   private synchronized Optional<ApolloCall.Callback<T>> terminate() {
@@ -198,8 +204,9 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
       case TERMINATED:
         throw new IllegalStateException(
             CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+      default:
+        throw new IllegalStateException("Unknown state");
     }
-    throw new IllegalStateException("Unknown state: " + state.get().name());
   }
 
 }


### PR DESCRIPTION
With the addition of multi-response callbacks, the states in ApolloCall / Prefetch / Query watcher  are more complex. We also must be sure to properly track/untrack calls, null out callbacks in certain states.

This is an attempt to use a FSM to model this behavior.

- [x] Migrate Prefetch
- [x] Migrate QueryWatcher

closes https://github.com/apollographql/apollo-android/issues/560