### PR TITLE
Second attempt to fix ArrayIndexOutOfBoundException

### DIFF
--- a/apollo-integration/src/test/resources/AllPlanetsListOfObjectWithNullObject.json
+++ b/apollo-integration/src/test/resources/AllPlanetsListOfObjectWithNullObject.json
@@ -1,0 +1,47 @@
+{
+  "data": {
+    "allPlanets": {
+      "__typename": "PlanetsConnection",
+      "planets": [
+        {
+          "__typename": "Planet",
+          "name": "Tatooine",
+          "climates": [
+            "arid"
+          ],
+          "surfaceWater": 1,
+          "filmConnection": null
+        },
+        {
+          "__typename": "Planet",
+          "name": "Alderaan",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 40,
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 2,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -82,10 +82,12 @@ public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
 
   @Override public void didResolveObject(ResponseField field, Optional<R> objectSource) {
     path = pathStack.pop();
-    Record completedRecord = currentRecordBuilder.build();
-    valueStack.push(new CacheReference(completedRecord.key()));
-    dependentKeys.add(completedRecord.key());
-    recordSet.merge(completedRecord);
+    if (objectSource.isPresent()) {
+      Record completedRecord = currentRecordBuilder.build();
+      valueStack.push(new CacheReference(completedRecord.key()));
+      dependentKeys.add(completedRecord.key());
+      recordSet.merge(completedRecord);
+    }
     currentRecordBuilder = recordStack.pop().toBuilder();
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
@@ -131,9 +131,9 @@ import java.util.Map;
         Object value = values.get(i);
         if (value != null) {
           T item = (T) listReader.read(new ListItemReader(field, value));
-          readerShadow.didResolveElement(i);
           result.add(item);
         }
+        readerShadow.didResolveElement(i);
       }
       readerShadow.didResolveList(values);
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/reader/RealResponseReader.java
@@ -109,8 +109,8 @@ import java.util.Map;
     } else {
       parsedValue = (T) objectReader.read(new RealResponseReader(operationVariables, value, fieldValueResolver,
           customTypeAdapters, readerShadow));
-      readerShadow.didResolveObject(field, Optional.fromNullable(value));
     }
+    readerShadow.didResolveObject(field, Optional.fromNullable(value));
     didResolve(field);
     return parsedValue;
   }


### PR DESCRIPTION
Fixes 2 issues:
- the broken symmetry of invoking `willResolveObject` / `didResolveObject` in RealResponseReader that was the cause of ArrayIndexOutOfBoundException
- don't store `CacheReference` to object that resolved as null

Closes #575 

cc @adamame @eschlenz