### PR TITLE
Fix logic in apolloclient build when using callFactory

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -470,8 +470,9 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
             return false;
           }
         }
+        return true;
       }
-      return true;
+      return false;
     }
   }
 }


### PR DESCRIPTION
This was missing a return in the okhttp block and incorrectly fell through to a true return at the end, which should have actually been false.

Otherwise - if one provided a callfactory rather than an okhttpclient instance, it would fail with a ClassCastException trying to incorrectly add the interceptor