### PR TITLE
Make NormalizedCache to be chained

### DIFF
--- a/apollo-android-support/src/androidTest/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.java
+++ b/apollo-android-support/src/androidTest/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.java
@@ -28,7 +28,7 @@ public class SqlNormalizedCacheTest {
   public void setUp() {
     ApolloSqlHelper apolloSqlHelper = ApolloSqlHelper.create(InstrumentationRegistry.getTargetContext(),
         IN_MEMORY_DB);
-    sqlStore = new SqlNormalizedCacheFactory(apolloSqlHelper).createNormalizedCache(RecordFieldJsonAdapter.create());
+    sqlStore = new SqlNormalizedCacheFactory(apolloSqlHelper).create(RecordFieldJsonAdapter.create());
   }
 
   @Test

--- a/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.java
@@ -5,15 +5,14 @@ import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
-public final class SqlNormalizedCacheFactory implements NormalizedCacheFactory<SqlNormalizedCache> {
-
+public final class SqlNormalizedCacheFactory extends NormalizedCacheFactory<SqlNormalizedCache> {
   private final ApolloSqlHelper helper;
 
   public SqlNormalizedCacheFactory(ApolloSqlHelper helper) {
     this.helper = checkNotNull(helper, "helper == null");
   }
 
-  @Override public SqlNormalizedCache createNormalizedCache(RecordFieldJsonAdapter recordFieldAdapter) {
+  @Override public SqlNormalizedCache create(RecordFieldJsonAdapter recordFieldAdapter) {
     return new SqlNormalizedCache(recordFieldAdapter, helper);
   }
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Absent.java
@@ -82,6 +82,11 @@ final class Absent<T> extends Optional<T> {
     return Optional.absent();
   }
 
+  @Override public Optional<T> apply(Action<T> action) {
+    checkNotNull(action);
+    return Optional.absent();
+  }
+
   @Override
   public Set<T> asSet() {
     return Collections.emptySet();

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Action.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Action.java
@@ -1,0 +1,7 @@
+package com.apollographql.apollo.api.internal;
+
+import javax.annotation.Nonnull;
+
+public interface Action<T> {
+  void apply(@Nonnull T t);
+}

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Optional.java
@@ -218,6 +218,8 @@ public abstract class Optional<T> implements Serializable {
 
   public abstract <V> Optional<V> flatMap(Function<? super T, Optional<V>> function);
 
+  public abstract Optional<T> apply(Action<T> action);
+
   /**
    * Returns {@code true} if {@code object} is an {@code Optional} instance, and either the contained references are
    * {@linkplain Object#equals equal} to each other or both are absent. Note that {@code Optional} instances of

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Present.java
@@ -20,6 +20,7 @@ package com.apollographql.apollo.api.internal;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
@@ -67,6 +68,16 @@ final class Present<T> extends Optional<T> {
     checkNotNull(function);
     return checkNotNull(function.apply(reference),
         "the Function passed to Optional.flatMap() must not return null.");
+  }
+
+  @Override public Optional<T> apply(final Action<T> action) {
+    checkNotNull(action);
+    return map(new Function<T, T>() {
+      @Nonnull @Override public T apply(@Nonnull T t) {
+        action.apply(t);
+        return t;
+      }
+    });
   }
 
   @Override public T orNull() {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -103,16 +103,16 @@ public class ApolloCallTest {
     final AtomicReference<ApolloException> errorRef = new AtomicReference<>();
     final ApolloCall<EpisodeHeroNameQuery.Data> apolloCall = apolloClient.query(query)
         .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
-    new Thread(new Runnable() {
-      @Override public void run() {
-        try {
-          apolloCall.execute();
-        } catch (ApolloException e) {
-          errorRef.set(e);
-        }
+    apolloCall.enqueue(new ApolloCall.Callback<EpisodeHeroNameQuery.Data>() {
+      @Override public void onResponse(@Nonnull Response<EpisodeHeroNameQuery.Data> response) {
         responseLatch.countDown();
       }
-    }).start();
+
+      @Override public void onFailure(@Nonnull ApolloException e) {
+        errorRef.set(e);
+        responseLatch.countDown();
+      }
+    });
 
     Thread.sleep(500);
     apolloCall.cancel();

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -97,7 +97,7 @@ public class ApolloCallTest {
 
   @Test
   public void apolloCanceledExceptionExecute() throws Exception {
-    EpisodeHeroNameQuery query = EpisodeHeroNameQuery.builder().episode(Episode.EMPIRE).build();
+    EpisodeHeroNameQuery query = new EpisodeHeroNameQuery(Episode.EMPIRE);
     mockWebServer.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json")
         .setBodyDelay(TIME_OUT_SECONDS, TimeUnit.SECONDS));
 
@@ -105,6 +105,10 @@ public class ApolloCallTest {
 
     new Thread(new Runnable() {
       @Override public void run() {
+        try {
+          Thread.sleep(TimeUnit.SECONDS.toMillis(TIME_OUT_SECONDS / 2));
+        } catch (Throwable ignore) {
+        }
         call.cancel();
       }
     }).start();

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -7,6 +7,8 @@ import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery;
 import com.apollographql.apollo.integration.normalizer.type.Episode;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +23,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
 import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.Assert.fail;
 
 public class ApolloCallTest {
   private static final long TIME_OUT_SECONDS = 3;
@@ -94,31 +97,28 @@ public class ApolloCallTest {
 
   @Test
   public void apolloCanceledExceptionExecute() throws Exception {
-    final NamedCountDownLatch responseLatch = new NamedCountDownLatch("apolloCanceledExceptionExecute", 1);
-
     EpisodeHeroNameQuery query = EpisodeHeroNameQuery.builder().episode(Episode.EMPIRE).build();
     mockWebServer.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json")
         .setBodyDelay(TIME_OUT_SECONDS, TimeUnit.SECONDS));
 
-    final AtomicReference<ApolloException> errorRef = new AtomicReference<>();
-    final ApolloCall<EpisodeHeroNameQuery.Data> apolloCall = apolloClient.query(query)
-        .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
-    apolloCall.enqueue(new ApolloCall.Callback<EpisodeHeroNameQuery.Data>() {
-      @Override public void onResponse(@Nonnull Response<EpisodeHeroNameQuery.Data> response) {
-        responseLatch.countDown();
+    final ApolloCall call = apolloClient.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
+
+    new Thread(new Runnable() {
+      @Override public void run() {
+        try {
+          Thread.sleep(500);
+        } catch (Exception ignore) {
+        }
+        call.cancel();
       }
+    }).start();
 
-      @Override public void onFailure(@Nonnull ApolloException e) {
-        errorRef.set(e);
-        responseLatch.countDown();
-      }
-    });
-
-    Thread.sleep(500);
-    apolloCall.cancel();
-    responseLatch.await(TIME_OUT_SECONDS, TimeUnit.SECONDS);
-
-    assertThat(errorRef.get()).isInstanceOf(ApolloCanceledException.class);
+     try {
+      call.execute();
+      fail("expected ApolloException");
+    } catch (ApolloException e) {
+      assertThat(e).isInstanceOf(ApolloCanceledException.class);
+    }
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloCallTest.java
@@ -105,15 +105,11 @@ public class ApolloCallTest {
 
     new Thread(new Runnable() {
       @Override public void run() {
-        try {
-          Thread.sleep(500);
-        } catch (Exception ignore) {
-        }
         call.cancel();
       }
     }).start();
 
-     try {
+    try {
       call.execute();
       fail("expected ApolloException");
     } catch (ApolloException e) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
@@ -66,7 +66,7 @@ public class CacheHeadersTest {
     };
 
     final NormalizedCacheFactory<NormalizedCache> cacheFactory = new NormalizedCacheFactory<NormalizedCache>() {
-      @Override public NormalizedCache createNormalizedCache(RecordFieldJsonAdapter recordFieldAdapter) {
+      @Override public NormalizedCache create(RecordFieldJsonAdapter recordFieldAdapter) {
         return normalizedCache;
       }
     };
@@ -107,7 +107,7 @@ public class CacheHeadersTest {
     };
 
     final NormalizedCacheFactory<NormalizedCache> cacheFactory = new NormalizedCacheFactory<NormalizedCache>() {
-      @Override public NormalizedCache createNormalizedCache(RecordFieldJsonAdapter recordFieldAdapter) {
+      @Override public NormalizedCache create(RecordFieldJsonAdapter recordFieldAdapter) {
         return normalizedCache;
       }
     };

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -91,11 +91,11 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
       Map<ScalarType, CustomTypeAdapter> customTypeAdapters,
       ExecutorService dispatcher,
       HttpCachePolicy.Policy defaultHttpCachePolicy,
-        ResponseFetcher defaultResponseFetcher,
+      ResponseFetcher defaultResponseFetcher,
       CacheHeaders defaultCacheHeaders,
       ApolloLogger logger,
       List<ApolloInterceptor> applicationInterceptors,
-    boolean sendOperationIdentifiers) {
+      boolean sendOperationIdentifiers) {
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
     this.httpCache = httpCache;
@@ -239,9 +239,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
-     * Set the custom call factory for creating {@link Call} instances.
-     * <p>
-     * Note: Calling {@link #okHttpClient(OkHttpClient)} automatically sets this value.
+     * Set the custom call factory for creating {@link Call} instances. <p> Note: Calling {@link
+     * #okHttpClient(OkHttpClient)} automatically sets this value.
      */
     public Builder callFactory(@Nonnull Call.Factory factory) {
       this.callFactory = checkNotNull(factory, "factory == null");
@@ -341,8 +340,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
-     * Set the default {@link CacheHeaders} strategy that will be passed
-     * to the {@link com.apollographql.apollo.interceptor.FetchOptions} used in each new {@link ApolloCall}.
+     * Set the default {@link CacheHeaders} strategy that will be passed to the {@link
+     * com.apollographql.apollo.interceptor.FetchOptions} used in each new {@link ApolloCall}.
      *
      * @return The {@link Builder} object to be used for chaining method calls
      */
@@ -389,9 +388,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
-     *
      * @param sendOperationIdentifiers True if ApolloClient should send a operation identifier instead of the operation
-     *                        definition. Default: false.
+     *                                 definition. Default: false.
      * @return The {@link Builder} object to be used for chaining method calls
      */
     public Builder sendOperationIdentifiers(boolean sendOperationIdentifiers) {
@@ -433,10 +431,9 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
 
       ApolloStore apolloStore = this.apolloStore;
       if (cacheFactory.isPresent() && cacheKeyResolver.isPresent()) {
-        final NormalizedCache normalizedCache =
-            cacheFactory.get().createNormalizedCache(RecordFieldJsonAdapter.create());
-        apolloStore = new RealApolloStore(normalizedCache, cacheKeyResolver.get(), customTypeAdapters,
-            dispatcher, apolloLogger);
+        final NormalizedCache normalizedCache = cacheFactory.get().createChain(RecordFieldJsonAdapter.create());
+        apolloStore = new RealApolloStore(normalizedCache, cacheKeyResolver.get(), customTypeAdapters, dispatcher,
+            apolloLogger);
       }
 
       return new ApolloClient(serverUrl,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
@@ -1,8 +1,9 @@
 package com.apollographql.apollo.cache.normalized;
 
 import com.apollographql.apollo.ApolloClient;
-import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.ApolloCacheHeaders;
+import com.apollographql.apollo.cache.CacheHeaders;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,35 +14,33 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
 /**
  * A provider of {@link Record} for reading requests from cache.
  *
- * To serialize a {@link Record} to a standardized form use {@link #recordAdapter()} which handles
- * call custom scalar types registered on the {@link ApolloClient}.
+ * To serialize a {@link Record} to a standardized form use {@link #recordAdapter()} which handles call custom scalar
+ * types registered on the {@link ApolloClient}.
  *
- * If a {@link NormalizedCache} cannot return all the records needed to read a response, it will
- * be considered a cache miss.
+ * If a {@link NormalizedCache} cannot return all the records needed to read a response, it will be considered a cache
+ * miss.
  *
- * A {@link NormalizedCache} is recommended to implement support for {@link CacheHeaders} specified in
- * {@link ApolloCacheHeaders}.
+ * A {@link NormalizedCache} is recommended to implement support for {@link CacheHeaders} specified in {@link
+ * ApolloCacheHeaders}.
  *
  * A {@link NormalizedCache} can choose to store records in any manner.
  *
  * See {@link com.apollographql.apollo.cache.normalized.lru.LruNormalizedCache} for a in memory cache.
  */
 public abstract class NormalizedCache {
-
   private RecordFieldJsonAdapter recordFieldAdapter;
+  private Optional<NormalizedCache> nextCache = Optional.absent();
 
   /**
    * @param recordFieldAdapter An adapter which can deserialize and deserialize {@link Record}
    */
   public NormalizedCache(RecordFieldJsonAdapter recordFieldAdapter) {
     this.recordFieldAdapter = recordFieldAdapter;
-  }
-
-  protected RecordFieldJsonAdapter recordAdapter() {
-    return recordFieldAdapter;
   }
 
   /**
@@ -52,9 +51,8 @@ public abstract class NormalizedCache {
   @Nullable public abstract Record loadRecord(@Nonnull String key, @Nonnull CacheHeaders cacheHeaders);
 
   /**
-   * Calls through to {@link NormalizedCache#loadRecord(String, CacheHeaders)}.
-   * Implementations should override this method if the underlying storage technology can offer an optimized manner
-   * to read multiple records.
+   * Calls through to {@link NormalizedCache#loadRecord(String, CacheHeaders)}. Implementations should override this
+   * method if the underlying storage technology can offer an optimized manner to read multiple records.
    *
    * @param keys         The set of {@link Record} keys to read.
    * @param cacheHeaders The cache headers associated with the request which generated this record.
@@ -78,9 +76,8 @@ public abstract class NormalizedCache {
   @Nonnull public abstract Set<String> merge(@Nonnull Record record, @Nonnull CacheHeaders cacheHeaders);
 
   /**
-   * Calls through to {@link NormalizedCache#merge(Record, CacheHeaders)}. Implementations should override this
-   * method if the
-   * underlying storage technology can offer an optimized manner to store multiple records.
+   * Calls through to {@link NormalizedCache#merge(Record, CacheHeaders)}. Implementations should override this method
+   * if the underlying storage technology can offer an optimized manner to store multiple records.
    *
    * @param recordSet    The set of Records to merge.
    * @param cacheHeaders The {@link CacheHeaders} associated with the request which generated this record.
@@ -97,8 +94,7 @@ public abstract class NormalizedCache {
   /**
    * Clears all records from the cache.
    *
-   * Clients should call {@link ApolloClient#clearNormalizedCache()} for a thread-safe access to
-   * this method.
+   * Clients should call {@link ApolloClient#clearNormalizedCache()} for a thread-safe access to this method.
    */
   public abstract void clearAll();
 
@@ -109,4 +105,25 @@ public abstract class NormalizedCache {
    * @return {@code true} if record with such key was successfully removed, {@code false} otherwise
    */
   public abstract boolean remove(@Nonnull CacheKey cacheKey);
+
+  public final NormalizedCache chain(@Nonnull NormalizedCache cache) {
+    checkNotNull(cache, "cache == null");
+
+    NormalizedCache leafCache = this;
+    while (leafCache.nextCache.isPresent()) {
+      leafCache = leafCache.nextCache.get();
+    }
+    leafCache.nextCache = Optional.of(cache);
+
+    return this;
+  }
+
+  public final Optional<NormalizedCache> nextCache() {
+    return nextCache;
+  }
+
+  protected final RecordFieldJsonAdapter recordAdapter() {
+    return recordFieldAdapter;
+  }
+
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
@@ -2,7 +2,6 @@ package com.apollographql.apollo.cache.normalized;
 
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.internal.Optional;
-import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.CacheHeaders;
 
 import java.util.ArrayList;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCacheFactory.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCacheFactory.java
@@ -2,12 +2,19 @@ package com.apollographql.apollo.cache.normalized;
 
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.ScalarType;
+import com.apollographql.apollo.api.internal.Function;
+import com.apollographql.apollo.api.internal.Optional;
+
+import javax.annotation.Nonnull;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 /**
  * A Factory used to construct an instance of a {@link NormalizedCache} configured with the custom scalar adapters set
  * in {@link com.apollographql.apollo.ApolloClient.Builder#addCustomTypeAdapter(ScalarType, CustomTypeAdapter)}.
  */
-public interface NormalizedCacheFactory<T extends NormalizedCache> {
+public abstract class NormalizedCacheFactory<T extends NormalizedCache> {
+  private Optional<NormalizedCacheFactory> nextFactory = Optional.absent();
 
   /**
    * @param recordFieldAdapter A {@link RecordFieldJsonAdapter} configured with the custom scalar adapters set in {@link
@@ -15,6 +22,30 @@ public interface NormalizedCacheFactory<T extends NormalizedCache> {
    *                           CustomTypeAdapter)}.
    * @return An implementation of {@link NormalizedCache}.
    */
-  T createNormalizedCache(RecordFieldJsonAdapter recordFieldAdapter);
+  public abstract T create(RecordFieldJsonAdapter recordFieldAdapter);
 
+  public final NormalizedCache createChain(final RecordFieldJsonAdapter recordFieldAdapter) {
+    if (nextFactory.isPresent()) {
+      return create(recordFieldAdapter)
+          .chain(nextFactory.map(new Function<NormalizedCacheFactory, NormalizedCache>() {
+            @Nonnull @Override public NormalizedCache apply(@Nonnull NormalizedCacheFactory factory) {
+              return factory.createChain(recordFieldAdapter);
+            }
+          }).get());
+    } else {
+      return create(recordFieldAdapter);
+    }
+  }
+
+  public final NormalizedCacheFactory<T> chain(@Nonnull NormalizedCacheFactory factory) {
+    checkNotNull(factory, "factory == null");
+
+    NormalizedCacheFactory leafFactory = this;
+    while (leafFactory.nextFactory.isPresent()) {
+      leafFactory = (NormalizedCacheFactory) leafFactory.nextFactory.get();
+    }
+    leafFactory.nextFactory = Optional.of(factory);
+
+    return this;
+  }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheFactory.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheFactory.java
@@ -1,30 +1,21 @@
 package com.apollographql.apollo.cache.normalized.lru;
 
-import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory;
 import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
-public final class LruNormalizedCacheFactory implements NormalizedCacheFactory<LruNormalizedCache> {
-
+public final class LruNormalizedCacheFactory extends NormalizedCacheFactory<LruNormalizedCache> {
   private final EvictionPolicy evictionPolicy;
-  private final Optional<NormalizedCacheFactory> optionalSecondaryCache;
-
-  public LruNormalizedCacheFactory(EvictionPolicy evictionPolicy) {
-    this(evictionPolicy, null);
-  }
 
   /**
-   * @param evictionPolicy        The {@link EvictionPolicy} to manage the primary cache.
-   * @param secondaryCacheFactory A {@link NormalizedCacheFactory} to create a secondary cache.
+   * @param evictionPolicy {@link EvictionPolicy} to manage the primary cache.
    */
-  public LruNormalizedCacheFactory(EvictionPolicy evictionPolicy, NormalizedCacheFactory secondaryCacheFactory) {
+  public LruNormalizedCacheFactory(EvictionPolicy evictionPolicy) {
     this.evictionPolicy = checkNotNull(evictionPolicy, "evictionPolicy == null");
-    this.optionalSecondaryCache = Optional.fromNullable(secondaryCacheFactory);
   }
 
-  @Override public LruNormalizedCache createNormalizedCache(RecordFieldJsonAdapter fieldAdapter) {
-    return new LruNormalizedCache(fieldAdapter, evictionPolicy, optionalSecondaryCache);
+  @Override public LruNormalizedCache create(final RecordFieldJsonAdapter fieldAdapter) {
+    return new LruNormalizedCache(fieldAdapter, evictionPolicy);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -183,19 +183,15 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   @Override public synchronized void cancel() {
     switch (state.get()) {
       case ACTIVE:
+        state.set(CANCELED);
         try {
           interceptorChain.dispose();
           if (queryReFetcher.isPresent()) {
             queryReFetcher.get().cancel();
           }
-          Callback<T> callback = originalCallback.get();
-          if (callback != null) {
-            callback.onCanceledError(new ApolloCanceledException("Call canceled"));
-          }
         } finally {
           tracker.unregisterCall(this);
           originalCallback.set(null);
-          state.set(CANCELED);
         }
         break;
       case IDLE:

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -188,6 +188,10 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
           if (queryReFetcher.isPresent()) {
             queryReFetcher.get().cancel();
           }
+          Callback<T> callback = originalCallback.get();
+          if (callback != null) {
+            callback.onCanceledError(new ApolloCanceledException("Call canceled"));
+          }
         } finally {
           tracker.unregisterCall(this);
           originalCallback.set(null);


### PR DESCRIPTION
Refactor the way how normalized caches connected with each other.
Now, instead of having primary and secondary caches only, we allow user to build a chain with arbitrary number of cache instances.

Logic of `loadRecord`/`merge`/ `clearAll`/ `remove` records from the chain of caches will be the same as it was before for `LruNormalizedCache` with primary and secondary caches.

Part of #583

Next step is to create OptimisticUpdateCache based on Lru and make it to be the first cache in the chain