### PR TITLE
Introduce OptimisticNormalizedCache and API to write/rollback

### DIFF
--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/HeroNameWithId.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/HeroNameWithId.graphql
@@ -1,0 +1,6 @@
+query HeroNameWithId {
+  hero {
+    id
+    name
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
@@ -2,16 +2,16 @@ package com.apollographql.apollo;
 
 import android.support.annotation.NonNull;
 
-import com.apollographql.apollo.cache.normalized.CacheKey;
-import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesQuery;
-import com.apollographql.apollo.integration.normalizer.type.Episode;
 import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesQuery;
+import com.apollographql.apollo.integration.normalizer.type.Episode;
 
 import org.junit.After;
 import org.junit.Before;
@@ -46,7 +46,7 @@ public class CacheHeadersTest {
 
   @Test
   public void testHeadersReceived() throws ApolloException, IOException {
-    final NormalizedCache normalizedCache = new NormalizedCache(RecordFieldJsonAdapter.create()) {
+    final NormalizedCache normalizedCache = new NormalizedCache() {
       @Nullable @Override public Record loadRecord(@NonNull String key, @NonNull CacheHeaders cacheHeaders) {
         assertThat(cacheHeaders.hasHeader(ApolloCacheHeaders.DO_NOT_STORE)).isTrue();
         return null;
@@ -87,7 +87,7 @@ public class CacheHeadersTest {
 
   @Test
   public void testDefaultHeadersReceived() throws IOException, ApolloException {
-    final NormalizedCache normalizedCache = new NormalizedCache(RecordFieldJsonAdapter.create()) {
+    final NormalizedCache normalizedCache = new NormalizedCache() {
       @Nullable @Override public Record loadRecord(@NonNull String key, @NonNull CacheHeaders cacheHeaders) {
         assertThat(cacheHeaders.hasHeader(ApolloCacheHeaders.DO_NOT_STORE)).isTrue();
         return null;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -361,9 +361,8 @@ public class NormalizedCacheTestCase {
     assertThat(masterQueryResponse.data().hero().friends()).hasSize(3);
 
     CharacterNameByIdQuery detailQuery = new CharacterNameByIdQuery("1002");
-    Response<CharacterNameByIdQuery.Data> detailQueryResponse = apolloClient.query(detailQuery).responseFetcher
-        (ApolloResponseFetchers
-        .CACHE_ONLY).execute();
+    Response<CharacterNameByIdQuery.Data> detailQueryResponse = apolloClient.query(detailQuery)
+        .responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute();
     assertThat(detailQueryResponse.fromCache()).isTrue();
     assertThat(detailQueryResponse.data().character().asHuman().name()).isEqualTo("Han Solo");
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/OptimisticCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/OptimisticCacheTestCase.java
@@ -1,0 +1,187 @@
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy;
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory;
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesQuery;
+import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDsQuery;
+import com.apollographql.apollo.integration.normalizer.HeroNameWithIdQuery;
+import com.apollographql.apollo.integration.normalizer.type.Episode;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class OptimisticCacheTestCase {
+  private ApolloClient apolloClient;
+  private MockWebServer server;
+
+  @Before public void setUp() {
+    server = new MockWebServer();
+
+    OkHttpClient okHttpClient = new OkHttpClient.Builder()
+        .writeTimeout(2, TimeUnit.SECONDS)
+        .readTimeout(2, TimeUnit.SECONDS)
+        .build();
+
+    apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .okHttpClient(okHttpClient)
+        .normalizedCache(new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION), new IdFieldCacheKeyResolver())
+        .dispatcher(Utils.immediateExecutorService())
+        .build();
+  }
+
+  @After public void tearDown() {
+    try {
+      server.shutdown();
+    } catch (IOException ignored) {
+    }
+  }
+
+  private MockResponse mockResponse(String fileName) throws IOException {
+    return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
+  }
+
+  @Test public void simple_write_rollback() throws Exception {
+    server.enqueue(mockResponse("HeroAndFriendsNameResponse.json"));
+    HeroAndFriendsNamesQuery query = new HeroAndFriendsNamesQuery(Episode.JEDI);
+    apolloClient.query(query).execute();
+
+    UUID updateVersion = UUID.randomUUID();
+    HeroAndFriendsNamesQuery.Data data = new HeroAndFriendsNamesQuery.Data(new HeroAndFriendsNamesQuery.Hero(
+        "Droid",
+        "R222-D222",
+        Arrays.asList(
+            new HeroAndFriendsNamesQuery.Friend(
+                "Human",
+                "SuperMan"
+            ),
+            new HeroAndFriendsNamesQuery.Friend(
+                "Human",
+                "Batman"
+            )
+        )
+    ));
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query, data, updateVersion).execute();
+
+    data = apolloClient.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data.hero().name()).isEqualTo("R222-D222");
+    assertThat(data.hero().friends()).hasSize(2);
+    assertThat(data.hero().friends().get(0).name()).isEqualTo("SuperMan");
+    assertThat(data.hero().friends().get(1).name()).isEqualTo("Batman");
+
+    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion).execute();
+
+    data = apolloClient.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data.hero().name()).isEqualTo("R2-D2");
+    assertThat(data.hero().friends()).hasSize(3);
+    assertThat(data.hero().friends().get(0).name()).isEqualTo("Luke Skywalker");
+    assertThat(data.hero().friends().get(1).name()).isEqualTo("Han Solo");
+    assertThat(data.hero().friends().get(2).name()).isEqualTo("Leia Organa");
+  }
+
+  @Test public void partial_rollback() throws Exception {
+    server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
+    HeroAndFriendsNamesWithIDsQuery query1 = new HeroAndFriendsNamesWithIDsQuery(Episode.JEDI);
+    apolloClient.query(query1).execute();
+
+    UUID updateVersion1 = UUID.randomUUID();
+    HeroAndFriendsNamesWithIDsQuery.Data data1 = new HeroAndFriendsNamesWithIDsQuery.Data(
+        new HeroAndFriendsNamesWithIDsQuery.Hero(
+            "Droid",
+            "2001",
+            "R222-D222",
+            Arrays.asList(
+                new HeroAndFriendsNamesWithIDsQuery.Friend(
+                    "Human",
+                    "1000",
+                    "SuperMan"
+                ),
+                new HeroAndFriendsNamesWithIDsQuery.Friend(
+                    "Human",
+                    "1003",
+                    "Batman"
+                )
+            )
+        )
+    );
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query1, data1, updateVersion1).execute();
+
+    // check if query1 see optimistic updates
+    data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data1.hero().id()).isEqualTo("2001");
+    assertThat(data1.hero().name()).isEqualTo("R222-D222");
+    assertThat(data1.hero().friends()).hasSize(2);
+    assertThat(data1.hero().friends().get(0).id()).isEqualTo("1000");
+    assertThat(data1.hero().friends().get(0).name()).isEqualTo("SuperMan");
+    assertThat(data1.hero().friends().get(1).id()).isEqualTo("1003");
+    assertThat(data1.hero().friends().get(1).name()).isEqualTo("Batman");
+
+    server.enqueue(mockResponse("HeroNameWithIdResponse.json"));
+    HeroNameWithIdQuery query2 = new HeroNameWithIdQuery();
+    apolloClient.query(query2).execute();
+
+    UUID updateVersion2 = UUID.randomUUID();
+    HeroNameWithIdQuery.Data data2 = new HeroNameWithIdQuery.Data(new HeroNameWithIdQuery.Hero(
+        "Human",
+        "1000",
+        "Beast"
+    ));
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query2, data2, updateVersion2).execute();
+
+    // check if query1 see the latest optimistic updates
+    data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data1.hero().id()).isEqualTo("2001");
+    assertThat(data1.hero().name()).isEqualTo("R222-D222");
+    assertThat(data1.hero().friends()).hasSize(2);
+    assertThat(data1.hero().friends().get(0).id()).isEqualTo("1000");
+    assertThat(data1.hero().friends().get(0).name()).isEqualTo("Beast");
+    assertThat(data1.hero().friends().get(1).id()).isEqualTo("1003");
+    assertThat(data1.hero().friends().get(1).name()).isEqualTo("Batman");
+
+    // check if query2 see the latest optimistic updates
+    data2 = apolloClient.query(query2).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data2.hero().id()).isEqualTo("1000");
+    assertThat(data2.hero().name()).isEqualTo("Beast");
+
+    // rollback query1 optimistic updates
+    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion1).execute();
+
+    // check if query1 see the latest optimistic updates
+    data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data1.hero().id()).isEqualTo("2001");
+    assertThat(data1.hero().name()).isEqualTo("R2-D2");
+    assertThat(data1.hero().friends()).hasSize(3);
+    assertThat(data1.hero().friends().get(0).id()).isEqualTo("1000");
+    assertThat(data1.hero().friends().get(0).name()).isEqualTo("Beast");
+    assertThat(data1.hero().friends().get(1).id()).isEqualTo("1002");
+    assertThat(data1.hero().friends().get(1).name()).isEqualTo("Han Solo");
+    assertThat(data1.hero().friends().get(2).id()).isEqualTo("1003");
+    assertThat(data1.hero().friends().get(2).name()).isEqualTo("Leia Organa");
+
+    // check if query2 see the latest optimistic updates
+    data2 = apolloClient.query(query2).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data2.hero().id()).isEqualTo("1000");
+    assertThat(data2.hero().name()).isEqualTo("Beast");
+
+    // rollback query2 optimistic updates
+    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion2).execute();
+
+    // check if query2 see the latest optimistic updates
+    data2 = apolloClient.query(query2).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data2.hero().id()).isEqualTo("1000");
+    assertThat(data2.hero().name()).isEqualTo("SuperMan");
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
@@ -8,7 +8,6 @@ import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
-import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import org.junit.Test;
@@ -25,7 +24,7 @@ public class ApolloStoreTest {
 
   @Test public void storeClearAllCallsNormalizedCacheClearAll() throws Exception {
     final NamedCountDownLatch latch = new NamedCountDownLatch("storeClearAllCallsNormalizedCacheClearAll", 1);
-    final RealApolloStore realApolloStore = new RealApolloStore(new NormalizedCache(RecordFieldJsonAdapter.create()) {
+    final RealApolloStore realApolloStore = new RealApolloStore(new NormalizedCache() {
       @Nullable @Override public Record loadRecord(@Nonnull String key, @Nonnull CacheHeaders cacheHeaders) {
         return null;
       }

--- a/apollo-integration/src/test/resources/HeroNameWithIdResponse.json
+++ b/apollo-integration/src/test/resources/HeroNameWithIdResponse.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "hero": {
+      "__typename": "Human",
+      "id": "1000",
+      "name": "SuperMan"
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
@@ -14,6 +14,7 @@ import com.apollographql.apollo.internal.cache.normalized.WriteableStore;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
@@ -163,8 +164,8 @@ public interface ApolloStore {
       @Nonnull Operation<D, T, V> operation, @Nonnull D operationData);
 
   /**
-   * Write operation to the store and publish changes of {@link Record} which have changed, that will notify any
-   * {@link com.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
+   * Write operation to the store and publish changes of {@link Record} which have changed, that will notify any {@link
+   * com.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
    *
    * @param operation     {@link Operation} response data of which should be written to the store
    * @param operationData {@link Operation.Data} operation response data to be written to the store
@@ -189,8 +190,8 @@ public interface ApolloStore {
       @Nonnull Operation.Variables variables);
 
   /**
-   * Write fragment to the store and publish changes of {@link Record} which have changed, that will notify any
-   * {@link com.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
+   * Write fragment to the store and publish changes of {@link Record} which have changed, that will notify any {@link
+   * com.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
    *
    * @param fragment data to be written to the store
    * @param cacheKey {@link CacheKey} to be used as root record key
@@ -199,6 +200,49 @@ public interface ApolloStore {
    */
   @Nonnull ApolloStoreOperation<Boolean> writeAndPublish(@Nonnull GraphqlFragment fragment, @Nonnull CacheKey cacheKey,
       @Nonnull Operation.Variables variables);
+
+  /**
+   * Write operation data to the optimistic store.
+   *
+   * @param operation     {@link Operation} response data of which should be written to the store
+   * @param operationData {@link Operation.Data} operation response data to be written to the store
+   * @param updateVersion optimistic update version that will be required to rollback changes
+   * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of {@link Record} which
+   * have changed
+   */
+  @Nonnull <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>>
+  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion);
+
+  /**
+   * Write operation data to the optimistic store and publish changes of {@link Record}s which have changed, that will
+   * notify any {@linkcom.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
+   *
+   * @param operation     {@link Operation} response data of which should be written to the store
+   * @param operationData {@link Operation.Data} operation response data to be written to the store
+   * @param updateVersion optimistic update version that will be required to rollback changes
+   * @return {@ApolloStoreOperation} to be performed
+   */
+  @Nonnull <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Boolean>
+  writeOptimisticUpdatesAndPublish(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData,
+      @Nonnull UUID updateVersion);
+
+  /**
+   * Rollback operation data optimistic updates.
+   *
+   * @param updateVersion optimistic update version to rollback
+   * @return {@ApolloStoreOperation} to be performed
+   */
+  @Nonnull ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID updateVersion);
+
+  /**
+   * Rollback operation data optimistic updates and publish changes of {@link Record}s which have changed, that will
+   * notify any {@linkcom.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
+   *
+   * @param updateVersion optimistic update version to rollback
+   * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of {@link Record} which
+   * have changed
+   */
+  @Nonnull ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID updateVersion);
 
   ApolloStore NO_APOLLO_STORE = new NoOpApolloStore();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
@@ -32,15 +32,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
  * See {@link com.apollographql.apollo.cache.normalized.lru.LruNormalizedCache} for a in memory cache.
  */
 public abstract class NormalizedCache {
-  private RecordFieldJsonAdapter recordFieldAdapter;
   private Optional<NormalizedCache> nextCache = Optional.absent();
-
-  /**
-   * @param recordFieldAdapter An adapter which can deserialize and deserialize {@link Record}
-   */
-  public NormalizedCache(RecordFieldJsonAdapter recordFieldAdapter) {
-    this.recordFieldAdapter = recordFieldAdapter;
-  }
 
   /**
    * @param key          The key of the record to read.
@@ -120,9 +112,4 @@ public abstract class NormalizedCache {
   public final Optional<NormalizedCache> nextCache() {
     return nextCache;
   }
-
-  protected final RecordFieldJsonAdapter recordAdapter() {
-    return recordFieldAdapter;
-  }
-
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
@@ -1,0 +1,123 @@
+package com.apollographql.apollo.cache.normalized;
+
+import com.apollographql.apollo.api.internal.Action;
+import com.apollographql.apollo.api.internal.Function;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.cache.CacheHeaders;
+import com.nytimes.android.external.cache.Cache;
+import com.nytimes.android.external.cache.CacheBuilder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
+public final class OptimisticNormalizedCache extends NormalizedCache {
+  private final Cache<String, Record> lruCache = CacheBuilder.newBuilder().build();
+
+  @Nullable @Override public Record loadRecord(@Nonnull final String key, @Nonnull final CacheHeaders cacheHeaders) {
+    checkNotNull(key, "key == null");
+    checkNotNull(cacheHeaders, "cacheHeaders == null");
+
+    try {
+      return lruCache.get(key, new Callable<Record>() {
+        @Override public Record call() throws Exception {
+          return nextCache().flatMap(new Function<NormalizedCache, Optional<Record>>() {
+            @Nonnull @Override public Optional<Record> apply(@Nonnull NormalizedCache cache) {
+              return Optional.fromNullable(cache.loadRecord(key, cacheHeaders));
+            }
+          }).get(); // lruCache.get(key, callable) requires non-null.
+        }
+      });
+    } catch (Exception ignore) {
+      return null;
+    }
+  }
+
+  @Nonnull @Override public Set<String> merge(@Nonnull final Record record, @Nonnull final CacheHeaders cacheHeaders) {
+    checkNotNull(record, "record == null");
+    checkNotNull(cacheHeaders, "cacheHeaders == null");
+
+    return nextCache().map(new Function<NormalizedCache, Set<String>>() {
+      @Nonnull @Override public Set<String> apply(@Nonnull NormalizedCache cache) {
+        return cache.merge(record, cacheHeaders);
+      }
+    }).or(Collections.<String>emptySet());
+  }
+
+  @Override public void clearAll() {
+    lruCache.invalidateAll();
+    //noinspection ResultOfMethodCallIgnored
+    nextCache().apply(new Action<NormalizedCache>() {
+      @Override public void apply(@Nonnull NormalizedCache cache) {
+        cache.clearAll();
+      }
+    });
+  }
+
+  @Override public boolean remove(@Nonnull final CacheKey cacheKey) {
+    checkNotNull(cacheKey, "cacheKey == null");
+
+    boolean result = nextCache().map(new Function<NormalizedCache, Boolean>() {
+      @Nonnull @Override public Boolean apply(@Nonnull NormalizedCache cache) {
+        return cache.remove(cacheKey);
+      }
+    }).or(Boolean.FALSE);
+
+    if (lruCache.getIfPresent(cacheKey.key()) != null) {
+      lruCache.invalidate(cacheKey.key());
+      result = true;
+    }
+
+    return result;
+  }
+
+  @Nonnull public Set<String> mergeOptimisticUpdates(@Nonnull Collection<Record> recordSet) {
+    Set<String> aggregatedDependentKeys = new LinkedHashSet<>();
+    for (Record record : recordSet) {
+      aggregatedDependentKeys.addAll(mergeOptimisticUpdate(record));
+    }
+    return aggregatedDependentKeys;
+  }
+
+  @Nonnull public Set<String> mergeOptimisticUpdate(@Nonnull final Record record) {
+    checkNotNull(record, "record == null");
+
+    final Record oldRecord = lruCache.getIfPresent(record.key());
+    if (oldRecord == null) {
+      lruCache.put(record.key(), record);
+      return Collections.emptySet();
+    } else {
+      Set<String> changedKeys = oldRecord.mergeWith(record);
+      //re-insert to trigger new weight calculation
+      lruCache.put(record.key(), oldRecord);
+      return changedKeys;
+    }
+  }
+
+  @Nonnull public Set<String> removeOptimisticUpdates(@Nonnull final UUID version) {
+    checkNotNull(version, "version == null");
+
+    Map<String, Record> cachedRecords = lruCache.asMap();
+    List<String> invalidateKeys = new ArrayList<>();
+    for (Map.Entry<String, Record> cachedRecordEntry : cachedRecords.entrySet()) {
+      if (version.equals(cachedRecordEntry.getValue().version()) || cachedRecordEntry.getValue().version() == null) {
+        invalidateKeys.add(cachedRecordEntry.getKey());
+      }
+    }
+    lruCache.invalidateAll(invalidateKeys);
+
+    return new HashSet<>(invalidateKeys);
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
@@ -8,7 +8,6 @@ import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
-import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.cache.CacheBuilder;
 import com.nytimes.android.external.cache.Weigher;
@@ -31,8 +30,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 public final class LruNormalizedCache extends NormalizedCache {
   private final Cache<String, Record> lruCache;
 
-  LruNormalizedCache(final RecordFieldJsonAdapter recordFieldAdapter, EvictionPolicy evictionPolicy) {
-    super(recordFieldAdapter);
+  LruNormalizedCache(EvictionPolicy evictionPolicy) {
     final CacheBuilder<Object, Object> lruCacheBuilder = CacheBuilder.newBuilder();
     if (evictionPolicy.maxSizeBytes().isPresent()) {
       lruCacheBuilder.maximumWeight(evictionPolicy.maxSizeBytes().get())

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheFactory.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheFactory.java
@@ -16,6 +16,6 @@ public final class LruNormalizedCacheFactory extends NormalizedCacheFactory<LruN
   }
 
   @Override public LruNormalizedCache create(final RecordFieldJsonAdapter fieldAdapter) {
-    return new LruNormalizedCache(fieldAdapter, evictionPolicy);
+    return new LruNormalizedCache(evictionPolicy);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -130,7 +130,8 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
   }
 
   @Nonnull @Override
-  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>> writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion) {
+  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>>
+  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion) {
     return ApolloStoreOperation.emptyOperation(Collections.<String>emptySet());
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -17,13 +17,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * An alternative to {@link RealApolloStore} for when a no-operation cache
- * is needed.
+ * An alternative to {@link RealApolloStore} for when a no-operation cache is needed.
  */
 public final class NoOpApolloStore implements ApolloStore, ReadableStore, WriteableStore {
 
@@ -127,5 +127,26 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
   public ApolloStoreOperation<Boolean> writeAndPublish(@Nonnull GraphqlFragment fragment, @Nonnull CacheKey cacheKey,
       @Nonnull Operation.Variables variables) {
     return ApolloStoreOperation.emptyOperation(Boolean.FALSE);
+  }
+
+  @Nonnull @Override
+  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>> writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion) {
+    return ApolloStoreOperation.emptyOperation(Collections.<String>emptySet());
+  }
+
+  @Nonnull @Override
+  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Boolean>
+  writeOptimisticUpdatesAndPublish(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData,
+      @Nonnull UUID updateVersion) {
+    return ApolloStoreOperation.emptyOperation(Boolean.FALSE);
+  }
+
+  @Nonnull @Override
+  public ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID updateVersion) {
+    return ApolloStoreOperation.emptyOperation(Boolean.FALSE);
+  }
+
+  @Nonnull @Override public ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID updateVersion) {
+    return ApolloStoreOperation.emptyOperation(Collections.<String>emptySet());
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -13,17 +13,20 @@ import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
+import com.apollographql.apollo.cache.normalized.OptimisticNormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.internal.field.CacheFieldValueResolver;
 import com.apollographql.apollo.internal.reader.RealResponseReader;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -35,7 +38,7 @@ import javax.annotation.Nullable;
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class RealApolloStore implements ApolloStore, ReadableStore, WriteableStore {
-  private final NormalizedCache normalizedCache;
+  private final OptimisticNormalizedCache optimisticCache;
   private final CacheKeyResolver cacheKeyResolver;
   private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
   private final ReadWriteLock lock;
@@ -46,7 +49,9 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
   public RealApolloStore(@Nonnull NormalizedCache normalizedCache, @Nonnull CacheKeyResolver cacheKeyResolver,
       @Nonnull final Map<ScalarType, CustomTypeAdapter> customTypeAdapters, @Nonnull ExecutorService dispatcher,
       @Nonnull ApolloLogger logger) {
-    this.normalizedCache = checkNotNull(normalizedCache, "cacheStore == null");
+    checkNotNull(normalizedCache, "cacheStore == null");
+
+    this.optimisticCache = (OptimisticNormalizedCache) new OptimisticNormalizedCache().chain(normalizedCache);
     this.cacheKeyResolver = checkNotNull(cacheKeyResolver, "cacheKeyResolver == null");
     this.customTypeAdapters = checkNotNull(customTypeAdapters, "customTypeAdapters == null");
     this.dispatcher = checkNotNull(dispatcher, "dispatcher == null");
@@ -102,7 +107,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
       @Override public Boolean perform() {
         return writeTransaction(new Transaction<WriteableStore, Boolean>() {
           @Override public Boolean execute(WriteableStore cache) {
-            normalizedCache.clearAll();
+            optimisticCache.clearAll();
             return Boolean.TRUE;
           }
         });
@@ -116,7 +121,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
       @Override protected Boolean perform() {
         return writeTransaction(new Transaction<WriteableStore, Boolean>() {
           @Override public Boolean execute(WriteableStore cache) {
-            return normalizedCache.remove(cacheKey);
+            return optimisticCache.remove(cacheKey);
           }
         });
       }
@@ -131,7 +136,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
           @Override public Integer execute(WriteableStore cache) {
             int count = 0;
             for (CacheKey cacheKey : cacheKeys) {
-              if (normalizedCache.remove(cacheKey)) {
+              if (optimisticCache.remove(cacheKey)) {
                 count++;
               }
             }
@@ -161,19 +166,19 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
   }
 
   @Override public NormalizedCache normalizedCache() {
-    return normalizedCache;
+    return optimisticCache;
   }
 
   @Nullable public Record read(@Nonnull String key, @Nonnull CacheHeaders cacheHeaders) {
-    return normalizedCache.loadRecord(checkNotNull(key, "key == null"), cacheHeaders);
+    return optimisticCache.loadRecord(checkNotNull(key, "key == null"), cacheHeaders);
   }
 
   @Nonnull public Collection<Record> read(@Nonnull Collection<String> keys, @Nonnull CacheHeaders cacheHeaders) {
-    return normalizedCache.loadRecords(checkNotNull(keys, "keys == null"), cacheHeaders);
+    return optimisticCache.loadRecords(checkNotNull(keys, "keys == null"), cacheHeaders);
   }
 
   @Nonnull public Set<String> merge(@Nonnull Collection<Record> recordSet, @Nonnull CacheHeaders cacheHeaders) {
-    return normalizedCache.merge(checkNotNull(recordSet, "recordSet == null"), cacheHeaders);
+    return optimisticCache.merge(checkNotNull(recordSet, "recordSet == null"), cacheHeaders);
   }
 
   @Override public CacheKeyResolver cacheKeyResolver() {
@@ -223,7 +228,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     checkNotNull(operationData, "operationData == null");
     return new ApolloStoreOperation<Set<String>>(dispatcher) {
       @Override protected Set<String> perform() {
-        return doWrite(operation, operationData);
+        return doWrite(operation, operationData, false, null);
       }
     };
   }
@@ -232,7 +237,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
   writeAndPublish(@Nonnull final Operation<D, T, V> operation, @Nonnull final D operationData) {
     return new ApolloStoreOperation<Boolean>(dispatcher) {
       @Override protected Boolean perform() {
-        Set<String> changedKeys = doWrite(operation, operationData);
+        Set<String> changedKeys = doWrite(operation, operationData, false, null);
         publish(changedKeys);
         return Boolean.TRUE;
       }
@@ -265,6 +270,58 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     return new ApolloStoreOperation<Boolean>(dispatcher) {
       @Override protected Boolean perform() {
         Set<String> changedKeys = doWrite(fragment, cacheKey, variables);
+        publish(changedKeys);
+        return Boolean.TRUE;
+      }
+    };
+  }
+
+  @Nonnull @Override
+  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>>
+  writeOptimisticUpdates(@Nonnull final Operation<D, T, V> operation, @Nonnull final D operationData,
+      @Nonnull final UUID updateVersion) {
+    return new ApolloStoreOperation<Set<String>>(dispatcher) {
+      @Override protected Set<String> perform() {
+        return doWrite(operation, operationData, true, updateVersion);
+      }
+    };
+  }
+
+  @Nonnull @Override
+  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Boolean>
+  writeOptimisticUpdatesAndPublish(@Nonnull final Operation<D, T, V> operation, @Nonnull final D operationData,
+      @Nonnull final UUID updateVersion) {
+    return new ApolloStoreOperation<Boolean>(dispatcher) {
+      @Override protected Boolean perform() {
+        Set<String> changedKeys = doWrite(operation, operationData, true, updateVersion);
+        publish(changedKeys);
+        return Boolean.TRUE;
+      }
+    };
+  }
+
+  @Nonnull @Override
+  public ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull final UUID updateVersion) {
+    return new ApolloStoreOperation<Set<String>>(dispatcher) {
+      @Override protected Set<String> perform() {
+        return writeTransaction(new Transaction<WriteableStore, Set<String>>() {
+          @Override public Set<String> execute(WriteableStore cache) {
+            return optimisticCache.removeOptimisticUpdates(updateVersion);
+          }
+        });
+      }
+    };
+  }
+
+  @Nonnull @Override
+  public ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull final UUID updateVersion) {
+    return new ApolloStoreOperation<Boolean>(dispatcher) {
+      @Override protected Boolean perform() {
+        Set<String> changedKeys = writeTransaction(new Transaction<WriteableStore, Set<String>>() {
+          @Override public Set<String> execute(WriteableStore cache) {
+            return optimisticCache.removeOptimisticUpdates(updateVersion);
+          }
+        });
         publish(changedKeys);
         return Boolean.TRUE;
       }
@@ -340,7 +397,8 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
   }
 
   private <D extends Operation.Data, T, V extends Operation.Variables> Set<String> doWrite(
-      final Operation<D, T, V> operation, final D operationData) {
+      final Operation<D, T, V> operation, final D operationData, final boolean optimistic,
+      final UUID optimisticUpdateVersion) {
     return writeTransaction(new Transaction<WriteableStore, Set<String>>() {
       @Override public Set<String> execute(WriteableStore cache) {
         CacheResponseWriter cacheResponseWriter = new CacheResponseWriter(operation.variables(),
@@ -349,7 +407,15 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
         ResponseNormalizer<Map<String, Object>> responseNormalizer = networkResponseNormalizer();
         responseNormalizer.willResolveRootQuery(operation);
         Collection<Record> records = cacheResponseWriter.normalize(responseNormalizer);
-        return merge(records, CacheHeaders.NONE);
+        if (optimistic) {
+          List<Record> updatedRecords = new ArrayList<>();
+          for (Record record : records) {
+            updatedRecords.add(record.toBuilder().version(optimisticUpdateVersion).build());
+          }
+          return optimisticCache.mergeOptimisticUpdates(updatedRecords);
+        } else {
+          return optimisticCache.merge(records, CacheHeaders.NONE);
+        }
       }
     });
   }


### PR DESCRIPTION
Introduce `OptimisticNormalizedCache` to be always used as first layer in a chain
Introduce `ApolloStore` API to write/rollback optimistic updates
Some small refactoring related to `RecordFieldJsonAdapter` that required only for SQL cache

Part of #583