### PR TITLE
bug/fixNonClonedCall

### DIFF
--- a/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -79,7 +79,8 @@ public final class RxApollo {
   }
 
   /**
-   * Converts an {@link ApolloCall} to a Observable. The number of emissions this Observable will have
+   * Converts an {@link Apollo
+   } to a Observable. The number of emissions this Observable will have
    * is based on the {@link com.apollographql.apollo.fetcher.ResponseFetcher} used with the call.
    *
    * @param call             the ApolloCall to convert
@@ -87,9 +88,10 @@ public final class RxApollo {
    * @param backpressureMode The {@link rx.Emitter.BackpressureMode} to use.
    * @return the converted Observable
    */
-  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloCall<T> call,
+  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloCall<T> originalCall,
       Emitter.BackpressureMode backpressureMode) {
-    checkNotNull(call, "call == null");
+    checkNotNull(originalCall, "call == null");
+    Call<T> call = originalCall.clone();
     return Observable.create(new Action1<Emitter<Response<T>>>() {
       @Override public void call(final Emitter<Response<T>> emitter) {
         emitter.setCancellation(new Cancellable() {


### PR DESCRIPTION
Currently we are not cloning the `originalCall` when creating an `Observable` this pr will make sure we clone in case a user calls `.retry()`