### PR TITLE
Rename to mutationId and fix issue with partial optimistic store

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/OptimisticCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/OptimisticCacheTestCase.java
@@ -5,6 +5,8 @@ import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory;
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesQuery;
 import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDsQuery;
+import com.apollographql.apollo.integration.normalizer.HeroNameQuery;
+import com.apollographql.apollo.integration.normalizer.HeroNameWithEnumsQuery;
 import com.apollographql.apollo.integration.normalizer.HeroNameWithIdQuery;
 import com.apollographql.apollo.integration.normalizer.type.Episode;
 
@@ -54,12 +56,12 @@ public class OptimisticCacheTestCase {
     return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
   }
 
-  @Test public void simple_write_rollback() throws Exception {
+  @Test public void simple() throws Exception {
     server.enqueue(mockResponse("HeroAndFriendsNameResponse.json"));
     HeroAndFriendsNamesQuery query = new HeroAndFriendsNamesQuery(Episode.JEDI);
     apolloClient.query(query).execute();
 
-    UUID updateVersion = UUID.randomUUID();
+    UUID mutationId = UUID.randomUUID();
     HeroAndFriendsNamesQuery.Data data = new HeroAndFriendsNamesQuery.Data(new HeroAndFriendsNamesQuery.Hero(
         "Droid",
         "R222-D222",
@@ -74,7 +76,7 @@ public class OptimisticCacheTestCase {
             )
         )
     ));
-    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query, data, updateVersion).execute();
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query, data, mutationId).execute();
 
     data = apolloClient.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
     assertThat(data.hero().name()).isEqualTo("R222-D222");
@@ -82,7 +84,7 @@ public class OptimisticCacheTestCase {
     assertThat(data.hero().friends().get(0).name()).isEqualTo("SuperMan");
     assertThat(data.hero().friends().get(1).name()).isEqualTo("Batman");
 
-    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion).execute();
+    apolloClient.apolloStore().rollbackOptimisticUpdates(mutationId).execute();
 
     data = apolloClient.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
     assertThat(data.hero().name()).isEqualTo("R2-D2");
@@ -92,12 +94,12 @@ public class OptimisticCacheTestCase {
     assertThat(data.hero().friends().get(2).name()).isEqualTo("Leia Organa");
   }
 
-  @Test public void partial_rollback() throws Exception {
+  @Test public void two_optimistic_two_rollback() throws Exception {
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsResponse.json"));
     HeroAndFriendsNamesWithIDsQuery query1 = new HeroAndFriendsNamesWithIDsQuery(Episode.JEDI);
     apolloClient.query(query1).execute();
 
-    UUID updateVersion1 = UUID.randomUUID();
+    UUID mutationId1 = UUID.randomUUID();
     HeroAndFriendsNamesWithIDsQuery.Data data1 = new HeroAndFriendsNamesWithIDsQuery.Data(
         new HeroAndFriendsNamesWithIDsQuery.Hero(
             "Droid",
@@ -117,7 +119,7 @@ public class OptimisticCacheTestCase {
             )
         )
     );
-    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query1, data1, updateVersion1).execute();
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query1, data1, mutationId1).execute();
 
     // check if query1 see optimistic updates
     data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
@@ -133,13 +135,13 @@ public class OptimisticCacheTestCase {
     HeroNameWithIdQuery query2 = new HeroNameWithIdQuery();
     apolloClient.query(query2).execute();
 
-    UUID updateVersion2 = UUID.randomUUID();
+    UUID mutationId2 = UUID.randomUUID();
     HeroNameWithIdQuery.Data data2 = new HeroNameWithIdQuery.Data(new HeroNameWithIdQuery.Hero(
         "Human",
         "1000",
         "Beast"
     ));
-    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query2, data2, updateVersion2).execute();
+    apolloClient.apolloStore().writeOptimisticUpdatesAndPublish(query2, data2, mutationId2).execute();
 
     // check if query1 see the latest optimistic updates
     data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
@@ -157,7 +159,7 @@ public class OptimisticCacheTestCase {
     assertThat(data2.hero().name()).isEqualTo("Beast");
 
     // rollback query1 optimistic updates
-    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion1).execute();
+    apolloClient.apolloStore().rollbackOptimisticUpdates(mutationId1).execute();
 
     // check if query1 see the latest optimistic updates
     data1 = apolloClient.query(query1).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
@@ -177,11 +179,35 @@ public class OptimisticCacheTestCase {
     assertThat(data2.hero().name()).isEqualTo("Beast");
 
     // rollback query2 optimistic updates
-    apolloClient.apolloStore().rollbackOptimisticUpdatesAndPublish(updateVersion2).execute();
+    apolloClient.apolloStore().rollbackOptimisticUpdates(mutationId2).execute();
 
     // check if query2 see the latest optimistic updates
     data2 = apolloClient.query(query2).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
     assertThat(data2.hero().id()).isEqualTo("1000");
     assertThat(data2.hero().name()).isEqualTo("SuperMan");
+  }
+
+  @Test public void full_persisted_partial_optimistic() throws Exception {
+    server.enqueue(mockResponse("HeroNameWithEnumsResponse.json"));
+    apolloClient.query(new HeroNameWithEnumsQuery()).execute();
+
+    UUID mutationId = UUID.randomUUID();
+    apolloClient.apolloStore().writeOptimisticUpdates(
+        new HeroNameQuery(),
+        new HeroNameQuery.Data(new HeroNameQuery.Hero("Droid", "R22-D22")),
+        mutationId
+    ).execute();
+
+    HeroNameWithEnumsQuery.Data data = apolloClient.query(new HeroNameWithEnumsQuery()).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data.hero().name()).isEqualTo("R22-D22");
+    assertThat(data.hero().firstAppearsIn()).isEqualTo(Episode.EMPIRE);
+    assertThat(data.hero().appearsIn()).isEqualTo(Arrays.asList(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI));
+
+    apolloClient.apolloStore().rollbackOptimisticUpdates(mutationId).execute();
+
+    data = apolloClient.query(new HeroNameWithEnumsQuery()).responseFetcher(ApolloResponseFetchers.CACHE_ONLY).execute().data();
+    assertThat(data.hero().name()).isEqualTo("R2-D2");
+    assertThat(data.hero().firstAppearsIn()).isEqualTo(Episode.EMPIRE);
+    assertThat(data.hero().appearsIn()).isEqualTo(Arrays.asList(Episode.NEWHOPE, Episode.EMPIRE, Episode.JEDI));
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStore.java
@@ -206,12 +206,12 @@ public interface ApolloStore {
    *
    * @param operation     {@link Operation} response data of which should be written to the store
    * @param operationData {@link Operation.Data} operation response data to be written to the store
-   * @param updateVersion optimistic update version that will be required to rollback changes
+   * @param mutationId    mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of {@link Record} which
    * have changed
    */
   @Nonnull <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>>
-  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion);
+  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID mutationId);
 
   /**
    * Write operation data to the optimistic store and publish changes of {@link Record}s which have changed, that will
@@ -219,30 +219,30 @@ public interface ApolloStore {
    *
    * @param operation     {@link Operation} response data of which should be written to the store
    * @param operationData {@link Operation.Data} operation response data to be written to the store
-   * @param updateVersion optimistic update version that will be required to rollback changes
+   * @param mutationId    mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed
    */
   @Nonnull <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Boolean>
   writeOptimisticUpdatesAndPublish(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData,
-      @Nonnull UUID updateVersion);
+      @Nonnull UUID mutationId);
 
   /**
    * Rollback operation data optimistic updates.
    *
-   * @param updateVersion optimistic update version to rollback
+   * @param mutationId mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed
    */
-  @Nonnull ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID updateVersion);
+  @Nonnull ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID mutationId);
 
   /**
    * Rollback operation data optimistic updates and publish changes of {@link Record}s which have changed, that will
    * notify any {@linkcom.apollographql.apollo.ApolloQueryWatcher} that depends on these {@link Record} to re-fetch.
    *
-   * @param updateVersion optimistic update version to rollback
+   * @param mutationId mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of {@link Record} which
    * have changed
    */
-  @Nonnull ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID updateVersion);
+  @Nonnull ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID mutationId);
 
   ApolloStore NO_APOLLO_STORE = new NoOpApolloStore();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -31,15 +30,23 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     checkNotNull(cacheHeaders, "cacheHeaders == null");
 
     try {
-      return lruCache.get(key, new Callable<Record>() {
-        @Override public Record call() throws Exception {
-          return nextCache().flatMap(new Function<NormalizedCache, Optional<Record>>() {
-            @Nonnull @Override public Optional<Record> apply(@Nonnull NormalizedCache cache) {
-              return Optional.fromNullable(cache.loadRecord(key, cacheHeaders));
-            }
-          }).get(); // lruCache.get(key, callable) requires non-null.
+      final Optional<Record> nonOptimisticRecord = nextCache().flatMap(new Function<NormalizedCache, Optional<Record>>() {
+        @Nonnull @Override public Optional<Record> apply(@Nonnull NormalizedCache cache) {
+          return Optional.fromNullable(cache.loadRecord(key, cacheHeaders));
         }
       });
+      final Record optimisticRecord = lruCache.getIfPresent(key);
+      if (optimisticRecord != null) {
+        return nonOptimisticRecord.transform(new Function<Record, Record>() {
+          @Nonnull @Override public Record apply(@Nonnull Record record) {
+            Record result = record.toBuilder().build();
+            result.mergeWith(optimisticRecord);
+            return result;
+          }
+        }).or(optimisticRecord);
+      } else {
+        return nonOptimisticRecord.orNull();
+      }
     } catch (Exception ignore) {
       return null;
     }
@@ -106,13 +113,13 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     }
   }
 
-  @Nonnull public Set<String> removeOptimisticUpdates(@Nonnull final UUID version) {
-    checkNotNull(version, "version == null");
+  @Nonnull public Set<String> removeOptimisticUpdates(@Nonnull final UUID mutationId) {
+    checkNotNull(mutationId, "mutationId == null");
 
     Map<String, Record> cachedRecords = lruCache.asMap();
     List<String> invalidateKeys = new ArrayList<>();
     for (Map.Entry<String, Record> cachedRecordEntry : cachedRecords.entrySet()) {
-      if (version.equals(cachedRecordEntry.getValue().version()) || cachedRecordEntry.getValue().version() == null) {
+      if (mutationId.equals(cachedRecordEntry.getValue().mutationId()) || cachedRecordEntry.getValue().mutationId() == null) {
         invalidateKeys.add(cachedRecordEntry.getKey());
       }
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
@@ -30,11 +30,12 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     checkNotNull(cacheHeaders, "cacheHeaders == null");
 
     try {
-      final Optional<Record> nonOptimisticRecord = nextCache().flatMap(new Function<NormalizedCache, Optional<Record>>() {
-        @Nonnull @Override public Optional<Record> apply(@Nonnull NormalizedCache cache) {
-          return Optional.fromNullable(cache.loadRecord(key, cacheHeaders));
-        }
-      });
+      final Optional<Record> nonOptimisticRecord = nextCache()
+          .flatMap(new Function<NormalizedCache, Optional<Record>>() {
+            @Nonnull @Override public Optional<Record> apply(@Nonnull NormalizedCache cache) {
+              return Optional.fromNullable(cache.loadRecord(key, cacheHeaders));
+            }
+          });
       final Record optimisticRecord = lruCache.getIfPresent(key);
       if (optimisticRecord != null) {
         return nonOptimisticRecord.transform(new Function<Record, Record>() {
@@ -119,7 +120,8 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     Map<String, Record> cachedRecords = lruCache.asMap();
     List<String> invalidateKeys = new ArrayList<>();
     for (Map.Entry<String, Record> cachedRecordEntry : cachedRecords.entrySet()) {
-      if (mutationId.equals(cachedRecordEntry.getValue().mutationId()) || cachedRecordEntry.getValue().mutationId() == null) {
+      if (mutationId.equals(cachedRecordEntry.getValue().mutationId())
+          || cachedRecordEntry.getValue().mutationId() == null) {
         invalidateKeys.add(cachedRecordEntry.getKey());
       }
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -2,6 +2,7 @@ package com.apollographql.apollo.cache.normalized;
 
 import com.apollographql.apollo.internal.cache.normalized.RecordWeigher;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -22,18 +23,18 @@ public final class Record {
 
   private final String key;
   private final Map<String, Object> fields;
-  private volatile UUID version;
+  private volatile UUID mutationId;
   private volatile int sizeInBytes = UNKNOWN_SIZE_ESTIMATE;
 
   public static class Builder {
     private final Map<String, Object> fields;
     private final String key;
-    private UUID version;
+    private UUID mutationId;
 
-    public Builder(String key, Map<String, Object> fields, UUID version) {
+    public Builder(String key, Map<String, Object> fields, UUID mutationId) {
       this.key = key;
-      this.fields = fields;
-      this.version = version;
+      this.fields = new LinkedHashMap<>(fields);
+      this.mutationId = mutationId;
     }
 
     public Builder addField(@Nonnull String key, @Nullable Object value) {
@@ -51,13 +52,13 @@ public final class Record {
       return key;
     }
 
-    public Builder version(UUID version) {
-      this.version = version;
+    public Builder mutationId(UUID mutationId) {
+      this.mutationId = mutationId;
       return this;
     }
 
     public Record build() {
-      return new Record(key, fields, version);
+      return new Record(key, fields, mutationId);
     }
   }
 
@@ -66,13 +67,13 @@ public final class Record {
   }
 
   public Builder toBuilder() {
-    return new Builder(key(), this.fields, version);
+    return new Builder(key(), this.fields, mutationId);
   }
 
-  Record(String key, Map<String, Object> fields, UUID version) {
+  Record(String key, Map<String, Object> fields, UUID mutationId) {
     this.key = key;
     this.fields = fields;
-    this.version = version;
+    this.mutationId = mutationId;
   }
 
   public Object field(String fieldKey) {
@@ -87,8 +88,8 @@ public final class Record {
     return key;
   }
 
-  public UUID version() {
-    return version;
+  public UUID mutationId() {
+    return mutationId;
   }
 
   /**
@@ -108,7 +109,7 @@ public final class Record {
         adjustSizeEstimate(newFieldValue, oldFieldValue);
       }
     }
-    version = otherRecord.version;
+    mutationId = otherRecord.mutationId;
     return changedKeys;
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -2,7 +2,6 @@ package com.apollographql.apollo.cache.normalized;
 
 import com.apollographql.apollo.internal.cache.normalized.RecordWeigher;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/NoOpApolloStore.java
@@ -135,23 +135,23 @@ public final class NoOpApolloStore implements ApolloStore, ReadableStore, Writea
 
   @Nonnull @Override
   public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Set<String>>
-  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID updateVersion) {
+  writeOptimisticUpdates(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData, @Nonnull UUID mutationId) {
     return ApolloStoreOperation.emptyOperation(Collections.<String>emptySet());
   }
 
   @Nonnull @Override
   public <D extends Operation.Data, T, V extends Operation.Variables> ApolloStoreOperation<Boolean>
   writeOptimisticUpdatesAndPublish(@Nonnull Operation<D, T, V> operation, @Nonnull D operationData,
-      @Nonnull UUID updateVersion) {
+      @Nonnull UUID mutationId) {
     return ApolloStoreOperation.emptyOperation(Boolean.FALSE);
   }
 
   @Nonnull @Override
-  public ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID updateVersion) {
+  public ApolloStoreOperation<Boolean> rollbackOptimisticUpdatesAndPublish(@Nonnull UUID mutationId) {
     return ApolloStoreOperation.emptyOperation(Boolean.FALSE);
   }
 
-  @Nonnull @Override public ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID updateVersion) {
+  @Nonnull @Override public ApolloStoreOperation<Set<String>> rollbackOptimisticUpdates(@Nonnull UUID mutationId) {
     return ApolloStoreOperation.emptyOperation(Collections.<String>emptySet());
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -121,7 +121,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
           @Nonnull @Override public List<Record> apply(@Nonnull Collection<Record> records) {
             final List<Record> result = new ArrayList<>(records.size());
             for (Record record : records) {
-              result.add(record.toBuilder().version(request.uniqueId).build());
+              result.add(record.toBuilder().mutationId(request.uniqueId).build());
             }
             return result;
           }


### PR DESCRIPTION
Rename record `version`, `updateVersion` to `mutationId`
Fix issue with query from cache is not resolved when optimistic cache has only partial records and persisted cache has the rest
Fix build issue

Part of #583