### PR TITLE
clone call for each subscriber

### DIFF
--- a/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -76,8 +76,9 @@ public class Rx2Apollo {
 
     return Observable.create(new ObservableOnSubscribe<Response<T>>() {
       @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {
-        cancelOnObservableDisposed(emitter, originalCall);
-        originalCall.enqueue(new ApolloCall.Callback<T>() {
+        ApolloCall<T> call = originalCall.clone();
+        cancelOnObservableDisposed(emitter, call);
+        call.enqueue(new ApolloCall.Callback<T>() {
           @Override public void onResponse(@Nonnull Response<T> response) {
             if (!emitter.isDisposed()) {
               emitter.onNext(response);

--- a/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -82,16 +82,17 @@ public final class RxApollo {
    * Converts an {@link ApolloCall} to a Observable. The number of emissions this Observable will have
    * is based on the {@link com.apollographql.apollo.fetcher.ResponseFetcher} used with the call.
    *
-   * @param call             the ApolloCall to convert
+   * @param originalCall             the ApolloCall to convert
    * @param <T>              the value type
    * @param backpressureMode The {@link rx.Emitter.BackpressureMode} to use.
    * @return the converted Observable
    */
-  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloCall<T> call,
+  @Nonnull public static <T> Observable<Response<T>> from(@Nonnull final ApolloCall<T> originalCall,
       Emitter.BackpressureMode backpressureMode) {
-    checkNotNull(call, "call == null");
+    checkNotNull(originalCall, "call == null");
     return Observable.create(new Action1<Emitter<Response<T>>>() {
       @Override public void call(final Emitter<Response<T>> emitter) {
+        final ApolloCall<T> call = originalCall.clone();
         emitter.setCancellation(new Cancellable() {
           @Override public void cancel() throws Exception {
             call.cancel();


### PR DESCRIPTION
take 2 :-).

We should really add an `isExecuted` to `ApolloCall` similar to `Retrofit`'s Call.  Otherwise there isn't a good way to test this or see whether we actually need to clone.