### PR TITLE
replace hardcoded separator with File.separator

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -34,7 +34,7 @@ public class ApolloClassGenTask extends SourceTask {
     nullValueType = nullableValueType == null ? NullableValueType.ANNOTATED
         : NullableValueType.Companion.findByValue(nullableValueType);
     generateAccessors = accessors;
-    outputDir = new File(getProject().getBuildDir() + "/" + Joiner.on(File.separator).join(GraphQLCompiler.Companion
+    outputDir = new File(getProject().getBuildDir() + File.separator + Joiner.on(File.separator).join(GraphQLCompiler.Companion
         .getOUTPUT_DIRECTORY()));
     useSemanticNaming = semanticNaming;
   }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodeGenInstallTask.java
@@ -30,10 +30,10 @@ public class ApolloCodeGenInstallTask extends NpmTask {
     // TODO: set to const when ApolloPlugin is in java
     setGroup("apollo");
     setDescription("Runs npm install for apollo-codegen");
-    installDir = getProject().file(getProject().getBuildDir() + "/" + INSTALL_DIR);
+    installDir = getProject().file(getProject().getBuildDir() + File.separator + INSTALL_DIR);
     File workingDir = new File(getProject().getBuildDir(), "apollo-codegen");
     setWorkingDir(workingDir);
-    apolloPackageFile = getProject().file(workingDir + "/package.json");
+    apolloPackageFile = getProject().file(workingDir + File.separator + "package.json");
 
     final boolean isSameCodegenVersion = isSameApolloCodegenVersion(getApolloVersion());
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
@@ -39,7 +39,7 @@ public class ApolloIRGenTask extends NodeTask {
   public void init(String variantName, ImmutableList<String> variantSourceSets) {
     variant = variantName;
     sourceSets = variantSourceSets;
-    outputDir = new File(getProject().getBuildDir() + "/" +
+    outputDir = new File(getProject().getBuildDir() + File.separator +
         Joiner.on(File.separator).join(GraphQLCompiler.Companion.getOUTPUT_DIRECTORY()) + "/generatedIR/" + variant);
   }
 
@@ -53,14 +53,15 @@ public class ApolloIRGenTask extends NodeTask {
 
     ImmutableMap<String, ApolloCodegenArgs> schemaQueryMap = buildSchemaQueryMap(getInputs().getSourceFiles().getFiles());
     for (Map.Entry<String, ApolloCodegenArgs> entry : schemaQueryMap.entrySet()) {
-      String irOutput = outputDir.getAbsolutePath() + "/" + getProject().relativePath(entry.getValue().getSchemaFile().getParent());
+      String irOutput = outputDir.getAbsolutePath() + File.separator + getProject().relativePath(entry.getValue()
+          .getSchemaFile().getParent());
       new File(irOutput).mkdirs();
       List<String> apolloArgs = Lists.newArrayList("generate");
       apolloArgs.addAll(entry.getValue().getQueryFiles());
       apolloArgs.addAll(Lists.newArrayList("--add-typename",
           "--schema", entry.getValue().getSchemaFile().getAbsolutePath(),
-          "--output", irOutput + "/" + Utils.capitalize(variant) + "API.json",
-          "--operation-ids-path", irOutput + "/" + Utils.capitalize(variant) + "OperationIdMap.json",
+          "--output", irOutput + File.separator + Utils.capitalize(variant) + "API.json",
+          "--operation-ids-path", irOutput + File.separator + Utils.capitalize(variant) + "OperationIdMap.json",
           "--merge-in-fields-from-fragment-spreads", "false",
           "--target", "json"));
       setArgs(apolloArgs);
@@ -166,7 +167,7 @@ public class ApolloIRGenTask extends NodeTask {
     Path absolutePath = Paths.get(file.getAbsolutePath());
     Path basePath = Paths.get(getProject().file("src").getAbsolutePath());
 
-    return basePath.relativize(absolutePath).toString().split("/")[0];
+    return basePath.relativize(absolutePath).toString().split(File.separator)[0];
   }
 
   /**
@@ -176,7 +177,7 @@ public class ApolloIRGenTask extends NodeTask {
    */
   private String getPathRelativeToSourceSet(File file) {
     Path absolutePath = Paths.get(file.getAbsolutePath());
-    Path basePath = Paths.get(getProject().file("src").getAbsolutePath() + "/" + getSourceSetNameFromFile(file));
+    Path basePath = Paths.get(getProject().file("src").getAbsolutePath() + File.separator + getSourceSetNameFromFile(file));
 
     return basePath.relativize(absolutePath).toString();
   }


### PR DESCRIPTION
This applies the suggested fix in #615 - replaces all hard-coded instances of "/" with "File.separator.

