### PR TITLE
Introduce record version history for optimistic store

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -91,6 +91,10 @@ public final class Record {
     return mutationId;
   }
 
+  public Record clone() {
+    return toBuilder().build();
+  }
+
   /**
    * @param otherRecord The record to merge into this record.
    * @return A set of field keys which have changed, or were added. A field key incorporates any GraphQL arguments in


### PR DESCRIPTION
Rolling back optimistic updates is smart now, it keeps the history of record updates.
If mutation finished it's execution it rolls back only its version of the record and keeps the rest versions for still running mutations.

Closes #583