### PR TITLE
Treat ID as custom scalar type

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
@@ -13,6 +13,7 @@ import com.squareup.javapoet.TypeName
 import java.util.*
 
 object ClassNames {
+  val OBJECT: ClassName = ClassName.get(Object::class.java)
   val STRING: ClassName = ClassName.get(String::class.java)
   val LIST: ClassName = ClassName.get(List::class.java)
   val GRAPHQL_OPERATION: ClassName = ClassName.get(Operation::class.java)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.compiler.ClassNames.parameterizedGuavaOptional
 import com.apollographql.apollo.compiler.ClassNames.parameterizedJavaOptional
 import com.apollographql.apollo.compiler.ClassNames.parameterizedOptional
 import com.apollographql.apollo.compiler.ir.CodeGenerationContext
+import com.apollographql.apollo.compiler.ir.ScalarType
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeName
 
@@ -12,17 +13,17 @@ class JavaTypeResolver(
     private val packageName: String,
     private val deprecated: Boolean = false
 ) {
-  fun resolve(typeName: String, isOptional: Boolean = !typeName.endsWith("!"), nullableValueType: NullableValueType? = null): TypeName {
+  fun resolve(typeName: String, isOptional: Boolean = !typeName.endsWith("!"),
+      nullableValueType: NullableValueType? = null): TypeName {
     val normalizedTypeName = typeName.removeSuffix("!")
     val isList = normalizedTypeName.startsWith('[') && normalizedTypeName.endsWith(']')
     val customScalarType = context.customTypeMap[normalizedTypeName]
     val javaType = when {
       isList -> ClassNames.parameterizedListOf(resolve(normalizedTypeName.removeSurrounding("[", "]"), false))
-      normalizedTypeName == "String" -> ClassNames.STRING
-      normalizedTypeName == "ID" -> ClassNames.STRING
-      normalizedTypeName == "Int" -> if (isOptional) TypeName.INT.box() else TypeName.INT
-      normalizedTypeName == "Boolean" -> if (isOptional) TypeName.BOOLEAN.box() else TypeName.BOOLEAN
-      normalizedTypeName == "Float" -> if (isOptional) TypeName.DOUBLE.box() else TypeName.DOUBLE
+      normalizedTypeName == ScalarType.STRING.name -> ClassNames.STRING
+      normalizedTypeName == ScalarType.INT.name -> if (isOptional) TypeName.INT.box() else TypeName.INT
+      normalizedTypeName == ScalarType.BOOLEAN.name -> if (isOptional) TypeName.BOOLEAN.box() else TypeName.BOOLEAN
+      normalizedTypeName == ScalarType.FLOAT.name -> if (isOptional) TypeName.DOUBLE.box() else TypeName.DOUBLE
       customScalarType != null -> customScalarType.toJavaType()
       else -> ClassName.get(packageName, normalizedTypeName)
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/ScalarType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/ScalarType.kt
@@ -1,0 +1,9 @@
+package com.apollographql.apollo.compiler.ir
+
+sealed class ScalarType(val name: String) {
+  object ID : ScalarType("ID")
+  object STRING : ScalarType("String")
+  object INT : ScalarType("Int")
+  object BOOLEAN : ScalarType("Boolean")
+  object FLOAT : ScalarType("Float")
+}

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.arguments_complex.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.arguments_simple.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.java
@@ -2,6 +2,8 @@ package com.example.custom_scalar_type.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
+import java.lang.Integer;
+import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Date;
@@ -42,6 +44,18 @@ public enum CustomType implements ScalarType {
     @Override
     public Class javaType() {
       return String.class;
+    }
+  },
+
+  ID {
+    @Override
+    public String typeName() {
+      return "ID";
+    }
+
+    @Override
+    public Class javaType() {
+      return Integer.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.deprecation.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directives/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.directives.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.enum_type.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.fragment_friends_connection.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.example.fragment_in_fragment.type.CustomType;
 import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,7 +24,7 @@ import javax.annotation.Nullable;
 public class StarshipFragment implements GraphqlFragment {
   static final ResponseField[] $responseFields = {
     ResponseField.forString("__typename", "__typename", null, false),
-    ResponseField.forString("id", "id", null, false),
+    ResponseField.forCustomType("id", "id", null, false, CustomType.ID),
     ResponseField.forString("name", "name", null, true),
     ResponseField.forObject("pilotConnection", "pilotConnection", null, true)
   };
@@ -101,7 +102,7 @@ public class StarshipFragment implements GraphqlFragment {
       @Override
       public void marshal(ResponseWriter writer) {
         writer.writeString($responseFields[0], __typename);
-        writer.writeString($responseFields[1], id);
+        writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], id);
         writer.writeString($responseFields[2], name.isPresent() ? name.get() : null);
         writer.writeObject($responseFields[3], pilotConnection.isPresent() ? pilotConnection.get().marshaller() : null);
       }
@@ -160,7 +161,7 @@ public class StarshipFragment implements GraphqlFragment {
     @Override
     public StarshipFragment map(ResponseReader reader) {
       final String __typename = reader.readString($responseFields[0]);
-      final String id = reader.readString($responseFields[1]);
+      final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
       final String name = reader.readString($responseFields[2]);
       final PilotConnection pilotConnection = reader.readObject($responseFields[3], new ResponseReader.ObjectReader<PilotConnection>() {
         @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.fragment_in_fragment.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.fragment_with_inline_fragment.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.fragments_with_type_condition.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_details.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_details_guava.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_details_java_optional.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_details_nullable.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_details_semantic_naming.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.hero_name.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.example.inline_fragments_with_friends.type.CustomType;
 import com.example.inline_fragments_with_friends.type.Episode;
 import java.lang.Double;
 import java.lang.NullPointerException;
@@ -740,7 +741,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static class Friend1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false),
-      ResponseField.forString("id", "id", null, false)
+      ResponseField.forCustomType("id", "id", null, false, CustomType.ID)
     };
 
     final @Nonnull String __typename;
@@ -780,7 +781,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeString($responseFields[1], id);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], id);
         }
       };
     }
@@ -827,7 +828,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public Friend1 map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
-        final String id = reader.readString($responseFields[1]);
+        final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
         return new Friend1(__typename, id);
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.inline_fragments_with_friends.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.java
@@ -2,6 +2,7 @@ package com.example.mutation_create_review.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
+import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import javax.annotation.Generated;
@@ -17,6 +18,18 @@ public enum CustomType implements ScalarType {
     @Override
     public Class javaType() {
       return Object.class;
+    }
+  },
+
+  ID {
+    @Override
+    public String typeName() {
+      return "ID";
+    }
+
+    @Override
+    public Class javaType() {
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Integer;
+import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/CustomType.java
@@ -2,6 +2,7 @@ package com.example.mutation_create_review_semantic_naming.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
+import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import javax.annotation.Generated;
@@ -17,6 +18,18 @@ public enum CustomType implements ScalarType {
     @Override
     public Class javaType() {
       return Object.class;
+    }
+  },
+
+  ID {
+    @Override
+    public String typeName() {
+      return "ID";
+    }
+
+    @Override
+    public Class javaType() {
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Integer;
+import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.util.List;

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.nested_conditional_inline.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.no_accessors.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.reserved_words.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.example.scalar_types.type.CustomType;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Integer;
@@ -86,8 +87,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("graphQlString", "graphQlString", null, true),
-      ResponseField.forString("graphQlIdNullable", "graphQlIdNullable", null, true),
-      ResponseField.forString("graphQlIdNonNullable", "graphQlIdNonNullable", null, false),
+      ResponseField.forCustomType("graphQlIdNullable", "graphQlIdNullable", null, true, CustomType.ID),
+      ResponseField.forCustomType("graphQlIdNonNullable", "graphQlIdNonNullable", null, false, CustomType.ID),
       ResponseField.forInt("graphQlIntNullable", "graphQlIntNullable", null, true),
       ResponseField.forInt("graphQlIntNonNullable", "graphQlIntNonNullable", null, false),
       ResponseField.forDouble("graphQlFloatNullable", "graphQlFloatNullable", null, true),
@@ -197,8 +198,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], graphQlString.isPresent() ? graphQlString.get() : null);
-          writer.writeString($responseFields[1], graphQlIdNullable.isPresent() ? graphQlIdNullable.get() : null);
-          writer.writeString($responseFields[2], graphQlIdNonNullable);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], graphQlIdNullable.isPresent() ? graphQlIdNullable.get() : null);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[2], graphQlIdNonNullable);
           writer.writeInt($responseFields[3], graphQlIntNullable.isPresent() ? graphQlIntNullable.get() : null);
           writer.writeInt($responseFields[4], graphQlIntNonNullable);
           writer.writeDouble($responseFields[5], graphQlFloatNullable.isPresent() ? graphQlFloatNullable.get() : null);
@@ -305,8 +306,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public Data map(ResponseReader reader) {
         final String graphQlString = reader.readString($responseFields[0]);
-        final String graphQlIdNullable = reader.readString($responseFields[1]);
-        final String graphQlIdNonNullable = reader.readString($responseFields[2]);
+        final String graphQlIdNullable = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
+        final String graphQlIdNonNullable = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[2]);
         final Integer graphQlIntNullable = reader.readInt($responseFields[3]);
         final int graphQlIntNonNullable = reader.readInt($responseFields[4]);
         final Double graphQlFloatNullable = reader.readDouble($responseFields[5]);

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.scalar_types.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.simple_fragment.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.simple_inline_fragment.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.example.two_heroes_unique.type.CustomType;
 import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
@@ -292,7 +293,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false),
-      ResponseField.forString("id", "id", null, false),
+      ResponseField.forCustomType("id", "id", null, false, CustomType.ID),
       ResponseField.forString("name", "name", null, false)
     };
 
@@ -346,7 +347,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeString($responseFields[1], id);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], id);
           writer.writeString($responseFields[2], name);
         }
       };
@@ -398,7 +399,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public Luke map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
-        final String id = reader.readString($responseFields[1]);
+        final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
         final String name = reader.readString($responseFields[2]);
         return new Luke(__typename, id, name);
       }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.two_heroes_unique.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.example.two_heroes_with_friends.type.CustomType;
 import java.lang.Integer;
 import java.lang.NullPointerException;
 import java.lang.Object;
@@ -670,7 +671,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false),
-      ResponseField.forString("id", "id", null, false),
+      ResponseField.forCustomType("id", "id", null, false, CustomType.ID),
       ResponseField.forString("name", "name", null, false),
       ResponseField.forObject("friendsConnection", "friendsConnection", null, false)
     };
@@ -739,7 +740,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeString($responseFields[1], id);
+          writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], id);
           writer.writeString($responseFields[2], name);
           writer.writeObject($responseFields[3], friendsConnection.marshaller());
         }
@@ -798,7 +799,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public Luke map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
-        final String id = reader.readString($responseFields[1]);
+        final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
         final String name = reader.readString($responseFields[2]);
         final FriendsConnection1 friendsConnection = reader.readObject($responseFields[3], new ResponseReader.ObjectReader<FriendsConnection1>() {
           @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.two_heroes_with_friends.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/CustomType.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/CustomType.java
@@ -1,27 +1,13 @@
-package com.example.input_object_type.type;
+package com.example.unique_type_name.type;
 
 import com.apollographql.apollo.api.ScalarType;
 import java.lang.Class;
-import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Date;
 import javax.annotation.Generated;
 
 @Generated("Apollo GraphQL")
 public enum CustomType implements ScalarType {
-  DATE {
-    @Override
-    public String typeName() {
-      return "Date";
-    }
-
-    @Override
-    public Class javaType() {
-      return Date.class;
-    }
-  },
-
   ID {
     @Override
     public String typeName() {
@@ -30,7 +16,7 @@ public enum CustomType implements ScalarType {
 
     @Override
     public Class javaType() {
-      return Integer.class;
+      return String.class;
     }
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -65,7 +65,7 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
           .filter { it.isDirectory }
           .map {
             val customTypeMap = if (it.name == "custom_scalar_type" || it.name == "input_object_type") {
-              mapOf("Date" to "java.util.Date", "URL" to "java.lang.String")
+              mapOf("Date" to "java.util.Date", "URL" to "java.lang.String", "ID" to "java.lang.Integer")
             } else {
               emptyMap()
             }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -26,9 +26,6 @@ class JavaTypeResolverTest {
     Assert.assertEquals(ClassNames.STRING.annotated(Annotations.NONNULL), defaultResolver.resolve("String!"))
     Assert.assertEquals(ClassNames.parameterizedOptional(ClassNames.STRING), defaultResolver.resolve("String", true))
 
-    Assert.assertEquals(ClassNames.STRING.annotated(Annotations.NONNULL), defaultResolver.resolve("ID!"))
-    Assert.assertEquals(ClassNames.parameterizedOptional(ClassNames.STRING), defaultResolver.resolve("ID", true))
-
     Assert.assertEquals(TypeName.INT, defaultResolver.resolve("Int!"))
     Assert.assertEquals(ClassNames.parameterizedOptional(TypeName.INT.box()), defaultResolver.resolve("Int", true))
 
@@ -46,11 +43,6 @@ class JavaTypeResolverTest {
         defaultResolver.resolve("[String!]!"))
     Assert.assertEquals(ClassNames.parameterizedOptional(ClassNames.parameterizedListOf(ClassNames.STRING)),
         defaultResolver.resolve("[String!]", true))
-
-    Assert.assertEquals(ClassNames.parameterizedListOf(ClassNames.STRING).annotated(Annotations.NONNULL),
-        defaultResolver.resolve("[ID]!"))
-    Assert.assertEquals(ClassNames.parameterizedOptional(ClassNames.parameterizedListOf(ClassNames.STRING)),
-        defaultResolver.resolve("[ID]", true))
 
     Assert.assertEquals(ClassNames.parameterizedListOf(TypeName.INT.box()).annotated(Annotations.NONNULL),
         defaultResolver.resolve("[Int]!"))
@@ -83,13 +75,18 @@ class JavaTypeResolverTest {
 
   @Test
   fun resolveCustomScalarType() {
-    val context = defaultContext.copy(customTypeMap = mapOf("Date" to "java.util.Date", "UnsupportedType" to "Object"))
+    val context = defaultContext.copy(customTypeMap = mapOf("Date" to "java.util.Date", "UnsupportedType" to "Object",
+        "ID" to "java.lang.Integer"))
     Assert.assertEquals(ClassName.get(Date::class.java).annotated(Annotations.NONNULL),
         JavaTypeResolver(context, packageName).resolve("Date", false))
     Assert.assertEquals(ClassNames.parameterizedOptional(Date::class.java),
         JavaTypeResolver(context, packageName).resolve("Date", true))
     Assert.assertEquals(ClassNames.parameterizedOptional(ClassName.get("", "Object")),
         JavaTypeResolver(context, packageName).resolve("UnsupportedType", true))
+    Assert.assertEquals(ClassName.get(Integer::class.java).annotated(Annotations.NONNULL),
+        JavaTypeResolver(context, packageName).resolve("ID", false))
+    Assert.assertEquals(ClassNames.parameterizedOptional(Integer::class.java),
+        JavaTypeResolver(context, packageName).resolve("ID", true))
   }
 
   companion object {


### PR DESCRIPTION
User now will be able to provide custom type adapter for ID GraphQL type.
By default if mapping is not provided in plugin configuration it will be mapped to String.

Closes #585 
