### PR TITLE
Generate data model builder

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -27,7 +27,9 @@ class GraphQLCompiler {
         nullableValueType = args.nullableValueType,
         generateAccessors = args.generateAccessors,
         ir = ir,
-        useSemanticNaming = args.useSemanticNaming)
+        useSemanticNaming = args.useSemanticNaming,
+        generateModelBuilder = args.generateModelBuilder
+    )
     ir.writeJavaFiles(context, args.outputDir)
   }
 
@@ -77,5 +79,7 @@ class GraphQLCompiler {
       val customTypeMap: Map<String, String>,
       val nullableValueType: NullableValueType,
       val generateAccessors: Boolean,
-      val useSemanticNaming: Boolean)
+      val useSemanticNaming: Boolean,
+      val generateModelBuilder: Boolean
+  )
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -42,8 +42,11 @@ class OperationTypeSpecBuilder(
         .addType(operation.toTypeSpec(newContext))
         .addOperationName()
         .build()
-        .flatten(excludeTypeNames = listOf(Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
-            (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName()))
+        .flatten(excludeTypeNames = listOf(
+            Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
+            (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
+            BuilderTypeSpecBuilder.CLASS_NAME
+        ))
   }
 
   private fun TypeSpec.Builder.addOperationSuperInterface(context: CodeGenerationContext): TypeSpec.Builder {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
@@ -11,5 +11,6 @@ data class CodeGenerationContext(
     val nullableValueType: NullableValueType,
     val generateAccessors: Boolean,
     val ir: CodeGenerationIR,
-    val useSemanticNaming: Boolean
+    val useSemanticNaming: Boolean,
+    val generateModelBuilder: Boolean
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -29,7 +29,15 @@ data class Field(
         fragmentSpreads = fragmentSpreads ?: emptyList(),
         inlineFragments = inlineFragments ?: emptyList(),
         context = context
-    ).build(Modifier.PUBLIC, Modifier.STATIC)
+    )
+        .build(Modifier.PUBLIC, Modifier.STATIC)
+        .let {
+          if (context.generateModelBuilder) {
+            it.withBuilder()
+          } else {
+            it
+          }
+        }
   }
 
   fun accessorMethodSpec(context: CodeGenerationContext): MethodSpec {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -20,23 +20,34 @@ data class Fragment(
 ) : CodeGenerator {
 
   /** Returns the Java interface that represents this Fragment object. */
-  override fun toTypeSpec(context: CodeGenerationContext): TypeSpec =
-      SchemaTypeSpecBuilder(
-          typeName = formatClassName(),
-          fields = fields,
-          fragmentSpreads = fragmentSpreads,
-          inlineFragments = inlineFragments,
-          context = context
-      )
-          .build(Modifier.PUBLIC)
-          .toBuilder()
-          .addSuperinterface(ClassNames.FRAGMENT)
-          .addAnnotation(Annotations.GENERATED_BY_APOLLO)
-          .addFragmentDefinitionField()
-          .addTypeConditionField()
-          .build()
-          .flatten(excludeTypeNames = listOf(Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
-              (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName()))
+  override fun toTypeSpec(context: CodeGenerationContext): TypeSpec {
+    return SchemaTypeSpecBuilder(
+        typeName = formatClassName(),
+        fields = fields,
+        fragmentSpreads = fragmentSpreads,
+        inlineFragments = inlineFragments,
+        context = context
+    )
+        .build(Modifier.PUBLIC)
+        .toBuilder()
+        .addSuperinterface(ClassNames.FRAGMENT)
+        .addAnnotation(Annotations.GENERATED_BY_APOLLO)
+        .addFragmentDefinitionField()
+        .addTypeConditionField()
+        .build()
+        .flatten(excludeTypeNames = listOf(
+            Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
+            (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
+            BuilderTypeSpecBuilder.CLASS_NAME
+        ))
+        .let {
+          if (context.generateModelBuilder) {
+            it.withBuilder()
+          } else {
+            it
+          }
+        }
+  }
 
   fun formatClassName() = fragmentName.capitalize()
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.compiler.ir
 
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.compiler.SchemaTypeSpecBuilder
+import com.apollographql.apollo.compiler.withBuilder
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
@@ -28,12 +29,19 @@ data class Operation(
           .toBuilder()
           .addSuperinterface(Operation.Data::class.java)
           .build()
+          .let {
+            if (context.generateModelBuilder) {
+              it.withBuilder()
+            } else {
+              it
+            }
+          }
 
-  fun isMutation() : Boolean {
+  fun isMutation(): Boolean {
     return operationType == TYPE_MUTATION
   }
 
-  fun isQuery() : Boolean {
+  fun isQuery(): Boolean {
     return operationType == TYPE_QUERY
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -12,10 +12,10 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.arguments_complex.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -85,6 +85,36 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    private int stars;
+
+    private double greenValue;
+
+    Builder() {
+    }
+
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
+
+    public Builder stars(int stars) {
+      this.stars = stars;
+      return this;
+    }
+
+    public Builder greenValue(double greenValue) {
+      this.greenValue = greenValue;
+      return this;
+    }
+
+    public TestQuery build() {
+      return new TestQuery(episode, stars, greenValue);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
@@ -130,36 +160,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeDouble("greenValue", greenValue);
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nullable Episode episode;
-
-    private int stars;
-
-    private double greenValue;
-
-    Builder() {
-    }
-
-    public Builder episode(@Nullable Episode episode) {
-      this.episode = episode;
-      return this;
-    }
-
-    public Builder stars(int stars) {
-      this.stars = stars;
-      return this;
-    }
-
-    public Builder greenValue(double greenValue) {
-      this.greenValue = greenValue;
-      return this;
-    }
-
-    public TestQuery build() {
-      return new TestQuery(episode, stars, greenValue);
     }
   }
 
@@ -285,14 +285,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public HeroWithReview(@Nonnull String __typename, @Nonnull String name,
         @Nullable Double height) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -12,9 +12,9 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.arguments_simple.type.Episode;
 import java.io.IOException;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -83,6 +83,29 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    private boolean includeName;
+
+    Builder() {
+    }
+
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
+
+    public Builder includeName(boolean includeName) {
+      this.includeName = includeName;
+      return this;
+    }
+
+    public TestQuery build() {
+      return new TestQuery(episode, includeName);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
@@ -119,29 +142,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeBoolean("includeName", includeName);
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nullable Episode episode;
-
-    private boolean includeName;
-
-    Builder() {
-    }
-
-    public Builder episode(@Nullable Episode episode) {
-      this.episode = episode;
-      return this;
-    }
-
-    public Builder includeName(boolean includeName) {
-      this.includeName = includeName;
-      return this;
-    }
-
-    public TestQuery build() {
-      return new TestQuery(episode, includeName);
     }
   }
 
@@ -247,10 +247,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nullable String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.name = Optional.fromNullable(name);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -9,8 +9,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.custom_scalar_type.type.CustomType;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -206,34 +206,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull Date birthDate,
         @Nonnull List<Date> appearanceDates, @Nonnull Object fieldWithUnsupportedType,
         @Nonnull String profileLink, @Nonnull List<String> links) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (birthDate == null) {
-        throw new NullPointerException("birthDate can't be null");
-      }
-      this.birthDate = birthDate;
-      if (appearanceDates == null) {
-        throw new NullPointerException("appearanceDates can't be null");
-      }
-      this.appearanceDates = appearanceDates;
-      if (fieldWithUnsupportedType == null) {
-        throw new NullPointerException("fieldWithUnsupportedType can't be null");
-      }
-      this.fieldWithUnsupportedType = fieldWithUnsupportedType;
-      if (profileLink == null) {
-        throw new NullPointerException("profileLink can't be null");
-      }
-      this.profileLink = profileLink;
-      if (links == null) {
-        throw new NullPointerException("links can't be null");
-      }
-      this.links = links;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.birthDate = Utils.checkNotNull(birthDate, "birthDate == null");
+      this.appearanceDates = Utils.checkNotNull(appearanceDates, "appearanceDates == null");
+      this.fieldWithUnsupportedType = Utils.checkNotNull(fieldWithUnsupportedType, "fieldWithUnsupportedType == null");
+      this.profileLink = Utils.checkNotNull(profileLink, "profileLink == null");
+      this.links = Utils.checkNotNull(links, "links == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -12,10 +12,10 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.deprecation.type.Episode;
 import java.io.IOException;
 import java.lang.Deprecated;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -85,6 +85,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    Builder() {
+    }
+
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
+
+    public TestQuery build() {
+      return new TestQuery(episode);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
@@ -112,22 +128,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeString("episode", episode != null ? episode.name() : null);
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nullable Episode episode;
-
-    Builder() {
-    }
-
-    public Builder episode(@Nullable Episode episode) {
-      this.episode = episode;
-      return this;
-    }
-
-    public TestQuery build() {
-      return new TestQuery(episode);
     }
   }
 
@@ -237,18 +237,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull @Deprecated String deprecated) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (deprecated == null) {
-        throw new NullPointerException("deprecated can't be null");
-      }
-      this.deprecated = deprecated;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.deprecated = Utils.checkNotNull(deprecated, "deprecated == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -9,7 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
-import java.lang.NullPointerException;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -181,10 +181,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nullable String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.name = Optional.fromNullable(name);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -9,8 +9,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.enum_type.type.Episode;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -192,22 +192,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Episode firstAppearsIn) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (appearsIn == null) {
-        throw new NullPointerException("appearsIn can't be null");
-      }
-      this.appearsIn = appearsIn;
-      if (firstAppearsIn == null) {
-        throw new NullPointerException("firstAppearsIn can't be null");
-      }
-      this.firstAppearsIn = firstAppearsIn;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
+      this.firstAppearsIn = Utils.checkNotNull(firstAppearsIn, "firstAppearsIn == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -10,8 +10,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragment_friends_connection.fragment.HeroDetails;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -186,14 +186,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -262,10 +256,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
-        if (heroDetails == null) {
-          throw new NullPointerException("heroDetails can't be null");
-        }
-        this.heroDetails = heroDetails;
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
       public @Nonnull HeroDetails heroDetails() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -7,8 +7,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -59,18 +59,9 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
-    if (friendsConnection == null) {
-      throw new NullPointerException("friendsConnection can't be null");
-    }
-    this.friendsConnection = friendsConnection;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
+    this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
   }
 
   public @Nonnull String __typename() {
@@ -182,10 +173,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -308,10 +296,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -408,14 +393,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -11,9 +11,9 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragment_in_fragment.fragment.PilotFragment;
 import com.example.fragment_in_fragment.fragment.StarshipFragment;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -197,10 +197,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public AllStarships1(@Nonnull String __typename, @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.edges = Optional.fromNullable(edges);
     }
 
@@ -309,10 +306,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -409,14 +403,8 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -485,10 +473,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull StarshipFragment starshipFragment) {
-        if (starshipFragment == null) {
-          throw new NullPointerException("starshipFragment can't be null");
-        }
-        this.starshipFragment = starshipFragment;
+        this.starshipFragment = Utils.checkNotNull(starshipFragment, "starshipFragment == null");
       }
 
       public @Nonnull StarshipFragment starshipFragment() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -7,7 +7,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
-import java.lang.NullPointerException;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -51,10 +51,7 @@ public class PilotFragment implements GraphqlFragment {
 
   public PilotFragment(@Nonnull String __typename, @Nullable String name,
       @Nullable Homeworld homeworld) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
     this.name = Optional.fromNullable(name);
     this.homeworld = Optional.fromNullable(homeworld);
   }
@@ -164,10 +161,7 @@ public class PilotFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Homeworld(@Nonnull String __typename, @Nullable String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.name = Optional.fromNullable(name);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -8,8 +8,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragment_in_fragment.type.CustomType;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -63,14 +63,8 @@ public class StarshipFragment implements GraphqlFragment {
 
   public StarshipFragment(@Nonnull String __typename, @Nonnull String id, @Nullable String name,
       @Nullable PilotConnection pilotConnection) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (id == null) {
-      throw new NullPointerException("id can't be null");
-    }
-    this.id = id;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.id = Utils.checkNotNull(id, "id == null");
     this.name = Optional.fromNullable(name);
     this.pilotConnection = Optional.fromNullable(pilotConnection);
   }
@@ -190,10 +184,7 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public PilotConnection(@Nonnull String __typename, @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.edges = Optional.fromNullable(edges);
     }
 
@@ -302,10 +293,7 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -402,14 +390,8 @@ public class StarshipFragment implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -478,10 +460,7 @@ public class StarshipFragment implements GraphqlFragment {
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull PilotFragment pilotFragment) {
-        if (pilotFragment == null) {
-          throw new NullPointerException("pilotFragment can't be null");
-        }
-        this.pilotFragment = pilotFragment;
+        this.pilotFragment = Utils.checkNotNull(pilotFragment, "pilotFragment == null");
       }
 
       public @Nonnull PilotFragment pilotFragment() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -10,9 +10,9 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
 import com.example.fragment_with_inline_fragment.type.Episode;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -156,6 +156,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.hero = hero.isPresent() ? hero.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<Data> {
       final Hero.Mapper heroFieldMapper = new Hero.Mapper();
 
@@ -167,6 +177,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
             return heroFieldMapper.map(reader);
           }
         });
+        return new Data(hero);
+      }
+    }
+
+    public static final class Builder {
+      private @Nullable Hero hero;
+
+      Builder() {
+      }
+
+      public Builder hero(@Nullable Hero hero) {
+        this.hero = hero;
+        return this;
+      }
+
+      public Data build() {
         return new Data(hero);
       }
     }
@@ -197,22 +223,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (appearsIn == null) {
-        throw new NullPointerException("appearsIn can't be null");
-      }
-      this.appearsIn = appearsIn;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -302,6 +316,19 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.name = name;
+      builder.appearsIn = appearsIn;
+      builder.fragments = fragments;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static class Fragments {
       final @Nonnull HeroDetails heroDetails;
 
@@ -312,10 +339,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
-        if (heroDetails == null) {
-          throw new NullPointerException("heroDetails can't be null");
-        }
-        this.heroDetails = heroDetails;
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
       public @Nonnull HeroDetails heroDetails() {
@@ -401,6 +425,47 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
             return fragmentsFieldMapper.map(reader, conditionalType);
           }
         });
+        return new Hero(__typename, name, appearsIn, fragments);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nonnull String name;
+
+      private @Nonnull List<Episode> appearsIn;
+
+      private @Nonnull Fragments fragments;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder name(@Nonnull String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Builder appearsIn(@Nonnull List<Episode> appearsIn) {
+        this.appearsIn = appearsIn;
+        return this;
+      }
+
+      public Builder fragments(@Nonnull Fragments fragments) {
+        this.fragments = fragments;
+        return this;
+      }
+
+      public Hero build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        Utils.checkNotNull(name, "name == null");
+        Utils.checkNotNull(appearsIn, "appearsIn == null");
+        Utils.checkNotNull(fragments, "fragments == null");
         return new Hero(__typename, name, appearsIn, fragments);
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -7,8 +7,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -67,18 +67,9 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection, @Nullable AsDroid asDroid) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
-    if (friendsConnection == null) {
-      throw new NullPointerException("friendsConnection can't be null");
-    }
-    this.friendsConnection = friendsConnection;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
+    this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     this.asDroid = Optional.fromNullable(asDroid);
   }
 
@@ -165,6 +156,19 @@ public class HeroDetails implements GraphqlFragment {
     return $hashCode;
   }
 
+  public Builder toBuilder() {
+    Builder builder = new Builder();
+    builder.__typename = __typename;
+    builder.name = name;
+    builder.friendsConnection = friendsConnection;
+    builder.asDroid = asDroid.isPresent() ? asDroid.get() : null;
+    return builder;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
   public static final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final FriendsConnection.Mapper friendsConnectionFieldMapper = new FriendsConnection.Mapper();
 
@@ -211,10 +215,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -297,6 +298,18 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.totalCount = totalCount.isPresent() ? totalCount.get() : null;
+      builder.edges = edges.isPresent() ? edges.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<FriendsConnection> {
       final Edge.Mapper edgeFieldMapper = new Edge.Mapper();
 
@@ -315,6 +328,37 @@ public class HeroDetails implements GraphqlFragment {
             });
           }
         });
+        return new FriendsConnection(__typename, totalCount, edges);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nullable Integer totalCount;
+
+      private @Nullable List<Edge> edges;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder totalCount(@Nullable Integer totalCount) {
+        this.totalCount = totalCount;
+        return this;
+      }
+
+      public Builder edges(@Nullable List<Edge> edges) {
+        this.edges = edges;
+        return this;
+      }
+
+      public FriendsConnection build() {
+        Utils.checkNotNull(__typename, "__typename == null");
         return new FriendsConnection(__typename, totalCount, edges);
       }
     }
@@ -337,10 +381,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -403,6 +444,17 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.node = node.isPresent() ? node.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<Edge> {
       final Node.Mapper nodeFieldMapper = new Node.Mapper();
 
@@ -415,6 +467,30 @@ public class HeroDetails implements GraphqlFragment {
             return nodeFieldMapper.map(reader);
           }
         });
+        return new Edge(__typename, node);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nullable Node node;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder node(@Nullable Node node) {
+        this.node = node;
+        return this;
+      }
+
+      public Edge build() {
+        Utils.checkNotNull(__typename, "__typename == null");
         return new Edge(__typename, node);
       }
     }
@@ -437,14 +513,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {
@@ -506,11 +576,47 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.name = name;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<Node> {
       @Override
       public Node map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
         final String name = reader.readString($responseFields[1]);
+        return new Node(__typename, name);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nonnull String name;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder name(@Nonnull String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Node build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        Utils.checkNotNull(name, "name == null");
         return new Node(__typename, name);
       }
     }
@@ -540,18 +646,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection, @Nullable String primaryFunction) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
 
@@ -678,10 +775,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -764,6 +858,18 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.totalCount = totalCount.isPresent() ? totalCount.get() : null;
+      builder.edges = edges.isPresent() ? edges.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<FriendsConnection1> {
       final Edge1.Mapper edge1FieldMapper = new Edge1.Mapper();
 
@@ -782,6 +888,37 @@ public class HeroDetails implements GraphqlFragment {
             });
           }
         });
+        return new FriendsConnection1(__typename, totalCount, edges);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nullable Integer totalCount;
+
+      private @Nullable List<Edge1> edges;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder totalCount(@Nullable Integer totalCount) {
+        this.totalCount = totalCount;
+        return this;
+      }
+
+      public Builder edges(@Nullable List<Edge1> edges) {
+        this.edges = edges;
+        return this;
+      }
+
+      public FriendsConnection1 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
         return new FriendsConnection1(__typename, totalCount, edges);
       }
     }
@@ -804,10 +941,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -870,6 +1004,17 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.node = node.isPresent() ? node.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<Edge1> {
       final Node1.Mapper node1FieldMapper = new Node1.Mapper();
 
@@ -882,6 +1027,30 @@ public class HeroDetails implements GraphqlFragment {
             return node1FieldMapper.map(reader);
           }
         });
+        return new Edge1(__typename, node);
+      }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nullable Node1 node;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder node(@Nullable Node1 node) {
+        this.node = node;
+        return this;
+      }
+
+      public Edge1 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
         return new Edge1(__typename, node);
       }
     }
@@ -904,14 +1073,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {
@@ -973,6 +1136,17 @@ public class HeroDetails implements GraphqlFragment {
       return $hashCode;
     }
 
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.name = name;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
     public static final class Mapper implements ResponseFieldMapper<Node1> {
       @Override
       public Node1 map(ResponseReader reader) {
@@ -980,6 +1154,71 @@ public class HeroDetails implements GraphqlFragment {
         final String name = reader.readString($responseFields[1]);
         return new Node1(__typename, name);
       }
+    }
+
+    public static final class Builder {
+      private @Nonnull String __typename;
+
+      private @Nonnull String name;
+
+      Builder() {
+      }
+
+      public Builder __typename(@Nonnull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder name(@Nonnull String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Node1 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        Utils.checkNotNull(name, "name == null");
+        return new Node1(__typename, name);
+      }
+    }
+  }
+
+  public static final class Builder {
+    private @Nonnull String __typename;
+
+    private @Nonnull String name;
+
+    private @Nonnull FriendsConnection friendsConnection;
+
+    private @Nullable AsDroid asDroid;
+
+    Builder() {
+    }
+
+    public Builder __typename(@Nonnull String __typename) {
+      this.__typename = __typename;
+      return this;
+    }
+
+    public Builder name(@Nonnull String name) {
+      this.name = name;
+      return this;
+    }
+
+    public Builder friendsConnection(@Nonnull FriendsConnection friendsConnection) {
+      this.friendsConnection = friendsConnection;
+      return this;
+    }
+
+    public Builder asDroid(@Nullable AsDroid asDroid) {
+      this.asDroid = asDroid;
+      return this;
+    }
+
+    public HeroDetails build() {
+      Utils.checkNotNull(__typename, "__typename == null");
+      Utils.checkNotNull(name, "name == null");
+      Utils.checkNotNull(friendsConnection, "friendsConnection == null");
+      return new HeroDetails(__typename, name, friendsConnection, asDroid);
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -10,9 +10,9 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragments_with_type_condition.fragment.DroidDetails;
 import com.example.fragments_with_type_condition.fragment.HumanDetails;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -215,14 +215,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public R2(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -414,14 +408,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Luke(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.java
@@ -7,7 +7,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
-import java.lang.NullPointerException;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -48,14 +48,8 @@ public class DroidDetails implements GraphqlFragment {
 
   public DroidDetails(@Nonnull String __typename, @Nonnull String name,
       @Nullable String primaryFunction) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
     this.primaryFunction = Optional.fromNullable(primaryFunction);
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.java
@@ -7,8 +7,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -48,14 +48,8 @@ public class HumanDetails implements GraphqlFragment {
   private volatile boolean $hashCodeMemoized;
 
   public HumanDetails(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
     this.height = Optional.fromNullable(height);
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
@@ -9,8 +9,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -198,18 +198,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -322,10 +313,7 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -448,10 +436,7 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -548,14 +533,8 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -8,9 +8,9 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import com.google.common.base.Optional;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -198,18 +198,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -322,10 +313,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -448,10 +436,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -548,14 +533,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -8,8 +8,8 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -198,18 +198,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -322,10 +313,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.ofNullable(totalCount);
       this.edges = Optional.ofNullable(edges);
     }
@@ -448,10 +436,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.ofNullable(node);
     }
 
@@ -548,14 +533,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -8,8 +8,8 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -197,18 +197,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -321,10 +312,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = totalCount;
       this.edges = edges;
     }
@@ -447,10 +435,7 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = node;
     }
 
@@ -547,14 +532,8 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
@@ -9,8 +9,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -198,18 +198,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
 
     public Hero(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -322,10 +313,7 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -448,10 +436,7 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -548,14 +533,8 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -9,7 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
-import java.lang.NullPointerException;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -181,14 +181,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -9,10 +9,10 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.inline_fragments_with_friends.type.CustomType;
 import com.example.inline_fragments_with_friends.type.Episode;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -209,14 +209,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
     }
@@ -354,14 +348,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name, @Nullable Double height,
         @Nullable List<Friend> friends) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
       this.friends = Optional.fromNullable(friends);
     }
@@ -497,14 +485,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull List<Episode> appearsIn) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (appearsIn == null) {
-        throw new NullPointerException("appearsIn can't be null");
-      }
-      this.appearsIn = appearsIn;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
     }
 
     public @Nonnull String __typename() {
@@ -612,14 +594,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends, @Nullable String primaryFunction) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.friends = Optional.fromNullable(friends);
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
@@ -755,14 +731,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend1(@Nonnull String __typename, @Nonnull String id) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (id == null) {
-        throw new NullPointerException("id can't be null");
-      }
-      this.id = id;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.id = Utils.checkNotNull(id, "id == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -16,8 +16,6 @@ import com.apollographql.apollo.api.internal.Utils;
 import com.example.input_object_type.type.Episode;
 import com.example.input_object_type.type.ReviewInput;
 import java.io.IOException;
-import java.lang.IllegalStateException;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -89,6 +87,31 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nonnull Episode ep;
+
+    private @Nonnull ReviewInput review;
+
+    Builder() {
+    }
+
+    public Builder ep(@Nonnull Episode ep) {
+      this.ep = ep;
+      return this;
+    }
+
+    public Builder review(@Nonnull ReviewInput review) {
+      this.review = review;
+      return this;
+    }
+
+    public TestQuery build() {
+      Utils.checkNotNull(ep, "ep == null");
+      Utils.checkNotNull(review, "review == null");
+      return new TestQuery(ep, review);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nonnull Episode ep;
 
@@ -125,31 +148,6 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
           writer.writeObject("review", review.marshaller());
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nonnull Episode ep;
-
-    private @Nonnull ReviewInput review;
-
-    Builder() {
-    }
-
-    public Builder ep(@Nonnull Episode ep) {
-      this.ep = ep;
-      return this;
-    }
-
-    public Builder review(@Nonnull ReviewInput review) {
-      this.review = review;
-      return this;
-    }
-
-    public TestQuery build() {
-      if (ep == null) throw new IllegalStateException("ep can't be null");
-      if (review == null) throw new IllegalStateException("review can't be null");
-      return new TestQuery(ep, review);
     }
   }
 
@@ -262,10 +260,7 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     private volatile boolean $hashCodeMemoized;
 
     public CreateReview(@Nonnull String __typename, int stars, @Nullable String commentary) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.stars = stars;
       this.commentary = Optional.fromNullable(commentary);
     }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -2,8 +2,8 @@ package com.example.input_object_type.type;
 
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import java.io.IOException;
-import java.lang.IllegalStateException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -220,7 +220,7 @@ public final class ReviewInput {
     }
 
     public ReviewInput build() {
-      if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
+      Utils.checkNotNull(favoriteColor, "favoriteColor == null");
       return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -16,8 +16,6 @@ import com.apollographql.apollo.api.internal.Utils;
 import com.example.mutation_create_review.type.Episode;
 import com.example.mutation_create_review.type.ReviewInput;
 import java.io.IOException;
-import java.lang.IllegalStateException;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -89,6 +87,31 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nonnull Episode ep;
+
+    private @Nonnull ReviewInput review;
+
+    Builder() {
+    }
+
+    public Builder ep(@Nonnull Episode ep) {
+      this.ep = ep;
+      return this;
+    }
+
+    public Builder review(@Nonnull ReviewInput review) {
+      this.review = review;
+      return this;
+    }
+
+    public CreateReviewForEpisode build() {
+      Utils.checkNotNull(ep, "ep == null");
+      Utils.checkNotNull(review, "review == null");
+      return new CreateReviewForEpisode(ep, review);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nonnull Episode ep;
 
@@ -125,31 +148,6 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
           writer.writeObject("review", review.marshaller());
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nonnull Episode ep;
-
-    private @Nonnull ReviewInput review;
-
-    Builder() {
-    }
-
-    public Builder ep(@Nonnull Episode ep) {
-      this.ep = ep;
-      return this;
-    }
-
-    public Builder review(@Nonnull ReviewInput review) {
-      this.review = review;
-      return this;
-    }
-
-    public CreateReviewForEpisode build() {
-      if (ep == null) throw new IllegalStateException("ep can't be null");
-      if (review == null) throw new IllegalStateException("review can't be null");
-      return new CreateReviewForEpisode(ep, review);
     }
   }
 
@@ -262,10 +260,7 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     private volatile boolean $hashCodeMemoized;
 
     public CreateReview(@Nonnull String __typename, int stars, @Nullable String commentary) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.stars = stars;
       this.commentary = Optional.fromNullable(commentary);
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -2,8 +2,8 @@ package com.example.mutation_create_review.type;
 
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import java.io.IOException;
-import java.lang.IllegalStateException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -220,7 +220,7 @@ public final class ReviewInput {
     }
 
     public ReviewInput build() {
-      if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
+      Utils.checkNotNull(favoriteColor, "favoriteColor == null");
       return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -16,8 +16,6 @@ import com.apollographql.apollo.api.internal.Utils;
 import com.example.mutation_create_review_semantic_naming.type.Episode;
 import com.example.mutation_create_review_semantic_naming.type.ReviewInput;
 import java.io.IOException;
-import java.lang.IllegalStateException;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -89,6 +87,31 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nonnull Episode ep;
+
+    private @Nonnull ReviewInput review;
+
+    Builder() {
+    }
+
+    public Builder ep(@Nonnull Episode ep) {
+      this.ep = ep;
+      return this;
+    }
+
+    public Builder review(@Nonnull ReviewInput review) {
+      this.review = review;
+      return this;
+    }
+
+    public CreateReviewForEpisodeMutation build() {
+      Utils.checkNotNull(ep, "ep == null");
+      Utils.checkNotNull(review, "review == null");
+      return new CreateReviewForEpisodeMutation(ep, review);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nonnull Episode ep;
 
@@ -125,31 +148,6 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
           writer.writeObject("review", review.marshaller());
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nonnull Episode ep;
-
-    private @Nonnull ReviewInput review;
-
-    Builder() {
-    }
-
-    public Builder ep(@Nonnull Episode ep) {
-      this.ep = ep;
-      return this;
-    }
-
-    public Builder review(@Nonnull ReviewInput review) {
-      this.review = review;
-      return this;
-    }
-
-    public CreateReviewForEpisodeMutation build() {
-      if (ep == null) throw new IllegalStateException("ep can't be null");
-      if (review == null) throw new IllegalStateException("review can't be null");
-      return new CreateReviewForEpisodeMutation(ep, review);
     }
   }
 
@@ -262,10 +260,7 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     private volatile boolean $hashCodeMemoized;
 
     public CreateReview(@Nonnull String __typename, int stars, @Nullable String commentary) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.stars = stars;
       this.commentary = Optional.fromNullable(commentary);
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -2,8 +2,8 @@ package com.example.mutation_create_review_semantic_naming.type;
 
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
+import com.apollographql.apollo.api.internal.Utils;
 import java.io.IOException;
-import java.lang.IllegalStateException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -220,7 +220,7 @@ public final class ReviewInput {
     }
 
     public ReviewInput build() {
-      if (favoriteColor == null) throw new IllegalStateException("favoriteColor can't be null");
+      Utils.checkNotNull(favoriteColor, "favoriteColor == null");
       return new ReviewInput(stars, nullableIntFieldWithDefaultValue, commentary, favoriteColor, enumWithDefaultValue, nullableEnum, listOfCustomScalar, listOfEnums);
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -12,10 +12,10 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.nested_conditional_inline.type.Episode;
 import java.io.IOException;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -108,6 +108,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     return OPERATION_NAME;
   }
 
+  public static final class Builder {
+    private @Nullable Episode episode;
+
+    Builder() {
+    }
+
+    public Builder episode(@Nullable Episode episode) {
+      this.episode = episode;
+      return this;
+    }
+
+    public TestQuery build() {
+      return new TestQuery(episode);
+    }
+  }
+
   public static final class Variables extends Operation.Variables {
     private final @Nullable Episode episode;
 
@@ -135,22 +151,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeString("episode", episode != null ? episode.name() : null);
         }
       };
-    }
-  }
-
-  public static final class Builder {
-    private @Nullable Episode episode;
-
-    Builder() {
-    }
-
-    public Builder episode(@Nullable Episode episode) {
-      this.episode = episode;
-      return this;
-    }
-
-    public TestQuery build() {
-      return new TestQuery(episode);
     }
   }
 
@@ -263,14 +263,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
     }
@@ -402,14 +396,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend> friends) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.friends = Optional.fromNullable(friends);
     }
 
@@ -528,14 +516,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman1 asHuman) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.asHuman = Optional.fromNullable(asHuman);
     }
 
@@ -647,14 +629,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman1(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
     }
 
@@ -755,14 +731,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.friends = Optional.fromNullable(friends);
     }
 
@@ -881,14 +851,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Friend1(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman2 asHuman) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.asHuman = Optional.fromNullable(asHuman);
     }
 
@@ -1000,14 +964,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman2(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -10,9 +10,9 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.no_accessors.fragment.HeroDetails;
 import com.example.no_accessors.type.Episode;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -199,22 +199,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
         @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (appearsIn == null) {
-        throw new NullPointerException("appearsIn can't be null");
-      }
-      this.appearsIn = appearsIn;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public ResponseFieldMarshaller marshaller() {
@@ -292,10 +280,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
-        if (heroDetails == null) {
-          throw new NullPointerException("heroDetails can't be null");
-        }
-        this.heroDetails = heroDetails;
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
       public ResponseFieldMarshaller marshaller() {

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/fragment/HeroDetails.java
@@ -7,8 +7,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -73,18 +73,9 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection, @Nullable AsDroid asDroid) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
-    if (friendsConnection == null) {
-      throw new NullPointerException("friendsConnection can't be null");
-    }
-    this.friendsConnection = friendsConnection;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
+    this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     this.asDroid = Optional.fromNullable(asDroid);
   }
 
@@ -201,10 +192,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -312,10 +300,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -404,14 +389,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public ResponseFieldMarshaller marshaller() {
@@ -505,18 +484,9 @@ public class HeroDetails implements GraphqlFragment {
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection, @Nullable String primaryFunction) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
 
@@ -624,10 +594,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -735,10 +702,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -827,14 +791,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public ResponseFieldMarshaller marshaller() {

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -9,11 +9,11 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.scalar_types.type.CustomType;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -135,10 +135,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Nullable List<GraphQlListOfObject> graphQlListOfObjects) {
       this.graphQlString = Optional.fromNullable(graphQlString);
       this.graphQlIdNullable = Optional.fromNullable(graphQlIdNullable);
-      if (graphQlIdNonNullable == null) {
-        throw new NullPointerException("graphQlIdNonNullable can't be null");
-      }
-      this.graphQlIdNonNullable = graphQlIdNonNullable;
+      this.graphQlIdNonNullable = Utils.checkNotNull(graphQlIdNonNullable, "graphQlIdNonNullable == null");
       this.graphQlIntNullable = Optional.fromNullable(graphQlIntNullable);
       this.graphQlIntNonNullable = graphQlIntNonNullable;
       this.graphQlFloatNullable = Optional.fromNullable(graphQlFloatNullable);

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -10,8 +10,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.simple_fragment.fragment.HeroDetails;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -186,14 +186,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Hero(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -262,10 +256,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
-        if (heroDetails == null) {
-          throw new NullPointerException("heroDetails can't be null");
-        }
-        this.heroDetails = heroDetails;
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
       public @Nonnull HeroDetails heroDetails() {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
@@ -6,7 +6,7 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
-import java.lang.NullPointerException;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -41,14 +41,8 @@ public class HeroDetails implements GraphqlFragment {
   private volatile boolean $hashCodeMemoized;
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
   }
 
   public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -9,8 +9,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -198,14 +198,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@Nonnull String __typename, @Nonnull String name, @Nullable AsHuman asHuman,
         @Nullable AsDroid asDroid) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.asHuman = Optional.fromNullable(asHuman);
       this.asDroid = Optional.fromNullable(asDroid);
     }
@@ -339,14 +333,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name, @Nullable Double height) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
     }
 
@@ -453,14 +441,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public AsDroid(@Nonnull String __typename, @Nonnull String name,
         @Nullable String primaryFunction) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.primaryFunction = Optional.fromNullable(primaryFunction);
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -10,8 +10,8 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.two_heroes_unique.type.CustomType;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -211,14 +211,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public R2(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {
@@ -310,18 +304,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Luke(@Nonnull String __typename, @Nonnull String id, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (id == null) {
-        throw new NullPointerException("id can't be null");
-      }
-      this.id = id;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.id = Utils.checkNotNull(id, "id == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -10,9 +10,9 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.two_heroes_with_friends.type.CustomType;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -239,18 +239,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public R2(@Nonnull String __typename, @Nonnull String name,
         @Nonnull FriendsConnection friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -363,10 +354,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -489,10 +477,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -589,14 +574,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {
@@ -692,22 +671,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Luke(@Nonnull String __typename, @Nonnull String id, @Nonnull String name,
         @Nonnull FriendsConnection1 friendsConnection) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (id == null) {
-        throw new NullPointerException("id can't be null");
-      }
-      this.id = id;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (friendsConnection == null) {
-        throw new NullPointerException("friendsConnection can't be null");
-      }
-      this.friendsConnection = friendsConnection;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.id = Utils.checkNotNull(id, "id == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
     }
 
     public @Nonnull String __typename() {
@@ -833,10 +800,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public FriendsConnection1(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge1> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -959,10 +923,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -1059,14 +1020,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private volatile boolean $hashCodeMemoized;
 
     public Node1(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -10,10 +10,10 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.unique_type_name.fragment.HeroDetails;
 import com.example.unique_type_name.type.Episode;
 import java.lang.Double;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -211,14 +211,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public HeroDetailQuery1(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend> friends, @Nullable AsHuman asHuman) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.friends = Optional.fromNullable(friends);
       this.asHuman = Optional.fromNullable(asHuman);
     }
@@ -361,14 +355,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     private volatile boolean $hashCodeMemoized;
 
     public Friend(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {
@@ -464,14 +452,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public AsHuman(@Nonnull String __typename, @Nonnull String name,
         @Nullable List<Friend1> friends, @Nullable Double height) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.friends = Optional.fromNullable(friends);
       this.height = Optional.fromNullable(height);
     }
@@ -614,18 +596,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     public Friend1(@Nonnull String __typename, @Nonnull String name,
         @Nonnull List<Episode> appearsIn, @Nullable List<Friend2> friends) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
-      if (appearsIn == null) {
-        throw new NullPointerException("appearsIn can't be null");
-      }
-      this.appearsIn = appearsIn;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
       this.friends = Optional.fromNullable(friends);
     }
 
@@ -773,14 +746,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     private volatile boolean $hashCodeMemoized;
 
     public Friend2(@Nonnull String __typename, @Nonnull Fragments fragments) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (fragments == null) {
-        throw new NullPointerException("fragments can't be null");
-      }
-      this.fragments = fragments;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
     }
 
     public @Nonnull String __typename() {
@@ -849,10 +816,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       private volatile boolean $hashCodeMemoized;
 
       public Fragments(@Nonnull HeroDetails heroDetails) {
-        if (heroDetails == null) {
-          throw new NullPointerException("heroDetails can't be null");
-        }
-        this.heroDetails = heroDetails;
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
       public @Nonnull HeroDetails heroDetails() {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -7,8 +7,8 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
-import java.lang.NullPointerException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -59,18 +59,9 @@ public class HeroDetails implements GraphqlFragment {
 
   public HeroDetails(@Nonnull String __typename, @Nonnull String name,
       @Nonnull FriendsConnection friendsConnection) {
-    if (__typename == null) {
-      throw new NullPointerException("__typename can't be null");
-    }
-    this.__typename = __typename;
-    if (name == null) {
-      throw new NullPointerException("name can't be null");
-    }
-    this.name = name;
-    if (friendsConnection == null) {
-      throw new NullPointerException("friendsConnection can't be null");
-    }
-    this.friendsConnection = friendsConnection;
+    this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    this.name = Utils.checkNotNull(name, "name == null");
+    this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
   }
 
   public @Nonnull String __typename() {
@@ -182,10 +173,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public FriendsConnection(@Nonnull String __typename, @Nullable Integer totalCount,
         @Nullable List<Edge> edges) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.totalCount = Optional.fromNullable(totalCount);
       this.edges = Optional.fromNullable(edges);
     }
@@ -308,10 +296,7 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Edge(@Nonnull String __typename, @Nullable Node node) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.node = Optional.fromNullable(node);
     }
 
@@ -408,14 +393,8 @@ public class HeroDetails implements GraphqlFragment {
     private volatile boolean $hashCodeMemoized;
 
     public Node(@Nonnull String __typename, @Nonnull String name) {
-      if (__typename == null) {
-        throw new NullPointerException("__typename can't be null");
-      }
-      this.__typename = __typename;
-      if (name == null) {
-        throw new NullPointerException("name can't be null");
-      }
-      this.name = name;
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @Nonnull String __typename() {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -80,6 +80,10 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
               it.name == "mutation_create_review_semantic_naming" -> true
               else -> false
             }
+            val generateModelBuilder = when {
+              it.name == "fragment_with_inline_fragment" -> true
+              else -> false
+            }
             val generateAccessors = (it.name != "no_accessors")
             val args = GraphQLCompiler.Arguments(
                 irFile = File(it, "TestOperation.json"),
@@ -87,7 +91,9 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
                 customTypeMap = customTypeMap,
                 nullableValueType = nullableValueType,
                 generateAccessors = generateAccessors,
-                useSemanticNaming = useSemanticNaming)
+                useSemanticNaming = useSemanticNaming,
+                generateModelBuilder = generateModelBuilder
+            )
             arrayOf(it.name, args)
           }
     }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -18,7 +18,9 @@ class JavaTypeResolverTest {
       nullableValueType = NullableValueType.APOLLO_OPTIONAL,
       generateAccessors = true,
       ir = CodeGenerationIR(emptyList(), emptyList(), emptyList()),
-      useSemanticNaming = false)
+      useSemanticNaming = false,
+      generateModelBuilder = false
+  )
   private val defaultResolver = JavaTypeResolver(defaultContext, packageName)
 
   @Test

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -102,7 +102,8 @@ class ApolloPlugin implements Plugin<Project> {
   private void addVariantTasks(Object variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection<?> sourceSets) {
     ApolloIRGenTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
     ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name, project.apollo.customTypeMapping,
-        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming)
+        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming,
+        project.apollo.generateModelBuilder)
     variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir)
     apolloIRGenTask.dependsOn(variantIRTask)
     apolloClassGenTask.dependsOn(variantClassTask)
@@ -113,7 +114,8 @@ class ApolloPlugin implements Plugin<Project> {
 
     ApolloIRGenTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
     ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name, project.apollo.customTypeMapping,
-        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming)
+        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming,
+        project.apollo.generateModelBuilder)
     apolloIRGenTask.dependsOn(sourceSetIRTask)
     apolloClassGenTask.dependsOn(sourceSetClassTask)
 
@@ -149,7 +151,7 @@ class ApolloPlugin implements Plugin<Project> {
 
   private ApolloClassGenTask createApolloClassGenTask(String name, Map<String, String> customTypeMapping,
                                                       String nullableValueType, boolean generateAccessors,
-                                                      boolean useSemanticNaming) {
+                                                      boolean useSemanticNaming, boolean generateModelBuilder) {
     String taskName = String.format(ApolloClassGenTask.NAME, name.capitalize())
     ApolloClassGenTask task = project.tasks.create(taskName, ApolloClassGenTask) {
       group = TASK_GROUP
@@ -158,7 +160,7 @@ class ApolloPlugin implements Plugin<Project> {
       source = project.tasks.findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())).outputDir
       include "**${File.separatorChar}*API.json"
     }
-    task.init(name, customTypeMapping, nullableValueType, generateAccessors, useSemanticNaming)
+    task.init(name, customTypeMapping, nullableValueType, generateAccessors, useSemanticNaming, generateModelBuilder)
     return task
   }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -26,9 +26,10 @@ public class ApolloClassGenTask extends SourceTask {
   @Input private boolean generateAccessors;
   @OutputDirectory private File outputDir;
   private Boolean useSemanticNaming;
+  private Boolean generateModelBuilder;
 
   public void init(String buildVariant, Map<String, String> typeMapping, String nullableValueType, boolean accessors,
-      boolean semanticNaming) {
+      boolean semanticNaming, boolean modelBuilder) {
     variant = buildVariant;
     customTypeMapping = typeMapping;
     nullValueType = nullableValueType == null ? NullableValueType.ANNOTATED
@@ -37,6 +38,7 @@ public class ApolloClassGenTask extends SourceTask {
     outputDir = new File(getProject().getBuildDir() + File.separator + Joiner.on(File.separator).join(GraphQLCompiler.Companion
         .getOUTPUT_DIRECTORY()));
     useSemanticNaming = semanticNaming;
+    generateModelBuilder = modelBuilder;
   }
 
   @TaskAction
@@ -45,7 +47,7 @@ public class ApolloClassGenTask extends SourceTask {
       @Override
       public void execute(InputFileDetails inputFileDetails) {
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFileDetails.getFile(), outputDir,
-            customTypeMapping, nullValueType, generateAccessors, useSemanticNaming);
+            customTypeMapping, nullValueType, generateAccessors, useSemanticNaming, generateModelBuilder);
         new GraphQLCompiler().write(args);
       }
     });

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
@@ -13,6 +13,7 @@ public class ApolloExtension {
   private String nullableValueType = NullableValueType.ANNOTATED.getValue();
   private boolean generateAccessors = true;
   private boolean useSemanticNaming = true;
+  private boolean generateModelBuilder;
 
   public Map<String, String> getCustomTypeMapping() {
     return customTypeMapping;
@@ -44,6 +45,14 @@ public class ApolloExtension {
 
   public void setGenerateAccessors(boolean generateAccessors) {
     this.generateAccessors = generateAccessors;
+  }
+
+  public boolean isGenerateModelBuilder() {
+    return generateModelBuilder;
+  }
+
+  public void generateModelBuilder(boolean generateModelBuilder) {
+    this.generateModelBuilder = generateModelBuilder;
   }
 
   public void setCustomTypeMapping(Closure closure) {


### PR DESCRIPTION
Introduce plugin configuration `generateModelBuilder` to enable / disable data model builder generation.
By default it's set to false.

Closes #594

Examples:
https://github.com/apollographql/apollo-android/pull/622/files#diff-1429b2a1e17efe3e3dd15137018df33e

https://github.com/apollographql/apollo-android/pull/622/files#diff-e0f8aa3bbca9447766d25967d5c39f5f