### PR TITLE
fix windows file separator handling

### DIFF
--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import javax.annotation.Nullable;
 
@@ -167,7 +168,7 @@ public class ApolloIRGenTask extends NodeTask {
     Path absolutePath = Paths.get(file.getAbsolutePath());
     Path basePath = Paths.get(getProject().file("src").getAbsolutePath());
 
-    return basePath.relativize(absolutePath).toString().split(File.separator)[0];
+    return basePath.relativize(absolutePath).toString().split(Matcher.quoteReplacement(File.separator))[0];
   }
 
   /**


### PR DESCRIPTION
`File.separator` isn't valid regex on windows, using `Matcher.quoteReplacement` fixes that.

Closes #615