### PR TITLE
Provide explicit schema path option to gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,21 @@ apollo {
 }
 ```
 
+### Explicit Schema location
+By default Apollo-Android tries to lookup GraphQL schema file in `/graphql` folder, the same folder where all your GraphQL queries are stored. 
+For example if query files are located at `/src/main/graphql/com/example/api` then the schema file should be placed to the same location `/src/main/graphql/com/example/api`. Relative path of schema file to `/src/main/graphql` root folder defines the package name for generated models, in our example the package name of generated models will be `com.example.api`.
+
+Alternatively, you can explicitly provide GraphQL schema file location and package name for generated models:
+
+#### Usage
+
+```groovy
+apollo {
+  schemaFilePath = "/path_to_schema_file/my-schema.json"
+  outputPackageName = "com.my-example.graphql.api"
+}
+```
+
 ### Download
 
 RxJava1:

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -93,7 +93,8 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
                 nullableValueType = nullableValueType,
                 generateAccessors = generateAccessors,
                 useSemanticNaming = useSemanticNaming,
-                generateModelBuilder = generateModelBuilder
+                generateModelBuilder = generateModelBuilder,
+                outputPackageName = null
             )
             arrayOf(it.name, args)
           }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -101,9 +101,7 @@ class ApolloPlugin implements Plugin<Project> {
 
   private void addVariantTasks(Object variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection<?> sourceSets) {
     ApolloIRGenTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
-    ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name, project.apollo.customTypeMapping,
-        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming,
-        project.apollo.generateModelBuilder)
+    ApolloClassGenTask variantClassTask = createApolloClassGenTask(variant.name)
     variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir)
     apolloIRGenTask.dependsOn(variantIRTask)
     apolloClassGenTask.dependsOn(variantClassTask)
@@ -113,9 +111,7 @@ class ApolloPlugin implements Plugin<Project> {
     String taskName = "main".equals(sourceSet.name) ? "" : sourceSet.name
 
     ApolloIRGenTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
-    ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name, project.apollo.customTypeMapping,
-        project.apollo.nullableValueType, project.apollo.generateAccessors, project.apollo.useSemanticNaming,
-        project.apollo.generateModelBuilder)
+    ApolloClassGenTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name)
     apolloIRGenTask.dependsOn(sourceSetIRTask)
     apolloClassGenTask.dependsOn(sourceSetClassTask)
 
@@ -144,23 +140,20 @@ class ApolloPlugin implements Plugin<Project> {
 
     ImmutableList.Builder<String> sourceSetNamesList = ImmutableList.builder();
     sourceSets.each { sourceSet -> sourceSetNamesList.add(sourceSet.name) }
-
-    task.init(sourceSetOrVariantName, sourceSetNamesList.build())
+    task.init(sourceSetOrVariantName, sourceSetNamesList.build(), project.apollo)
     return task
   }
 
-  private ApolloClassGenTask createApolloClassGenTask(String name, Map<String, String> customTypeMapping,
-                                                      String nullableValueType, boolean generateAccessors,
-                                                      boolean useSemanticNaming, boolean generateModelBuilder) {
+  private ApolloClassGenTask createApolloClassGenTask(String name) {
     String taskName = String.format(ApolloClassGenTask.NAME, name.capitalize())
     ApolloClassGenTask task = project.tasks.create(taskName, ApolloClassGenTask) {
       group = TASK_GROUP
       description = "Generate Android classes for ${name.capitalize()} GraphQL queries"
       dependsOn(getProject().getTasks().findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())));
-      source = project.tasks.findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())).outputDir
+      source = project.tasks.findByName(String.format(ApolloIRGenTask.NAME, name.capitalize())).outputFolder
       include "**${File.separatorChar}*API.json"
     }
-    task.init(name, customTypeMapping, nullableValueType, generateAccessors, useSemanticNaming, generateModelBuilder)
+    task.init(name, project.apollo)
     return task
   }
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -15,30 +15,23 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.api.tasks.incremental.InputFileDetails;
 
 import java.io.File;
-import java.util.Map;
 
 public class ApolloClassGenTask extends SourceTask {
   static final String NAME = "generate%sApolloClasses";
 
   @Internal private String variant;
-  @Input private Map<String, String> customTypeMapping;
-  @Input private NullableValueType nullValueType;
-  @Input private boolean generateAccessors;
+  @Internal private ApolloExtension apolloExtension;
   @OutputDirectory private File outputDir;
-  private Boolean useSemanticNaming;
-  private Boolean generateModelBuilder;
+  private NullableValueType nullableValueType;
 
-  public void init(String buildVariant, Map<String, String> typeMapping, String nullableValueType, boolean accessors,
-      boolean semanticNaming, boolean modelBuilder) {
-    variant = buildVariant;
-    customTypeMapping = typeMapping;
-    nullValueType = nullableValueType == null ? NullableValueType.ANNOTATED
-        : NullableValueType.Companion.findByValue(nullableValueType);
-    generateAccessors = accessors;
+  public void init(String variant, ApolloExtension apolloExtension) {
+    this.variant = variant;
+    this.apolloExtension = apolloExtension;
+    nullableValueType = apolloExtension.getNullableValueType() == null
+        ? NullableValueType.ANNOTATED
+        : NullableValueType.Companion.findByValue(apolloExtension.getNullableValueType());
     outputDir = new File(getProject().getBuildDir() + File.separator + Joiner.on(File.separator).join(GraphQLCompiler.Companion
         .getOUTPUT_DIRECTORY()));
-    useSemanticNaming = semanticNaming;
-    generateModelBuilder = modelBuilder;
   }
 
   @TaskAction
@@ -47,7 +40,9 @@ public class ApolloClassGenTask extends SourceTask {
       @Override
       public void execute(InputFileDetails inputFileDetails) {
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFileDetails.getFile(), outputDir,
-            customTypeMapping, nullValueType, generateAccessors, useSemanticNaming, generateModelBuilder);
+            apolloExtension.getCustomTypeMapping(), nullableValueType, apolloExtension.isGenerateAccessors(),
+            apolloExtension.isUseSemanticNaming(), apolloExtension.isGenerateModelBuilder(),
+            apolloExtension.getOutputPackageName());
         new GraphQLCompiler().write(args);
       }
     });
@@ -69,27 +64,19 @@ public class ApolloClassGenTask extends SourceTask {
     this.outputDir = outputDir;
   }
 
-  public Map<String, String> getCustomTypeMapping() {
-    return customTypeMapping;
+  public NullableValueType getNullableValueType() {
+    return nullableValueType;
   }
 
-  public void setCustomTypeMapping(Map<String, String> customTypeMapping) {
-    this.customTypeMapping = customTypeMapping;
+  public void setNullableValueType(NullableValueType nullableValueType) {
+    this.nullableValueType = nullableValueType;
   }
 
-  public NullableValueType getNullValueType() {
-    return nullValueType;
+  public ApolloExtension getApolloExtension() {
+    return apolloExtension;
   }
 
-  public void setNullValueType(NullableValueType nullValueType) {
-    this.nullValueType = nullValueType;
-  }
-
-  public boolean shouldGenerateAccessors() {
-    return generateAccessors;
-  }
-
-  public void setGenerateAccessors(boolean generateAccessors) {
-    this.generateAccessors = generateAccessors;
+  public void setApolloExtension(ApolloExtension apolloExtension) {
+    this.apolloExtension = apolloExtension;
   }
 }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodegenArgs.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodegenArgs.java
@@ -4,20 +4,13 @@ import java.io.File;
 import java.util.Set;
 
 final class ApolloCodegenArgs {
-  private final File schemaFile;
-  private final Set<String> queryFiles;
+  final File schemaFile;
+  final Set<String> queryFilePaths;
+  final File irOutputFolder;
 
-  ApolloCodegenArgs(File schema, Set<String> queries) {
-      schemaFile = schema;
-      queryFiles = queries;
-    }
-
-  File getSchemaFile() {
-    return schemaFile;
+  ApolloCodegenArgs(File schemaFile, Set<String> queryFilePaths, File irOutputFolder) {
+    this.schemaFile = schemaFile;
+    this.queryFilePaths = queryFilePaths;
+    this.irOutputFolder = irOutputFolder;
   }
-
-  Set<String> getQueryFiles() {
-    return queryFiles;
-  }
-
 }

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
@@ -14,6 +14,8 @@ public class ApolloExtension {
   private boolean generateAccessors = true;
   private boolean useSemanticNaming = true;
   private boolean generateModelBuilder;
+  private String schemaFilePath;
+  private String outputPackageName;
 
   public Map<String, String> getCustomTypeMapping() {
     return customTypeMapping;
@@ -59,5 +61,21 @@ public class ApolloExtension {
     closure.setDelegate(customTypeMapping);
     closure.setResolveStrategy(Closure.DELEGATE_FIRST);
     closure.call();
+  }
+
+  public String getSchemaFilePath() {
+    return schemaFilePath;
+  }
+
+  public void setSchemaFilePath(String schemaFilePath) {
+    this.schemaFilePath = schemaFilePath;
+  }
+
+  public String getOutputPackageName() {
+    return outputPackageName;
+  }
+
+  public void setOutputPackageName(String outputPackageName) {
+    this.outputPackageName = outputPackageName;
   }
 }


### PR DESCRIPTION
Adds new plugin options:
 - `schemaFilePath` path to the schema.json location
 - `outputPackageName` the package name for model generation

Closes #633 