### PR TITLE
Introduce ApolloCall status event notification

### DIFF
--- a/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloCallback.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloCallback.java
@@ -52,10 +52,10 @@ public final class ApolloCallback<T> extends ApolloCall.Callback<T> {
     });
   }
 
-  @Override public void onCompleted() {
+  @Override public void onStatusEvent(@Nonnull final ApolloCall.StatusEvent event) {
     handler.post(new Runnable() {
       @Override public void run() {
-        delegate.onCompleted();
+        delegate.onStatusEvent(event);
       }
     });
   }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorChainTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorChainTest.java
@@ -70,6 +70,10 @@ public class ApolloInterceptorChainTest {
           @Override public void onCompleted() {
 
           }
+
+          @Override public void onFetch(ApolloInterceptor.FetchSourceType sourceType) {
+
+          }
         });
 
     //If counter's count doesn't go down to zero, it means interceptor's interceptAsync wasn't called
@@ -118,6 +122,10 @@ public class ApolloInterceptorChainTest {
           @Override public void onCompleted() {
 
           }
+
+          @Override public void onFetch(ApolloInterceptor.FetchSourceType sourceType) {
+
+          }
         });
 
     if (counter.get() != 0) {
@@ -162,6 +170,10 @@ public class ApolloInterceptorChainTest {
           }
 
           @Override public void onCompleted() {
+
+          }
+
+          @Override public void onFetch(ApolloInterceptor.FetchSourceType sourceType) {
 
           }
         });

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -122,6 +122,10 @@ public class ApolloInterceptorTest {
           @Override public void onCompleted() {
             callBack.onCompleted();
           }
+
+          @Override public void onFetch(FetchSourceType sourceType) {
+            callBack.onFetch(sourceType);
+          }
         });
       }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/fetcher/BaseFetcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/fetcher/BaseFetcherTest.java
@@ -68,10 +68,12 @@ class BaseFetcherTest {
       completedOrErrorLatch.countDown();
     }
 
-    @Override public void onCompleted() {
-      if (completed) throw new IllegalStateException("onCompleted already called Do not reuse tracking callback.");
-      completed = true;
-      completedOrErrorLatch.countDown();
+    @Override public void onStatusEvent(@Nonnull ApolloCall.StatusEvent event) {
+      if (event == ApolloCall.StatusEvent.COMPLETED) {
+        if (completed) throw new IllegalStateException("onCompleted already called Do not reuse tracking callback.");
+        completed = true;
+        completedOrErrorLatch.countDown();
+      }
     }
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -87,10 +87,11 @@ public interface ApolloCall<T> extends Cancelable {
     public abstract void onFailure(@Nonnull ApolloException e);
 
     /**
-     * Gets called when the {@link #onResponse(Response)} has been called for the last time. Not called in the
-     * case of an error. {@link #onFailure(ApolloException)} will be called instead.
+     * Gets called whenever any action happen to this {@link ApolloCall}.
+     *
+     * @param event status that corresponds to a {@link ApolloCall} action
      */
-    public void onCompleted() { }
+    public void onStatusEvent(@Nonnull StatusEvent event) { }
 
     /**
      * <p>Gets called when an http request error takes place. This is the case when the returned http status code
@@ -127,5 +128,27 @@ public interface ApolloCall<T> extends Cancelable {
     public void onCanceledError(@Nonnull ApolloCanceledException e) {
       onFailure(e);
     }
+  }
+
+  /**
+   * Represents a status event that corresponds to a {@link ApolloCall} action
+   */
+  enum StatusEvent {
+    /**
+     * {@link ApolloCall} is scheduled for execution
+     */
+    SCHEDULED,
+    /**
+     * {@link ApolloCall} fetches response from cache
+     */
+    FETCH_CACHE,
+    /**
+     * {@link ApolloCall} fetches response from network
+     */
+    FETCH_NETWORK,
+    /**
+     * {@link ApolloCall} is finished its execution
+     */
+    COMPLETED
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -54,6 +54,13 @@ public interface ApolloInterceptor {
     void onResponse(@Nonnull InterceptorResponse response);
 
     /**
+     * Called when interceptor starts fetching response from source type
+     *
+     * @param sourceType type of source been used to fetch response from
+     */
+    void onFetch(FetchSourceType sourceType);
+
+    /**
      * Gets called when an unexpected exception occurs while performing operations on the request or processing the
      * response returned by the next set of interceptors. Will be called at most once.
      */
@@ -63,6 +70,20 @@ public interface ApolloInterceptor {
      * Called after the last call to {@link #onResponse}. Do not call after {@link #onFailure(ApolloException)}.
      */
     void onCompleted();
+  }
+
+  /**
+   * Fetch source type
+   */
+  enum FetchSourceType {
+    /**
+     * Response is fetched from the cache (SQLite or memory or both)
+     */
+    CACHE,
+    /**
+     * Response is fetched from the network
+     */
+    NETWORK
   }
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -4,8 +4,8 @@ import com.apollographql.apollo.ApolloPrefetch;
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.ScalarType;
-import com.apollographql.apollo.cache.http.HttpCache;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.cache.http.HttpCache;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.exception.ApolloCanceledException;
 import com.apollographql.apollo.exception.ApolloException;
@@ -126,6 +126,9 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
       @Override public void onCompleted() {
         // Prefetch is only called with NETWORK_ONLY, so callback api does not need onComplete as it is the same as
         // onResponse.
+      }
+
+      @Override public void onFetch(ApolloInterceptor.FetchSourceType sourceType) {
       }
     };
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheAndNetworkFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheAndNetworkFetcher.java
@@ -36,7 +36,7 @@ public final class CacheAndNetworkFetcher implements ResponseFetcher {
 
     @Override
     public void interceptAsync(@Nonnull InterceptorRequest request, @Nonnull ApolloInterceptorChain chain,
-        @Nonnull Executor dispatcher, @Nonnull CallBack callBack) {
+        @Nonnull Executor dispatcher, @Nonnull final CallBack callBack) {
       if (disposed) return;
       originalCallback = callBack;
       InterceptorRequest cacheRequest = request.withFetchOptions(request.fetchOptions.toCacheFetchOptions());
@@ -50,7 +50,10 @@ public final class CacheAndNetworkFetcher implements ResponseFetcher {
         }
 
         @Override public void onCompleted() {
+        }
 
+        @Override public void onFetch(FetchSourceType sourceType) {
+          callBack.onFetch(sourceType);
         }
       });
 
@@ -65,7 +68,10 @@ public final class CacheAndNetworkFetcher implements ResponseFetcher {
         }
 
         @Override public void onCompleted() {
+        }
 
+        @Override public void onFetch(FetchSourceType sourceType) {
+          callBack.onFetch(sourceType);
         }
       });
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheFirstFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheFirstFetcher.java
@@ -44,6 +44,10 @@ public final class CacheFirstFetcher implements ResponseFetcher {
         @Override public void onCompleted() {
           callBack.onCompleted();
         }
+
+        @Override public void onFetch(FetchSourceType sourceType) {
+          callBack.onFetch(sourceType);
+        }
       });
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheOnlyFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheOnlyFetcher.java
@@ -46,6 +46,10 @@ public final class CacheOnlyFetcher implements ResponseFetcher {
         @Override public void onCompleted() {
           callBack.onCompleted();
         }
+
+        @Override public void onFetch(FetchSourceType sourceType) {
+          callBack.onFetch(sourceType);
+        }
       });
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/NetworkFirstFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/NetworkFirstFetcher.java
@@ -50,6 +50,10 @@ public final class NetworkFirstFetcher implements ResponseFetcher {
         @Override public void onCompleted() {
           callBack.onCompleted();
         }
+
+        @Override public void onFetch(FetchSourceType sourceType) {
+            callBack.onFetch(sourceType);
+          }
       });
 
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -56,6 +56,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
       @Override public void run() {
         if (disposed) return;
         if (request.fetchOptions.fetchFromCache) {
+          callBack.onFetch(FetchSourceType.CACHE);
           final InterceptorResponse cachedResponse;
           try {
             cachedResponse = resolveFromCache(request.operation, request.fetchOptions);
@@ -92,6 +93,10 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
             }
 
             @Override public void onCompleted() {
+            }
+
+            @Override public void onFetch(FetchSourceType sourceType) {
+              callBack.onFetch(sourceType);
             }
           });
         }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
@@ -67,6 +67,10 @@ public final class ApolloParseInterceptor implements ApolloInterceptor {
       @Override public void onCompleted() {
         // call onCompleted in onResponse in case of error
       }
+
+      @Override public void onFetch(FetchSourceType sourceType) {
+        callBack.onFetch(sourceType);
+      }
     });
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -73,6 +73,8 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     if (disposed) return;
     dispatcher.execute(new Runnable() {
       @Override public void run() {
+        callBack.onFetch(FetchSourceType.NETWORK);
+
         try {
           httpCall = httpCall(request.operation);
         } catch (IOException e) {

--- a/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -91,8 +91,8 @@ public class Rx2Apollo {
             }
           }
 
-          @Override public void onCompleted() {
-            if (!emitter.isDisposed()) {
+          @Override public void onStatusEvent(@Nonnull ApolloCall.StatusEvent event) {
+            if (event == ApolloCall.StatusEvent.COMPLETED && !emitter.isDisposed()) {
               emitter.onComplete();
             }
           }

--- a/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rxsupport/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -107,8 +107,10 @@ public final class RxApollo {
             emitter.onError(e);
           }
 
-          @Override public void onCompleted() {
-            emitter.onCompleted();
+          @Override public void onStatusEvent(@Nonnull ApolloCall.StatusEvent event) {
+            if (event == ApolloCall.StatusEvent.COMPLETED) {
+              emitter.onCompleted();
+            }
           }
         });
       }


### PR DESCRIPTION
Introduce `ApolloCall.StatusEvent` enum to support different status events that corresponds to action happen to `ApolloCall`.
These events will be emitted via `ApolloCall.Callback#onStatusEvent(StatusEvent)`

See: https://github.com/apollographql/apollo-android/pull/654/files#diff-18999fee7e5f70c2f862624cbab6d833

Closes #632 