### PR TITLE
Introduce InputType for optional values with undefined state

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -1,0 +1,21 @@
+package com.apollographql.apollo.api;
+
+import javax.annotation.Nullable;
+
+public final class Input<V> {
+  public final V value;
+  public final boolean defined;
+
+  private Input(V value, boolean defined) {
+    this.value = value;
+    this.defined = defined;
+  }
+
+  public static <V> Input<V> fromNullable(@Nullable V value) {
+    return new Input<>(value, true);
+  }
+
+  public static <V> Input<V> absent() {
+    return new Input<>(null, false);
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
@@ -1,9 +1,6 @@
 package com.apollographql.apollo.compiler
 
-import com.apollographql.apollo.api.GraphqlFragment
-import com.apollographql.apollo.api.Mutation
-import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.*
 import com.apollographql.apollo.api.internal.Optional
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder
 import com.apollographql.apollo.api.internal.Utils
@@ -29,6 +26,7 @@ object ClassNames {
   val JAVA_OPTIONAL: ClassName = ClassName.get("java.util", "Optional")
   val API_UTILS: ClassName = ClassName.get(Utils::class.java)
   val FRAGMENT: ClassName = ClassName.get(GraphqlFragment::class.java)
+  val INPUT_TYPE: ClassName = ClassName.get(Input::class.java)
 
   fun <K : Any> parameterizedListOf(type: Class<K>): TypeName =
       ParameterizedTypeName.get(LIST, ClassName.get(type))
@@ -55,13 +53,13 @@ object ClassNames {
   fun parameterizedOptional(type: TypeName): TypeName =
       ParameterizedTypeName.get(OPTIONAL, type)
 
-  fun <K : Any> parameterizedGuavaOptional(type: Class<K>): TypeName =
-      ParameterizedTypeName.get(GUAVA_OPTIONAL, ClassName.get(type))
-
   fun parameterizedGuavaOptional(type: TypeName): TypeName =
       ParameterizedTypeName.get(GUAVA_OPTIONAL, type)
 
   fun parameterizedJavaOptional(type: TypeName): TypeName =
       ParameterizedTypeName.get(JAVA_OPTIONAL, type)
+
+  fun parameterizedInputType(type: TypeName): TypeName =
+      ParameterizedTypeName.get(INPUT_TYPE, type)
 
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.compiler
 
 import com.apollographql.apollo.compiler.ClassNames.parameterizedGuavaOptional
+import com.apollographql.apollo.compiler.ClassNames.parameterizedInputType
 import com.apollographql.apollo.compiler.ClassNames.parameterizedJavaOptional
 import com.apollographql.apollo.compiler.ClassNames.parameterizedOptional
 import com.apollographql.apollo.compiler.ir.CodeGenerationContext
@@ -35,6 +36,7 @@ class JavaTypeResolver(
         NullableValueType.APOLLO_OPTIONAL -> parameterizedOptional(javaType)
         NullableValueType.GUAVA_OPTIONAL -> parameterizedGuavaOptional(javaType)
         NullableValueType.JAVA_OPTIONAL -> parameterizedJavaOptional(javaType)
+        NullableValueType.INPUT_TYPE -> parameterizedInputType(javaType)
         else -> javaType.annotated(Annotations.NULLABLE)
       }.let {
         if (deprecated) it.annotated(Annotations.DEPRECATED) else it

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/NullableValueType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/NullableValueType.kt
@@ -4,7 +4,8 @@ enum class NullableValueType(val value: String) {
   ANNOTATED("annotated"),
   APOLLO_OPTIONAL("apolloOptional"),
   GUAVA_OPTIONAL("guavaOptional"),
-  JAVA_OPTIONAL("javaOptional");
+  JAVA_OPTIONAL("javaOptional"),
+  INPUT_TYPE("inputType");
 
   companion object {
     fun findByValue(value: String): NullableValueType? = NullableValueType.values().find { it.value == value }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
@@ -100,11 +100,18 @@ class VariablesTypeSpecBuilder(
 
   private fun marshallerMethodSpec(): MethodSpec {
     val writeCode = variables
-        .map { InputFieldSpec.build(name = it.name, graphQLType = it.type, context = context) }
+        .map {
+          InputFieldSpec.build(
+              name = it.name,
+              graphQLType = it.type,
+              context = context,
+              nullableValueType = NullableValueType.ANNOTATED
+          )
+        }
         .map {
           it.writeValueCode(
               writerParam = CodeBlock.of("\$L", WRITER_PARAM.name),
-              marshaller = CodeBlock.of("${MARSHALLER_PARAM_NAME}()")
+              marshaller = CodeBlock.of("\$L()", MARSHALLER_PARAM_NAME)
           )
         }
         .fold(CodeBlock.builder(), CodeBlock.Builder::add)

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
@@ -1,5 +1,6 @@
 package com.example.input_object_type.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import java.io.IOException;
@@ -12,13 +13,13 @@ import javax.annotation.Nullable;
 public final class ColorInput {
   private final int red;
 
-  private final @Nullable Double green;
+  private final Input<Double> green;
 
   private final double blue;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
+  ColorInput(int red, Input<Double> green, double blue, Input<Episode> enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
@@ -36,7 +37,7 @@ public final class ColorInput {
    * Green color
    */
   public @Nullable Double green() {
-    return this.green;
+    return this.green.value;
   }
 
   /**
@@ -50,7 +51,7 @@ public final class ColorInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   public static Builder builder() {
@@ -62,9 +63,13 @@ public final class ColorInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("red", red);
-        writer.writeDouble("green", green);
+        if (green.defined) {
+          writer.writeDouble("green", green.value);
+        }
         writer.writeDouble("blue", blue);
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
       }
     };
   }
@@ -72,11 +77,11 @@ public final class ColorInput {
   public static final class Builder {
     private int red = 1;
 
-    private @Nullable Double green = 0.0;
+    private Input<Double> green = Input.fromNullable(0.0);
 
     private double blue = 1.5;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
     Builder() {
     }
@@ -93,7 +98,7 @@ public final class ColorInput {
      * Green color
      */
     public Builder green(@Nullable Double green) {
-      this.green = green;
+      this.green = Input.fromNullable(green);
       return this;
     }
 
@@ -109,7 +114,7 @@ public final class ColorInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -1,5 +1,6 @@
 package com.example.input_object_type.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.internal.Utils;
@@ -17,24 +18,24 @@ import javax.annotation.Nullable;
 public final class ReviewInput {
   private final int stars;
 
-  private final @Nullable Integer nullableIntFieldWithDefaultValue;
+  private final Input<Integer> nullableIntFieldWithDefaultValue;
 
-  private final @Nullable String commentary;
+  private final Input<String> commentary;
 
   private final @Nonnull ColorInput favoriteColor;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  private final @Nullable Episode nullableEnum;
+  private final Input<Episode> nullableEnum;
 
-  private final @Nullable List<Date> listOfCustomScalar;
+  private final Input<List<Date>> listOfCustomScalar;
 
-  private final @Nullable List<Episode> listOfEnums;
+  private final Input<List<Episode>> listOfEnums;
 
-  ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
-      @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
-      @Nullable List<Date> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
+  ReviewInput(int stars, Input<Integer> nullableIntFieldWithDefaultValue, Input<String> commentary,
+      @Nonnull ColorInput favoriteColor, Input<Episode> enumWithDefaultValue,
+      Input<Episode> nullableEnum, Input<List<Date>> listOfCustomScalar,
+      Input<List<Episode>> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
@@ -56,14 +57,14 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Integer nullableIntFieldWithDefaultValue() {
-    return this.nullableIntFieldWithDefaultValue;
+    return this.nullableIntFieldWithDefaultValue.value;
   }
 
   /**
    * Comment about the movie, optional
    */
   public @Nullable String commentary() {
-    return this.commentary;
+    return this.commentary.value;
   }
 
   /**
@@ -77,28 +78,28 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable Episode nullableEnum() {
-    return this.nullableEnum;
+    return this.nullableEnum.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Date> listOfCustomScalar() {
-    return this.listOfCustomScalar;
+    return this.listOfCustomScalar.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Episode> listOfEnums() {
-    return this.listOfEnums;
+    return this.listOfEnums.value;
   }
 
   public static Builder builder() {
@@ -110,27 +111,39 @@ public final class ReviewInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("stars", stars);
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
-        writer.writeString("commentary", commentary);
+        if (nullableIntFieldWithDefaultValue.defined) {
+          writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value);
+        }
+        if (commentary.defined) {
+          writer.writeString("commentary", commentary.value);
+        }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
-        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
-        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Date $item : listOfCustomScalar) {
-              listItemWriter.writeCustom(CustomType.DATE, $item);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
+        if (nullableEnum.defined) {
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+        }
+        if (listOfCustomScalar.defined) {
+          writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Date $item : listOfCustomScalar.value) {
+                listItemWriter.writeCustom(CustomType.DATE, $item);
+              }
             }
-          }
-        } : null);
-        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Episode $item : listOfEnums) {
-              listItemWriter.writeString($item.name());
+          } : null);
+        }
+        if (listOfEnums.defined) {
+          writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : listOfEnums.value) {
+                listItemWriter.writeString($item.name());
+              }
             }
-          }
-        } : null);
+          } : null);
+        }
       }
     };
   }
@@ -138,19 +151,19 @@ public final class ReviewInput {
   public static final class Builder {
     private int stars;
 
-    private @Nullable Integer nullableIntFieldWithDefaultValue = 10;
+    private Input<Integer> nullableIntFieldWithDefaultValue = Input.fromNullable(10);
 
-    private @Nullable String commentary;
+    private Input<String> commentary = Input.absent();
 
     private @Nonnull ColorInput favoriteColor;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
-    private @Nullable Episode nullableEnum;
+    private Input<Episode> nullableEnum = Input.absent();
 
-    private @Nullable List<Date> listOfCustomScalar;
+    private Input<List<Date>> listOfCustomScalar = Input.absent();
 
-    private @Nullable List<Episode> listOfEnums;
+    private Input<List<Episode>> listOfEnums = Input.absent();
 
     Builder() {
     }
@@ -167,7 +180,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableIntFieldWithDefaultValue(@Nullable Integer nullableIntFieldWithDefaultValue) {
-      this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
+      this.nullableIntFieldWithDefaultValue = Input.fromNullable(nullableIntFieldWithDefaultValue);
       return this;
     }
 
@@ -175,7 +188,7 @@ public final class ReviewInput {
      * Comment about the movie, optional
      */
     public Builder commentary(@Nullable String commentary) {
-      this.commentary = commentary;
+      this.commentary = Input.fromNullable(commentary);
       return this;
     }
 
@@ -191,7 +204,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 
@@ -199,7 +212,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableEnum(@Nullable Episode nullableEnum) {
-      this.nullableEnum = nullableEnum;
+      this.nullableEnum = Input.fromNullable(nullableEnum);
       return this;
     }
 
@@ -207,7 +220,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfCustomScalar(@Nullable List<Date> listOfCustomScalar) {
-      this.listOfCustomScalar = listOfCustomScalar;
+      this.listOfCustomScalar = Input.fromNullable(listOfCustomScalar);
       return this;
     }
 
@@ -215,7 +228,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
-      this.listOfEnums = listOfEnums;
+      this.listOfEnums = Input.fromNullable(listOfEnums);
       return this;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
@@ -1,5 +1,6 @@
 package com.example.mutation_create_review.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import java.io.IOException;
@@ -12,13 +13,13 @@ import javax.annotation.Nullable;
 public final class ColorInput {
   private final int red;
 
-  private final @Nullable Double green;
+  private final Input<Double> green;
 
   private final double blue;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
+  ColorInput(int red, Input<Double> green, double blue, Input<Episode> enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
@@ -36,7 +37,7 @@ public final class ColorInput {
    * Green color
    */
   public @Nullable Double green() {
-    return this.green;
+    return this.green.value;
   }
 
   /**
@@ -50,7 +51,7 @@ public final class ColorInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   public static Builder builder() {
@@ -62,9 +63,13 @@ public final class ColorInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("red", red);
-        writer.writeDouble("green", green);
+        if (green.defined) {
+          writer.writeDouble("green", green.value);
+        }
         writer.writeDouble("blue", blue);
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
       }
     };
   }
@@ -72,11 +77,11 @@ public final class ColorInput {
   public static final class Builder {
     private int red = 1;
 
-    private @Nullable Double green = 0.0;
+    private Input<Double> green = Input.fromNullable(0.0);
 
     private double blue = 1.5;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
     Builder() {
     }
@@ -93,7 +98,7 @@ public final class ColorInput {
      * Green color
      */
     public Builder green(@Nullable Double green) {
-      this.green = green;
+      this.green = Input.fromNullable(green);
       return this;
     }
 
@@ -109,7 +114,7 @@ public final class ColorInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -1,5 +1,6 @@
 package com.example.mutation_create_review.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.internal.Utils;
@@ -17,24 +18,24 @@ import javax.annotation.Nullable;
 public final class ReviewInput {
   private final int stars;
 
-  private final @Nullable Integer nullableIntFieldWithDefaultValue;
+  private final Input<Integer> nullableIntFieldWithDefaultValue;
 
-  private final @Nullable String commentary;
+  private final Input<String> commentary;
 
   private final @Nonnull ColorInput favoriteColor;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  private final @Nullable Episode nullableEnum;
+  private final Input<Episode> nullableEnum;
 
-  private final @Nullable List<Object> listOfCustomScalar;
+  private final Input<List<Object>> listOfCustomScalar;
 
-  private final @Nullable List<Episode> listOfEnums;
+  private final Input<List<Episode>> listOfEnums;
 
-  ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
-      @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
-      @Nullable List<Object> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
+  ReviewInput(int stars, Input<Integer> nullableIntFieldWithDefaultValue, Input<String> commentary,
+      @Nonnull ColorInput favoriteColor, Input<Episode> enumWithDefaultValue,
+      Input<Episode> nullableEnum, Input<List<Object>> listOfCustomScalar,
+      Input<List<Episode>> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
@@ -56,14 +57,14 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Integer nullableIntFieldWithDefaultValue() {
-    return this.nullableIntFieldWithDefaultValue;
+    return this.nullableIntFieldWithDefaultValue.value;
   }
 
   /**
    * Comment about the movie, optional
    */
   public @Nullable String commentary() {
-    return this.commentary;
+    return this.commentary.value;
   }
 
   /**
@@ -77,28 +78,28 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable Episode nullableEnum() {
-    return this.nullableEnum;
+    return this.nullableEnum.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Object> listOfCustomScalar() {
-    return this.listOfCustomScalar;
+    return this.listOfCustomScalar.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Episode> listOfEnums() {
-    return this.listOfEnums;
+    return this.listOfEnums.value;
   }
 
   public static Builder builder() {
@@ -110,27 +111,39 @@ public final class ReviewInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("stars", stars);
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
-        writer.writeString("commentary", commentary);
+        if (nullableIntFieldWithDefaultValue.defined) {
+          writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value);
+        }
+        if (commentary.defined) {
+          writer.writeString("commentary", commentary.value);
+        }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
-        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
-        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Object $item : listOfCustomScalar) {
-              listItemWriter.writeCustom(CustomType.DATE, $item);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
+        if (nullableEnum.defined) {
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+        }
+        if (listOfCustomScalar.defined) {
+          writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Object $item : listOfCustomScalar.value) {
+                listItemWriter.writeCustom(CustomType.DATE, $item);
+              }
             }
-          }
-        } : null);
-        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Episode $item : listOfEnums) {
-              listItemWriter.writeString($item.name());
+          } : null);
+        }
+        if (listOfEnums.defined) {
+          writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : listOfEnums.value) {
+                listItemWriter.writeString($item.name());
+              }
             }
-          }
-        } : null);
+          } : null);
+        }
       }
     };
   }
@@ -138,19 +151,19 @@ public final class ReviewInput {
   public static final class Builder {
     private int stars;
 
-    private @Nullable Integer nullableIntFieldWithDefaultValue = 10;
+    private Input<Integer> nullableIntFieldWithDefaultValue = Input.fromNullable(10);
 
-    private @Nullable String commentary;
+    private Input<String> commentary = Input.absent();
 
     private @Nonnull ColorInput favoriteColor;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
-    private @Nullable Episode nullableEnum;
+    private Input<Episode> nullableEnum = Input.absent();
 
-    private @Nullable List<Object> listOfCustomScalar;
+    private Input<List<Object>> listOfCustomScalar = Input.absent();
 
-    private @Nullable List<Episode> listOfEnums;
+    private Input<List<Episode>> listOfEnums = Input.absent();
 
     Builder() {
     }
@@ -167,7 +180,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableIntFieldWithDefaultValue(@Nullable Integer nullableIntFieldWithDefaultValue) {
-      this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
+      this.nullableIntFieldWithDefaultValue = Input.fromNullable(nullableIntFieldWithDefaultValue);
       return this;
     }
 
@@ -175,7 +188,7 @@ public final class ReviewInput {
      * Comment about the movie, optional
      */
     public Builder commentary(@Nullable String commentary) {
-      this.commentary = commentary;
+      this.commentary = Input.fromNullable(commentary);
       return this;
     }
 
@@ -191,7 +204,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 
@@ -199,7 +212,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableEnum(@Nullable Episode nullableEnum) {
-      this.nullableEnum = nullableEnum;
+      this.nullableEnum = Input.fromNullable(nullableEnum);
       return this;
     }
 
@@ -207,7 +220,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfCustomScalar(@Nullable List<Object> listOfCustomScalar) {
-      this.listOfCustomScalar = listOfCustomScalar;
+      this.listOfCustomScalar = Input.fromNullable(listOfCustomScalar);
       return this;
     }
 
@@ -215,7 +228,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
-      this.listOfEnums = listOfEnums;
+      this.listOfEnums = Input.fromNullable(listOfEnums);
       return this;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
@@ -1,5 +1,6 @@
 package com.example.mutation_create_review_semantic_naming.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import java.io.IOException;
@@ -12,13 +13,13 @@ import javax.annotation.Nullable;
 public final class ColorInput {
   private final int red;
 
-  private final @Nullable Double green;
+  private final Input<Double> green;
 
   private final double blue;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  ColorInput(int red, @Nullable Double green, double blue, @Nullable Episode enumWithDefaultValue) {
+  ColorInput(int red, Input<Double> green, double blue, Input<Episode> enumWithDefaultValue) {
     this.red = red;
     this.green = green;
     this.blue = blue;
@@ -36,7 +37,7 @@ public final class ColorInput {
    * Green color
    */
   public @Nullable Double green() {
-    return this.green;
+    return this.green.value;
   }
 
   /**
@@ -50,7 +51,7 @@ public final class ColorInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   public static Builder builder() {
@@ -62,9 +63,13 @@ public final class ColorInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("red", red);
-        writer.writeDouble("green", green);
+        if (green.defined) {
+          writer.writeDouble("green", green.value);
+        }
         writer.writeDouble("blue", blue);
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
       }
     };
   }
@@ -72,11 +77,11 @@ public final class ColorInput {
   public static final class Builder {
     private int red = 1;
 
-    private @Nullable Double green = 0.0;
+    private Input<Double> green = Input.fromNullable(0.0);
 
     private double blue = 1.5;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
     Builder() {
     }
@@ -93,7 +98,7 @@ public final class ColorInput {
      * Green color
      */
     public Builder green(@Nullable Double green) {
-      this.green = green;
+      this.green = Input.fromNullable(green);
       return this;
     }
 
@@ -109,7 +114,7 @@ public final class ColorInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -1,5 +1,6 @@
 package com.example.mutation_create_review_semantic_naming.type;
 
+import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.internal.Utils;
@@ -17,24 +18,24 @@ import javax.annotation.Nullable;
 public final class ReviewInput {
   private final int stars;
 
-  private final @Nullable Integer nullableIntFieldWithDefaultValue;
+  private final Input<Integer> nullableIntFieldWithDefaultValue;
 
-  private final @Nullable String commentary;
+  private final Input<String> commentary;
 
   private final @Nonnull ColorInput favoriteColor;
 
-  private final @Nullable Episode enumWithDefaultValue;
+  private final Input<Episode> enumWithDefaultValue;
 
-  private final @Nullable Episode nullableEnum;
+  private final Input<Episode> nullableEnum;
 
-  private final @Nullable List<Object> listOfCustomScalar;
+  private final Input<List<Object>> listOfCustomScalar;
 
-  private final @Nullable List<Episode> listOfEnums;
+  private final Input<List<Episode>> listOfEnums;
 
-  ReviewInput(int stars, @Nullable Integer nullableIntFieldWithDefaultValue,
-      @Nullable String commentary, @Nonnull ColorInput favoriteColor,
-      @Nullable Episode enumWithDefaultValue, @Nullable Episode nullableEnum,
-      @Nullable List<Object> listOfCustomScalar, @Nullable List<Episode> listOfEnums) {
+  ReviewInput(int stars, Input<Integer> nullableIntFieldWithDefaultValue, Input<String> commentary,
+      @Nonnull ColorInput favoriteColor, Input<Episode> enumWithDefaultValue,
+      Input<Episode> nullableEnum, Input<List<Object>> listOfCustomScalar,
+      Input<List<Episode>> listOfEnums) {
     this.stars = stars;
     this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
     this.commentary = commentary;
@@ -56,14 +57,14 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Integer nullableIntFieldWithDefaultValue() {
-    return this.nullableIntFieldWithDefaultValue;
+    return this.nullableIntFieldWithDefaultValue.value;
   }
 
   /**
    * Comment about the movie, optional
    */
   public @Nullable String commentary() {
-    return this.commentary;
+    return this.commentary.value;
   }
 
   /**
@@ -77,28 +78,28 @@ public final class ReviewInput {
    * for test purpose only
    */
   public @Nullable Episode enumWithDefaultValue() {
-    return this.enumWithDefaultValue;
+    return this.enumWithDefaultValue.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable Episode nullableEnum() {
-    return this.nullableEnum;
+    return this.nullableEnum.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Object> listOfCustomScalar() {
-    return this.listOfCustomScalar;
+    return this.listOfCustomScalar.value;
   }
 
   /**
    * for test purpose only
    */
   public @Nullable List<Episode> listOfEnums() {
-    return this.listOfEnums;
+    return this.listOfEnums.value;
   }
 
   public static Builder builder() {
@@ -110,27 +111,39 @@ public final class ReviewInput {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         writer.writeInt("stars", stars);
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue);
-        writer.writeString("commentary", commentary);
+        if (nullableIntFieldWithDefaultValue.defined) {
+          writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value);
+        }
+        if (commentary.defined) {
+          writer.writeString("commentary", commentary.value);
+        }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
-        writer.writeString("enumWithDefaultValue", enumWithDefaultValue != null ? enumWithDefaultValue.name() : null);
-        writer.writeString("nullableEnum", nullableEnum != null ? nullableEnum.name() : null);
-        writer.writeList("listOfCustomScalar", listOfCustomScalar != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Object $item : listOfCustomScalar) {
-              listItemWriter.writeCustom(CustomType.DATE, $item);
+        if (enumWithDefaultValue.defined) {
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+        }
+        if (nullableEnum.defined) {
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+        }
+        if (listOfCustomScalar.defined) {
+          writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Object $item : listOfCustomScalar.value) {
+                listItemWriter.writeCustom(CustomType.DATE, $item);
+              }
             }
-          }
-        } : null);
-        writer.writeList("listOfEnums", listOfEnums != null ? new InputFieldWriter.ListWriter() {
-          @Override
-          public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-            for (Episode $item : listOfEnums) {
-              listItemWriter.writeString($item.name());
+          } : null);
+        }
+        if (listOfEnums.defined) {
+          writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
+            @Override
+            public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
+              for (Episode $item : listOfEnums.value) {
+                listItemWriter.writeString($item.name());
+              }
             }
-          }
-        } : null);
+          } : null);
+        }
       }
     };
   }
@@ -138,19 +151,19 @@ public final class ReviewInput {
   public static final class Builder {
     private int stars;
 
-    private @Nullable Integer nullableIntFieldWithDefaultValue = 10;
+    private Input<Integer> nullableIntFieldWithDefaultValue = Input.fromNullable(10);
 
-    private @Nullable String commentary;
+    private Input<String> commentary = Input.absent();
 
     private @Nonnull ColorInput favoriteColor;
 
-    private @Nullable Episode enumWithDefaultValue = Episode.JEDI;
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
 
-    private @Nullable Episode nullableEnum;
+    private Input<Episode> nullableEnum = Input.absent();
 
-    private @Nullable List<Object> listOfCustomScalar;
+    private Input<List<Object>> listOfCustomScalar = Input.absent();
 
-    private @Nullable List<Episode> listOfEnums;
+    private Input<List<Episode>> listOfEnums = Input.absent();
 
     Builder() {
     }
@@ -167,7 +180,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableIntFieldWithDefaultValue(@Nullable Integer nullableIntFieldWithDefaultValue) {
-      this.nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue;
+      this.nullableIntFieldWithDefaultValue = Input.fromNullable(nullableIntFieldWithDefaultValue);
       return this;
     }
 
@@ -175,7 +188,7 @@ public final class ReviewInput {
      * Comment about the movie, optional
      */
     public Builder commentary(@Nullable String commentary) {
-      this.commentary = commentary;
+      this.commentary = Input.fromNullable(commentary);
       return this;
     }
 
@@ -191,7 +204,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder enumWithDefaultValue(@Nullable Episode enumWithDefaultValue) {
-      this.enumWithDefaultValue = enumWithDefaultValue;
+      this.enumWithDefaultValue = Input.fromNullable(enumWithDefaultValue);
       return this;
     }
 
@@ -199,7 +212,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder nullableEnum(@Nullable Episode nullableEnum) {
-      this.nullableEnum = nullableEnum;
+      this.nullableEnum = Input.fromNullable(nullableEnum);
       return this;
     }
 
@@ -207,7 +220,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfCustomScalar(@Nullable List<Object> listOfCustomScalar) {
-      this.listOfCustomScalar = listOfCustomScalar;
+      this.listOfCustomScalar = Input.fromNullable(listOfCustomScalar);
       return this;
     }
 
@@ -215,7 +228,7 @@ public final class ReviewInput {
      * for test purpose only
      */
     public Builder listOfEnums(@Nullable List<Episode> listOfEnums) {
-      this.listOfEnums = listOfEnums;
+      this.listOfEnums = Input.fromNullable(listOfEnums);
       return this;
     }
 


### PR DESCRIPTION
Introduce wrapper class InputType for optional values that can be in 3 states: some value, null and undefined.
Update generation of input object types to utilize new InputType wrapper and don't serialize optional value if it's undefined.

Example of new version of generated input type: https://github.com/apollographql/apollo-android/pull/658/files#diff-3e61595a5be610256c7f274f6f95d5f5

Closes #652 