### PR TITLE
Extract operation response parser

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -56,6 +56,14 @@ public final class Response<T> {
     return fromCache;
   }
 
+  public Builder<T> toBuilder() {
+    return new Builder<T>(operation)
+        .data(data)
+        .errors(errors)
+        .dependentKeys(dependentKeys)
+        .fromCache(fromCache);
+  }
+
   public static final class Builder<T> {
     private final Operation operation;
     private T data;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -16,7 +16,7 @@ import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.OptimisticNormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.internal.field.CacheFieldValueResolver;
-import com.apollographql.apollo.internal.reader.RealResponseReader;
+import com.apollographql.apollo.internal.response.RealResponseReader;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.util.ArrayList;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -8,7 +8,7 @@ import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.CacheReference;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.cache.normalized.RecordSet;
-import com.apollographql.apollo.internal.reader.ResponseReaderShadow;
+import com.apollographql.apollo.internal.response.ResponseReaderShadow;
 import com.apollographql.apollo.internal.util.SimpleStack;
 
 import java.util.ArrayList;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.reader;
+package com.apollographql.apollo.internal.response;
 
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ResponseReaderShadow.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ResponseReaderShadow.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.reader;
+package com.apollographql.apollo.internal.response;
 
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.Operation;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -13,6 +13,7 @@ import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
+import com.apollographql.apollo.internal.response.RealResponseReader;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Introduce OperationResponseParser responsible for parsing response from buffered source.
Can be used in tests with mocked raw response string.

Closes #653