### PR TITLE
Add default scalar type adapters for java built in  types

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
@@ -159,7 +159,7 @@ public class ResponseField {
    * @param conditions   list of conditions for this field
    * @return Field instance representing {@link Type#CUSTOM}
    */
-  public static ResponseField forCustomType(String responseName, String fieldName, Map<String, Object> arguments,
+  public static CustomTypeField forCustomType(String responseName, String fieldName, Map<String, Object> arguments,
       boolean optional, ScalarType scalarType, List<Condition> conditions) {
     return new CustomTypeField(responseName, fieldName, arguments, optional, scalarType, conditions);
   }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -18,6 +18,7 @@ import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery;
 import com.apollographql.apollo.integration.normalizer.HeroNameQuery;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.response.OperationResponseParser;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 
 import org.junit.After;
@@ -305,7 +306,7 @@ public class IntegrationTest {
 
     HeroNameQuery query = new HeroNameQuery();
     Response<HeroNameQuery.Data> response = new OperationResponseParser<>(query, query.responseFieldMapper(),
-        Collections.<ScalarType, CustomTypeAdapter>emptyMap(), ResponseNormalizer.NO_OP_NORMALIZER)
+        new ScalarTypeAdapters(Collections.EMPTY_MAP), ResponseNormalizer.NO_OP_NORMALIZER)
         .parse(new Buffer().writeUtf8(json));
 
     assertThat(response.data().hero().name()).isEqualTo("R2-D2");

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import org.junit.Test;
@@ -40,7 +41,8 @@ public class ApolloStoreTest {
       @Override public boolean remove(@Nonnull CacheKey cacheKey) {
         return false;
       }
-    }, CacheKeyResolver.DEFAULT, Collections.EMPTY_MAP, Executors.newSingleThreadExecutor(), new ApolloLogger(Optional.<Logger>absent()));
+    }, CacheKeyResolver.DEFAULT, new ScalarTypeAdapters(Collections.EMPTY_MAP), Executors.newSingleThreadExecutor(),
+        new ApolloLogger(Optional.<Logger>absent()));
     realApolloStore.clearAll().execute();
     latch.awaitOrThrowWithTimeout(3, TimeUnit.SECONDS);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/CustomTypeAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/CustomTypeAdapter.java
@@ -1,5 +1,7 @@
 package com.apollographql.apollo;
 
+import javax.annotation.Nonnull;
+
 /**
  * CustomTypeAdapter class represents the adapter for converting GraphQL custom scalar types to Java objects.
  *
@@ -65,7 +67,7 @@ public interface CustomTypeAdapter<T> {
    * @param value the value to de-serialize
    * @return custom scalar type
    */
-  T decode(String value);
+  @Nonnull T decode(@Nonnull String value);
 
   /**
    * Serializes the custom scalar type to the corresponding string value. Usually used in serializing variables or input
@@ -74,5 +76,5 @@ public interface CustomTypeAdapter<T> {
    * @param value the custom scalar type to serialize
    * @return serialized string value
    */
-  String encode(T value);
+  @Nonnull String encode(@Nonnull T value);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
@@ -2,23 +2,21 @@ package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloQueryWatcher;
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.cache.normalized.ApolloStore;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,7 +47,7 @@ final class QueryReFetcher {
           .serverUrl(builder.serverUrl)
           .httpCallFactory(builder.httpCallFactory)
           .responseFieldMapperFactory(builder.responseFieldMapperFactory)
-          .customTypeAdapters(builder.customTypeAdapters)
+          .scalarTypeAdapters(builder.scalarTypeAdapters)
           .apolloStore(builder.apolloStore)
           .httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
           .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
@@ -122,7 +120,7 @@ final class QueryReFetcher {
     HttpUrl serverUrl;
     Call.Factory httpCallFactory;
     ResponseFieldMapperFactory responseFieldMapperFactory;
-    Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+    ScalarTypeAdapters scalarTypeAdapters;
     ApolloStore apolloStore;
     Executor dispatcher;
     ApolloLogger logger;
@@ -154,8 +152,8 @@ final class QueryReFetcher {
       return this;
     }
 
-    Builder customTypeAdapters(Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
-      this.customTypeAdapters = customTypeAdapters;
+    Builder scalarTypeAdapters(ScalarTypeAdapters scalarTypeAdapters) {
+      this.scalarTypeAdapters = scalarTypeAdapters;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -2,12 +2,10 @@ package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloMutationCall;
 import com.apollographql.apollo.ApolloQueryCall;
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.ResponseFieldMapper;
-import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Action;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.CacheHeaders;
@@ -27,13 +25,13 @@ import com.apollographql.apollo.internal.interceptor.ApolloCacheInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloParseInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.internal.interceptor.RealApolloInterceptorChain;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -58,7 +56,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final HttpCache httpCache;
   final HttpCachePolicy.Policy httpCachePolicy;
   final ResponseFieldMapperFactory responseFieldMapperFactory;
-  final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  final ScalarTypeAdapters scalarTypeAdapters;
   final ApolloStore apolloStore;
   final CacheHeaders cacheHeaders;
   final FetchOptions fetchOptions;
@@ -87,7 +85,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     httpCache = builder.httpCache;
     httpCachePolicy = builder.httpCachePolicy;
     responseFieldMapperFactory = builder.responseFieldMapperFactory;
-    customTypeAdapters = builder.customTypeAdapters;
+    scalarTypeAdapters = builder.scalarTypeAdapters;
     apolloStore = builder.apolloStore;
     responseFetcher = builder.responseFetcher;
     cacheHeaders = builder.cacheHeaders;
@@ -108,7 +106,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
           .serverUrl(builder.serverUrl)
           .httpCallFactory(builder.httpCallFactory)
           .responseFieldMapperFactory(builder.responseFieldMapperFactory)
-          .customTypeAdapters(builder.customTypeAdapters)
+          .scalarTypeAdapters(builder.scalarTypeAdapters)
           .apolloStore(builder.apolloStore)
           .dispatcher(builder.dispatcher)
           .logger(builder.logger)
@@ -284,7 +282,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .httpCache(httpCache)
         .httpCachePolicy(httpCachePolicy)
         .responseFieldMapperFactory(responseFieldMapperFactory)
-        .customTypeAdapters(customTypeAdapters)
+        .scalarTypeAdapters(scalarTypeAdapters)
         .apolloStore(apolloStore)
         .cacheHeaders(cacheHeaders)
         .responseFetcher(responseFetcher)
@@ -360,9 +358,9 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.add(responseFetcher.provideInterceptor(logger));
     interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
-        customTypeAdapters, logger));
+        scalarTypeAdapters, logger));
     interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false,
-        customTypeAdapters, logger, sendOperationdIdentifiers));
+        scalarTypeAdapters, logger, sendOperationdIdentifiers));
 
     return new RealApolloInterceptorChain(interceptors);
   }
@@ -374,7 +372,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     HttpCache httpCache;
     HttpCachePolicy.Policy httpCachePolicy;
     ResponseFieldMapperFactory responseFieldMapperFactory;
-    Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+    ScalarTypeAdapters scalarTypeAdapters;
     ApolloStore apolloStore;
     ResponseFetcher responseFetcher;
     CacheHeaders cacheHeaders;
@@ -418,8 +416,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
       return this;
     }
 
-    public Builder<T> customTypeAdapters(Map<ScalarType, CustomTypeAdapter> customTypeAdapters) {
-      this.customTypeAdapters = customTypeAdapters;
+    public Builder<T> scalarTypeAdapters(ScalarTypeAdapters scalarTypeAdapters) {
+      this.scalarTypeAdapters = scalarTypeAdapters;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -1,9 +1,7 @@
 package com.apollographql.apollo.internal;
 
 import com.apollographql.apollo.ApolloPrefetch;
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
-import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.http.HttpCache;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
@@ -16,10 +14,10 @@ import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.interceptor.FetchOptions;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.internal.interceptor.RealApolloInterceptorChain;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -40,7 +38,7 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
   final HttpUrl serverUrl;
   final Call.Factory httpCallFactory;
   final HttpCache httpCache;
-  final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  final ScalarTypeAdapters scalarTypeAdapters;
   final Executor dispatcher;
   final ApolloLogger logger;
   final ApolloCallTracker tracker;
@@ -50,20 +48,20 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
   final AtomicReference<ApolloPrefetch.Callback> originalCallback = new AtomicReference<>();
 
   public RealApolloPrefetch(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory, HttpCache httpCache,
-      Map<ScalarType, CustomTypeAdapter> customTypeAdapters, Executor dispatcher, ApolloLogger logger,
-      ApolloCallTracker callTracker, boolean sendOperationIds) {
+      ScalarTypeAdapters scalarTypeAdapters, Executor dispatcher, ApolloLogger logger, ApolloCallTracker callTracker,
+      boolean sendOperationIds) {
     this.operation = operation;
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
     this.httpCache = httpCache;
-    this.customTypeAdapters = customTypeAdapters;
+    this.scalarTypeAdapters = scalarTypeAdapters;
     this.dispatcher = dispatcher;
     this.logger = logger;
     this.tracker = callTracker;
     this.sendOperationIds = sendOperationIds;
     interceptorChain = new RealApolloInterceptorChain(Collections.<ApolloInterceptor>singletonList(
         new ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, true,
-            customTypeAdapters, logger, sendOperationIds)
+            scalarTypeAdapters, logger, sendOperationIds)
     ));
   }
 
@@ -134,7 +132,7 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
   }
 
   @Override public ApolloPrefetch clone() {
-    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, httpCache, customTypeAdapters, dispatcher,
+    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, httpCache, scalarTypeAdapters, dispatcher,
         logger, tracker, sendOperationIds);
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -1,8 +1,6 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
-import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.http.HttpCache;
 import com.apollographql.apollo.cache.http.HttpCachePolicy;
@@ -11,10 +9,10 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.internal.json.InputFieldJsonWriter;
 import com.apollographql.apollo.internal.json.JsonWriter;
+import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.util.ApolloLogger;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.concurrent.Executor;
 
 import javax.annotation.Nonnull;
@@ -49,20 +47,20 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
   final Optional<HttpCachePolicy.Policy> cachePolicy;
   final boolean prefetch;
   final ApolloLogger logger;
-  final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  final ScalarTypeAdapters scalarTypeAdapters;
   final boolean sendOperationIdentifiers;
   volatile Call httpCall;
   volatile boolean disposed;
 
   public ApolloServerInterceptor(@Nonnull HttpUrl serverUrl, @Nonnull Call.Factory httpCallFactory,
       @Nullable HttpCachePolicy.Policy cachePolicy, boolean prefetch,
-      @Nonnull Map<ScalarType, CustomTypeAdapter> customTypeAdapters, @Nonnull ApolloLogger logger,
+      @Nonnull ScalarTypeAdapters scalarTypeAdapters, @Nonnull ApolloLogger logger,
       boolean sendOperationIdentifiers) {
     this.serverUrl = checkNotNull(serverUrl, "serverUrl == null");
     this.httpCallFactory = checkNotNull(httpCallFactory, "httpCallFactory == null");
     this.cachePolicy = Optional.fromNullable(cachePolicy);
     this.prefetch = prefetch;
-    this.customTypeAdapters = checkNotNull(customTypeAdapters, "customTypeAdapters == null");
+    this.scalarTypeAdapters = checkNotNull(scalarTypeAdapters, "scalarTypeAdapters == null");
     this.logger = checkNotNull(logger, "logger == null");
     this.sendOperationIdentifiers = sendOperationIdentifiers;
   }
@@ -142,7 +140,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
       jsonWriter.name("query").value(operation.queryDocument().replaceAll("\\n", ""));
     }
     jsonWriter.name("variables").beginObject();
-    operation.variables().marshaller().marshal(new InputFieldJsonWriter(jsonWriter, customTypeAdapters));
+    operation.variables().marshaller().marshal(new InputFieldJsonWriter(jsonWriter, scalarTypeAdapters));
     jsonWriter.endObject();
     jsonWriter.endObject();
     jsonWriter.close();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/OperationResponseParser.java
@@ -1,11 +1,9 @@
 package com.apollographql.apollo.internal.response;
 
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
-import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
 import com.apollographql.apollo.internal.json.BufferedSourceJsonReader;
@@ -25,15 +23,14 @@ import static com.apollographql.apollo.internal.json.ApolloJsonReader.responseJs
 public class OperationResponseParser<D extends Operation.Data, W> {
   private final Operation<D, W, ?> operation;
   private final ResponseFieldMapper responseFieldMapper;
-  private final Map<ScalarType, CustomTypeAdapter> customTypeAdapters;
+  private final ScalarTypeAdapters scalarTypeAdapters;
   private final ResponseNormalizer<Map<String, Object>> responseNormalizer;
 
   public OperationResponseParser(Operation<D, W, ?> operation, ResponseFieldMapper responseFieldMapper,
-      Map<ScalarType, CustomTypeAdapter> customTypeAdapters,
-      ResponseNormalizer<Map<String, Object>> responseNormalizer) {
+      ScalarTypeAdapters scalarTypeAdapters, ResponseNormalizer<Map<String, Object>> responseNormalizer) {
     this.operation = operation;
     this.responseFieldMapper = responseFieldMapper;
-    this.customTypeAdapters = customTypeAdapters;
+    this.scalarTypeAdapters = scalarTypeAdapters;
     this.responseNormalizer = responseNormalizer;
   }
 
@@ -55,7 +52,7 @@ public class OperationResponseParser<D extends Operation.Data, W> {
             @Override public Object read(ResponseJsonStreamReader reader) throws IOException {
               Map<String, Object> buffer = reader.toMap();
               RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(
-                  operation.variables(), buffer, new MapFieldValueResolver(), customTypeAdapters, responseNormalizer);
+                  operation.variables(), buffer, new MapFieldValueResolver(), scalarTypeAdapters, responseNormalizer);
               return responseFieldMapper.map(realResponseReader);
             }
           });

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ScalarTypeAdapters.java
@@ -1,0 +1,77 @@
+package com.apollographql.apollo.internal.response;
+
+import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.api.ScalarType;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
+public final class ScalarTypeAdapters {
+  private static final Map<Class, CustomTypeAdapter> DEFAULT_ADAPTERS = defaultAdapters();
+  private final Map<ScalarType, CustomTypeAdapter> customAdapters;
+
+  public ScalarTypeAdapters(@Nonnull Map<ScalarType, CustomTypeAdapter> customAdapters) {
+    this.customAdapters = checkNotNull(customAdapters, "customAdapters == null");
+  }
+
+  @SuppressWarnings("unchecked") @Nonnull public <T> CustomTypeAdapter<T> adapterFor(@Nonnull ScalarType scalarType) {
+    checkNotNull(scalarType, "scalarType == null");
+
+    CustomTypeAdapter<T> customTypeAdapter = customAdapters.get(scalarType);
+    if (customTypeAdapter == null) {
+      customTypeAdapter = DEFAULT_ADAPTERS.get(scalarType.javaType());
+    }
+
+    if (customTypeAdapter == null) {
+      throw new IllegalArgumentException(String.format("Can't map GraphQL type: %s to: %s. Did you forget to add "
+          + "custom type adapter?", scalarType.typeName(), scalarType.javaType()));
+    }
+
+    return customTypeAdapter;
+  }
+
+  private static Map<Class, CustomTypeAdapter> defaultAdapters() {
+    Map<Class, CustomTypeAdapter> adapters = new LinkedHashMap<>();
+    adapters.put(String.class, new DefaultCustomTypeAdapter<String>() {
+      @Nonnull @Override public String decode(@Nonnull String value) {
+        return value;
+      }
+    });
+    adapters.put(Boolean.class, new DefaultCustomTypeAdapter<Boolean>() {
+      @Nonnull @Override public Boolean decode(@Nonnull String value) {
+        return Boolean.parseBoolean(value);
+      }
+    });
+    adapters.put(Integer.class, new DefaultCustomTypeAdapter<Integer>() {
+      @Nonnull @Override public Integer decode(@Nonnull String value) {
+        return Integer.parseInt(value);
+      }
+    });
+    adapters.put(Long.class, new DefaultCustomTypeAdapter<Long>() {
+      @Nonnull @Override public Long decode(@Nonnull String value) {
+        return Long.parseLong(value);
+      }
+    });
+    adapters.put(Float.class, new DefaultCustomTypeAdapter<Float>() {
+      @Nonnull @Override public Float decode(@Nonnull String value) {
+        return Float.parseFloat(value);
+      }
+    });
+    adapters.put(Double.class, new DefaultCustomTypeAdapter<Double>() {
+      @Nonnull @Override public Double decode(@Nonnull String value) {
+        return Double.parseDouble(value);
+      }
+    });
+    return adapters;
+  }
+
+  private abstract static class DefaultCustomTypeAdapter<T> implements CustomTypeAdapter<T> {
+    @Nonnull @Override public String encode(@Nonnull T value) {
+      return value.toString();
+    }
+  }
+}


### PR DESCRIPTION
Add `ScalarTypeAdapters` abstraction with default support for java lang types:
- String
- Boolean
- Integer
- Long
- Float
- Double

The order of adapter resolving is next:
- first check if adapter is provided by user (registered CustomTypeAdapter)
- if user adapter is not found try default one
- if no adapter found throw exception

Closes #663