### PR TITLE
Update sample app to 0.4.1

### DIFF
--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.apolloReleaseVersion = '0.3.2'
+  ext.apolloReleaseVersion = '0.4.1'
 
   dependencies {
     classpath dep.androidPlugin

--- a/apollo-sample/src/main/AndroidManifest.xml
+++ b/apollo-sample/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
       </intent-filter>
     </activity>
 
-    <activity android:name="com.apollographql.apollo.sample.detail.GitHuntEntryDetailActivity"></activity>
+    <activity android:name="com.apollographql.apollo.sample.detail.GitHuntEntryDetailActivity"/>
   </application>
 
 </manifest>

--- a/apollo-sample/src/main/graphql/com/apollographql/apollo/sample/schema.json
+++ b/apollo-sample/src/main/graphql/com/apollographql/apollo/sample/schema.json
@@ -1,28 +1,98 @@
 {
   "data": {
     "__schema": {
-      "queryType": {
-        "name": "Query"
-      },
+      "directives": [
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Skipped when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "skip"
+        },
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Included when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "include"
+        },
+        {
+          "args": [
+            {
+              "defaultValue": "\"No longer supported\"",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "name": "reason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "name": "deprecated"
+        }
+      ],
       "mutationType": {
         "name": "Mutation"
+      },
+      "queryType": {
+        "name": "Query"
       },
       "subscriptionType": {
         "name": "Subscription"
       },
       "types": [
         {
-          "kind": "OBJECT",
-          "name": "Query",
           "description": "",
+          "enumValues": null,
           "fields": [
             {
-              "name": "feed",
-              "description": "A feed of repository submissions",
               "args": [
                 {
-                  "name": "type",
+                  "defaultValue": null,
                   "description": "The sort order for the feed",
+                  "name": "type",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -31,30 +101,33 @@
                       "name": "FeedType",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "offset",
+                  "defaultValue": null,
                   "description": "The number of items to skip, for pagination",
+                  "name": "offset",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "limit",
+                  "defaultValue": null,
                   "description": "The number of items to fetch starting from the offset, for pagination",
+                  "name": "limit",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "A feed of repository submissions",
+              "isDeprecated": false,
+              "name": "feed",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -63,17 +136,14 @@
                   "name": "Entry",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "entry",
-              "description": "A single entry",
               "args": [
                 {
-                  "name": "repoFullName",
+                  "defaultValue": null,
                   "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -82,116 +152,111 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "A single entry",
+              "isDeprecated": false,
+              "name": "entry",
               "type": {
                 "kind": "OBJECT",
                 "name": "Entry",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "currentUser",
-              "description": "Return the currently logged in user, or null if nobody is logged in",
               "args": [],
+              "deprecationReason": null,
+              "description": "Return the currently logged in user, or null if nobody is logged in",
+              "isDeprecated": false,
+              "name": "currentUser",
               "type": {
                 "kind": "OBJECT",
                 "name": "User",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Query",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "FeedType",
           "description": "A list of options for the sort order of the feed",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": [
             {
-              "name": "HOT",
+              "deprecationReason": null,
               "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "HOT"
             },
             {
-              "name": "NEW",
+              "deprecationReason": null,
               "description": "Newest entries first",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "NEW"
             },
             {
-              "name": "TOP",
+              "deprecationReason": null,
               "description": "Highest score entries first",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "TOP"
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Int",
-          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
+          "kind": "ENUM",
+          "name": "FeedType",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Entry",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null
+        },
+        {
           "description": "Information about a GitHub repository submitted to GitHunt",
+          "enumValues": null,
           "fields": [
             {
-              "name": "repository",
+              "args": [],
+              "deprecationReason": null,
               "description": "Information about the repository from GitHub",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Repository",
-                  "ofType": null
-                }
-              },
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "repository",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Repository",
+                "ofType": null
+              }
             },
             {
-              "name": "postedBy",
+              "args": [],
+              "deprecationReason": null,
               "description": "The GitHub user who submitted this entry",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "User",
-                  "ofType": null
-                }
-              },
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "postedBy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
             },
             {
-              "name": "createdAt",
-              "description": "A timestamp of when the entry was submitted",
               "args": [],
+              "deprecationReason": null,
+              "description": "A timestamp of when the entry was submitted",
+              "isDeprecated": false,
+              "name": "createdAt",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -200,14 +265,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "score",
-              "description": "The score of this repository, upvotes - downvotes",
               "args": [],
+              "deprecationReason": null,
+              "description": "The score of this repository, upvotes - downvotes",
+              "isDeprecated": false,
+              "name": "score",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -216,14 +281,14 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "hotScore",
-              "description": "The hot score of this repository",
               "args": [],
+              "deprecationReason": null,
+              "description": "The hot score of this repository",
+              "isDeprecated": false,
+              "name": "hotScore",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -232,35 +297,35 @@
                   "name": "Float",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "comments",
-              "description": "Comments posted about this repository",
               "args": [
                 {
-                  "name": "limit",
+                  "defaultValue": null,
                   "description": "",
+                  "name": "limit",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "offset",
+                  "defaultValue": null,
                   "description": "",
+                  "name": "offset",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Comments posted about this repository",
+              "isDeprecated": false,
+              "name": "comments",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -273,14 +338,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "commentCount",
+              "args": [],
+              "deprecationReason": null,
               "description": "The number of comments posted about this repository",
-              "args": [],
+              "isDeprecated": false,
+              "name": "commentCount",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -289,14 +354,14 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "id",
+              "args": [],
+              "deprecationReason": null,
               "description": "The SQL ID of this entry",
-              "args": [],
+              "isDeprecated": false,
+              "name": "id",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -305,14 +370,14 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "vote",
-              "description": "XXX to be changed",
               "args": [],
+              "deprecationReason": null,
+              "description": "XXX to be changed",
+              "isDeprecated": false,
+              "name": "vote",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -321,25 +386,25 @@
                   "name": "Vote",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Entry",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Repository",
           "description": "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
+              "args": [],
+              "deprecationReason": null,
               "description": "Just the name of the repository, e.g. GitHunt-API",
-              "args": [],
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -348,14 +413,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "full_name",
+              "args": [],
+              "deprecationReason": null,
               "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
-              "args": [],
+              "isDeprecated": false,
+              "name": "full_name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -364,26 +429,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": "The description of the repository",
               "args": [],
+              "deprecationReason": null,
+              "description": "The description of the repository",
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "html_url",
-              "description": "The link to the repository on GitHub",
               "args": [],
+              "deprecationReason": null,
+              "description": "The link to the repository on GitHub",
+              "isDeprecated": false,
+              "name": "html_url",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -392,14 +457,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "stargazers_count",
-              "description": "The number of people who have starred this repository on GitHub",
               "args": [],
+              "deprecationReason": null,
+              "description": "The number of people who have starred this repository on GitHub",
+              "isDeprecated": false,
+              "name": "stargazers_count",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -408,59 +473,59 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "open_issues_count",
-              "description": "The number of open issues on this repository on GitHub",
               "args": [],
+              "deprecationReason": null,
+              "description": "The number of open issues on this repository on GitHub",
+              "isDeprecated": false,
+              "name": "open_issues_count",
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "owner",
-              "description": "The owner of this repository on GitHub, e.g. apollostack",
               "args": [],
+              "deprecationReason": null,
+              "description": "The owner of this repository on GitHub, e.g. apollostack",
+              "isDeprecated": false,
+              "name": "owner",
               "type": {
                 "kind": "OBJECT",
                 "name": "User",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Repository",
           "possibleTypes": null
         },
         {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
           "kind": "SCALAR",
           "name": "String",
-          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "User",
           "description": "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "login",
+              "args": [],
+              "deprecationReason": null,
               "description": "The name of the user, e.g. apollostack",
-              "args": [],
+              "isDeprecated": false,
+              "name": "login",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -469,14 +534,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "avatar_url",
+              "args": [],
+              "deprecationReason": null,
               "description": "The URL to a directly embeddable image for this user's avatar",
-              "args": [],
+              "isDeprecated": false,
+              "name": "avatar_url",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -485,14 +550,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "html_url",
-              "description": "The URL of this user's GitHub page",
               "args": [],
+              "deprecationReason": null,
+              "description": "The URL of this user's GitHub page",
+              "isDeprecated": false,
+              "name": "html_url",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -501,35 +566,35 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "User",
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "Float",
           "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "enumValues": null,
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
+          "kind": "SCALAR",
+          "name": "Float",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Comment",
           "description": "A comment about an entry, submitted by a user",
+          "enumValues": null,
           "fields": [
             {
-              "name": "id",
-              "description": "The SQL ID of this entry",
               "args": [],
+              "deprecationReason": null,
+              "description": "The SQL ID of this entry",
+              "isDeprecated": false,
+              "name": "id",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -538,30 +603,26 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "postedBy",
+              "args": [],
+              "deprecationReason": null,
               "description": "The GitHub user who posted the comment",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "User",
-                  "ofType": null
-                }
-              },
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "postedBy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
             },
             {
-              "name": "createdAt",
-              "description": "A timestamp of when the comment was posted",
               "args": [],
+              "deprecationReason": null,
+              "description": "A timestamp of when the comment was posted",
+              "isDeprecated": false,
+              "name": "createdAt",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -570,14 +631,14 @@
                   "name": "Float",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "content",
+              "args": [],
+              "deprecationReason": null,
               "description": "The text of the comment",
-              "args": [],
+              "isDeprecated": false,
+              "name": "content",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -586,14 +647,14 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "repoName",
-              "description": "The repository which this comment is about",
               "args": [],
+              "deprecationReason": null,
+              "description": "The repository which this comment is about",
+              "isDeprecated": false,
+              "name": "repoName",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -602,25 +663,25 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Comment",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Vote",
           "description": "XXX to be removed",
+          "enumValues": null,
           "fields": [
             {
-              "name": "vote_value",
-              "description": "",
               "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "vote_value",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -629,28 +690,25 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Vote",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Mutation",
           "description": "",
+          "enumValues": null,
           "fields": [
             {
-              "name": "submitRepository",
-              "description": "Submit a new repository, returns the new submission",
               "args": [
                 {
-                  "name": "repoFullName",
+                  "defaultValue": null,
                   "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -659,25 +717,25 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Submit a new repository, returns the new submission",
+              "isDeprecated": false,
+              "name": "submitRepository",
               "type": {
                 "kind": "OBJECT",
                 "name": "Entry",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "vote",
-              "description": "Vote on a repository submission, returns the submission that was voted on",
               "args": [
                 {
-                  "name": "repoFullName",
+                  "defaultValue": null,
                   "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -686,12 +744,12 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "type",
+                  "defaultValue": null,
                   "description": "The type of vote - UP, DOWN, or CANCEL",
+                  "name": "type",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -700,25 +758,25 @@
                       "name": "VoteType",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Vote on a repository submission, returns the submission that was voted on",
+              "isDeprecated": false,
+              "name": "vote",
               "type": {
                 "kind": "OBJECT",
                 "name": "Entry",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "submitComment",
-              "description": "Comment on a repository, returns the new comment",
               "args": [
                 {
-                  "name": "repoFullName",
+                  "defaultValue": null,
                   "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -727,12 +785,12 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 },
                 {
-                  "name": "commentContent",
+                  "defaultValue": null,
                   "description": "The text content for the new comment",
+                  "name": "commentContent",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -741,65 +799,65 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Comment on a repository, returns the new comment",
+              "isDeprecated": false,
+              "name": "submitComment",
               "type": {
                 "kind": "OBJECT",
                 "name": "Comment",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Mutation",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "VoteType",
           "description": "The type of vote to record, when submitting a vote",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "UP"
+            },
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "DOWN"
+            },
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "CANCEL"
+            }
+          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
-            {
-              "name": "UP",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "DOWN",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "CANCEL",
-              "description": "",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
+          "kind": "ENUM",
+          "name": "VoteType",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "Subscription",
           "description": "",
+          "enumValues": null,
           "fields": [
             {
-              "name": "commentAdded",
-              "description": "Subscription fires on every comment added",
               "args": [
                 {
-                  "name": "repoFullName",
+                  "defaultValue": null,
                   "description": "",
+                  "name": "repoFullName",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -808,33 +866,36 @@
                       "name": "String",
                       "ofType": null
                     }
-                  },
-                  "defaultValue": null
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": "Subscription fires on every comment added",
+              "isDeprecated": false,
+              "name": "commentAdded",
               "type": {
                 "kind": "OBJECT",
                 "name": "Comment",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "Subscription",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Schema",
           "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "types",
-              "description": "A list of all types supported by this server.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of all types supported by this server.",
+              "isDeprecated": false,
+              "name": "types",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -846,18 +907,19 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Type"
+                      "name": "__Type",
+                      "ofType": null
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "queryType",
-              "description": "The type that query operations will be rooted at.",
               "args": [],
+              "deprecationReason": null,
+              "description": "The type that query operations will be rooted at.",
+              "isDeprecated": false,
+              "name": "queryType",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -866,38 +928,38 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "mutationType",
+              "args": [],
+              "deprecationReason": null,
               "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "mutationType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "subscriptionType",
+              "args": [],
+              "deprecationReason": null,
               "description": "If this server support subscription, the type that subscription operations will be rooted at.",
-              "args": [],
+              "isDeprecated": false,
+              "name": "subscriptionType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "directives",
-              "description": "A list of all directives supported by this server.",
               "args": [],
+              "deprecationReason": null,
+              "description": "A list of all directives supported by this server.",
+              "isDeprecated": false,
+              "name": "directives",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -909,29 +971,30 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__Directive"
+                      "name": "__Directive",
+                      "ofType": null
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Schema",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Type",
           "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "kind",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "kind",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -940,49 +1003,49 @@
                   "name": "__TypeKind",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "name",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "description",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "fields",
-              "description": null,
               "args": [
                 {
-                  "name": "includeDeprecated",
+                  "defaultValue": "false",
                   "description": null,
+                  "name": "includeDeprecated",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  },
-                  "defaultValue": "false"
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -995,14 +1058,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "interfaces",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1015,14 +1078,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "possibleTypes",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1035,25 +1098,25 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "enumValues",
-              "description": null,
               "args": [
                 {
-                  "name": "includeDeprecated",
+                  "defaultValue": "false",
                   "description": null,
+                  "name": "includeDeprecated",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "ofType": null
-                  },
-                  "defaultValue": "false"
+                  }
                 }
               ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "enumValues",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1066,14 +1129,14 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "inputFields",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "inputFields",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -1086,106 +1149,106 @@
                     "ofType": null
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "ofType",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ofType",
               "type": {
                 "kind": "OBJECT",
                 "name": "__Type",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Type",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "__TypeKind",
           "description": "An enum describing what kind of type a given `__Type` is.",
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
           "enumValues": [
             {
-              "name": "SCALAR",
+              "deprecationReason": null,
               "description": "Indicates this type is a scalar.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "SCALAR"
             },
             {
-              "name": "OBJECT",
+              "deprecationReason": null,
               "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "OBJECT"
             },
             {
-              "name": "INTERFACE",
+              "deprecationReason": null,
               "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "INTERFACE"
             },
             {
-              "name": "UNION",
+              "deprecationReason": null,
               "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "UNION"
             },
             {
-              "name": "ENUM",
+              "deprecationReason": null,
               "description": "Indicates this type is an enum. `enumValues` is a valid field.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "ENUM"
             },
             {
-              "name": "INPUT_OBJECT",
+              "deprecationReason": null,
               "description": "Indicates this type is an input object. `inputFields` is a valid field.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "INPUT_OBJECT"
             },
             {
-              "name": "LIST",
+              "deprecationReason": null,
               "description": "Indicates this type is a list. `ofType` is a valid field.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "LIST"
             },
             {
-              "name": "NON_NULL",
+              "deprecationReason": null,
               "description": "Indicates this type is a non-null. `ofType` is a valid field.",
               "isDeprecated": false,
-              "deprecationReason": null
+              "name": "NON_NULL"
             }
           ],
-          "possibleTypes": null
-        },
-        {
-          "kind": "SCALAR",
-          "name": "Boolean",
-          "description": "The `Boolean` scalar type represents `true` or `false`.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": null,
+          "kind": "ENUM",
+          "name": "__TypeKind",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Field",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "possibleTypes": null
+        },
+        {
           "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1194,26 +1257,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "args",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1225,18 +1288,19 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__InputValue"
+                      "name": "__InputValue",
+                      "ofType": null
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "type",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1245,14 +1309,14 @@
                   "name": "__Type",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isDeprecated",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1261,104 +1325,104 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "deprecationReason",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Field",
           "possibleTypes": null
         },
         {
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "isDeprecated": false,
+              "name": "defaultValue",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "kind": "OBJECT",
           "name": "__InputValue",
-          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
-          "fields": [
-            {
-              "name": "name",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "description",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "type",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "__Type",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "defaultValue",
-              "description": "A GraphQL-formatted string representing the default value for this input value.",
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [],
-          "enumValues": null,
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__EnumValue",
           "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1367,26 +1431,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "isDeprecated",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1395,37 +1459,37 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "deprecationReason",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__EnumValue",
           "possibleTypes": null
         },
         {
-          "kind": "OBJECT",
-          "name": "__Directive",
           "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "enumValues": null,
           "fields": [
             {
-              "name": "name",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1434,26 +1498,26 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "description",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "locations",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locations",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1465,18 +1529,19 @@
                     "name": null,
                     "ofType": {
                       "kind": "ENUM",
-                      "name": "__DirectiveLocation"
+                      "name": "__DirectiveLocation",
+                      "ofType": null
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
-              "name": "args",
-              "description": null,
               "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1488,18 +1553,19 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "__InputValue"
+                      "name": "__InputValue",
+                      "ofType": null
                     }
                   }
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
+              }
             },
             {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
               "name": "onOperation",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1508,14 +1574,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             },
             {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
               "name": "onFragment",
-              "description": null,
-              "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1524,14 +1590,14 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             },
             {
-              "name": "onField",
-              "description": null,
               "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onField",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -1540,206 +1606,133 @@
                   "name": "Boolean",
                   "ofType": null
                 }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Use `locations`."
+              }
             }
           ],
           "inputFields": null,
           "interfaces": [],
-          "enumValues": null,
+          "kind": "OBJECT",
+          "name": "__Directive",
           "possibleTypes": null
         },
         {
-          "kind": "ENUM",
-          "name": "__DirectiveLocation",
           "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "name": "QUERY"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "name": "MUTATION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "name": "SUBSCRIPTION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "name": "FIELD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_SPREAD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "name": "INLINE_FRAGMENT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "name": "SCHEMA"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "name": "SCALAR"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "name": "OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "name": "FIELD_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "name": "ARGUMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "name": "INTERFACE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "name": "UNION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "name": "ENUM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "name": "ENUM_VALUE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "name": "INPUT_FIELD_DEFINITION"
+            }
+          ],
           "fields": null,
           "inputFields": null,
           "interfaces": null,
-          "enumValues": [
-            {
-              "name": "QUERY",
-              "description": "Location adjacent to a query operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "MUTATION",
-              "description": "Location adjacent to a mutation operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SUBSCRIPTION",
-              "description": "Location adjacent to a subscription operation.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD",
-              "description": "Location adjacent to a field.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_DEFINITION",
-              "description": "Location adjacent to a fragment definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FRAGMENT_SPREAD",
-              "description": "Location adjacent to a fragment spread.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INLINE_FRAGMENT",
-              "description": "Location adjacent to an inline fragment.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCHEMA",
-              "description": "Location adjacent to a schema definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "SCALAR",
-              "description": "Location adjacent to a scalar definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "OBJECT",
-              "description": "Location adjacent to an object type definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "FIELD_DEFINITION",
-              "description": "Location adjacent to a field definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ARGUMENT_DEFINITION",
-              "description": "Location adjacent to an argument definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INTERFACE",
-              "description": "Location adjacent to an interface definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "UNION",
-              "description": "Location adjacent to a union definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM",
-              "description": "Location adjacent to an enum definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "ENUM_VALUE",
-              "description": "Location adjacent to an enum value definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_OBJECT",
-              "description": "Location adjacent to an input object type definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "INPUT_FIELD_DEFINITION",
-              "description": "Location adjacent to an input object field definition.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
           "possibleTypes": null
-        }
-      ],
-      "directives": [
-        {
-          "name": "skip",
-          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": "Skipped when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "include",
-          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-          "locations": [
-            "FIELD",
-            "FRAGMENT_SPREAD",
-            "INLINE_FRAGMENT"
-          ],
-          "args": [
-            {
-              "name": "if",
-              "description": "Included when true.",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ]
-        },
-        {
-          "name": "deprecated",
-          "description": "Marks an element of a GraphQL schema as no longer supported.",
-          "locations": [
-            "FIELD_DEFINITION",
-            "ENUM_VALUE"
-          ],
-          "args": [
-            {
-              "name": "reason",
-              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": "\"No longer supported\""
-            }
-          ]
         }
       ]
     }

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/GitHuntApplication.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/GitHuntApplication.java
@@ -3,8 +3,8 @@ package com.apollographql.apollo.sample;
 import android.app.Application;
 
 import com.apollographql.apollo.ApolloClient;
-import com.apollographql.apollo.api.Field;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory;
@@ -21,7 +21,7 @@ import okhttp3.OkHttpClient;
 
 public class GitHuntApplication extends Application {
 
-  private static final String BASE_URL = "https://githunt-api.herokuapp.com/graphql";
+  private static final String BASE_URL = "https://api.githunt.com/graphql/";
   private static final String SQL_CACHE_NAME = "githuntdb";
   private ApolloClient apolloClient;
 
@@ -31,25 +31,28 @@ public class GitHuntApplication extends Application {
         .build();
 
     ApolloSqlHelper apolloSqlHelper = new ApolloSqlHelper(this, SQL_CACHE_NAME);
-    NormalizedCacheFactory normalizedCacheFactory = new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION,
-        new SqlNormalizedCacheFactory(apolloSqlHelper));
+    NormalizedCacheFactory normalizedCacheFactory = new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION)
+        .chain(new SqlNormalizedCacheFactory(apolloSqlHelper));
 
     CacheKeyResolver cacheKeyResolver = new CacheKeyResolver() {
-      @Nonnull @Override public CacheKey fromFieldRecordSet(@Nonnull Field field, @Nonnull Map<String, Object> map) {
-        String typeName = (String) map.get("__typename");
+      @Nonnull @Override
+      public CacheKey fromFieldRecordSet(@Nonnull ResponseField field, @Nonnull Map<String, Object> recordSet) {
+        String typeName = (String) recordSet.get("__typename");
         if ("User".equals(typeName)) {
-          String userKey = typeName + "." + map.get("login");
+          String userKey = typeName + "." + recordSet.get("login");
           return CacheKey.from(userKey);
         }
-        if (map.containsKey("id")) {
-          String typeNameAndIDKey = map.get("__typename") + "." + map.get("id");
+        if (recordSet.containsKey("id")) {
+          String typeNameAndIDKey = recordSet.get("__typename") + "." + recordSet.get("id");
           return CacheKey.from(typeNameAndIDKey);
         }
         return CacheKey.NO_KEY;
       }
 
+      // Use this resolver to customize the key for fields with variables: eg entry(repoFullName: $repoFullName).
+      // This is useful if you want to make query to be able to resolved, even if it has never been run before.
       @Nonnull @Override
-      public CacheKey fromFieldArguments(@Nonnull Field field, @Nonnull Operation.Variables variables) {
+      public CacheKey fromFieldArguments(@Nonnull ResponseField field, @Nonnull Operation.Variables variables) {
         return CacheKey.NO_KEY;
       }
     };

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
@@ -14,7 +14,7 @@ import android.widget.TextView;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.cache.normalized.CacheControl;
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 import com.apollographql.apollo.sample.EntryDetailQuery;
 import com.apollographql.apollo.sample.GitHuntApplication;
@@ -22,7 +22,7 @@ import com.apollographql.apollo.sample.R;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import io.reactivex.observers.DisposableSingleObserver;
+import io.reactivex.observers.DisposableObserver;
 import io.reactivex.schedulers.Schedulers;
 
 public class GitHuntEntryDetailActivity extends AppCompatActivity {
@@ -90,19 +90,23 @@ public class GitHuntEntryDetailActivity extends AppCompatActivity {
   private void fetchRepositoryDetails() {
     ApolloCall<EntryDetailQuery.Data> entryDetailQuery = application.apolloClient()
         .query(new EntryDetailQuery(repoFullName))
-        .cacheControl(CacheControl.CACHE_FIRST);
+        .responseFetcher(ApolloResponseFetchers.CACHE_FIRST);
 
     //Example call using Rx2Support
     disposables.add(Rx2Apollo.from(entryDetailQuery)
         .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribeWith(new DisposableSingleObserver<Response<EntryDetailQuery.Data>>() {
-          @Override public void onSuccess(Response<EntryDetailQuery.Data> dataResponse) {
+        .subscribeWith(new DisposableObserver<Response<EntryDetailQuery.Data>>() {
+          @Override public void onNext(Response<EntryDetailQuery.Data> dataResponse) {
             setEntryData(dataResponse.data());
           }
 
           @Override public void onError(Throwable e) {
             Log.e(TAG, e.getMessage(), e);
+          }
+
+          @Override public void onComplete() {
+
           }
         }));
   }

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import static com.apollographql.apollo.sample.FeedQuery.*;
+import static com.apollographql.apollo.sample.FeedQuery.FeedEntry;
 
 public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNavigator {
 
@@ -93,7 +93,7 @@ public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNav
   }
 
   private void fetchFeed() {
-    final FeedQuery feedQuery = builder()
+    final FeedQuery feedQuery = FeedQuery.builder()
         .limit(FEED_SIZE)
         .type(FeedType.HOT)
         .build();

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
@@ -15,15 +15,21 @@ import android.widget.ProgressBar;
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloCallback;
 import com.apollographql.apollo.api.Response;
-import com.apollographql.apollo.cache.normalized.CacheControl;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.sample.FeedQuery;
 import com.apollographql.apollo.sample.GitHuntApplication;
 import com.apollographql.apollo.sample.R;
 import com.apollographql.apollo.sample.detail.GitHuntEntryDetailActivity;
 import com.apollographql.apollo.sample.type.FeedType;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import javax.annotation.Nonnull;
+
+import static com.apollographql.apollo.sample.FeedQuery.*;
 
 public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNavigator {
 
@@ -58,7 +64,7 @@ public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNav
   private ApolloCall.Callback<FeedQuery.Data> dataCallback
       = new ApolloCallback<>(new ApolloCall.Callback<FeedQuery.Data>() {
     @Override public void onResponse(@Nonnull Response<FeedQuery.Data> response) {
-      feedAdapter.setFeed(response.data().feedEntries());
+      feedAdapter.setFeed(feedResponseToEntriesWithRepositories(response));
       progressBar.setVisibility(View.GONE);
       content.setVisibility(View.VISIBLE);
     }
@@ -68,14 +74,32 @@ public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNav
     }
   }, uiHandler);
 
+  private List<FeedEntry> feedResponseToEntriesWithRepositories(Response<FeedQuery.Data> response) {
+    List<FeedEntry> feedEntriesWithRepos = new ArrayList<>();
+    final FeedQuery.Data responseData = response.data();
+    if (responseData == null) {
+      return Collections.emptyList();
+    }
+    final List<FeedEntry> feedEntries = responseData.feedEntries();
+    if (feedEntries == null) {
+      return Collections.emptyList();
+    }
+    for (FeedEntry entry : feedEntries) {
+      if (entry.repository() != null) {
+        feedEntriesWithRepos.add(entry);
+      }
+    }
+    return feedEntriesWithRepos;
+  }
+
   private void fetchFeed() {
-    final FeedQuery feedQuery = FeedQuery.builder()
+    final FeedQuery feedQuery = builder()
         .limit(FEED_SIZE)
         .type(FeedType.HOT)
         .build();
     githuntFeedCall = application.apolloClient()
         .query(feedQuery)
-        .cacheControl(CacheControl.NETWORK_FIRST);
+        .responseFetcher(ApolloResponseFetchers.NETWORK_FIRST);
     githuntFeedCall.enqueue(dataCallback);
   }
 


### PR DESCRIPTION
Updates sample to `0.4.1` which required 
- a schema update, 
- a change to the graphql url
- A filtering of feed entries, as repositories can now be null
- Update to chain cache
- Update cache key resolver
- Update to use `ApolloResponseFetchers`
- Use Observer instead of Single