### PR TITLE
Make generateModelBuilder generate deep builders (instead of shallow)

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Mutator.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Mutator.java
@@ -1,0 +1,17 @@
+package com.apollographql.apollo.api.internal;
+
+/**
+ * Represents an operation that accepts a single input argument, mutate it and returns no result
+ *
+ * @param <T> the type of the input to the operation
+ */
+public interface Mutator<T> {
+
+  /**
+   * Performs this operation on the given argument.
+   *
+   * @param t the input argument
+   */
+  void accept(T t);
+
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
@@ -10,19 +10,21 @@ class BuilderTypeSpecBuilder(
     val fields: List<Pair<String, TypeName>>,
     val fieldDefaultValues: Map<String, Any?>,
     val fieldJavaDocs: Map<String, String>,
-    val typeDeclarations: List<TypeDeclaration>
+    val typeDeclarations: List<TypeDeclaration>,
+    val buildableTypes: List<TypeName> = emptyList()
 ) {
   fun build(): TypeSpec {
-    return TypeSpec.classBuilder(builderClass)
+    return TypeSpec.classBuilder(ClassNames.BUILDER.simpleName())
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-        .addBuilderFields()
+        .apply { addFields(builderFields()) }
         .addMethod(MethodSpec.constructorBuilder().build())
-        .addBuilderMethods()
-        .addBuilderBuildMethod()
+        .apply { addMethods(setFieldMethods()) }
+        .apply { addMethods(setFieldWithMutatorMethods()) }
+        .addMethod(buildMethod())
         .build()
   }
 
-  private fun TypeSpec.Builder.addBuilderFields(): TypeSpec.Builder {
+  private fun builderFields(): List<FieldSpec> {
     fun valueCode(value: Any, type: TypeName): CodeBlock = when {
       value is Number -> CodeBlock.of("\$L", value.castTo(type))
       type.isEnum(typeDeclarations) -> CodeBlock.of("\$T.\$L", type, value)
@@ -41,7 +43,7 @@ class BuilderTypeSpecBuilder(
           .build()
     }
 
-    return addFields(fields.map { (fieldName, fieldType) ->
+    return fields.map { (fieldName, fieldType) ->
       val rawFieldType = fieldType.unwrapOptionalType(true).let {
         if (it.isList()) it.listParamType() else it
       }
@@ -59,55 +61,134 @@ class BuilderTypeSpecBuilder(
           .addModifiers(Modifier.PRIVATE)
           .initializer(initializer ?: fieldType.defaultOptionalValue())
           .build()
-    })
+    }
   }
 
-  private fun TypeSpec.Builder.addBuilderMethods(): TypeSpec.Builder {
-    return addMethods(fields.map { (fieldName, fieldType) ->
+  private fun setFieldMethods(): List<MethodSpec> {
+    return fields.map { (fieldName, fieldType) ->
       val javaDoc = fieldJavaDocs[fieldName]
-      MethodSpec.methodBuilder(fieldName)
-          .addModifiers(Modifier.PUBLIC)
-          .addParameter(ParameterSpec.builder(fieldType.unwrapOptionalType(), fieldName).build())
-          .let {
-            if (!javaDoc.isNullOrBlank())
-              it.addJavadoc(CodeBlock.of("\$L\n", javaDoc))
-            else
-              it
+      setFieldMethod(fieldName, fieldType, javaDoc)
+    }
+  }
+
+  private fun setFieldMethod(fieldName: String, fieldType: TypeName, javaDoc: String?): MethodSpec {
+    return MethodSpec.methodBuilder(fieldName)
+        .addModifiers(Modifier.PUBLIC)
+        .addParameter(ParameterSpec.builder(fieldType.unwrapOptionalType(), fieldName).build())
+        .let {
+          if (!javaDoc.isNullOrBlank())
+            it.addJavadoc(CodeBlock.of("\$L\n", javaDoc))
+          else
+            it
+        }
+        .returns(ClassNames.BUILDER)
+        .addStatement("this.\$L = \$L", fieldName, fieldType.wrapOptionalValue(CodeBlock.of("\$L", fieldName)))
+        .addStatement("return this")
+        .build()
+  }
+
+  private fun setFieldWithMutatorMethods(): List<MethodSpec> {
+    return fields
+        .map { (fieldName, fieldType) ->
+          fieldName to fieldType.withoutAnnotations()
+        }
+        .filter { (_, type) ->
+          if (type.isList()) {
+            buildableTypes.contains(type.listParamType())
+          } else {
+            buildableTypes.contains(type)
           }
-          .returns(builderClass)
-          .addStatement("this.\$L = \$L", fieldName, fieldType.wrapOptionalValue(CodeBlock.of("\$L", fieldName)))
+        }
+        .map { (fieldName, fieldType) ->
+          setFieldWithMutatorMethod(fieldName, fieldType)
+        }
+  }
+
+  private fun setFieldWithMutatorMethod(fieldName: String, fieldType: TypeName): MethodSpec {
+    fun setFieldCode(mutatorParam: ParameterSpec): CodeBlock {
+      return CodeBlock.builder()
+          .addStatement("\$T.\$L builder = this.\$L != null ? this.\$L.\$L() : \$T.\$L()", fieldType,
+              ClassNames.BUILDER.simpleName(), fieldName, fieldName, TO_BUILDER_METHOD_NAME, fieldType,
+              ClassNames.BUILDER.simpleName().decapitalize())
+          .addStatement("\$L.accept(builder)", mutatorParam.name)
+          .addStatement("this.\$L = builder.build()", fieldName)
           .addStatement("return this")
           .build()
-    })
+    }
+
+    fun setListFieldCode(mutatorParam: ParameterSpec): CodeBlock {
+      return CodeBlock.builder()
+          .addStatement("\$T<\$T.\$L> builders = new \$T<>()", ClassNames.LIST, fieldType.listParamType(),
+              ClassNames.BUILDER.simpleName(), ClassNames.ARRAY_LIST)
+          .beginControlFlow("if (this.\$L != null)", fieldName)
+          .beginControlFlow("for (\$T item : this.\$L)", fieldType.listParamType(), fieldName)
+          .addStatement("builders.add(item != null ? item.toBuilder() : null)")
+          .endControlFlow()
+          .endControlFlow()
+          .addStatement("\$L.accept(builders)", mutatorParam.name)
+          .addStatement("\$T<\$T> \$L = new \$T<>()", ClassNames.LIST, fieldType.listParamType(), fieldName,
+              ClassNames.ARRAY_LIST)
+          .beginControlFlow("for (\$T.\$L item : builders)", fieldType.listParamType(), ClassNames.BUILDER.simpleName())
+          .addStatement("\$L.add(item != null ? item.build() : null)", fieldName)
+          .endControlFlow()
+          .addStatement("this.\$L = \$L", fieldName, fieldName)
+          .addStatement("return this")
+          .build()
+    }
+
+    val javaDoc = fieldJavaDocs[fieldName]
+    val mutatorParam = mutatorParam(fieldType)
+    return MethodSpec.methodBuilder(fieldName)
+        .addModifiers(Modifier.PUBLIC)
+        .addParameter(mutatorParam)
+        .apply { if (!javaDoc.isNullOrBlank()) addJavadoc(CodeBlock.of("\$L\n", javaDoc)) }
+        .returns(ClassNames.BUILDER)
+        .addStatement("\$T.checkNotNull(\$L, \$S)", ClassNames.API_UTILS, mutatorParam.name,
+            "${mutatorParam.name} == null")
+        .addCode(if (fieldType.isList()) setListFieldCode(mutatorParam) else setFieldCode(mutatorParam))
+        .build()
   }
 
-  private fun TypeSpec.Builder.addBuilderBuildMethod(): TypeSpec.Builder {
+  private fun buildMethod(): MethodSpec {
     val validationCodeBuilder = fields.filter { (_, fieldType) ->
       !fieldType.isPrimitive && fieldType.annotations.contains(Annotations.NONNULL)
     }.map { (fieldName, _) ->
       CodeBlock.of("\$T.checkNotNull(\$L, \$S);\n", ClassNames.API_UTILS, fieldName, "$fieldName == null")
     }.fold(CodeBlock.builder(), CodeBlock.Builder::add)
 
-    return addMethod(MethodSpec
+    return MethodSpec
         .methodBuilder("build")
         .addModifiers(Modifier.PUBLIC)
         .returns(targetObjectClassName)
         .addCode(validationCodeBuilder.build())
         .addStatement("return new \$T\$L", targetObjectClassName,
             fields.map { it.first }.joinToString(prefix = "(", separator = ", ", postfix = ")"))
-        .build())
+        .build()
   }
 
   companion object {
-    val CLASS_NAME: String = "Builder"
-    private val builderClass = ClassName.get("", CLASS_NAME)
+    val TO_BUILDER_METHOD_NAME = "toBuilder"
+
+    private fun mutatorParam(fieldType: TypeName): ParameterSpec {
+      val fieldBuilderType = if (fieldType.isList()) {
+        ParameterizedTypeName.get(ClassNames.LIST,
+            ClassName.get("",
+                "${(fieldType.listParamType() as ClassName).simpleName()}.${ClassNames.BUILDER.simpleName()}"))
+      } else {
+        ClassName.get("", "${(fieldType as ClassName).simpleName()}.${ClassNames.BUILDER.simpleName()}")
+      }
+      return ParameterSpec.builder(
+          ParameterizedTypeName.get(ClassNames.MUTATOR, fieldBuilderType),
+          "mutator"
+      ).addAnnotation(Annotations.NONNULL).build()
+    }
 
     fun builderFactoryMethod(): MethodSpec {
       return MethodSpec
           .methodBuilder("builder")
           .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-          .returns(builderClass)
-          .addStatement("return new \$T()", builderClass)
+          .returns(ClassNames.BUILDER)
+          .addStatement("return new \$T()", ClassNames.BUILDER)
           .build()
     }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.compiler
 
 import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.internal.Mutator
 import com.apollographql.apollo.api.internal.Optional
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder
 import com.apollographql.apollo.api.internal.Utils
@@ -13,6 +14,7 @@ object ClassNames {
   val OBJECT: ClassName = ClassName.get(Object::class.java)
   val STRING: ClassName = ClassName.get(String::class.java)
   val LIST: ClassName = ClassName.get(List::class.java)
+  val ARRAY_LIST: ClassName = ClassName.get(ArrayList::class.java)
   val GRAPHQL_OPERATION: ClassName = ClassName.get(Operation::class.java)
   val GRAPHQL_QUERY: ClassName = ClassName.get(Query::class.java)
   val GRAPHQL_MUTATION: ClassName = ClassName.get(Mutation::class.java)
@@ -27,6 +29,8 @@ object ClassNames {
   val API_UTILS: ClassName = ClassName.get(Utils::class.java)
   val FRAGMENT: ClassName = ClassName.get(GraphqlFragment::class.java)
   val INPUT_TYPE: ClassName = ClassName.get(Input::class.java)
+  val BUILDER: ClassName = ClassName.get("", "Builder")
+  val MUTATOR: ClassName = ClassName.get(Mutator::class.java)
 
   fun <K : Any> parameterizedListOf(type: Class<K>): TypeName =
       ParameterizedTypeName.get(LIST, ClassName.get(type))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -45,7 +45,7 @@ class OperationTypeSpecBuilder(
         .flatten(excludeTypeNames = listOf(
             Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
             (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
-            BuilderTypeSpecBuilder.CLASS_NAME
+            ClassNames.BUILDER.simpleName()
         ))
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -176,6 +176,13 @@ class SchemaTypeSpecBuilder(
         .withToStringImplementation()
         .withEqualsImplementation()
         .withHashCodeImplementation()
+        .let {
+          if (context.generateModelBuilder) {
+            it.withBuilder()
+          } else {
+            it
+          }
+        }
   }
 
   private fun formatUniqueTypeName(typeName: String, reservedTypeNames: List<String>): String {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -38,7 +38,7 @@ data class Fragment(
         .flatten(excludeTypeNames = listOf(
             Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
             (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
-            BuilderTypeSpecBuilder.CLASS_NAME
+            ClassNames.BUILDER.simpleName()
         ))
         .let {
           if (context.generateModelBuilder) {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Mutator;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
@@ -190,6 +191,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public Builder hero(@Nullable Hero hero) {
         this.hero = hero;
+        return this;
+      }
+
+      public Builder hero(@Nonnull Mutator<Hero.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        Hero.Builder builder = this.hero != null ? this.hero.toBuilder() : Hero.builder();
+        mutator.accept(builder);
+        this.hero = builder.build();
         return this;
       }
 
@@ -391,6 +400,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return $hashCode;
       }
 
+      public Builder toBuilder() {
+        Builder builder = new Builder();
+        builder.heroDetails = heroDetails;
+        return builder;
+      }
+
+      public static Builder builder() {
+        return new Builder();
+      }
+
       public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();
 
@@ -401,6 +420,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
             heroDetails = heroDetailsFieldMapper.map(reader);
           }
           return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
+        }
+      }
+
+      public static final class Builder {
+        private @Nonnull HeroDetails heroDetails;
+
+        Builder() {
+        }
+
+        public Builder heroDetails(@Nonnull HeroDetails heroDetails) {
+          this.heroDetails = heroDetails;
+          return this;
+        }
+
+        public Fragments build() {
+          Utils.checkNotNull(heroDetails, "heroDetails == null");
+          return new Fragments(heroDetails);
         }
       }
     }
@@ -457,6 +493,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public Builder fragments(@Nonnull Fragments fragments) {
         this.fragments = fragments;
+        return this;
+      }
+
+      public Builder fragments(@Nonnull Mutator<Fragments.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        Fragments.Builder builder = this.fragments != null ? this.fragments.toBuilder() : Fragments.builder();
+        mutator.accept(builder);
+        this.fragments = builder.build();
         return this;
       }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -6,12 +6,14 @@ import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Mutator;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.Utils;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -354,6 +356,23 @@ public class HeroDetails implements GraphqlFragment {
         return this;
       }
 
+      public Builder edges(@Nonnull Mutator<List<Edge.Builder>> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        List<Edge.Builder> builders = new ArrayList<>();
+        if (this.edges != null) {
+          for (Edge item : this.edges) {
+            builders.add(item != null ? item.toBuilder() : null);
+          }
+        }
+        mutator.accept(builders);
+        List<Edge> edges = new ArrayList<>();
+        for (Edge.Builder item : builders) {
+          edges.add(item != null ? item.build() : null);
+        }
+        this.edges = edges;
+        return this;
+      }
+
       public FriendsConnection build() {
         Utils.checkNotNull(__typename, "__typename == null");
         return new FriendsConnection(__typename, totalCount, edges);
@@ -483,6 +502,14 @@ public class HeroDetails implements GraphqlFragment {
 
       public Builder node(@Nullable Node node) {
         this.node = node;
+        return this;
+      }
+
+      public Builder node(@Nonnull Mutator<Node.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        Node.Builder builder = this.node != null ? this.node.toBuilder() : Node.builder();
+        mutator.accept(builder);
+        this.node = builder.build();
         return this;
       }
 
@@ -795,6 +822,14 @@ public class HeroDetails implements GraphqlFragment {
         return this;
       }
 
+      public Builder friendsConnection(@Nonnull Mutator<FriendsConnection1.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        FriendsConnection1.Builder builder = this.friendsConnection != null ? this.friendsConnection.toBuilder() : FriendsConnection1.builder();
+        mutator.accept(builder);
+        this.friendsConnection = builder.build();
+        return this;
+      }
+
       public AsDroid build() {
         Utils.checkNotNull(__typename, "__typename == null");
         Utils.checkNotNull(name, "name == null");
@@ -965,6 +1000,23 @@ public class HeroDetails implements GraphqlFragment {
         return this;
       }
 
+      public Builder edges(@Nonnull Mutator<List<Edge1.Builder>> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        List<Edge1.Builder> builders = new ArrayList<>();
+        if (this.edges != null) {
+          for (Edge1 item : this.edges) {
+            builders.add(item != null ? item.toBuilder() : null);
+          }
+        }
+        mutator.accept(builders);
+        List<Edge1> edges = new ArrayList<>();
+        for (Edge1.Builder item : builders) {
+          edges.add(item != null ? item.build() : null);
+        }
+        this.edges = edges;
+        return this;
+      }
+
       public FriendsConnection1 build() {
         Utils.checkNotNull(__typename, "__typename == null");
         return new FriendsConnection1(__typename, totalCount, edges);
@@ -1094,6 +1146,14 @@ public class HeroDetails implements GraphqlFragment {
 
       public Builder node(@Nullable Node1 node) {
         this.node = node;
+        return this;
+      }
+
+      public Builder node(@Nonnull Mutator<Node1.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        Node1.Builder builder = this.node != null ? this.node.toBuilder() : Node1.builder();
+        mutator.accept(builder);
+        this.node = builder.build();
         return this;
       }
 
@@ -1259,6 +1319,22 @@ public class HeroDetails implements GraphqlFragment {
 
     public Builder asDroid(@Nullable AsDroid asDroid) {
       this.asDroid = asDroid;
+      return this;
+    }
+
+    public Builder friendsConnection(@Nonnull Mutator<FriendsConnection.Builder> mutator) {
+      Utils.checkNotNull(mutator, "mutator == null");
+      FriendsConnection.Builder builder = this.friendsConnection != null ? this.friendsConnection.toBuilder() : FriendsConnection.builder();
+      mutator.accept(builder);
+      this.friendsConnection = builder.build();
+      return this;
+    }
+
+    public Builder asDroid(@Nonnull Mutator<AsDroid.Builder> mutator) {
+      Utils.checkNotNull(mutator, "mutator == null");
+      AsDroid.Builder builder = this.asDroid != null ? this.asDroid.toBuilder() : AsDroid.builder();
+      mutator.accept(builder);
+      this.asDroid = builder.build();
       return this;
     }
 


### PR DESCRIPTION
For each builder generate additional setter with `Mutator<*.Builder>` as an argument:

```
public Builder hero(@Nonnull Mutator<Hero.Builder> mutator) {
  Hero.Builder builder = this.hero != null ? this.hero.toBuilder() : Hero.builder();

  mutator.accept(builder);

  this.hero = builder.build();
  return this;
}
```

That will allow user to do next:
```
data.toBuilder()
  .hero(someHero)
  // or
  .hero(new Consumer<>() {
    void accept(Hero.Builder builder) {
      builder.name("Joe")
       .age(31)
    }
  })
```

This will be even better with lambda support:
```
data.toBuilder()
  .hero(someHero)
  // or
  .hero(builder -> builder
       .name("Joe")
       .age(31)
  )
```

Closes #643