### PR TITLE
Fix small typo in method name in ApolloClient

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -464,15 +464,15 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     private static okhttp3.Call.Factory addHttpCacheInterceptorIfNeeded(Call.Factory callFactory,
-        Interceptor httCacheInterceptor) {
+        Interceptor httpCacheInterceptor) {
       if (callFactory instanceof OkHttpClient) {
         OkHttpClient client = (OkHttpClient) callFactory;
         for (Interceptor interceptor : client.interceptors()) {
-          if (interceptor.getClass().equals(httCacheInterceptor.getClass())) {
+          if (interceptor.getClass().equals(httpCacheInterceptor.getClass())) {
             return callFactory;
           }
         }
-        return client.newBuilder().addInterceptor(httCacheInterceptor).build();
+        return client.newBuilder().addInterceptor(httpCacheInterceptor).build();
       }
       return callFactory;
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -423,7 +423,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
 
       HttpCache httpCache = this.httpCache;
       if (httpCache != null) {
-        callFactory = addHttCacheInterceptorIfNeeded(callFactory, httpCache.interceptor());
+        callFactory = addHttpCacheInterceptorIfNeeded(callFactory, httpCache.interceptor());
       }
 
       Executor dispatcher = this.dispatcher;
@@ -463,7 +463,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
       });
     }
 
-    private static okhttp3.Call.Factory addHttCacheInterceptorIfNeeded(Call.Factory callFactory,
+    private static okhttp3.Call.Factory addHttpCacheInterceptorIfNeeded(Call.Factory callFactory,
         Interceptor httCacheInterceptor) {
       if (callFactory instanceof OkHttpClient) {
         OkHttpClient client = (OkHttpClient) callFactory;


### PR DESCRIPTION
## What's there in this PR?
* A small typo in the method name (`addHttCacheInterceptorIfNeeded` -> `addHttpCacheInterceptorIfNeeded`)