### PR TITLE
Add support of enum unknown values

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -1,8 +1,9 @@
 package com.apollographql.apollo.compiler.ir
 
 import com.apollographql.apollo.compiler.Annotations
+import com.apollographql.apollo.compiler.ClassNames
 import com.apollographql.apollo.compiler.InputTypeSpecBuilder
-import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.*
 import javax.lang.model.element.Modifier
 
 data class TypeDeclaration(
@@ -23,13 +24,6 @@ data class TypeDeclaration(
   }
 
   private fun enumTypeToTypeSpec(): TypeSpec {
-    fun TypeSpec.Builder.addEnumJavaDoc(): TypeSpec.Builder {
-      if (!description.isNullOrEmpty()) {
-        addJavadoc("\$L\n", description)
-      }
-      return this
-    }
-
     fun TypeSpec.Builder.addEnumConstants(): TypeSpec.Builder {
       values?.forEach { value ->
         val typeSpec = TypeSpec.anonymousClassBuilder("")
@@ -54,11 +48,56 @@ data class TypeDeclaration(
       return this
     }
 
+    val enumConstants = values?.map { value ->
+      value.name to TypeSpec.anonymousClassBuilder("")
+          .apply {
+            if (!value.description.isNullOrEmpty()) {
+              addJavadoc("\$L\n", value.description)
+            }
+          }
+          .apply {
+            if (value.isDeprecated == true) {
+              addAnnotation(Annotations.DEPRECATED)
+              if (!value.deprecationReason.isNullOrBlank()) {
+                addJavadoc("@deprecated \$L\n", value.deprecationReason)
+              }
+            }
+          }
+          .build()
+    }
+    val unknownConstantTypeSpec = TypeSpec.anonymousClassBuilder("")
+        .addJavadoc("\$L\n", "Auto generated constant for unknown enum values")
+        .build()
+    val safeValueOfMethodSpec = MethodSpec.methodBuilder(ENUM_SAFE_VALUE_OF)
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addParameter(ParameterSpec.builder(ClassNames.STRING, "value").build())
+        .returns(ClassName.get("", name))
+        .addCode(CodeBlock.builder()
+            .beginControlFlow("for (\$L enumValue : values())", name)
+            .beginControlFlow("if (enumValue.name().equals(value))")
+            .addStatement("return enumValue")
+            .endControlFlow()
+            .endControlFlow()
+            .addStatement("return \$L.\$L", name, ENUM_UNKNOWN_CONSTANT)
+            .build()
+        )
+        .build()
+
     return TypeSpec.enumBuilder(name)
         .addAnnotation(Annotations.GENERATED_BY_APOLLO)
         .addModifiers(Modifier.PUBLIC)
-        .addEnumConstants()
-        .addEnumJavaDoc()
+        .apply {
+          enumConstants?.forEach { (name, typeSpec) ->
+            addEnumConstant(name, typeSpec)
+          }
+        }
+        .addEnumConstant(ENUM_UNKNOWN_CONSTANT, unknownConstantTypeSpec)
+        .apply {
+          if (!description.isNullOrEmpty()) {
+            addJavadoc("\$L\n", description)
+          }
+        }
+        .addMethod(safeValueOfMethodSpec)
         .build()
   }
 
@@ -69,5 +108,7 @@ data class TypeDeclaration(
     val KIND_INPUT_OBJECT_TYPE: String = "InputObjectType"
     val KIND_ENUM: String = "EnumType"
     val KIND_SCALAR_TYPE: String = "ScalarType"
+    val ENUM_UNKNOWN_CONSTANT: String = "\$UNKNOWN"
+    val ENUM_SAFE_VALUE_OF: String = "safeValueOf"
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.arguments_complex.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.arguments_simple.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.deprecation.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -295,13 +295,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final List<Episode> appearsIn = reader.readList($responseFields[2], new ResponseReader.ListReader<Episode>() {
           @Override
           public Episode read(ResponseReader.ListItemReader listItemReader) {
-            return Episode.valueOf(listItemReader.readString());
+            return Episode.safeValueOf(listItemReader.readString());
           }
         });
         final String firstAppearsInStr = reader.readString($responseFields[3]);
         final Episode firstAppearsIn;
         if (firstAppearsInStr != null) {
-          firstAppearsIn = Episode.valueOf(firstAppearsInStr);
+          firstAppearsIn = Episode.safeValueOf(firstAppearsInStr);
         } else {
           firstAppearsIn = null;
         }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.java
@@ -1,5 +1,6 @@
 package com.example.enum_type.type;
 
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -20,5 +21,19 @@ public enum Episode {
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983. (JEDI in lowercase)
    */
-  jedi
+  jedi,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -451,7 +451,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final List<Episode> appearsIn = reader.readList($responseFields[2], new ResponseReader.ListReader<Episode>() {
           @Override
           public Episode read(ResponseReader.ListItemReader listItemReader) {
-            return Episode.valueOf(listItemReader.readString());
+            return Episode.safeValueOf(listItemReader.readString());
           }
         });
         final Fragments fragments = reader.readConditional($responseFields[3], new ResponseReader.ConditionalTypeReader<Fragments>() {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.fragment_with_inline_fragment.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -557,7 +557,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final List<Episode> appearsIn = reader.readList($responseFields[1], new ResponseReader.ListReader<Episode>() {
           @Override
           public Episode read(ResponseReader.ListItemReader listItemReader) {
-            return Episode.valueOf(listItemReader.readString());
+            return Episode.safeValueOf(listItemReader.readString());
           }
         });
         return new Friend(__typename, appearsIn);

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.inline_fragments_with_friends.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.input_object_type.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.mutation_create_review.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.mutation_create_review_semantic_naming.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.java
@@ -1,5 +1,6 @@
 package com.example.nested_conditional_inline.type;
 
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -20,5 +21,19 @@ public enum Episode {
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI
+  JEDI,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/TestQuery.java
@@ -352,7 +352,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final List<Episode> appearsIn = reader.readList($responseFields[2], new ResponseReader.ListReader<Episode>() {
           @Override
           public Episode read(ResponseReader.ListItemReader listItemReader) {
-            return Episode.valueOf(listItemReader.readString());
+            return Episode.safeValueOf(listItemReader.readString());
           }
         });
         final Fragments fragments = reader.readConditional($responseFields[3], new ResponseReader.ConditionalTypeReader<Fragments>() {

--- a/apollo-compiler/src/test/graphql/com/example/no_accessors/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/no_accessors/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.no_accessors.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -701,7 +701,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
         final List<Episode> appearsIn = reader.readList($responseFields[2], new ResponseReader.ListReader<Episode>() {
           @Override
           public Episode read(ResponseReader.ListItemReader listItemReader) {
-            return Episode.valueOf(listItemReader.readString());
+            return Episode.safeValueOf(listItemReader.readString());
           }
         });
         final List<Friend2> friends = reader.readList($responseFields[3], new ResponseReader.ListReader<Friend2>() {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.java
@@ -1,6 +1,7 @@
 package com.example.unique_type_name.type;
 
 import java.lang.Deprecated;
+import java.lang.String;
 import javax.annotation.Generated;
 
 /**
@@ -28,5 +29,19 @@ public enum Episode {
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
 }


### PR DESCRIPTION
**Problem**: whenever server returns new unsupported by client enum value it's a breaking changes, as `ResponseReader` tries to map raw string value to appropriate generated enum constant by `.valueOf`.

**Proposal**: to have a fallback value called `$UNKNOWN`, so that any unsupported by client enum value is mapped to it. This will allow to handle such case gracefully.

Examples:

https://github.com/apollographql/apollo-android/pull/712/files#diff-9a0209432c8d9c39a92ea1e525dbee0d

https://github.com/apollographql/apollo-android/pull/712/files#diff-d88c16e23165a268eb39d908f34c5ab7