### PR TITLE
Operation json writer

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/cache/normalized/ApolloStoreTest.java
@@ -8,7 +8,7 @@ import com.apollographql.apollo.cache.normalized.CacheKey;
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.NormalizedCache;
 import com.apollographql.apollo.cache.normalized.Record;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.ApolloLogger;
 
 import org.junit.Test;

--- a/apollo-integration/src/test/resources/OperationJsonWriter.json
+++ b/apollo-integration/src/test/resources/OperationJsonWriter.json
@@ -1,0 +1,1039 @@
+{
+  "data": {
+    "allPlanets": {
+      "__typename": "PlanetsConnection",
+      "planets": [
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 5,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Tatooine",
+          "climates": [
+            "arid"
+          ],
+          "surfaceWater": 1.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 2,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Alderaan",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 40.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "A New Hope",
+                "producers": [
+                  "Gary Kurtz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Yavin IV",
+          "climates": [
+            "temperate",
+            "tropical"
+          ],
+          "surfaceWater": 8.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Hoth",
+          "climates": [
+            "frozen"
+          ],
+          "surfaceWater": 100.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 3,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Dagobah",
+          "climates": [
+            "murky"
+          ],
+          "surfaceWater": 8.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Bespin",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 0.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Endor",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 8.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 4,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Naboo",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 12.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 4,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Return of the Jedi",
+                "producers": [
+                  "Howard G. Kazanjian",
+                  "George Lucas",
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "The Phantom Menace",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              },
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Coruscant",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Kamino",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 100.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Attack of the Clones",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Geonosis",
+          "climates": [
+            "temperate",
+            "arid"
+          ],
+          "surfaceWater": 5.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Utapau",
+          "climates": [
+            "temperate",
+            "arid",
+            "windy"
+          ],
+          "surfaceWater": 0.9
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Mustafar",
+          "climates": [
+            "hot"
+          ],
+          "surfaceWater": 0.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Kashyyyk",
+          "climates": [
+            "tropical"
+          ],
+          "surfaceWater": 60.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Polis Massa",
+          "climates": [
+            "artificial temperate"
+          ],
+          "surfaceWater": 0.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Mygeeto",
+          "climates": [
+            "frigid"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Felucia",
+          "climates": [
+            "hot",
+            "humid"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Cato Neimoidia",
+          "climates": [
+            "temperate",
+            "moist"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "Revenge of the Sith",
+                "producers": [
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Saleucami",
+          "climates": [
+            "hot"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Stewjon",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Eriadu",
+          "climates": [
+            "polluted"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Corellia",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 70.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Rodia",
+          "climates": [
+            "hot"
+          ],
+          "surfaceWater": 60.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Nal Hutta",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Dantooine",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Bestine IV",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 98.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 1,
+            "films": [
+              {
+                "__typename": "Film",
+                "title": "The Empire Strikes Back",
+                "producers": [
+                  "Gary Kutz",
+                  "Rick McCallum"
+                ]
+              }
+            ]
+          },
+          "name": "Ord Mantell",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 10.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "unknown",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Trandosha",
+          "climates": [
+            "arid"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Socorro",
+          "climates": [
+            "arid"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Mon Cala",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 100.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Chandrila",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 40.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Sullust",
+          "climates": [
+            "superheated"
+          ],
+          "surfaceWater": 5.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Toydaria",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Malastare",
+          "climates": [
+            "arid",
+            "temperate",
+            "tropical"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Dathomir",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Ryloth",
+          "climates": [
+            "temperate",
+            "arid",
+            "subartic"
+          ],
+          "surfaceWater": 5.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Aleen Minor",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Vulpter",
+          "climates": [
+            "temperate",
+            "artic"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Troiken",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Tund",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Haruun Kal",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Cerea",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 20.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Glee Anselm",
+          "climates": [
+            "tropical",
+            "temperate"
+          ],
+          "surfaceWater": 80.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Iridonia",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Tholoth",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Iktotch",
+          "climates": [
+            "arid",
+            "rocky",
+            "windy"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Quermia",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Dorin",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Champala",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Mirial",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Serenno",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Concord Dawn",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Zolan",
+          "climates": [
+            "unknown"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Ojom",
+          "climates": [
+            "frigid"
+          ],
+          "surfaceWater": 100.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Skako",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Muunilinst",
+          "climates": [
+            "temperate"
+          ],
+          "surfaceWater": 25.0
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Shili",
+          "climates": [
+            "temperate"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Kalee",
+          "climates": [
+            "arid",
+            "temperate",
+            "tropical"
+          ]
+        },
+        {
+          "__typename": "Planet",
+          "filmConnection": {
+            "__typename": "PlanetFilmsConnection",
+            "totalCount": 0,
+            "films": []
+          },
+          "name": "Umbara",
+          "climates": [
+            "unknown"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -24,7 +24,7 @@ import com.apollographql.apollo.internal.RealApolloCall;
 import com.apollographql.apollo.internal.RealApolloPrefetch;
 import com.apollographql.apollo.internal.ResponseFieldMapperFactory;
 import com.apollographql.apollo.internal.cache.normalized.RealApolloStore;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
@@ -11,7 +11,7 @@ import com.apollographql.apollo.cache.normalized.ApolloStore;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -24,7 +24,7 @@ import com.apollographql.apollo.internal.interceptor.ApolloCacheInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloParseInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.internal.interceptor.RealApolloInterceptorChain;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -12,7 +12,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.internal.interceptor.RealApolloInterceptorChain;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.util.Collections;
 import java.util.concurrent.Executor;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -8,7 +8,7 @@ import com.apollographql.apollo.cache.normalized.CacheKeyResolver;
 import com.apollographql.apollo.cache.normalized.CacheReference;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.cache.normalized.RecordSet;
-import com.apollographql.apollo.internal.response.ResponseReaderShadow;
+import com.apollographql.apollo.internal.response.ResolveDelegate;
 import com.apollographql.apollo.internal.util.SimpleStack;
 
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public abstract class ResponseNormalizer<R> implements ResponseReaderShadow<R> {
+public abstract class ResponseNormalizer<R> implements ResolveDelegate<R> {
   private SimpleStack<List<String>> pathStack;
   private SimpleStack<Record> recordStack;
   private SimpleStack<Object> valueStack;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
@@ -10,8 +10,8 @@ import com.apollographql.apollo.exception.ApolloParseException;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
-import com.apollographql.apollo.internal.response.OperationResponseParser;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.OperationResponseParser;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.ApolloLogger;
 
 import java.io.Closeable;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -9,7 +9,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.internal.json.InputFieldJsonWriter;
 import com.apollographql.apollo.internal.json.JsonWriter;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 import com.apollographql.apollo.internal.ApolloLogger;
 
 import java.io.IOException;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
@@ -4,7 +4,7 @@ import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.ScalarType;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.io.IOException;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ResolveDelegate.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/ResolveDelegate.java
@@ -6,7 +6,7 @@ import com.apollographql.apollo.api.internal.Optional;
 
 import java.util.List;
 
-public interface ResponseReaderShadow<R> {
+public interface ResolveDelegate<R> {
 
   void willResolveRootQuery(Operation operation);
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationJsonWriter.java
@@ -1,0 +1,127 @@
+package com.apollographql.apollo.response;
+
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseField;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.internal.json.JsonWriter;
+import com.apollographql.apollo.internal.response.RealResponseWriter;
+import com.apollographql.apollo.internal.response.ResolveDelegate;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
+public class OperationJsonWriter {
+  private final Operation.Data operationData;
+  private final ScalarTypeAdapters scalarTypeAdapters;
+
+  public OperationJsonWriter(Operation.Data operationData, ScalarTypeAdapters scalarTypeAdapters) {
+    this.operationData = operationData;
+    this.scalarTypeAdapters = scalarTypeAdapters;
+  }
+
+  public void write(@Nonnull JsonWriter jsonWriter) throws IOException {
+    checkNotNull(jsonWriter, "jsonWriter == null");
+
+    RealResponseWriter realResponseWriter = new RealResponseWriter(Operation.EMPTY_VARIABLES, scalarTypeAdapters);
+    operationData.marshaller().marshal(realResponseWriter);
+
+    jsonWriter.beginObject();
+    jsonWriter.name("data");
+    jsonWriter.beginObject();
+
+    try {
+      realResponseWriter.resolveFields(new JsonResponseResolver(jsonWriter));
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof IOException) {
+        throw (IOException) e.getCause();
+      } else {
+        throw e;
+      }
+    }
+
+    jsonWriter.endObject();
+    jsonWriter.endObject();
+  }
+
+  private static final class JsonResponseResolver implements ResolveDelegate<Map<String, Object>> {
+    private final JsonWriter jsonWriter;
+
+    JsonResponseResolver(JsonWriter jsonWriter) {
+      this.jsonWriter = jsonWriter;
+    }
+
+    @Override public void willResolveRootQuery(Operation operation) {
+    }
+
+    @Override public void willResolve(ResponseField field, Operation.Variables variables) {
+      try {
+        jsonWriter.name(field.responseName());
+        if (field.type() == ResponseField.Type.LIST) {
+          jsonWriter.beginArray();
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void didResolve(ResponseField field, Operation.Variables variables) {
+    }
+
+    @Override public void didResolveScalar(Object value) {
+      try {
+        if (value instanceof Number) {
+          jsonWriter.value((Number) value);
+        } else if (value instanceof Boolean) {
+          jsonWriter.value((boolean) value);
+        } else {
+          jsonWriter.value(value.toString());
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void willResolveObject(ResponseField field, Optional<Map<String, Object>> objectSource) {
+      try {
+        jsonWriter.beginObject();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void didResolveObject(ResponseField field, Optional<Map<String, Object>> objectSource) {
+      try {
+        jsonWriter.endObject();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void didResolveList(List array) {
+      try {
+        jsonWriter.endArray();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public void willResolveElement(int atIndex) {
+    }
+
+    @Override public void didResolveElement(int atIndex) {
+    }
+
+    @Override public void didResolveNull() {
+      try {
+        jsonWriter.nullValue();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.response;
+package com.apollographql.apollo.response;
 
 import com.apollographql.apollo.api.Error;
 import com.apollographql.apollo.api.Operation;
@@ -8,6 +8,7 @@ import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
 import com.apollographql.apollo.internal.json.BufferedSourceJsonReader;
 import com.apollographql.apollo.internal.json.ResponseJsonStreamReader;
+import com.apollographql.apollo.internal.response.RealResponseReader;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -20,11 +21,16 @@ import okio.BufferedSource;
 
 import static com.apollographql.apollo.internal.json.ApolloJsonReader.responseJsonStreamReader;
 
-public class OperationResponseParser<D extends Operation.Data, W> {
+public final class OperationResponseParser<D extends Operation.Data, W> {
   private final Operation<D, W, ?> operation;
   private final ResponseFieldMapper responseFieldMapper;
   private final ScalarTypeAdapters scalarTypeAdapters;
   private final ResponseNormalizer<Map<String, Object>> responseNormalizer;
+
+  @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D, W, ?> operation,
+      ResponseFieldMapper responseFieldMapper, ScalarTypeAdapters scalarTypeAdapters) {
+    this(operation, responseFieldMapper, scalarTypeAdapters, ResponseNormalizer.NO_OP_NORMALIZER);
+  }
 
   public OperationResponseParser(Operation<D, W, ?> operation, ResponseFieldMapper responseFieldMapper,
       ScalarTypeAdapters scalarTypeAdapters, ResponseNormalizer<Map<String, Object>> responseNormalizer) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.response;
+package com.apollographql.apollo.response;
 
 import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.ScalarType;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -16,7 +16,7 @@ import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
 import com.apollographql.apollo.internal.response.RealResponseReader;
-import com.apollographql.apollo.internal.response.ScalarTypeAdapters;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import org.junit.Test;
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    apolloVersion                : '0.4.2-SNAPSHOT',
+    apolloVersion                : '0.4.3-SNAPSHOT',
     cacheVersion                 : '2.0.2',
     okHttpVersion                : '3.8.1',
     kotlinVersion                : '1.1.2-3',


### PR DESCRIPTION
Even though we highly do not recommend to do this, I found sometimes it can help user to dump operation data back to json.

Example:
```
Buffer buffer = new Buffer();
OperationJsonWriter writer = new OperationJsonWriter(response.data(), new ScalarTypeAdapters(Collections.EMPTY_MAP));
writer.write(JsonWriter.of(buffer));
```

Closes #714 