### PR TITLE
Add errorprone compiler

### DIFF
--- a/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.java
@@ -67,6 +67,7 @@ public final class SqlNormalizedCache extends NormalizedCache {
     deleteAllRecordsStatement = database.compileStatement(DELETE_ALL_RECORD_STATEMENT);
   }
 
+  @Override
   @Nullable public Record loadRecord(@Nonnull final String key, @Nonnull final CacheHeaders cacheHeaders) {
     return selectRecordForKey(key)
         .apply(new Action<Record>() {
@@ -84,7 +85,9 @@ public final class SqlNormalizedCache extends NormalizedCache {
         .orNull();
   }
 
-  @Nonnull public Set<String> merge(@Nonnull final Record apolloRecord, @Nonnull final CacheHeaders cacheHeaders) {
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Nonnull @Override public Set<String> merge(@Nonnull final Record apolloRecord, @Nonnull final CacheHeaders
+      cacheHeaders) {
     if (cacheHeaders.hasHeader(DO_NOT_STORE)) {
       return Collections.emptySet();
     }
@@ -112,6 +115,7 @@ public final class SqlNormalizedCache extends NormalizedCache {
     return changedKeys;
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Nonnull @Override public Set<String> merge(@Nonnull final Collection<Record> recordSet,
       @Nonnull final CacheHeaders cacheHeaders) {
     if (cacheHeaders.hasHeader(DO_NOT_STORE)) {
@@ -138,6 +142,7 @@ public final class SqlNormalizedCache extends NormalizedCache {
     return changedKeys;
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override public void clearAll() {
     //noinspection ResultOfMethodCallIgnored
     nextCache().apply(new Action<NormalizedCache>() {
@@ -158,7 +163,7 @@ public final class SqlNormalizedCache extends NormalizedCache {
       }
     }).or(Boolean.FALSE);
 
-    return result | deleteRecord(cacheKey.key());
+    return result || deleteRecord(cacheKey.key());
   }
 
   public void close() {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseReader.java
@@ -21,6 +21,7 @@ public interface ResponseReader {
 
   <T> List<T> readList(ResponseField field, ListReader<T> listReader);
 
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   <T> T readCustomType(ResponseField.CustomTypeField field);
 
   <T> T readConditional(ResponseField field, ConditionalTypeReader<T> conditionalTypeReader);
@@ -49,6 +50,7 @@ public interface ResponseReader {
 
     Boolean readBoolean();
 
+    @SuppressWarnings("TypeParameterUnusedInFormals")
     <T> T readCustomType(ScalarType scalarType);
 
     <T> T readObject(ObjectReader<T> objectReader);

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/internal/OptionalTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/internal/OptionalTest.java
@@ -46,15 +46,17 @@ public final class OptionalTest {
     assertFalse(optionalName.isPresent());
   }
 
+  @Test
   public void testOf() {
     assertEquals("training", Optional.of("training").get());
   }
 
+  @Test
   public void testOfNull() {
     try {
       Optional.of(null);
       fail();
-    } catch (NullPointerException expected) {
+    } catch (NullPointerException ignore) {
     }
   }
 
@@ -86,7 +88,7 @@ public final class OptionalTest {
     try {
       optional.get();
       fail();
-    } catch (IllegalStateException expected) {
+    } catch (IllegalStateException ignore) {
     }
   }
 
@@ -142,7 +144,7 @@ public final class OptionalTest {
     try {
       presentAsSet.add("b");
       fail();
-    } catch (UnsupportedOperationException expected) {
+    } catch (UnsupportedOperationException ignore) {
     }
   }
 
@@ -152,7 +154,7 @@ public final class OptionalTest {
     try {
       absentAsSet.add("foo");
       fail();
-    } catch (UnsupportedOperationException expected) {
+    } catch (UnsupportedOperationException ignore) {
     }
   }
 
@@ -185,7 +187,7 @@ public final class OptionalTest {
                     }
                   });
       fail("Should throw if Function returns null.");
-    } catch (NullPointerException expected) {
+    } catch (NullPointerException ignore) {
     }
   }
 
@@ -293,7 +295,7 @@ public final class OptionalTest {
                     }
                   });
       fail("Should throw if Function returns null.");
-    } catch (NullPointerException expected) {
+    } catch (NullPointerException ignore) {
     }
   }
 

--- a/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
+++ b/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
@@ -33,6 +33,7 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
 public class ApolloIdlingResourceTest {
   private ApolloIdlingResource idlingResource;
@@ -93,13 +94,11 @@ public class ApolloIdlingResourceTest {
     try {
       server.shutdown();
     } catch (IOException ignored) {
-
     }
   }
 
   @Test
   public void onNullNamePassed_NullPointerExceptionIsThrown() {
-
     apolloClient = ApolloClient.builder()
         .okHttpClient(okHttpClient)
         .serverUrl(server.url("/"))
@@ -107,6 +106,7 @@ public class ApolloIdlingResourceTest {
 
     try {
       idlingResource = ApolloIdlingResource.create(null, apolloClient);
+      fail();
     } catch (Exception e) {
       assertThat(e).isInstanceOf(NullPointerException.class);
       assertThat(e.getMessage()).isEqualTo("name == null");
@@ -117,6 +117,7 @@ public class ApolloIdlingResourceTest {
   public void onNullApolloClientPassed_NullPointerExceptionIsThrown() {
     try {
       idlingResource = ApolloIdlingResource.create(IDLING_RESOURCE_NAME, null);
+      fail();
     } catch (Exception e) {
       assertThat(e).isInstanceOf(NullPointerException.class);
       assertThat(e.getMessage()).isEqualTo("apolloClient == null");
@@ -125,7 +126,6 @@ public class ApolloIdlingResourceTest {
 
   @Test
   public void checkValidIdlingResourceNameIsRegistered() {
-
     apolloClient = ApolloClient.builder()
         .okHttpClient(okHttpClient)
         .serverUrl(server.url("/"))
@@ -172,6 +172,7 @@ public class ApolloIdlingResourceTest {
     assertThat(idlingResource.isIdleNow()).isTrue();
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test
   public void checkIdlingResourceTransition_whenCallIsQueued() throws IOException, ApolloException {
     server.enqueue(mockResponse());

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloInterceptorTest.java
@@ -41,6 +41,7 @@ import static com.apollographql.apollo.Utils.assertResponse;
 import static com.apollographql.apollo.Utils.enqueueAndAssertResponse;
 import static com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorResponse;
 import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.fail;
 
 public class ApolloInterceptorTest {
   private static final String FILE_EPISODE_HERO_NAME_WITH_ID = "EpisodeHeroNameResponseWithId.json";
@@ -429,7 +430,7 @@ public class ApolloInterceptorTest {
     return new MockResponse().setChunkedBody(Utils.readFileToString(getClass(), "/" + fileName), 32);
   }
 
-  private class ExceptionHandlingExecutor extends ThreadPoolExecutor {
+  private static class ExceptionHandlingExecutor extends ThreadPoolExecutor {
 
     private String message;
     private Class<?> exceptionClass;
@@ -447,6 +448,7 @@ public class ApolloInterceptorTest {
         @Override public void run() {
           try {
             command.run();
+            fail();
           } catch (Exception e) {
             assertThat(e.getMessage()).isEqualTo(message);
             assertThat(e).isInstanceOf(exceptionClass);

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -38,6 +38,7 @@ import okio.Buffer;
 
 import static com.google.common.truth.Truth.assertThat;
 
+@SuppressWarnings("SimpleDateFormatConstant")
 public class HttpCacheTest {
   private static final int TIME_OUT_SECONDS = 3;
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -51,6 +51,7 @@ import okio.Buffer;
 import static com.apollographql.apollo.integration.normalizer.type.Episode.JEDI;
 import static com.google.common.truth.Truth.assertThat;
 
+@SuppressWarnings("SimpleDateFormatConstant")
 public class IntegrationTest {
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
 
@@ -92,7 +93,8 @@ public class IntegrationTest {
     }
   }
 
-  @SuppressWarnings("ConstantConditions") @Test public void allPlanetQuery() throws Exception {
+  @SuppressWarnings({"ConstantConditions", "CheckReturnValue"})
+  @Test public void allPlanetQuery() throws Exception {
     server.enqueue(mockResponse("HttpCacheTestAllPlanets.json"));
 
     assertResponse(

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -28,7 +28,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import io.reactivex.functions.Predicate;
@@ -171,6 +170,7 @@ public class NormalizedCacheTestCase {
     );
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test public void heroParentTypeDependentField() throws Exception {
     cacheAndAssertCachedResponse(
         server,

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
@@ -26,6 +26,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Locale;
 
 import io.reactivex.functions.Predicate;
 import okhttp3.OkHttpClient;
@@ -39,10 +40,11 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
+@SuppressWarnings("SimpleDateFormatConstant")
 public class ResponseWriteTestCase {
   private ApolloClient apolloClient;
   private MockWebServer server;
-  private SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-mm-dd");
+  private SimpleDateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-mm-dd", Locale.US);
 
   @Before public void setUp() {
     server = new MockWebServer();
@@ -375,6 +377,7 @@ public class ResponseWriteTestCase {
     );
   }
 
+  @SuppressWarnings("CheckReturnValue")
   @Test
   public void operation_with_inline_fragments() throws Exception {
     EpisodeHeroWithInlineFragmentQuery query = new EpisodeHeroWithInlineFragmentQuery(Input.fromNullable(Episode.NEWHOPE));

--- a/apollo-integration/src/test/java/com/apollographql/apollo/Utils.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/Utils.java
@@ -7,6 +7,7 @@ import com.apollographql.apollo.rx2.Rx2Apollo;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Executor;
@@ -31,7 +32,7 @@ public final class Utils {
 
     InputStreamReader inputStreamReader = null;
     try {
-      inputStreamReader = new InputStreamReader(contextClass.getResourceAsStream(streamIdentifier));
+      inputStreamReader = new InputStreamReader(contextClass.getResourceAsStream(streamIdentifier), Charset.defaultCharset());
       return CharStreams.toString(inputStreamReader);
     } catch (IOException e) {
       throw new IOException();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
@@ -7,11 +7,12 @@ import com.apollographql.apollo.cache.CacheHeaders;
 import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.cache.CacheBuilder;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -63,6 +64,7 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     }).or(Collections.<String>emptySet());
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override public void clearAll() {
     lruCache.invalidateAll();
     //noinspection ResultOfMethodCallIgnored
@@ -128,9 +130,9 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
     return changedCacheKeys;
   }
 
-  private final class RecordJournal {
+  private static final class RecordJournal {
     Record snapshot;
-    final LinkedList<Record> history = new LinkedList<>();
+    final List<Record> history = new ArrayList<>();
 
     RecordJournal(Record mutationRecord) {
       this.snapshot = mutationRecord.clone();
@@ -141,7 +143,7 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
      * Commits new version of record to the history and invalidate snapshot version.
      */
     Set<String> commit(Record record) {
-      history.addLast(record.clone());
+      history.add(history.size(), record.clone());
       return snapshot.mergeWith(record);
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -23,7 +23,7 @@ public final class Record {
   private final String key;
   private final Map<String, Object> fields;
   private volatile UUID mutationId;
-  private volatile int sizeInBytes = UNKNOWN_SIZE_ESTIMATE;
+  private int sizeInBytes = UNKNOWN_SIZE_ESTIMATE;
 
   public static class Builder {
     private final Map<String, Object> fields;
@@ -91,6 +91,7 @@ public final class Record {
     return mutationId;
   }
 
+  @Override
   public Record clone() {
     return toBuilder().build();
   }
@@ -130,14 +131,14 @@ public final class Record {
   /**
    * @return An approximate number of bytes this Record takes up.
    */
-  public int sizeEstimateBytes() {
+  public synchronized int sizeEstimateBytes() {
     if (sizeInBytes == UNKNOWN_SIZE_ESTIMATE) {
       sizeInBytes = RecordWeigher.calculateBytes(this);
     }
     return sizeInBytes;
   }
 
-  private void adjustSizeEstimate(Object newFieldValue, Object oldFieldValue) {
+  private synchronized void adjustSizeEstimate(Object newFieldValue, Object oldFieldValue) {
     if (sizeInBytes != UNKNOWN_SIZE_ESTIMATE) {
       sizeInBytes += RecordWeigher.byteChange(newFieldValue, oldFieldValue);
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.internal.json.JsonWriter;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +62,8 @@ public final class RecordFieldJsonAdapter {
   }
 
   public Map<String, Object> from(String jsonFieldSource) throws IOException {
-    final BufferedSource bufferSource = Okio.buffer(Okio.source(new ByteArrayInputStream(jsonFieldSource.getBytes())));
+    final BufferedSource bufferSource
+        = Okio.buffer(Okio.source(new ByteArrayInputStream(jsonFieldSource.getBytes(Charset.defaultCharset()))));
     return from(bufferSource);
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
@@ -12,6 +12,7 @@ import com.nytimes.android.external.cache.Cache;
 import com.nytimes.android.external.cache.CacheBuilder;
 import com.nytimes.android.external.cache.Weigher;
 
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -36,7 +37,7 @@ public final class LruNormalizedCache extends NormalizedCache {
       lruCacheBuilder.maximumWeight(evictionPolicy.maxSizeBytes().get())
           .weigher(new Weigher<String, Record>() {
             @Override public int weigh(String key, Record value) {
-              return key.getBytes().length + value.sizeEstimateBytes();
+              return key.getBytes(Charset.defaultCharset()).length + value.sizeEstimateBytes();
             }
           });
     }
@@ -77,13 +78,13 @@ public final class LruNormalizedCache extends NormalizedCache {
     return record;
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Nonnull @Override
   public Set<String> merge(@Nonnull final Record apolloRecord, @Nonnull final CacheHeaders cacheHeaders) {
     if (cacheHeaders.hasHeader(ApolloCacheHeaders.DO_NOT_STORE)) {
       return Collections.emptySet();
     }
 
-    //noinspection ResultOfMethodCallIgnored
     nextCache().apply(new Action<NormalizedCache>() {
       @Override public void apply(@Nonnull NormalizedCache cache) {
         cache.merge(apolloRecord, cacheHeaders);
@@ -103,8 +104,8 @@ public final class LruNormalizedCache extends NormalizedCache {
     }
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override public void clearAll() {
-    //noinspection ResultOfMethodCallIgnored
     nextCache().apply(new Action<NormalizedCache>() {
       @Override public void apply(@Nonnull NormalizedCache cache) {
         cache.clearAll();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -253,6 +253,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         callback.get().onStatusEvent(StatusEvent.COMPLETED);
       }
 
+      @SuppressWarnings("ResultOfMethodCallIgnored")
       @Override public void onFetch(final ApolloInterceptor.FetchSourceType sourceType) {
         responseCallback().apply(new Action<Callback<T>>() {
           @Override public void apply(@Nonnull Callback<T> callback) {
@@ -296,6 +297,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .optimisticUpdates(optimisticUpdates);
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   private synchronized void activate(Optional<Callback<T>> callback) throws ApolloCanceledException {
     switch (state.get()) {
       case IDLE:

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -169,14 +169,17 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     return optimisticCache;
   }
 
+  @Override
   @Nullable public Record read(@Nonnull String key, @Nonnull CacheHeaders cacheHeaders) {
     return optimisticCache.loadRecord(checkNotNull(key, "key == null"), cacheHeaders);
   }
 
+  @Override
   @Nonnull public Collection<Record> read(@Nonnull Collection<String> keys, @Nonnull CacheHeaders cacheHeaders) {
     return optimisticCache.loadRecords(checkNotNull(keys, "keys == null"), cacheHeaders);
   }
 
+  @Override
   @Nonnull public Set<String> merge(@Nonnull Collection<Record> recordSet, @Nonnull CacheHeaders cacheHeaders) {
     return optimisticCache.merge(checkNotNull(recordSet, "recordSet == null"), cacheHeaders);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RecordWeigher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RecordWeigher.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.cache.normalized.CacheReference;
 import com.apollographql.apollo.cache.normalized.Record;
 
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
@@ -21,9 +22,9 @@ public final class RecordWeigher {
   }
 
   public static int calculateBytes(Record record) {
-    int size = SIZE_OF_RECORD_OVERHEAD + record.key().getBytes().length;
+    int size = SIZE_OF_RECORD_OVERHEAD + record.key().getBytes(Charset.defaultCharset()).length;
     for (Map.Entry<String, Object> field : record.fields().entrySet()) {
-      size += (field.getKey().getBytes().length + weighField(field.getValue()));
+      size += (field.getKey().getBytes(Charset.defaultCharset()).length + weighField(field.getValue()));
     }
     return size;
   }
@@ -37,13 +38,14 @@ public final class RecordWeigher {
       return size;
     }
     if (field instanceof String) {
-      return ((String) field).getBytes().length;
+      return ((String) field).getBytes(Charset.defaultCharset()).length;
     } else if (field instanceof Boolean) {
       return SIZE_OF_BOOLEAN;
     } else if (field instanceof BigDecimal) {
       return SIZE_OF_BIG_DECIMAL;
     } else if (field instanceof CacheReference) {
-      return SIZE_OF_CACHE_REFERENCE_OVERHEAD + ((CacheReference) field).key().getBytes().length;
+      return SIZE_OF_CACHE_REFERENCE_OVERHEAD
+          + ((CacheReference) field).key().getBytes(Charset.defaultCharset()).length;
     } else if (field == null) {
       return SIZE_OF_NULL;
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
@@ -26,7 +26,8 @@ public final class CacheFieldValueResolver implements FieldValueResolver<Record>
     this.cacheHeaders = cacheHeaders;
   }
 
-  @SuppressWarnings("unchecked") @Override public <T> T valueFor(Record record, ResponseField field) {
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  @Override public <T> T valueFor(Record record, ResponseField field) {
     switch (field.type()) {
       case OBJECT:
         return (T) valueForObject(record, field);
@@ -90,7 +91,8 @@ public final class CacheFieldValueResolver implements FieldValueResolver<Record>
   }
 
 
-  @SuppressWarnings("unchecked") private <T> T fieldValue(Record record, ResponseField field) {
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  private <T> T fieldValue(Record record, ResponseField field) {
     String fieldKey = field.cacheKey(variables);
     if (!record.hasField(fieldKey)) {
       throw new NullPointerException("Missing value: " + field.fieldName());

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/FieldValueResolver.java
@@ -3,5 +3,6 @@ package com.apollographql.apollo.internal.field;
 import com.apollographql.apollo.api.ResponseField;
 
 public interface FieldValueResolver<R> {
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   <T> T valueFor(R recordSet, ResponseField field);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/BufferedSourceJsonReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/BufferedSourceJsonReader.java
@@ -601,6 +601,7 @@ public final class BufferedSourceJsonReader extends JsonReader {
     throw new JsonDataException("Expected a boolean but was " + peek() + " at path " + getPath());
   }
 
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   @Override public <T> T nextNull() throws IOException {
     int p = peeked;
     if (p == PEEKED_NONE) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonReader.java
@@ -285,6 +285,7 @@ public abstract class JsonReader implements Closeable {
    *
    * @throws JsonDataException if the next token is not null or if this reader is closed.
    */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public abstract <T> T nextNull() throws IOException;
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonUtf8Writer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/JsonUtf8Writer.java
@@ -259,13 +259,13 @@ final class JsonUtf8Writer extends JsonWriter {
   /**
    * Flushes and closes this writer and the underlying {@link Sink}.
    *
-   * @throws JsonDataException if the JSON document is incomplete.
+   * @throws IOException if the JSON document is incomplete.
    */
   @Override public void close() throws IOException {
     sink.close();
 
     int size = stackSize;
-    if (size > 1 || size == 1 && scopes[size - 1] != NONEMPTY_DOCUMENT) {
+    if (size > 1 || (size == 1 && scopes[size - 1] != NONEMPTY_DOCUMENT)) {
       throw new IOException("Incomplete document");
     }
     stackSize = 0;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
@@ -174,7 +174,8 @@ import java.util.Map;
     return result != null ? Collections.unmodifiableList(result) : null;
   }
 
-  @SuppressWarnings("unchecked") @Override public <T> T readCustomType(ResponseField.CustomTypeField field) {
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  @Override public <T> T readCustomType(ResponseField.CustomTypeField field) {
     if (shouldSkip(field)) {
       return null;
     }
@@ -216,13 +217,13 @@ import java.util.Map;
         for (ResponseField.Condition condition : field.conditions()) {
           if (condition instanceof ResponseField.TypeNameCondition) {
             if (((ResponseField.TypeNameCondition) condition).typeName().equals(value)) {
-              return (T) conditionalTypeReader.read(value, this);
+              return conditionalTypeReader.read(value, this);
             }
           }
         }
         return null;
       } else {
-        return (T) conditionalTypeReader.read(value, this);
+        return conditionalTypeReader.read(value, this);
       }
     }
   }
@@ -234,12 +235,12 @@ import java.util.Map;
         Boolean conditionValue = (Boolean) variableValues.get(booleanCondition.variableName());
         if (booleanCondition.inverted()) {
           // means it's a skip directive
-          if (conditionValue == Boolean.TRUE) {
+          if (Boolean.TRUE.equals(conditionValue)) {
             return true;
           }
         } else {
           // means it's an include directive
-          if (conditionValue == Boolean.FALSE) {
+          if (Boolean.FALSE.equals(conditionValue)) {
             return true;
           }
         }
@@ -296,7 +297,7 @@ import java.util.Map;
       return (Boolean) value;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
     @Override public <T> T readCustomType(ScalarType scalarType) {
       CustomTypeAdapter<T> typeAdapter = scalarTypeAdapters.adapterFor(scalarType);
       resolveDelegate.didResolveScalar(value);

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCacheTest.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -102,15 +103,15 @@ public class LruNormalizedCacheTest {
         .build()).create(basicFieldAdapter);
 
     Record.Builder testRecord1Builder = Record.builder("key1");
-    testRecord1Builder.addField("a", new String(new byte[1100]));
+    testRecord1Builder.addField("a", new String(new byte[1100], Charset.defaultCharset()));
     Record testRecord1 = testRecord1Builder.build();
 
     Record.Builder testRecord2Builder = Record.builder("key2");
-    testRecord2Builder.addField("a", new String(new byte[1100]));
+    testRecord2Builder.addField("a", new String(new byte[1100], Charset.defaultCharset()));
     Record testRecord2 = testRecord2Builder.build();
 
     Record.Builder testRecord3Builder = Record.builder("key3");
-    testRecord3Builder.addField("a", new String(new byte[10]));
+    testRecord3Builder.addField("a", new String(new byte[10], Charset.defaultCharset()));
     Record testRecord3 = testRecord3Builder.build();
 
     List<Record> records = Arrays.asList(
@@ -134,15 +135,15 @@ public class LruNormalizedCacheTest {
         .build()).create(basicFieldAdapter);
 
     Record.Builder testRecord1Builder = Record.builder("key1");
-    testRecord1Builder.addField("a", new String(new byte[10]));
+    testRecord1Builder.addField("a", new String(new byte[10], Charset.defaultCharset()));
     Record testRecord1 = testRecord1Builder.build();
 
     Record.Builder testRecord2Builder = Record.builder("key2");
-    testRecord2Builder.addField("a", new String(new byte[10]));
+    testRecord2Builder.addField("a", new String(new byte[10], Charset.defaultCharset()));
     Record testRecord2 = testRecord2Builder.build();
 
     Record.Builder testRecord3Builder = Record.builder("key3");
-    testRecord3Builder.addField("a", new String(new byte[10]));
+    testRecord3Builder.addField("a", new String(new byte[10], Charset.defaultCharset()));
     Record testRecord3 = testRecord3Builder.build();
 
     List<Record> records = Arrays.asList(
@@ -158,7 +159,7 @@ public class LruNormalizedCacheTest {
     assertThat(lruCache.loadRecord("key3", CacheHeaders.NONE)).isNotNull();
 
     Record.Builder largeTestRecordBuilder = Record.builder("key1");
-    largeTestRecordBuilder.addField("a", new String(new byte[2000]));
+    largeTestRecordBuilder.addField("a", new String(new byte[2000], Charset.defaultCharset()));
     Record largeTestRecord = largeTestRecordBuilder.build();
 
     lruCache.merge(largeTestRecord, CacheHeaders.NONE);
@@ -238,7 +239,7 @@ public class LruNormalizedCacheTest {
     primaryCacheStore.merge(record, CacheHeaders.NONE);
     primaryCacheStore.clearAll();
 
-    assertThat(primaryCacheStore.loadRecord("key", CacheHeaders.NONE));
+    assertThat(primaryCacheStore.loadRecord("key", CacheHeaders.NONE)).isNull();
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,21 @@
+buildscript {
+  apply from: rootProject.file("gradle/dependencies.gradle")
+
+  repositories {
+    maven { url "https://plugins.gradle.org/m2/" }
+  }
+
+  dependencies {
+    classpath dep.gradleErrorpronePlugin
+  }
+}
+
 subprojects {
   apply from: rootProject.file("gradle/dependencies.gradle")
 
   buildscript {
     repositories {
-      jcenter()
+      maven { url "https://plugins.gradle.org/m2/" }
       maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
@@ -12,15 +24,22 @@ subprojects {
       classpath dep.bintrayGradlePlugin
     }
   }
+
   repositories {
-    jcenter()
+    maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  }
+
+  apply plugin: "net.ltgt.errorprone"
+
+  configurations.errorprone {
+    resolutionStrategy.force dep.errorProneCore // Only upgrade dependency as needed
   }
 
   group = GROUP
   version = VERSION_NAME
 
-  if (!project.name.equals('apollo-gradle-plugin')) {
+  if (project.name != 'apollo-gradle-plugin') {
     apply plugin: 'checkstyle'
 
     checkstyle {
@@ -35,6 +54,12 @@ subprojects {
       include '**/*.java'
 
       classpath = files()
+    }
+
+    tasks.withType(JavaCompile) {
+      configure(options) {
+        compilerArgs << "-XepDisableWarningsInGeneratedCode" // Ignore generated code
+      }
     }
 
     afterEvaluate {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,5 +52,7 @@ ext.dep = [
     okhttpTestSupport       : "com.squareup.okhttp3:okhttp-testing-support:$versions.okHttpVersion",
     testRunner              : "com.android.support.test:runner:$versions.testRunner",
     espressoIdlingResource  : "com.android.support.test.espresso:espresso-idling-resource:$versions.espressoIdlingResourceVersion",
-    bintrayGradlePlugin     : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintray"
+    bintrayGradlePlugin     : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintray",
+    gradleErrorpronePlugin  : "net.ltgt.gradle:gradle-errorprone-plugin:0.0.12",
+    errorProneCore          : "com.google.errorprone:error_prone_core:2.1.1"
 ]


### PR DESCRIPTION
@digitalbuddha 
Closes https://github.com/apollographql/apollo-android/issues/201 

This PR adds the error prone compiler and fixes the following:
- CheckReturnValue
- MissingOverride
- ReferenceEquality
- DefaultCharset
- ClassCanBeStatic
- JdkObsolete
- NonAtomicVolatileUpdate
- ShortCircuitBoolean
- TypeParameterUnusedInFormals

We can force these to be errors and/or fix them all.