### PR TITLE
Speed up builds by removing unnecessary tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,39 @@
 language: android
-sudo: true
-
-android:
-  components:
-    - tools
-    - platform-tools
-    - tools  # Upgrade again after upgrading platform-tools
-    - build-tools-25.0.3
-    - android-22
-    - extra-google-m2repository
-    - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-22
-  licenses:
-    - android-sdk-preview-license-.+
-    - android-sdk-license-.+
-    - google-gdk-license-.+
 
 jdk:
   - oraclejdk8
 
-script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2 -x apollo-gradle-plugin:test -x apollo-integration:build -x apollo-integration:connectedCheck
-  - .buildscript/integration_tests_composite.sh
+before_install:
+  # Download SDK
+  - echo yes | sdkmanager "tools" &>/dev/null
+  - echo yes | sdkmanager "platform-tools" &>/dev/null
+  - echo yes | sdkmanager "build-tools;25.0.3" &>/dev/null
+  - echo yes | sdkmanager "platforms;android-25" &>/dev/null
+  - echo yes | sdkmanager "extras;google;m2repository" &>/dev/null
+  - echo yes | sdkmanager "extras;android;m2repository" &>/dev/null
+  # Download emulator
+  - echo yes | sdkmanager "platforms;android-22" &>/dev/null
+  - echo yes | sdkmanager "system-images;android-22;default;armeabi-v7a" &>/dev/null
+  # Update remaining dependencies and accept licenses
+  - echo yes | sdkmanager --update &>/dev/null
+  - echo yes | sdkmanager --licenses &>/dev/null
+  # Setup emulator
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-22;default;armeabi-v7a" &>/dev/null
+  - $ANDROID_HOME/emulator/emulator -avd test -no-audio -no-window & &>/dev/null
+
+install:
+  # Build debug
+  - ./gradlew clean checkstyle assemble assembleDebugAndroidTest check -x checkstyleTest --max-workers=2 -s
 
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
+  # Make sure the emulator is available
   - android-wait-for-emulator
+  # Wake up
   - adb shell input keyevent 82
+
+script:
+  - ./gradlew test connectedCheck -x apollo-gradle-plugin:test -x apollo-integration:build -x apollo-integration:connectedCheck --max-workers=2 -s
+  - .buildscript/integration_tests_composite.sh
 
 after_success:
   - .buildscript/deploy_snapshot.sh
@@ -36,7 +42,7 @@ env:
   global:
     - secure: "KOweJZUuxJmrvFX6I3JiH5gGERCuCL/zxkgEsUUwJDD8JsdGqfpEBA2rzMykV+5lLjToZvlJixrkIUiSAqUM4BxTLcYS97iGF8lnRilZhrT+o6VGtcD78cX3eMs/ASuV890/D64qJheVzWS4qSL3Cw+nVdh0rD7wn+5z4MAX/2yC59eEnvyff+Epr4rYmF1Bi0fBpVP7pR2ZKmr9+oTBZ7rdn9tfEkK9HLjs4IzuPFCkBBWun4a3WSKoeQUaaCmJBVMVwdOlABakLZ4by2nzBAyQ0RuQeK/21horrGqbnvFeLMqoi1MhYVkuGsm9CvoaaevmuqRuiklEc//7yfQ5oGJu42lf5Cvcy6Vce4HhQp4ZoOaEKD0usuaTvaJFitxfXwON4etrzaTcfYboxcWl7LfbYBAv7rCYRdxMcVQjA3c09Fqt6fsvIhA8Xk314BoVR0rSvhpaIZQPkXFiinebdqYpVe6KTa82W2TMIY0J7Wald42MmJIFoDaOWRMQbubby4G2W8M2qbtDj7zXbu/gr1/q1rl04VeiD6QNct0drwmnQ6Hk2U1pgWtEoYvHtIv3AyHD9kQgZuN70UfolP/0IwLeTa3kG+90a7hgpJ+a4DL6eERg5+2IqSz/w469gfR+dPr5PDYutuyslyAlz/cLValzP8vHkXIiS3nkJCXHDGY="
     - secure: "oH00sBHo0tBt8ROUq1CAf0ImZKgCbxuOQiRAXxcMXWpZXbuoeL4VP3vQMX89Ton3+ZcPp6+HEDyLeFYqLTpDC8sfIiMuHxUYZDEGogqA+BFEGizFB0Ucc6My2vNEe8nqgDLSNgkGjrpz5YkgCNPZi9cEXeoUUcVKKI+z4kxGq6icK5cKw0GgTMgvKP8EP36yCGotCgfU/Za2cuPHlVOgGgIgHK4ztaBtZOHJkJJ507Oy3WUlDQN9osJY6GeWglDD55xI8MhCC3XlhpnLcpKwno0wvIAJ0EpRFMcQCag6IZd9yK23g97+tY606QFWzt73C9nJaQyZiDPjNaiX+LCf0QChS6Sd+U8y2pibELev9OYa4hsUu0VE4f/FdTtU08cDJda7qU65VMb0WYB2yvpbm9ZvSltzFiQqIt9x6rHOvWpOT/P5vgamO1xVHcHLFaWsvUA4Smx99AShwZ0DynTkKl1LeGWtGs3i5hVv8OEoNVMtQ57DIqhnRhTJfqnojav1napVhnTv8OBTk2Xbxg0LDXuLRwpxth8OaOhNuCmmaRaDlEMhHAuvAzLW+Z2u6QztUg9Ia+KLCoxz20Hmh3+KHXkAfkUofph9BoXz7XEeRMkRd6J8zZFeJFw27Te5/YOhB3M6g/gZ6HTJrCQhxxuv+yjgtrCJsF5r/B/yMvEmMCQ="
-    - GRADLE_OPTS="-Xmx2048m -XX:MaxPermSize=1024m"
+    - GRADLE_OPTS="-Xmx4096m"
     - ADB_INSTALL_TIMEOUT=8 # minutes (2 minutes by default)
 
 branches:
@@ -49,9 +55,11 @@ notifications:
 sudo: false
 
 before_cache:
-    - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 
 cache:
   directories:
-    - ${TRAVIS_BUILD_DIR}/gradle/caches/
-    - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache

--- a/apollo-android-support/build.gradle
+++ b/apollo-android-support/build.gradle
@@ -10,6 +10,12 @@ android {
   compileSdkVersion androidConfig.compileSdkVersion
   buildToolsVersion androidConfig.buildToolsVersion
 
+  defaultConfig {
+    minSdkVersion androidConfig.minSdkVersion
+    targetSdkVersion androidConfig.targetSdkVersion
+    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+  }
+
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
@@ -19,16 +25,12 @@ android {
     textReport true
     textOutput 'stdout'
     ignore 'InvalidPackage'
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 
   dexOptions {
     preDexLibraries = isCi
-  }
-
-  defaultConfig {
-    minSdkVersion androidConfig.minSdkVersion
-    targetSdkVersion androidConfig.targetSdkVersion
-    testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
   }
 }
 

--- a/apollo-espresso-support/build.gradle
+++ b/apollo-espresso-support/build.gradle
@@ -10,6 +10,11 @@ android {
   compileSdkVersion androidConfig.compileSdkVersion
   buildToolsVersion androidConfig.buildToolsVersion
 
+  defaultConfig {
+    minSdkVersion androidConfig.minSdkVersion
+    targetSdkVersion androidConfig.targetSdkVersion
+  }
+
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
     targetCompatibility JavaVersion.VERSION_1_7
@@ -19,15 +24,12 @@ android {
     textReport true
     textOutput 'stdout'
     ignore 'InvalidPackage'
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 
   dexOptions {
     preDexLibraries = isCi
-  }
-
-  defaultConfig {
-    minSdkVersion androidConfig.minSdkVersion
-    targetSdkVersion androidConfig.targetSdkVersion
   }
 }
 

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -22,12 +22,15 @@ android {
     textReport true
     textOutput 'stdout'
     ignore 'InvalidPackage', 'GoogleAppIndexingWarning', 'AllowBackup'
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 
   packagingOptions {
     exclude 'META-INF/rxjava.properties'
   }
 }
+
 dependencies {
   compile dep.jsr305
   compile project(':apollo-api')

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -24,6 +24,8 @@ android {
     textReport true
     textOutput 'stdout'
     ignore 'InvalidPackage', 'GoogleAppIndexingWarning', 'AllowBackup'
+    // We run a full lint analysis as build part in CI, so skip vital checks for assemble tasks.
+    checkReleaseBuilds false
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ subprojects {
       classpath dep.bintrayGradlePlugin
     }
   }
+  
   repositories {
     jcenter()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
@@ -20,7 +21,7 @@ subprojects {
   group = GROUP
   version = VERSION_NAME
 
-  if (!project.name.equals('apollo-gradle-plugin')) {
+  if (project.name != 'apollo-gradle-plugin') {
     apply plugin: 'checkstyle'
 
     checkstyle {


### PR DESCRIPTION
@digitalbuddha @sav007

 - Removes `lint` tasks for debug/vital
 - Remove deprecated `XX:MaxPermSize` from `GRADLE_OPTS`
 - Add android build cache to Travis CI caches

 - Removes `debug` tasks
 - Release test apks need to be signed, signing with default `~/.android` key

## Before:
```
Verification tasks
------------------
check - Runs all checks.
connectedAndroidTest - Installs and runs instrumentation tests for all flavors on connected devices.
connectedCheck - Runs all device checks on currently connected devices.
connectedDebugAndroidTest - Installs and runs the tests for debug on connected devices.
deviceAndroidTest - Installs and runs instrumentation tests using all Device Providers.
deviceCheck - Runs all device checks using Device Providers and Test Servers.
lint - Runs lint on all variants.
lintDebug - Runs lint on the Debug build.
lintRelease - Runs lint on the Release build.
test - Run unit tests for all variants.
testDebugUnitTest - Run unit tests for the debug build.
testReleaseUnitTest - Run unit tests for the release build.
```

## After:
```
Verification tasks
------------------
check - Runs all checks.
connectedAndroidTest - Installs and runs instrumentation tests for all flavors on connected devices.
connectedCheck - Runs all device checks on currently connected devices.
deviceAndroidTest - Installs and runs instrumentation tests using all Device Providers.
deviceCheck - Runs all device checks using Device Providers and Test Servers.
lint - Runs lint on all variants.
lintRelease - Runs lint on the Release build.
test - Run unit tests for all variants.
testReleaseUnitTest - Run unit tests for the release build.
```