### PR TITLE
Use value equality comparison for CacheKey.NO_KEY

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -256,7 +256,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     checkNotNull(cacheKey, "cacheKey == null");
     checkNotNull(variables, "operation == null");
 
-    if (cacheKey == CacheKey.NO_KEY) {
+    if (cacheKey.equals(CacheKey.NO_KEY)) {
       throw new IllegalArgumentException("undefined cache key");
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/ResponseNormalizer.java
@@ -70,7 +70,7 @@ public abstract class ResponseNormalizer<R> implements ResolveDelegate<R> {
 
     CacheKey cacheKey = objectSource.isPresent() ? resolveCacheKey(field, objectSource.get()) : CacheKey.NO_KEY;
     String cacheKeyValue = cacheKey.key();
-    if (cacheKey == CacheKey.NO_KEY) {
+    if (cacheKey.equals(CacheKey.NO_KEY)) {
       cacheKeyValue = pathToString();
     } else {
       path = new ArrayList<>();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/field/CacheFieldValueResolver.java
@@ -44,7 +44,7 @@ public final class CacheFieldValueResolver implements FieldValueResolver<Record>
   private Record valueForObject(Record record, ResponseField field) {
     CacheReference cacheReference;
     CacheKey fieldCacheKey = cacheKeyResolver.fromFieldArguments(field, variables);
-    if (fieldCacheKey != CacheKey.NO_KEY) {
+    if (!fieldCacheKey.equals(CacheKey.NO_KEY)) {
       cacheReference = new CacheReference(fieldCacheKey.key());
     } else {
       cacheReference = fieldValue(record, field);


### PR DESCRIPTION
This resolves this warning when building
warning: [ReferenceEquality] Comparison using reference equality instead of value equality