### PR TITLE
Implement "useJavaBeansSemanticNaming"

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,34 @@ apollo {
 }
 ```
 
+### Java Beans Semantic Naming for Accessors
+By default, the generated classes have accessor methods whose names are identical to the name of the Schema field.
+
+```query Foo { bar }```
+
+results in a class signature like:
+
+```
+class Foo {
+    public Bar bar() { ... }
+}
+```
+
+Alternatively, turning on Java Beans Semantic Naming will result in those methods being pre-pended with `get` or `is`:
+
+```
+class Foo {
+    public Bar getBar() { ... }
+}
+```
+
+### Usage
+```groovy
+apollo {
+  useJavaBeansSemanticNaming = true
+}
+```
+
 ### Explicit Schema location
 By default Apollo-Android tries to lookup GraphQL schema file in `/graphql` folder, the same folder where all your GraphQL queries are stored. 
 For example, if query files are located at `/src/main/graphql/com/example/api` then the schema file should be placed in the same location `/src/main/graphql/com/example/api`. Relative path of schema file to `/src/main/graphql` root folder defines the package name for generated models, in our example the package name of generated models will be `com.example.api`.

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -27,7 +27,8 @@ class GraphQLCompiler {
         nullableValueType = args.nullableValueType,
         ir = ir,
         useSemanticNaming = args.useSemanticNaming,
-        generateModelBuilder = args.generateModelBuilder
+        generateModelBuilder = args.generateModelBuilder,
+        useJavaBeansSemanticNaming = args.useJavaBeansSemanticNaming
     )
     ir.writeJavaFiles(
         context = context,
@@ -84,6 +85,7 @@ class GraphQLCompiler {
       val nullableValueType: NullableValueType,
       val useSemanticNaming: Boolean,
       val generateModelBuilder: Boolean,
+      val useJavaBeansSemanticNaming: Boolean,
       val outputPackageName: String?
   )
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -118,7 +118,13 @@ class SchemaTypeSpecBuilder(
       inlineFragments.map { it.formatClassName() to it.toTypeSpec(context = context, abstract = abstract) }
 
   private fun fragmentsAccessorMethodSpec(): MethodSpec {
-    return MethodSpec.methodBuilder(FRAGMENTS_FIELD.name)
+    val fragmentsName = FRAGMENTS_FIELD.name
+    val name = if (context.useJavaBeansSemanticNaming) {
+      fragmentsName.toJavaBeansSemanticNaming(isBooleanField = false)
+    } else {
+      fragmentsName
+    }
+    return MethodSpec.methodBuilder(name)
         .returns(FRAGMENTS_FIELD.type)
         .addModifiers(Modifier.PUBLIC)
         .addModifiers(emptyList())
@@ -155,7 +161,12 @@ class SchemaTypeSpecBuilder(
     fun TypeSpec.Builder.addFragmentAccessorMethods(): TypeSpec.Builder {
       addMethods(fragmentSpreads.map { fragmentName ->
         val optional = isOptional(fragmentName)
-        MethodSpec.methodBuilder(fragmentName.decapitalize())
+        val methodName = if (context.useJavaBeansSemanticNaming) {
+          fragmentName.toJavaBeansSemanticNaming(isBooleanField = false)
+        } else {
+          fragmentName.decapitalize()
+        }
+        MethodSpec.methodBuilder(methodName)
             .returns(JavaTypeResolver(context = context, packageName = context.fragmentsPackage)
                 .resolve(typeName = fragmentName.capitalize(), isOptional = optional))
             .addModifiers(Modifier.PUBLIC)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -14,6 +14,11 @@ private val JAVA_RESERVED_WORDS = arrayOf(
 
 fun String.escapeJavaReservedWord() = if (JAVA_RESERVED_WORDS.contains(this)) "${this}_" else this
 
+fun String.toJavaBeansSemanticNaming(isBooleanField: Boolean): String {
+  val prefix = if (isBooleanField) "is" else "get"
+  return "$prefix${capitalize()}"
+}
+
 fun TypeName.overrideTypeName(typeNameOverrideMap: Map<String, String>): TypeName {
   if (this is ParameterizedTypeName) {
     val typeArguments = typeArguments.map { it.overrideTypeName(typeNameOverrideMap) }.toTypedArray()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
@@ -11,5 +11,6 @@ data class CodeGenerationContext(
     val nullableValueType: NullableValueType,
     val ir: CodeGenerationIR,
     val useSemanticNaming: Boolean,
-    val generateModelBuilder: Boolean
+    val generateModelBuilder: Boolean,
+    val useJavaBeansSemanticNaming: Boolean
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -43,9 +43,17 @@ data class Field(
   }
 
   fun accessorMethodSpec(context: CodeGenerationContext): MethodSpec {
-    return MethodSpec.methodBuilder(responseName.escapeJavaReservedWord())
+    val respName = responseName.escapeJavaReservedWord()
+    val returnTypeName = toTypeName(methodResponseType(), context)
+    val name = if (context.useJavaBeansSemanticNaming) {
+      val isBooleanField = returnTypeName == TypeName.BOOLEAN || returnTypeName == TypeName.BOOLEAN.box()
+      respName.toJavaBeansSemanticNaming(isBooleanField = isBooleanField)
+    } else {
+      respName
+    }
+    return MethodSpec.methodBuilder(name)
         .addModifiers(Modifier.PUBLIC)
-        .returns(toTypeName(methodResponseType(), context))
+        .returns(returnTypeName)
         .addStatement("return this.\$L", responseName.escapeJavaReservedWord())
         .let { if (description != null) it.addJavadoc("\$L\n", description) else it }
         .let {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.graphql
@@ -1,0 +1,26 @@
+query TestQuery {
+  hero {
+    name
+    ...HeroDetails
+    appearsIn
+  }
+}
+
+fragment HeroDetails on Character {
+  name
+  friendsConnection {
+    totalCount
+    edges {
+      node {
+        name
+      }
+    }
+    pageInfo {
+      hasNextPage
+    }
+  }
+  ... on Droid {
+    name
+    primaryFunction
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.json
@@ -1,0 +1,361 @@
+{
+	"operations": [
+		{
+			"filePath": "src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.graphql",
+			"operationName": "TestQuery",
+			"operationType": "query",
+			"rootType": "Query",
+			"variables": [],
+			"source": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}",
+			"fields": [
+				{
+					"responseName": "hero",
+					"fieldName": "hero",
+					"type": "Character",
+					"isConditional": false,
+					"isDeprecated": false,
+					"deprecationReason": null,
+					"fields": [
+						{
+							"responseName": "__typename",
+							"fieldName": "__typename",
+							"type": "String!",
+							"isConditional": false
+						},
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!",
+							"isConditional": false,
+							"description": "The name of the character",
+							"isDeprecated": false,
+							"deprecationReason": null
+						},
+						{
+							"responseName": "appearsIn",
+							"fieldName": "appearsIn",
+							"type": "[Episode]!",
+							"isConditional": false,
+							"description": "The movies this character appears in",
+							"isDeprecated": false,
+							"deprecationReason": null
+						}
+					],
+					"fragmentSpreads": [
+						"HeroDetails"
+					],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [],
+			"fragmentsReferenced": [
+				"HeroDetails"
+			],
+			"sourceWithFragments": "query TestQuery {\n  hero {\n    __typename\n    name\n    ...HeroDetails\n    appearsIn\n  }\n}\nfragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n    pageInfo {\n      __typename\n      hasNextPage\n    }\n  }\n  ... on Droid {\n    name\n    primaryFunction\n  }\n}",
+			"operationId": "c0463bc20566eabd263da887f6c45205c7b42522fa28585baf0e9f6021a2a8a6"
+		}
+	],
+	"fragments": [
+		{
+			"typeCondition": "Character",
+			"possibleTypes": [
+				"Human",
+				"Droid"
+			],
+			"fragmentName": "HeroDetails",
+			"filePath": "src/test/graphql/com/example/java_beans_semantic_naming/TestOperation.graphql",
+			"source": "fragment HeroDetails on Character {\n  __typename\n  name\n  friendsConnection {\n    __typename\n    totalCount\n    edges {\n      __typename\n      node {\n        __typename\n        name\n      }\n    }\n    pageInfo {\n      __typename\n      hasNextPage\n    }\n  }\n  ... on Droid {\n    name\n    primaryFunction\n  }\n}",
+			"fields": [
+				{
+					"responseName": "__typename",
+					"fieldName": "__typename",
+					"type": "String!",
+					"isConditional": false
+				},
+				{
+					"responseName": "name",
+					"fieldName": "name",
+					"type": "String!",
+					"isConditional": false,
+					"description": "The name of the character",
+					"isDeprecated": false,
+					"deprecationReason": null
+				},
+				{
+					"responseName": "friendsConnection",
+					"fieldName": "friendsConnection",
+					"type": "FriendsConnection!",
+					"isConditional": false,
+					"description": "The friends of the character exposed as a connection with edges",
+					"isDeprecated": false,
+					"deprecationReason": null,
+					"fields": [
+						{
+							"responseName": "__typename",
+							"fieldName": "__typename",
+							"type": "String!",
+							"isConditional": false
+						},
+						{
+							"responseName": "totalCount",
+							"fieldName": "totalCount",
+							"type": "Int",
+							"isConditional": false,
+							"description": "The total number of friends",
+							"isDeprecated": false,
+							"deprecationReason": null
+						},
+						{
+							"responseName": "edges",
+							"fieldName": "edges",
+							"type": "[FriendsEdge]",
+							"isConditional": false,
+							"description": "The edges for each of the character's friends.",
+							"isDeprecated": false,
+							"deprecationReason": null,
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"isConditional": false
+								},
+								{
+									"responseName": "node",
+									"fieldName": "node",
+									"type": "Character",
+									"isConditional": false,
+									"description": "The character represented by this friendship edge",
+									"isDeprecated": false,
+									"deprecationReason": null,
+									"fields": [
+										{
+											"responseName": "__typename",
+											"fieldName": "__typename",
+											"type": "String!",
+											"isConditional": false
+										},
+										{
+											"responseName": "name",
+											"fieldName": "name",
+											"type": "String!",
+											"isConditional": false,
+											"description": "The name of the character",
+											"isDeprecated": false,
+											"deprecationReason": null
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						},
+						{
+							"responseName": "pageInfo",
+							"fieldName": "pageInfo",
+							"type": "PageInfo!",
+							"isConditional": false,
+							"description": "Information for paginating this connection",
+							"isDeprecated": false,
+							"deprecationReason": null,
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"isConditional": false
+								},
+								{
+									"responseName": "hasNextPage",
+									"fieldName": "hasNextPage",
+									"type": "Boolean!",
+									"isConditional": false,
+									"isDeprecated": false,
+									"deprecationReason": null
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						}
+					],
+					"fragmentSpreads": [],
+					"inlineFragments": []
+				}
+			],
+			"fragmentSpreads": [],
+			"inlineFragments": [
+				{
+					"typeCondition": "Droid",
+					"possibleTypes": [
+						"Droid"
+					],
+					"fields": [
+						{
+							"responseName": "__typename",
+							"fieldName": "__typename",
+							"type": "String!",
+							"isConditional": false
+						},
+						{
+							"responseName": "name",
+							"fieldName": "name",
+							"type": "String!",
+							"isConditional": false,
+							"description": "What others call this droid",
+							"isDeprecated": false,
+							"deprecationReason": null
+						},
+						{
+							"responseName": "friendsConnection",
+							"fieldName": "friendsConnection",
+							"type": "FriendsConnection!",
+							"isConditional": false,
+							"description": "The friends of the droid exposed as a connection with edges",
+							"isDeprecated": false,
+							"deprecationReason": null,
+							"fields": [
+								{
+									"responseName": "__typename",
+									"fieldName": "__typename",
+									"type": "String!",
+									"isConditional": false
+								},
+								{
+									"responseName": "totalCount",
+									"fieldName": "totalCount",
+									"type": "Int",
+									"isConditional": false,
+									"description": "The total number of friends",
+									"isDeprecated": false,
+									"deprecationReason": null
+								},
+								{
+									"responseName": "edges",
+									"fieldName": "edges",
+									"type": "[FriendsEdge]",
+									"isConditional": false,
+									"description": "The edges for each of the character's friends.",
+									"isDeprecated": false,
+									"deprecationReason": null,
+									"fields": [
+										{
+											"responseName": "__typename",
+											"fieldName": "__typename",
+											"type": "String!",
+											"isConditional": false
+										},
+										{
+											"responseName": "node",
+											"fieldName": "node",
+											"type": "Character",
+											"isConditional": false,
+											"description": "The character represented by this friendship edge",
+											"isDeprecated": false,
+											"deprecationReason": null,
+											"fields": [
+												{
+													"responseName": "__typename",
+													"fieldName": "__typename",
+													"type": "String!",
+													"isConditional": false
+												},
+												{
+													"responseName": "name",
+													"fieldName": "name",
+													"type": "String!",
+													"isConditional": false,
+													"description": "The name of the character",
+													"isDeprecated": false,
+													"deprecationReason": null
+												}
+											],
+											"fragmentSpreads": [],
+											"inlineFragments": []
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								},
+								{
+									"responseName": "pageInfo",
+									"fieldName": "pageInfo",
+									"type": "PageInfo!",
+									"isConditional": false,
+									"description": "Information for paginating this connection",
+									"isDeprecated": false,
+									"deprecationReason": null,
+									"fields": [
+										{
+											"responseName": "__typename",
+											"fieldName": "__typename",
+											"type": "String!",
+											"isConditional": false
+										},
+										{
+											"responseName": "hasNextPage",
+											"fieldName": "hasNextPage",
+											"type": "Boolean!",
+											"isConditional": false,
+											"isDeprecated": false,
+											"deprecationReason": null
+										}
+									],
+									"fragmentSpreads": [],
+									"inlineFragments": []
+								}
+							],
+							"fragmentSpreads": [],
+							"inlineFragments": []
+						},
+						{
+							"responseName": "primaryFunction",
+							"fieldName": "primaryFunction",
+							"type": "String",
+							"isConditional": false,
+							"description": "This droid's primary function",
+							"isDeprecated": false,
+							"deprecationReason": null
+						}
+					],
+					"fragmentSpreads": []
+				}
+			]
+		}
+	],
+	"typesUsed": [
+		{
+			"kind": "EnumType",
+			"name": "Episode",
+			"description": "The episodes in the Star Wars trilogy",
+			"values": [
+				{
+					"name": "NEWHOPE",
+					"description": "Star Wars Episode IV: A New Hope, released in 1977.",
+					"isDeprecated": false,
+					"deprecationReason": null
+				},
+				{
+					"name": "EMPIRE",
+					"description": "Star Wars Episode V: The Empire Strikes Back, released in 1980.",
+					"isDeprecated": false,
+					"deprecationReason": null
+				},
+				{
+					"name": "JEDI",
+					"description": "Star Wars Episode VI: Return of the Jedi, released in 1983.",
+					"isDeprecated": false,
+					"deprecationReason": null
+				},
+				{
+					"name": "DEPRECATED",
+					"description": "Test deprecated enum value",
+					"isDeprecated": true,
+					"deprecationReason": "For test purpose only"
+				}
+			]
+		}
+	]
+}

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -1,0 +1,392 @@
+package com.example.java_beans_semantic_naming;
+
+import com.apollographql.apollo.api.FragmentResponseFieldMapper;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.ResponseField;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
+import com.example.java_beans_semantic_naming.fragment.HeroDetails;
+import com.example.java_beans_semantic_naming.type.Episode;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Generated("Apollo GraphQL")
+public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
+  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+      + "  hero {\n"
+      + "    __typename\n"
+      + "    name\n"
+      + "    ...HeroDetails\n"
+      + "    appearsIn\n"
+      + "  }\n"
+      + "}";
+
+  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
+   + HeroDetails.FRAGMENT_DEFINITION;
+
+  public static final OperationName OPERATION_NAME = new OperationName() {
+    @Override
+    public String name() {
+      return "TestQuery";
+    }
+  };
+
+  private final Operation.Variables variables;
+
+  public TestQuery() {
+    this.variables = Operation.EMPTY_VARIABLES;
+  }
+
+  @Override
+  public String operationId() {
+    return "c0463bc20566eabd263da887f6c45205c7b42522fa28585baf0e9f6021a2a8a6";
+  }
+
+  @Override
+  public String queryDocument() {
+    return QUERY_DOCUMENT;
+  }
+
+  @Override
+  public Optional<TestQuery.Data> wrapData(TestQuery.Data data) {
+    return Optional.fromNullable(data);
+  }
+
+  @Override
+  public Operation.Variables variables() {
+    return variables;
+  }
+
+  @Override
+  public ResponseFieldMapper<TestQuery.Data> responseFieldMapper() {
+    return new Data.Mapper();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public OperationName name() {
+    return OPERATION_NAME;
+  }
+
+  public static final class Builder {
+    Builder() {
+    }
+
+    public TestQuery build() {
+      return new TestQuery();
+    }
+  }
+
+  public static class Data implements Operation.Data {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final Optional<Hero> hero;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Data(@Nullable Hero hero) {
+      this.hero = Optional.fromNullable(hero);
+    }
+
+    public Optional<Hero> getHero() {
+      return this.hero;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Data{"
+          + "hero=" + hero
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Data) {
+        Data that = (Data) o;
+        return this.hero.equals(that.hero);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= hero.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
+      @Override
+      public Data map(ResponseReader reader) {
+        final Hero hero = reader.readObject($responseFields[0], new ResponseReader.ObjectReader<Hero>() {
+          @Override
+          public Hero read(ResponseReader reader) {
+            return heroFieldMapper.map(reader);
+          }
+        });
+        return new Data(hero);
+      }
+    }
+  }
+
+  public static class Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("appearsIn", "appearsIn", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forFragment("__typename", "__typename", Arrays.asList("Human",
+      "Droid"))
+    };
+
+    final @Nonnull String __typename;
+
+    final @Nonnull String name;
+
+    final @Nonnull List<Episode> appearsIn;
+
+    private final @Nonnull Fragments fragments;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Hero(@Nonnull String __typename, @Nonnull String name, @Nonnull List<Episode> appearsIn,
+        @Nonnull Fragments fragments) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.appearsIn = Utils.checkNotNull(appearsIn, "appearsIn == null");
+      this.fragments = Utils.checkNotNull(fragments, "fragments == null");
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @Nonnull String getName() {
+      return this.name;
+    }
+
+    /**
+     * The movies this character appears in
+     */
+    public @Nonnull List<Episode> getAppearsIn() {
+      return this.appearsIn;
+    }
+
+    public @Nonnull Fragments getFragments() {
+      return this.fragments;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], appearsIn, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeString(((com.example.java_beans_semantic_naming.type.Episode) value).name());
+            }
+          });
+          fragments.marshaller().marshal(writer);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Hero{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
+          + "appearsIn=" + appearsIn + ", "
+          + "fragments=" + fragments
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Hero) {
+        Hero that = (Hero) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
+         && this.appearsIn.equals(that.appearsIn)
+         && this.fragments.equals(that.fragments);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
+        h ^= appearsIn.hashCode();
+        h *= 1000003;
+        h ^= fragments.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static class Fragments {
+      final @Nonnull HeroDetails heroDetails;
+
+      private volatile String $toString;
+
+      private volatile int $hashCode;
+
+      private volatile boolean $hashCodeMemoized;
+
+      public Fragments(@Nonnull HeroDetails heroDetails) {
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
+      }
+
+      public @Nonnull HeroDetails getHeroDetails() {
+        return this.heroDetails;
+      }
+
+      public ResponseFieldMarshaller marshaller() {
+        return new ResponseFieldMarshaller() {
+          @Override
+          public void marshal(ResponseWriter writer) {
+            final HeroDetails $heroDetails = heroDetails;
+            if ($heroDetails != null) {
+              $heroDetails.marshaller().marshal(writer);
+            }
+          }
+        };
+      }
+
+      @Override
+      public String toString() {
+        if ($toString == null) {
+          $toString = "Fragments{"
+            + "heroDetails=" + heroDetails
+            + "}";
+        }
+        return $toString;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (o == this) {
+          return true;
+        }
+        if (o instanceof Fragments) {
+          Fragments that = (Fragments) o;
+          return this.heroDetails.equals(that.heroDetails);
+        }
+        return false;
+      }
+
+      @Override
+      public int hashCode() {
+        if (!$hashCodeMemoized) {
+          int h = 1;
+          h *= 1000003;
+          h ^= heroDetails.hashCode();
+          $hashCode = h;
+          $hashCodeMemoized = true;
+        }
+        return $hashCode;
+      }
+
+      public static final class Mapper implements FragmentResponseFieldMapper<Fragments> {
+        final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();
+
+        @Override
+        public @Nonnull Fragments map(ResponseReader reader, @Nonnull String conditionalType) {
+          HeroDetails heroDetails = null;
+          if (HeroDetails.POSSIBLE_TYPES.contains(conditionalType)) {
+            heroDetails = heroDetailsFieldMapper.map(reader);
+          }
+          return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
+        }
+      }
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Hero> {
+      final Fragments.Mapper fragmentsFieldMapper = new Fragments.Mapper();
+
+      @Override
+      public Hero map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        final List<Episode> appearsIn = reader.readList($responseFields[2], new ResponseReader.ListReader<Episode>() {
+          @Override
+          public Episode read(ResponseReader.ListItemReader listItemReader) {
+            return Episode.safeValueOf(listItemReader.readString());
+          }
+        });
+        final Fragments fragments = reader.readConditional($responseFields[3], new ResponseReader.ConditionalTypeReader<Fragments>() {
+          @Override
+          public Fragments read(String conditionalType, ResponseReader reader) {
+            return fragmentsFieldMapper.map(reader, conditionalType);
+          }
+        });
+        return new Hero(__typename, name, appearsIn, fragments);
+      }
+    }
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
@@ -1,0 +1,687 @@
+package com.example.java_beans_semantic_naming.fragment;
+
+import com.apollographql.apollo.api.GraphqlFragment;
+import com.apollographql.apollo.api.ResponseField;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
+import java.lang.Long;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Generated;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Generated("Apollo GraphQL")
+public interface HeroDetails extends GraphqlFragment {
+  String FRAGMENT_DEFINITION = "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    __typename\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "    pageInfo {\n"
+      + "      __typename\n"
+      + "      hasNextPage\n"
+      + "    }\n"
+      + "  }\n"
+      + "  ... on Droid {\n"
+      + "    name\n"
+      + "    primaryFunction\n"
+      + "  }\n"
+      + "}";
+
+  List<String> POSSIBLE_TYPES = Collections.unmodifiableList(Arrays.asList( "Human", "Droid"));
+
+  @Nonnull String get__typename();
+
+  /**
+   * The name of the character
+   */
+  @Nonnull String getName();
+
+  /**
+   * The friends of the character exposed as a connection with edges
+   */
+  @Nonnull FriendsConnection getFriendsConnection();
+
+  ResponseFieldMarshaller marshaller();
+
+  final class Mapper implements ResponseFieldMapper<HeroDetails> {
+    final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
+
+    @Override
+    public HeroDetails map(ResponseReader reader) {
+      final AsDroid asDroid = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid")), new ResponseReader.ConditionalTypeReader<AsDroid>() {
+        @Override
+        public AsDroid read(String conditionalType, ResponseReader reader) {
+          return asDroidFieldMapper.map(reader);
+        }
+      });
+      if (asDroid != null) {
+        return asDroid;
+      }
+      return null;
+    }
+  }
+
+  interface FriendsConnection {
+    @Nonnull String get__typename();
+
+    /**
+     * The total number of friends
+     */
+    Optional<Long> getTotalCount();
+
+    /**
+     * The edges for each of the character's friends.
+     */
+    Optional<? extends List<? extends Edge>> getEdges();
+
+    /**
+     * Information for paginating this connection
+     */
+    @Nonnull PageInfo getPageInfo();
+
+    ResponseFieldMarshaller marshaller();
+  }
+
+  interface Edge {
+    @Nonnull String get__typename();
+
+    /**
+     * The character represented by this friendship edge
+     */
+    Optional<? extends Node> getNode();
+
+    ResponseFieldMarshaller marshaller();
+  }
+
+  interface Node {
+    @Nonnull String get__typename();
+
+    /**
+     * The name of the character
+     */
+    @Nonnull String getName();
+
+    ResponseFieldMarshaller marshaller();
+  }
+
+  interface PageInfo {
+    @Nonnull String get__typename();
+
+    boolean isHasNextPage();
+
+    ResponseFieldMarshaller marshaller();
+  }
+
+  class AsDroid implements HeroDetails {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("primaryFunction", "primaryFunction", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @Nonnull String __typename;
+
+    final @Nonnull String name;
+
+    final @Nonnull FriendsConnection1 friendsConnection;
+
+    final Optional<String> primaryFunction;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsDroid(@Nonnull String __typename, @Nonnull String name,
+        @Nonnull FriendsConnection1 friendsConnection, @Nullable String primaryFunction) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
+      this.primaryFunction = Optional.fromNullable(primaryFunction);
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * What others call this droid
+     */
+    public @Nonnull String getName() {
+      return this.name;
+    }
+
+    /**
+     * The friends of the droid exposed as a connection with edges
+     */
+    public @Nonnull FriendsConnection1 getFriendsConnection() {
+      return this.friendsConnection;
+    }
+
+    /**
+     * This droid's primary function
+     */
+    public Optional<String> getPrimaryFunction() {
+      return this.primaryFunction;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+          writer.writeString($responseFields[3], primaryFunction.isPresent() ? primaryFunction.get() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsDroid{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
+          + "friendsConnection=" + friendsConnection + ", "
+          + "primaryFunction=" + primaryFunction
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsDroid) {
+        AsDroid that = (AsDroid) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
+         && this.friendsConnection.equals(that.friendsConnection)
+         && this.primaryFunction.equals(that.primaryFunction);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
+        h ^= friendsConnection.hashCode();
+        h *= 1000003;
+        h ^= primaryFunction.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsDroid> {
+      final FriendsConnection1.Mapper friendsConnection1FieldMapper = new FriendsConnection1.Mapper();
+
+      @Override
+      public AsDroid map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        final FriendsConnection1 friendsConnection = reader.readObject($responseFields[2], new ResponseReader.ObjectReader<FriendsConnection1>() {
+          @Override
+          public FriendsConnection1 read(ResponseReader reader) {
+            return friendsConnection1FieldMapper.map(reader);
+          }
+        });
+        final String primaryFunction = reader.readString($responseFields[3]);
+        return new AsDroid(__typename, name, friendsConnection, primaryFunction);
+      }
+    }
+  }
+
+  class FriendsConnection1 implements FriendsConnection {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forLong("totalCount", "totalCount", null, true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("edges", "edges", null, true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("pageInfo", "pageInfo", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @Nonnull String __typename;
+
+    final Optional<Long> totalCount;
+
+    final Optional<List<Edge1>> edges;
+
+    final @Nonnull PageInfo1 pageInfo;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public FriendsConnection1(@Nonnull String __typename, @Nullable Long totalCount,
+        @Nullable List<Edge1> edges, @Nonnull PageInfo1 pageInfo) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.totalCount = Optional.fromNullable(totalCount);
+      this.edges = Optional.fromNullable(edges);
+      this.pageInfo = Utils.checkNotNull(pageInfo, "pageInfo == null");
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The total number of friends
+     */
+    public Optional<Long> getTotalCount() {
+      return this.totalCount;
+    }
+
+    /**
+     * The edges for each of the character's friends.
+     */
+    public Optional<List<Edge1>> getEdges() {
+      return this.edges;
+    }
+
+    /**
+     * Information for paginating this connection
+     */
+    public @Nonnull PageInfo1 getPageInfo() {
+      return this.pageInfo;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeLong($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? edges.get() : null, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeObject(((Edge1) value).marshaller());
+            }
+          });
+          writer.writeObject($responseFields[3], pageInfo.marshaller());
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "FriendsConnection1{"
+          + "__typename=" + __typename + ", "
+          + "totalCount=" + totalCount + ", "
+          + "edges=" + edges + ", "
+          + "pageInfo=" + pageInfo
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof FriendsConnection1) {
+        FriendsConnection1 that = (FriendsConnection1) o;
+        return this.__typename.equals(that.__typename)
+         && this.totalCount.equals(that.totalCount)
+         && this.edges.equals(that.edges)
+         && this.pageInfo.equals(that.pageInfo);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= totalCount.hashCode();
+        h *= 1000003;
+        h ^= edges.hashCode();
+        h *= 1000003;
+        h ^= pageInfo.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<FriendsConnection1> {
+      final Edge1.Mapper edge1FieldMapper = new Edge1.Mapper();
+
+      final PageInfo1.Mapper pageInfo1FieldMapper = new PageInfo1.Mapper();
+
+      @Override
+      public FriendsConnection1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Long totalCount = reader.readLong($responseFields[1]);
+        final List<Edge1> edges = reader.readList($responseFields[2], new ResponseReader.ListReader<Edge1>() {
+          @Override
+          public Edge1 read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readObject(new ResponseReader.ObjectReader<Edge1>() {
+              @Override
+              public Edge1 read(ResponseReader reader) {
+                return edge1FieldMapper.map(reader);
+              }
+            });
+          }
+        });
+        final PageInfo1 pageInfo = reader.readObject($responseFields[3], new ResponseReader.ObjectReader<PageInfo1>() {
+          @Override
+          public PageInfo1 read(ResponseReader reader) {
+            return pageInfo1FieldMapper.map(reader);
+          }
+        });
+        return new FriendsConnection1(__typename, totalCount, edges, pageInfo);
+      }
+    }
+  }
+
+  class Edge1 implements Edge {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("node", "node", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @Nonnull String __typename;
+
+    final Optional<Node1> node;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Edge1(@Nonnull String __typename, @Nullable Node1 node) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.node = Optional.fromNullable(node);
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The character represented by this friendship edge
+     */
+    public Optional<Node1> getNode() {
+      return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Edge1{"
+          + "__typename=" + __typename + ", "
+          + "node=" + node
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Edge1) {
+        Edge1 that = (Edge1) o;
+        return this.__typename.equals(that.__typename)
+         && this.node.equals(that.node);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= node.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Edge1> {
+      final Node1.Mapper node1FieldMapper = new Node1.Mapper();
+
+      @Override
+      public Edge1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Node1 node = reader.readObject($responseFields[1], new ResponseReader.ObjectReader<Node1>() {
+          @Override
+          public Node1 read(ResponseReader reader) {
+            return node1FieldMapper.map(reader);
+          }
+        });
+        return new Edge1(__typename, node);
+      }
+    }
+  }
+
+  class Node1 implements Node {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @Nonnull String __typename;
+
+    final @Nonnull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Node1(@Nonnull String __typename, @Nonnull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @Nonnull String getName() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Node1{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Node1) {
+        Node1 that = (Node1) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Node1> {
+      @Override
+      public Node1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new Node1(__typename, name);
+      }
+    }
+  }
+
+  class PageInfo1 implements PageInfo {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forBoolean("hasNextPage", "hasNextPage", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @Nonnull String __typename;
+
+    final boolean hasNextPage;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public PageInfo1(@Nonnull String __typename, boolean hasNextPage) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.hasNextPage = hasNextPage;
+    }
+
+    public @Nonnull String get__typename() {
+      return this.__typename;
+    }
+
+    public boolean isHasNextPage() {
+      return this.hasNextPage;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeBoolean($responseFields[1], hasNextPage);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "PageInfo1{"
+          + "__typename=" + __typename + ", "
+          + "hasNextPage=" + hasNextPage
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof PageInfo1) {
+        PageInfo1 that = (PageInfo1) o;
+        return this.__typename.equals(that.__typename)
+         && this.hasNextPage == that.hasNextPage;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= Boolean.valueOf(hasNextPage).hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<PageInfo1> {
+      @Override
+      public PageInfo1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final boolean hasNextPage = reader.readBoolean($responseFields[1]);
+        return new PageInfo1(__typename, hasNextPage);
+      }
+    }
+  }
+}

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.java
@@ -1,0 +1,47 @@
+package com.example.java_beans_semantic_naming.type;
+
+import java.lang.Deprecated;
+import java.lang.String;
+import javax.annotation.Generated;
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+@Generated("Apollo GraphQL")
+public enum Episode {
+  /**
+   * Star Wars Episode IV: A New Hope, released in 1977.
+   */
+  NEWHOPE,
+
+  /**
+   * Star Wars Episode V: The Empire Strikes Back, released in 1980.
+   */
+  EMPIRE,
+
+  /**
+   * Star Wars Episode VI: Return of the Jedi, released in 1983.
+   */
+  JEDI,
+
+  /**
+   * Test deprecated enum value
+   * @deprecated For test purpose only
+   */
+  @Deprecated
+  DEPRECATED,
+
+  /**
+   * Auto generated constant for unknown enum values
+   */
+  $UNKNOWN;
+
+  public static Episode safeValueOf(String value) {
+    for (Episode enumValue : values()) {
+      if (enumValue.name().equals(value)) {
+        return enumValue;
+      }
+    }
+    return Episode.$UNKNOWN;
+  }
+}

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -85,6 +85,10 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
               it.name == "fragment_with_inline_fragment" -> true
               else -> false
             }
+            val useJavaBeansSemanticNaming = when {
+              it.name == "java_beans_semantic_naming" -> true
+              else -> false
+            }
             val args = GraphQLCompiler.Arguments(
                 irFile = File(it, "TestOperation.json"),
                 outputDir = GraphQLCompiler.Companion.OUTPUT_DIRECTORY.fold(File("build"), ::File),
@@ -92,6 +96,7 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
                 nullableValueType = nullableValueType,
                 useSemanticNaming = useSemanticNaming,
                 generateModelBuilder = generateModelBuilder,
+                useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
                 outputPackageName = null
             )
             arrayOf(it.name, args)

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -18,7 +18,8 @@ class JavaTypeResolverTest {
       nullableValueType = NullableValueType.APOLLO_OPTIONAL,
       ir = CodeGenerationIR(emptyList(), emptyList(), emptyList()),
       useSemanticNaming = false,
-      generateModelBuilder = false
+      generateModelBuilder = false,
+      useJavaBeansSemanticNaming = false
   )
   private val defaultResolver = JavaTypeResolver(defaultContext, packageName)
 

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -6,7 +6,6 @@ import com.apollographql.apollo.compiler.GraphQLCompiler;
 import com.apollographql.apollo.compiler.NullableValueType;
 
 import org.gradle.api.Action;
-import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
@@ -41,7 +40,8 @@ public class ApolloClassGenTask extends SourceTask {
       public void execute(InputFileDetails inputFileDetails) {
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(inputFileDetails.getFile(), outputDir,
             apolloExtension.getCustomTypeMapping(), nullableValueType, apolloExtension.isUseSemanticNaming(),
-            apolloExtension.isGenerateModelBuilder(), apolloExtension.getOutputPackageName());
+            apolloExtension.isGenerateModelBuilder(), apolloExtension.isUseJavaBeansSemanticNaming(), apolloExtension
+            .getOutputPackageName());
         new GraphQLCompiler().write(args);
       }
     });

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloExtension.java
@@ -13,6 +13,7 @@ public class ApolloExtension {
   private String nullableValueType = NullableValueType.ANNOTATED.getValue();
   private boolean useSemanticNaming = true;
   private boolean generateModelBuilder;
+  private boolean useJavaBeansSemanticNaming = false;
   private String schemaFilePath;
   private String outputPackageName;
 
@@ -36,12 +37,20 @@ public class ApolloExtension {
     this.useSemanticNaming = useSemanticNaming;
   }
 
+  public void setUseJavaBeansSemanticNaming(boolean useJavaBeansSemanticNaming) {
+    this.useJavaBeansSemanticNaming = useJavaBeansSemanticNaming;
+  }
+
   public boolean isUseSemanticNaming() {
     return useSemanticNaming;
   }
 
   public boolean isGenerateModelBuilder() {
     return generateModelBuilder;
+  }
+
+  public boolean isUseJavaBeansSemanticNaming() {
+    return useJavaBeansSemanticNaming;
   }
 
   public void setGenerateModelBuilder(boolean generateModelBuilder) {


### PR DESCRIPTION
When Java classes are consumed by Kotlin code, property access syntax is
enabled for any methods with prepended get (e.g. `getFoo()`). This means
that the consuming Kotlin code can access those fields like `thing.foo`.

Code generation with `useJavaBeansSemanticNaming` enabled should modify
any accessor functions only to support this use.

Boolean fields ought to be prefixed with `is` rather than `get` for the
most semantic naming (boxed and unboxed).

The property is added to the ApolloExtension to be passed to the
CodeGenerationContext so that the value can be defined by users of the
library.

Closes #749 
  