### PR TITLE
Remove synthetic accessors from source files

### DIFF
--- a/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloCallback.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloCallback.java
@@ -22,7 +22,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
  * android.os.NetworkOnMainThreadException} exception.
  */
 public final class ApolloCallback<T> extends ApolloCall.Callback<T> {
-  private final ApolloCall.Callback<T> delegate;
+  final ApolloCall.Callback<T> delegate;
   private final Handler handler;
 
   /**

--- a/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloPrefetchCallback.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloPrefetchCallback.java
@@ -14,7 +14,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
  * Android wrapper for {@link ApolloPrefetch.Callback} to be operated on specified {@link Handler}
  */
 public final class ApolloPrefetchCallback extends ApolloPrefetch.Callback {
-  private final ApolloPrefetch.Callback delegate;
+  final ApolloPrefetch.Callback delegate;
   private final Handler handler;
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -65,11 +65,11 @@ public final class Response<T> {
   }
 
   public static final class Builder<T> {
-    private final Operation operation;
-    private T data;
-    private List<Error> errors;
-    private Set<String> dependentKeys;
-    private boolean fromCache;
+    final Operation operation;
+    T data;
+    List<Error> errors;
+    Set<String> dependentKeys;
+    boolean fromCache;
 
     Builder(@Nonnull final Operation operation) {
       this.operation = checkNotNull(operation, "operation == null");

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
@@ -198,7 +198,7 @@ public class ResponseField {
         false, conditions);
   }
 
-  private ResponseField(Type type, String responseName, String fieldName, Map<String, Object> arguments,
+  ResponseField(Type type, String responseName, String fieldName, Map<String, Object> arguments,
       boolean optional, List<Condition> conditions) {
     this.type = type;
     this.responseName = responseName;

--- a/apollo-espresso-support/src/main/java/com/apollographql/apollo/test/espresso/ApolloIdlingResource.java
+++ b/apollo-espresso-support/src/main/java/com/apollographql/apollo/test/espresso/ApolloIdlingResource.java
@@ -17,7 +17,7 @@ public final class ApolloIdlingResource implements IdlingResource {
 
   private final String name;
   private final ApolloClient apolloClient;
-  private ResourceCallback callback;
+  ResourceCallback callback;
 
   /**
    * Creates a new {@link IdlingResource} from {@link ApolloClient} with a given name. Register this instance using

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloClassGenTask.java
@@ -20,9 +20,9 @@ public class ApolloClassGenTask extends SourceTask {
   static final String NAME = "generate%sApolloClasses";
 
   @Internal private String variant;
-  @Internal private ApolloExtension apolloExtension;
-  @OutputDirectory private File outputDir;
-  private NullableValueType nullableValueType;
+  @Internal ApolloExtension apolloExtension;
+  @OutputDirectory File outputDir;
+  NullableValueType nullableValueType;
 
   public void init(String variant, ApolloExtension apolloExtension) {
     this.variant = variant;

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodeGenInstallTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloCodeGenInstallTask.java
@@ -24,7 +24,7 @@ public class ApolloCodeGenInstallTask extends NpmTask {
   private static final String INSTALL_DIR =  "apollo-codegen/node_modules/apollo-codegen";
 
   @OutputDirectory private File installDir;
-  private File apolloPackageFile;
+  File apolloPackageFile;
   
   public ApolloCodeGenInstallTask() {
     // TODO: set to const when ApolloPlugin is in java

--- a/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
+++ b/apollo-gradle-plugin/src/main/java/com/apollographql/apollo/gradle/ApolloIRGenTask.java
@@ -36,7 +36,7 @@ public class ApolloIRGenTask extends NodeTask {
   static final String NAME = "generate%sApolloIR";
 
   @Internal private String variant;
-  @Internal private ImmutableList<String> sourceSets;
+  @Internal ImmutableList<String> sourceSets;
   @Internal private ApolloExtension extension;
 
   @OutputDirectory private File outputFolder;
@@ -215,7 +215,7 @@ public class ApolloIRGenTask extends NodeTask {
    *
    * @return - sourceSet name
    */
-  private String getSourceSetNameFromFile(File file) {
+  String getSourceSetNameFromFile(File file) {
     Path absolutePath = Paths.get(file.getAbsolutePath());
     Path basePath = Paths.get(getProject().file("src").getAbsolutePath());
 
@@ -227,7 +227,7 @@ public class ApolloIRGenTask extends NodeTask {
    *
    * @return path relative to sourceSet directory
    */
-  private String getPathRelativeToSourceSet(File file) {
+  String getPathRelativeToSourceSet(File file) {
     Path absolutePath = Paths.get(file.getAbsolutePath());
     Path basePath = Paths.get(getProject().file("src").getAbsolutePath() + File.separator + getSourceSetNameFromFile(file));
 

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
@@ -148,7 +148,7 @@ public final class ApolloHttpCache implements HttpCache {
     }
   }
 
-  private void closeQuietly(HttpCacheRecord cacheRecord) {
+  void closeQuietly(HttpCacheRecord cacheRecord) {
     try {
       if (cacheRecord != null) {
         cacheRecord.close();

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseBodyProxy.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseBodyProxy.java
@@ -126,7 +126,7 @@ final class ResponseBodyProxy extends ResponseBody {
       }
     }
 
-    private void abortCacheQuietly() {
+    void abortCacheQuietly() {
       closeQuietly(responseBodyCacheSink);
       try {
         cacheRecordEditor.abort();

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -36,8 +36,8 @@ public class ApolloPrefetchTest {
   private ApolloClient apolloClient;
   private MockWebServer server;
   @Rule public InMemoryFileSystem inMemoryFileSystem = new InMemoryFileSystem();
-  private okhttp3.Request lastHttRequest;
-  private okhttp3.Response lastHttResponse;
+  okhttp3.Request lastHttRequest;
+  okhttp3.Response lastHttResponse;
   private MockHttpCacheStore cacheStore;
   private OkHttpClient okHttpClient;
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/FaultyHttpCacheStore.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/FaultyHttpCacheStore.java
@@ -23,9 +23,9 @@ class FaultyHttpCacheStore implements HttpCacheStore {
   private static final int ENTRY_COUNT = 2;
 
   private DiskLruCache cache;
-  private final FaultySource faultySource = new FaultySource();
-  private final FaultySink faultySink = new FaultySink();
-  private FailStrategy failStrategy;
+  final FaultySource faultySource = new FaultySource();
+  final FaultySink faultySink = new FaultySink();
+  FailStrategy failStrategy;
 
   FaultyHttpCacheStore(FileSystem fileSystem) {
     this.cache = DiskLruCache.create(fileSystem, new File("/cache/"), VERSION, ENTRY_COUNT, Integer.MAX_VALUE);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -83,7 +83,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   private final List<ApolloInterceptor> applicationInterceptors;
   private final boolean sendOperationIdentifiers;
 
-  private ApolloClient(HttpUrl serverUrl,
+  ApolloClient(HttpUrl serverUrl,
       Call.Factory httpCallFactory,
       HttpCache httpCache,
       ApolloStore apolloStore,
@@ -232,7 +232,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     final List<ApolloInterceptor> applicationInterceptors = new ArrayList<>();
     boolean sendOperationIdentifiers;
 
-    private Builder() {
+    Builder() {
     }
 
     /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/CacheHeaders.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/CacheHeaders.java
@@ -52,7 +52,7 @@ public final class CacheHeaders {
     return builder;
   }
 
-  private CacheHeaders(Map<String, String> headerMap) {
+  CacheHeaders(Map<String, String> headerMap) {
     this.headerMap = headerMap;
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStoreOperation.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/ApolloStoreOperation.java
@@ -84,7 +84,7 @@ public abstract class ApolloStoreOperation<T> {
     });
   }
 
-  private void notifySuccess(T result) {
+  void notifySuccess(T result) {
     Callback<T> callback = this.callback.getAndSet(null);
     if (callback == null) {
       return;
@@ -92,7 +92,7 @@ public abstract class ApolloStoreOperation<T> {
     callback.onSuccess(result);
   }
 
-  private void notifyFailure(Throwable t) {
+  void notifyFailure(Throwable t) {
     Callback<T> callback = this.callback.getAndSet(null);
     if (callback == null) {
       return;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/EvictionPolicy.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/EvictionPolicy.java
@@ -49,7 +49,7 @@ public final class EvictionPolicy {
 
   public static class Builder {
 
-    private Builder() { }
+    Builder() { }
 
     private Optional<Long> maxSizeBytes = Optional.absent();
     private Optional<Long> maxEntries = Optional.absent();
@@ -87,7 +87,7 @@ public final class EvictionPolicy {
 
   }
 
-  private EvictionPolicy(Optional<Long> maxSizeBytes, Optional<Long> maxEntries, Optional<Long> expireAfterAccess,
+  EvictionPolicy(Optional<Long> maxSizeBytes, Optional<Long> maxEntries, Optional<Long> expireAfterAccess,
       Optional<TimeUnit> expireAfterAccessTimeUnit, Optional<Long> expireAfterWrite, Optional<TimeUnit>
       expireAfterWriteTimeUnit) {
     this.maxSizeBytes = maxSizeBytes;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
@@ -26,7 +26,7 @@ import okhttp3.Call;
 import okhttp3.HttpUrl;
 
 final class QueryReFetcher {
-  private final ApolloLogger logger;
+  final ApolloLogger logger;
   private final List<RealApolloCall> calls;
   private List<OperationName> queryWatchers;
   private ApolloCallTracker callTracker;
@@ -185,7 +185,7 @@ final class QueryReFetcher {
       return new QueryReFetcher(this);
     }
 
-    private Builder() {
+    Builder() {
     }
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -75,7 +75,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     return new Builder<>();
   }
 
-  private RealApolloCall(Builder<T> builder) {
+  RealApolloCall(Builder<T> builder) {
     operation = builder.operation;
     serverUrl = builder.serverUrl;
     httpCallFactory = builder.httpCallFactory;
@@ -320,7 +320,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     state.set(ACTIVE);
   }
 
-  private synchronized Optional<Callback<T>> responseCallback() {
+  synchronized Optional<Callback<T>> responseCallback() {
     switch (state.get()) {
       case ACTIVE:
       case CANCELED:
@@ -334,7 +334,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     }
   }
 
-  private synchronized Optional<Callback<T>> terminate() {
+  synchronized Optional<Callback<T>> terminate() {
     switch (state.get()) {
       case ACTIVE:
         tracker.unregisterCall(this);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -175,7 +175,7 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
     state.set(ACTIVE);
   }
 
-  private synchronized Optional<ApolloPrefetch.Callback> terminate() {
+  synchronized Optional<ApolloPrefetch.Callback> terminate() {
     switch (state.get()) {
       case ACTIVE:
         tracker.unregisterPrefetchCall(this);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -31,11 +31,11 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
 final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private RealApolloCall<T> activeCall;
   private ResponseFetcher refetchResponseFetcher = ApolloResponseFetchers.CACHE_FIRST;
-  private final ApolloStore apolloStore;
-  private Set<String> dependentKeys = Collections.emptySet();
-  private final ApolloLogger logger;
+  final ApolloStore apolloStore;
+  Set<String> dependentKeys = Collections.emptySet();
+  final ApolloLogger logger;
   private final ApolloCallTracker tracker;
-  private final ApolloStore.RecordChangeSubscriber recordChangeSubscriber = new ApolloStore.RecordChangeSubscriber() {
+  final ApolloStore.RecordChangeSubscriber recordChangeSubscriber = new ApolloStore.RecordChangeSubscriber() {
     @Override public void onCacheRecordsChanged(Set<String> changedRecordKeys) {
       if (!Utils.areDisjoint(dependentKeys, changedRecordKeys)) {
         refetch();
@@ -178,7 +178,7 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
     state.set(ACTIVE);
   }
 
-  private synchronized Optional<ApolloCall.Callback<T>> responseCallback() {
+  synchronized Optional<ApolloCall.Callback<T>> responseCallback() {
     switch (state.get()) {
       case ACTIVE:
       case CANCELED:
@@ -192,7 +192,7 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
     }
   }
 
-  private synchronized Optional<ApolloCall.Callback<T>> terminate() {
+  synchronized Optional<ApolloCall.Callback<T>> terminate() {
     switch (state.get()) {
       case ACTIVE:
         tracker.unregisterQueryWatcher(this);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealApolloStore.java
@@ -38,13 +38,13 @@ import javax.annotation.Nullable;
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class RealApolloStore implements ApolloStore, ReadableStore, WriteableStore {
-  private final OptimisticNormalizedCache optimisticCache;
-  private final CacheKeyResolver cacheKeyResolver;
-  private final ScalarTypeAdapters scalarTypeAdapters;
+  final OptimisticNormalizedCache optimisticCache;
+  final CacheKeyResolver cacheKeyResolver;
+  final ScalarTypeAdapters scalarTypeAdapters;
   private final ReadWriteLock lock;
   private final Set<RecordChangeSubscriber> subscribers;
   private final Executor dispatcher;
-  private final ApolloLogger logger;
+  final ApolloLogger logger;
 
   public RealApolloStore(@Nonnull NormalizedCache normalizedCache, @Nonnull CacheKeyResolver cacheKeyResolver,
       @Nonnull final ScalarTypeAdapters scalarTypeAdapters, @Nonnull Executor dispatcher,
@@ -334,7 +334,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     };
   }
 
-  private <D extends Operation.Data, T, V extends Operation.Variables> T doRead(final Operation<D, T, V> operation) {
+  <D extends Operation.Data, T, V extends Operation.Variables> T doRead(final Operation<D, T, V> operation) {
     return readTransaction(new Transaction<ReadableStore, T>() {
       @Nullable @Override public T execute(ReadableStore cache) {
         Record rootRecord = cache.read(CacheKeyResolver.rootKeyForOperation(operation).key(), CacheHeaders.NONE);
@@ -353,7 +353,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     });
   }
 
-  private <D extends Operation.Data, T, V extends Operation.Variables> Response<T> doRead(
+  <D extends Operation.Data, T, V extends Operation.Variables> Response<T> doRead(
       final Operation<D, T, V> operation, final ResponseFieldMapper<D> responseFieldMapper,
       final ResponseNormalizer<Record> responseNormalizer, final CacheHeaders cacheHeaders) {
     return readTransaction(new Transaction<ReadableStore, Response<T>>() {
@@ -383,7 +383,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     });
   }
 
-  private <F extends GraphqlFragment> F doRead(final ResponseFieldMapper<F> responseFieldMapper,
+  <F extends GraphqlFragment> F doRead(final ResponseFieldMapper<F> responseFieldMapper,
       final CacheKey cacheKey, final Operation.Variables variables) {
     return readTransaction(new Transaction<ReadableStore, F>() {
       @Nullable @Override public F execute(ReadableStore cache) {
@@ -402,7 +402,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     });
   }
 
-  private <D extends Operation.Data, T, V extends Operation.Variables> Set<String> doWrite(
+  <D extends Operation.Data, T, V extends Operation.Variables> Set<String> doWrite(
       final Operation<D, T, V> operation, final D operationData, final boolean optimistic,
       final UUID mutationId) {
     return writeTransaction(new Transaction<WriteableStore, Set<String>>() {
@@ -426,7 +426,7 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
     });
   }
 
-  private Set<String> doWrite(final GraphqlFragment fragment, final CacheKey cacheKey,
+  Set<String> doWrite(final GraphqlFragment fragment, final CacheKey cacheKey,
       final Operation.Variables variables) {
     return writeTransaction(new Transaction<WriteableStore, Set<String>>() {
       @Override public Set<String> execute(WriteableStore cache) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheAndNetworkFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheAndNetworkFetcher.java
@@ -80,22 +80,22 @@ public final class CacheAndNetworkFetcher implements ResponseFetcher {
       disposed = true;
     }
 
-    private synchronized void handleNetworkResponse(ApolloInterceptor.InterceptorResponse response) {
+    synchronized void handleNetworkResponse(ApolloInterceptor.InterceptorResponse response) {
       networkResponse = Optional.of(response);
       dispatch();
     }
 
-    private synchronized void handleNetworkError(ApolloException exception) {
+    synchronized void handleNetworkError(ApolloException exception) {
       networkException = Optional.of(exception);
       dispatch();
     }
 
-    private synchronized void handleCacheResponse(ApolloInterceptor.InterceptorResponse response) {
+    synchronized void handleCacheResponse(ApolloInterceptor.InterceptorResponse response) {
       cacheResponse = Optional.of(response);
       dispatch();
     }
 
-    private synchronized void handleCacheError(ApolloException exception) {
+    synchronized void handleCacheError(ApolloException exception) {
       cacheException = Optional.of(exception);
       dispatch();
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheFirstFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheFirstFetcher.java
@@ -23,7 +23,7 @@ public final class CacheFirstFetcher implements ResponseFetcher {
 
   private static final class CacheFirstInterceptor implements ApolloInterceptor {
 
-    private volatile boolean disposed;
+    volatile boolean disposed;
 
     @Override
     public void interceptAsync(@Nonnull final InterceptorRequest request, @Nonnull final ApolloInterceptorChain chain,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheOnlyFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/CacheOnlyFetcher.java
@@ -55,7 +55,7 @@ public final class CacheOnlyFetcher implements ResponseFetcher {
       //no-op
     }
 
-    private InterceptorResponse cacheMissResponse(Operation operation) {
+    InterceptorResponse cacheMissResponse(Operation operation) {
       return new InterceptorResponse(null, Response.builder(operation).fromCache(true).build(), null);
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/NetworkFirstFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/fetcher/NetworkFirstFetcher.java
@@ -22,8 +22,8 @@ public final class NetworkFirstFetcher implements ResponseFetcher {
   }
 
   private static final class NetworkFirstInterceptor implements ApolloInterceptor {
-    private volatile boolean disposed;
-    private final ApolloLogger logger;
+    volatile boolean disposed;
+    final ApolloLogger logger;
 
     NetworkFirstInterceptor(ApolloLogger logger) {
       this.logger = logger;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -34,11 +34,11 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
  * cache if {@link InterceptorRequest#fetchFromCache} is true. Saves all network responses to cache.
  */
 public final class ApolloCacheInterceptor implements ApolloInterceptor {
-  private final ApolloStore apolloStore;
+  final ApolloStore apolloStore;
   private final ResponseFieldMapper responseFieldMapper;
   private final Executor dispatcher;
-  private final ApolloLogger logger;
-  private volatile boolean disposed;
+  final ApolloLogger logger;
+  volatile boolean disposed;
 
   public ApolloCacheInterceptor(@Nonnull ApolloStore apolloStore, @Nonnull ResponseFieldMapper responseFieldMapper,
       @Nonnull Executor dispatcher, @Nonnull ApolloLogger logger) {
@@ -107,7 +107,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     disposed = true;
   }
 
-  private InterceptorResponse resolveFromCache(InterceptorRequest request) throws ApolloException {
+  InterceptorResponse resolveFromCache(InterceptorRequest request) throws ApolloException {
     ResponseNormalizer<Record> responseNormalizer = apolloStore.cacheResponseNormalizer();
     //noinspection unchecked
     ApolloStoreOperation<Response> apolloStoreOperation = apolloStore.read(request.operation, responseFieldMapper,
@@ -121,7 +121,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     throw new ApolloException(String.format("Cache miss for operation %s", request.operation));
   }
 
-  private Set<String> cacheResponse(final InterceptorResponse networkResponse,
+  Set<String> cacheResponse(final InterceptorResponse networkResponse,
       final InterceptorRequest request) {
     final Optional<List<Record>> records = networkResponse.cacheRecords.map(
         new Function<Collection<Record>, List<Record>>() {
@@ -151,7 +151,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     }
   }
 
-  private void writeOptimisticUpdatesAndPublish(final InterceptorRequest request) {
+  void writeOptimisticUpdatesAndPublish(final InterceptorRequest request) {
     dispatcher.execute(new Runnable() {
       @Override public void run() {
         try {
@@ -167,7 +167,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     });
   }
 
-  private void rollbackOptimisticUpdatesAndPublish(final InterceptorRequest request) {
+  void rollbackOptimisticUpdatesAndPublish(final InterceptorRequest request) {
     dispatcher.execute(new Runnable() {
       @Override public void run() {
         try {
@@ -179,7 +179,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     });
   }
 
-  private Set<String> rollbackOptimisticUpdates(final InterceptorRequest request) {
+  Set<String> rollbackOptimisticUpdates(final InterceptorRequest request) {
     try {
       return apolloStore.rollbackOptimisticUpdates(request.uniqueId).execute();
     } catch (Exception e) {
@@ -188,7 +188,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     }
   }
 
-  private void publishCacheKeys(final Set<String> cacheKeys) {
+  void publishCacheKeys(final Set<String> cacheKeys) {
     dispatcher.execute(new Runnable() {
       @Override public void run() {
         try {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.java
@@ -31,7 +31,7 @@ public final class ApolloParseInterceptor implements ApolloInterceptor {
   private final ResponseFieldMapper responseFieldMapper;
   private final ScalarTypeAdapters scalarTypeAdapters;
   private final ApolloLogger logger;
-  private volatile boolean disposed;
+  volatile boolean disposed;
 
   public ApolloParseInterceptor(HttpCache httpCache, ResponseNormalizer<Map<String, Object>> normalizer,
       ResponseFieldMapper responseFieldMapper, ScalarTypeAdapters scalarTypeAdapters, ApolloLogger logger) {
@@ -77,7 +77,7 @@ public final class ApolloParseInterceptor implements ApolloInterceptor {
     disposed = true;
   }
 
-  @SuppressWarnings("unchecked") private InterceptorResponse parse(Operation operation, okhttp3.Response httpResponse)
+  @SuppressWarnings("unchecked") InterceptorResponse parse(Operation operation, okhttp3.Response httpResponse)
       throws ApolloHttpException, ApolloParseException {
     String cacheKey = httpResponse.request().header(HttpCache.CACHE_KEY_HEADER);
     if (httpResponse.isSuccessful()) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -107,7 +107,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     this.httpCall = null;
   }
 
-  private Call httpCall(Operation operation) throws IOException {
+  Call httpCall(Operation operation) throws IOException {
     RequestBody requestBody = httpRequestBody(operation);
     Request.Builder requestBuilder = new Request.Builder()
         .url(serverUrl)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/ResponseJsonStreamReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/ResponseJsonStreamReader.java
@@ -142,11 +142,11 @@ public class ResponseJsonStreamReader {
     return result;
   }
 
-  private boolean isNextObject() throws IOException {
+  boolean isNextObject() throws IOException {
     return jsonReader.peek() == JsonReader.Token.BEGIN_OBJECT;
   }
 
-  private boolean isNextList() throws IOException {
+  boolean isNextList() throws IOException {
     return jsonReader.peek() == JsonReader.Token.BEGIN_ARRAY;
   }
 
@@ -168,7 +168,7 @@ public class ResponseJsonStreamReader {
     }
   }
 
-  private Map<String, Object> readObject(final ResponseJsonStreamReader streamReader) throws IOException {
+  Map<String, Object> readObject(final ResponseJsonStreamReader streamReader) throws IOException {
     return streamReader.nextObject(false, new ObjectReader<Map<String, Object>>() {
       @Override public Map<String, Object> read(ResponseJsonStreamReader streamReader) throws IOException {
         return streamReader.toMap();
@@ -176,7 +176,7 @@ public class ResponseJsonStreamReader {
     });
   }
 
-  private List<?> readList(final ResponseJsonStreamReader streamReader) throws IOException {
+  List<?> readList(final ResponseJsonStreamReader streamReader) throws IOException {
     return streamReader.nextList(false, new ListReader<Object>() {
       @Override public Object read(ResponseJsonStreamReader reader) throws IOException {
         if (streamReader.isNextList()) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
@@ -16,11 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("WeakerAccess") public final class RealResponseReader<R> implements ResponseReader {
-  private final Operation.Variables operationVariables;
+  final Operation.Variables operationVariables;
   private final R recordSet;
-  private final com.apollographql.apollo.response.ScalarTypeAdapters scalarTypeAdapters;
-  private final FieldValueResolver<R> fieldValueResolver;
-  private final ResolveDelegate<R> resolveDelegate;
+  final com.apollographql.apollo.response.ScalarTypeAdapters scalarTypeAdapters;
+  final FieldValueResolver<R> fieldValueResolver;
+  final ResolveDelegate<R> resolveDelegate;
   private final Map<String, Object> variableValues;
 
   public RealResponseReader(Operation.Variables operationVariables, R recordSet,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -22,10 +22,10 @@ import okio.BufferedSource;
 import static com.apollographql.apollo.internal.json.ApolloJsonReader.responseJsonStreamReader;
 
 public final class OperationResponseParser<D extends Operation.Data, W> {
-  private final Operation<D, W, ?> operation;
-  private final ResponseFieldMapper responseFieldMapper;
-  private final ScalarTypeAdapters scalarTypeAdapters;
-  private final ResponseNormalizer<Map<String, Object>> responseNormalizer;
+  final Operation<D, W, ?> operation;
+  final ResponseFieldMapper responseFieldMapper;
+  final ScalarTypeAdapters scalarTypeAdapters;
+  final ResponseNormalizer<Map<String, Object>> responseNormalizer;
 
   @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D, W, ?> operation,
       ResponseFieldMapper responseFieldMapper, ScalarTypeAdapters scalarTypeAdapters) {
@@ -93,7 +93,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
     });
   }
 
-  @SuppressWarnings("unchecked") private Error readError(ResponseJsonStreamReader reader) throws IOException {
+  @SuppressWarnings("unchecked") Error readError(ResponseJsonStreamReader reader) throws IOException {
     String message = null;
     final List<Error.Location> locations = new ArrayList<>();
     final Map<String, Object> customAttributes = new HashMap<>();

--- a/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -158,7 +158,7 @@ public final class RxApollo {
     });
   }
 
-  private static Subscription getSubscription(CompletableSubscriber subscriber, final Cancelable cancelable) {
+  static Subscription getSubscription(CompletableSubscriber subscriber, final Cancelable cancelable) {
     Subscription subscription = Subscriptions.create(new Action0() {
       @Override public void call() {
         cancelable.cancel();

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -132,11 +132,11 @@ public class Rx2Apollo {
     });
   }
 
-  private static void cancelOnCompletableDisposed(CompletableEmitter emitter, final Cancelable cancelable) {
+  static void cancelOnCompletableDisposed(CompletableEmitter emitter, final Cancelable cancelable) {
     emitter.setDisposable(getRx2Disposable(cancelable));
   }
 
-  private static <T> void cancelOnObservableDisposed(ObservableEmitter<T> emitter, final Cancelable cancelable) {
+  static <T> void cancelOnObservableDisposed(ObservableEmitter<T> emitter, final Cancelable cancelable) {
     emitter.setDisposable(getRx2Disposable(cancelable));
   }
 

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
@@ -27,7 +27,7 @@ import io.reactivex.schedulers.Schedulers;
 
 public class GitHuntEntryDetailActivity extends AppCompatActivity {
 
-  private static final String TAG = GitHuntEntryDetailActivity.class.getSimpleName();
+  static final String TAG = GitHuntEntryDetailActivity.class.getSimpleName();
   private static final String ARG_REPOSITORY_FULL_NAME = "arg_repo_full_name";
 
   private GitHuntApplication application;
@@ -75,7 +75,7 @@ public class GitHuntEntryDetailActivity extends AppCompatActivity {
     }
   }
 
-  private void setEntryData(EntryDetailQuery.Data data) {
+  void setEntryData(EntryDetailQuery.Data data) {
     content.setVisibility(View.VISIBLE);
     progressBar.setVisibility(View.GONE);
 

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/feed/GitHuntFeedActivity.java
@@ -33,7 +33,7 @@ import static com.apollographql.apollo.sample.FeedQuery.FeedEntry;
 
 public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNavigator {
 
-  private static final String TAG = GitHuntFeedActivity.class.getSimpleName();
+  static final String TAG = GitHuntFeedActivity.class.getSimpleName();
 
   private static final int FEED_SIZE = 20;
 
@@ -74,7 +74,7 @@ public class GitHuntFeedActivity extends AppCompatActivity implements GitHuntNav
     }
   }, uiHandler);
 
-  private List<FeedEntry> feedResponseToEntriesWithRepositories(Response<FeedQuery.Data> response) {
+  List<FeedEntry> feedResponseToEntriesWithRepositories(Response<FeedQuery.Data> response) {
     List<FeedEntry> feedEntriesWithRepos = new ArrayList<>();
     final FeedQuery.Data responseData = response.data();
     if (responseData == null) {


### PR DESCRIPTION
Closes #741 

Also I believe it would be a good idea to create an annotation `@VisibleToAvoidSynthetics`, something similar to the `@Thunk` used in AOSP ([here](https://android.googlesource.com/platform/packages/apps/Launcher3/+/master/src/com/android/launcher3/util/Thunk.java)) and use it for all the members whose visibility has been changed in this PR. This would prevent accidentally changing their visibility back to private in future. 

Is this something that should be added as well?  