### PR TITLE
Add the way to dump normalized cache

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCache.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -156,5 +157,50 @@ public abstract class NormalizedCache {
 
   public final Optional<NormalizedCache> nextCache() {
     return nextCache;
+  }
+
+  public Map<Class, Map<String, Record>> dump() {
+    Class clazz = this.getClass();
+    return Collections.singletonMap(clazz, Collections.<String, Record>emptyMap());
+  }
+
+  public static String prettifyDump(Map<Class, Map<String, Record>> dump) {
+    StringBuilder builder = new StringBuilder();
+    for (Map.Entry<Class, Map<String, Record>> dumpEntry : dump.entrySet()) {
+      builder.append(dumpEntry.getKey().getSimpleName())
+          .append(" {");
+      for (Map.Entry<String, Record> recordEntry : dumpEntry.getValue().entrySet()) {
+        builder
+            .append("\n  \"")
+            .append(recordEntry.getKey())
+            .append("\" : {");
+        for (Map.Entry<String, Object> fieldEntry : recordEntry.getValue().fields().entrySet()) {
+          builder
+              .append("\n    \"")
+              .append(fieldEntry.getKey())
+              .append("\" : ");
+          if (fieldEntry.getValue() instanceof CacheReference) {
+            builder.append("CacheRecordRef(")
+                .append(fieldEntry.getValue())
+                .append(")");
+          } else if (fieldEntry.getValue() instanceof List) {
+            builder.append("[");
+            for (Object item : (List) fieldEntry.getValue()) {
+              builder
+                  .append("\n      ")
+                  .append(item instanceof CacheReference ? "CacheRecordRef(" : "")
+                  .append(item)
+                  .append(item instanceof CacheReference ? ")" : "");
+            }
+            builder.append("\n    ]");
+          } else {
+            builder.append(fieldEntry.getValue());
+          }
+        }
+        builder.append("\n  }\n");
+      }
+      builder.append("}\n");
+    }
+    return builder.toString();
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/OptimisticNormalizedCache.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -122,6 +123,20 @@ public final class OptimisticNormalizedCache extends NormalizedCache {
   @Nonnull @Override
   protected Set<String> performMerge(@Nonnull Record apolloRecord, @Nonnull CacheHeaders cacheHeaders) {
     return Collections.emptySet();
+  }
+
+  @Override public Map<Class, Map<String, Record>> dump() {
+    Map<String, Record> records = new LinkedHashMap<>();
+    for (Map.Entry<String, RecordJournal> entry : lruCache.asMap().entrySet()) {
+      records.put(entry.getKey(), entry.getValue().snapshot);
+    }
+
+    Map<Class, Map<String, Record>> dump = new LinkedHashMap<>();
+    dump.put(this.getClass(), Collections.unmodifiableMap(records));
+    if (nextCache().isPresent()) {
+      dump.putAll(nextCache().get().dump());
+    }
+    return dump;
   }
 
   private static final class RecordJournal {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -96,6 +96,13 @@ public final class Record {
     return toBuilder().build();
   }
 
+  @Override public String toString() {
+    return "Record{"
+        + "key='" + key + '\''
+        + ", fields=" + fields
+        + '}';
+  }
+
   /**
    * @param otherRecord The record to merge into this record.
    * @return A set of field keys which have changed, or were added. A field key incorporates any GraphQL arguments in

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
@@ -14,6 +14,8 @@ import com.nytimes.android.external.cache.Weigher;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -123,5 +125,14 @@ public final class LruNormalizedCache extends NormalizedCache {
       lruCache.put(apolloRecord.key(), oldRecord);
       return changedKeys;
     }
+  }
+
+  @Override public Map<Class, Map<String, Record>> dump() {
+    Map<Class, Map<String, Record>> dump = new LinkedHashMap<>();
+    dump.put(this.getClass(), Collections.unmodifiableMap(new LinkedHashMap<>(lruCache.asMap())));
+    if (nextCache().isPresent()) {
+      dump.putAll(nextCache().get().dump());
+    }
+    return dump;
   }
 }


### PR DESCRIPTION
For testing purpose normalized cache should have the way to dump the cached record.
SQL normalized cache always returns empty dump for now as db file  can be easily loaded from the device and explored.

Closes https://github.com/apollographql/apollo-android/issues/824