### PR TITLE
Format cache keys as sorted json structure (cross platform cache sharing)

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
@@ -169,7 +169,7 @@ public class ResponseField {
    *
    * @param responseName     alias for the result of a field
    * @param fieldName        name of the field in the GraphQL operation
-   * @param conditionalTypes conditional GraphQL types
+   * @param typeConditions conditional GraphQL types
    * @return Field instance representing {@link Type#FRAGMENT}
    */
   public static ResponseField forFragment(String responseName, String fieldName, List<String> typeConditions) {
@@ -186,7 +186,7 @@ public class ResponseField {
    *
    * @param responseName     alias for the result of a field
    * @param fieldName        name of the field in the GraphQL operation
-   * @param conditionalTypes conditional GraphQL types
+   * @param typeConditions conditional GraphQL types
    * @return Field instance representing {@link Type#INLINE_FRAGMENT}
    */
   public static ResponseField forInlineFragment(String responseName, String fieldName, List<String> typeConditions) {
@@ -277,28 +277,45 @@ public class ResponseField {
       }
     });
     StringBuilder independentKey = new StringBuilder();
+    independentKey.append("{");
     for (int i = 0; i < sortedArguments.size(); i++) {
       Map.Entry<String, Object> argument = sortedArguments.get(i);
       if (argument.getValue() instanceof Map) {
         //noinspection unchecked
         final Map<String, Object> objectArg = (Map<String, Object>) argument.getValue();
-        boolean isArgumentVariable = isArgumentValueVariableType(objectArg);
         independentKey
+            .append("\"")
             .append(argument.getKey())
-            .append(":")
-            .append(isArgumentVariable ? "" : "[")
-            .append(orderIndependentKey(objectArg, variables))
-            .append(isArgumentVariable ? "" : "]");
+            .append("\":")
+            .append(orderIndependentKey(objectArg, variables));
       } else {
-        independentKey.append(argument.getKey())
-            .append(":")
-            .append(argument.getValue().toString());
+        independentKey
+            .append("\"")
+            .append(argument.getKey())
+            .append("\":")
+            .append(asJsonValue(argument.getValue()));
       }
       if (i < sortedArguments.size() - 1) {
         independentKey.append(",");
       }
     }
+    independentKey.append("}");
     return independentKey.toString();
+  }
+
+  private String asJsonValue(Object o) {
+    if (o instanceof Boolean ||
+        o instanceof Byte ||
+        o instanceof Character ||
+        o instanceof Double ||
+        o instanceof Float ||
+        o instanceof Integer ||
+        o instanceof Long ||
+        o instanceof Short) {
+      return o.toString();
+    } else {
+      return "\"" + o.toString() + "\"";
+    }
   }
 
   private boolean isArgumentValueVariableType(Map<String, Object> objectMap) {
@@ -317,7 +334,7 @@ public class ResponseField {
       //noinspection unchecked
       return orderIndependentKey((Map<String, Object>) resolvedVariable, variables);
     } else {
-      return resolvedVariable.toString();
+      return asJsonValue(resolvedVariable);
     }
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
@@ -167,8 +167,8 @@ public class ResponseField {
   /**
    * Factory method for creating a Field instance representing {@link Type#FRAGMENT}.
    *
-   * @param responseName     alias for the result of a field
-   * @param fieldName        name of the field in the GraphQL operation
+   * @param responseName   alias for the result of a field
+   * @param fieldName      name of the field in the GraphQL operation
    * @param typeConditions conditional GraphQL types
    * @return Field instance representing {@link Type#FRAGMENT}
    */
@@ -184,8 +184,8 @@ public class ResponseField {
   /**
    * Factory method for creating a Field instance representing {@link Type#INLINE_FRAGMENT}.
    *
-   * @param responseName     alias for the result of a field
-   * @param fieldName        name of the field in the GraphQL operation
+   * @param responseName   alias for the result of a field
+   * @param fieldName      name of the field in the GraphQL operation
    * @param typeConditions conditional GraphQL types
    * @return Field instance representing {@link Type#INLINE_FRAGMENT}
    */
@@ -304,14 +304,14 @@ public class ResponseField {
   }
 
   private String asJsonValue(Object o) {
-    if (o instanceof Boolean ||
-        o instanceof Byte ||
-        o instanceof Character ||
-        o instanceof Double ||
-        o instanceof Float ||
-        o instanceof Integer ||
-        o instanceof Long ||
-        o instanceof Short) {
+    if (o instanceof Boolean
+        || o instanceof Byte
+        || o instanceof Character
+        || o instanceof Double
+        || o instanceof Float
+        || o instanceof Integer
+        || o instanceof Long
+        || o instanceof Short) {
       return o.toString();
     } else {
       return "\"" + o.toString() + "\"";

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ResponseField.java
@@ -304,14 +304,7 @@ public class ResponseField {
   }
 
   private String asJsonValue(Object o) {
-    if (o instanceof Boolean
-        || o instanceof Byte
-        || o instanceof Character
-        || o instanceof Double
-        || o instanceof Float
-        || o instanceof Integer
-        || o instanceof Long
-        || o instanceof Short) {
+    if (o instanceof Boolean || o instanceof Number) {
       return o.toString();
     } else {
       return "\"" + o.toString() + "\"";

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/CacheKeyForFieldTest.java
@@ -22,7 +22,8 @@ public class CacheKeyForFieldTest {
 
   @Test
   public void testFieldWithNoArguments() {
-    ResponseField field = createResponseField("hero", "hero");
+    ResponseField field = ResponseField.forString("hero", "hero", null, false,
+        Collections.<ResponseField.Condition>emptyList());
     Operation.Variables variables = new Operation.Variables() {
       @Nonnull @Override public Map<String, Object> valueMap() {
         return super.valueMap();
@@ -33,7 +34,8 @@ public class CacheKeyForFieldTest {
 
   @Test
   public void testFieldWithNoArgumentsWithAlias() {
-    ResponseField field = createResponseField("r2", "hero");
+    ResponseField field = ResponseField.forString("r2", "hero", null, false,
+        Collections.<ResponseField.Condition>emptyList());
     Operation.Variables variables = new Operation.Variables() {
       @Nonnull @Override public Map<String, Object> valueMap() {
         return super.valueMap();

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/CacheKeyForFieldTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/graphql/CacheKeyForFieldTest.java
@@ -55,7 +55,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":\"JEDI\"})");
   }
 
   @Test
@@ -71,7 +71,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":\"JEDI\"})");
   }
 
   @Test
@@ -92,7 +92,7 @@ public class CacheKeyForFieldTest {
         return map;
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI)");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":\"JEDI\"})");
   }
 
   @Test
@@ -113,7 +113,7 @@ public class CacheKeyForFieldTest {
         return map;
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:null)");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":null})");
   }
 
   @Test
@@ -130,7 +130,7 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(color:blue,episode:JEDI)");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"color\":\"blue\",\"episode\":\"JEDI\"})");
   }
 
   @Test
@@ -175,7 +175,22 @@ public class CacheKeyForFieldTest {
         return super.valueMap();
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI,nested:[bar:2,foo:1])");
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":\"JEDI\",\"nested\":{\"bar\":2,\"foo\":1}})");
+  }
+
+  @Test
+  public void testFieldWithNonPrimitiveValue() {
+    //noinspection unchecked
+    ResponseField field = ResponseField.forString("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
+        .put("episode", Episode.JEDI)
+        .build(), false, Collections.<ResponseField.Condition>emptyList());
+
+    Operation.Variables variables = new Operation.Variables() {
+      @Nonnull @Override public Map<String, Object> valueMap() {
+        return super.valueMap();
+      }
+    };
+    assertThat(field.cacheKey(variables)).isEqualTo("hero({\"episode\":\"JEDI\"})");
   }
 
   @Test
@@ -200,7 +215,8 @@ public class CacheKeyForFieldTest {
         return map;
       }
     };
-    assertThat(field.cacheKey(variables)).isEqualTo("hero(episode:JEDI,nested:[bar:2,foo:1])");
+    assertThat(field.cacheKey(variables)).isEqualTo(
+        "hero({\"episode\":\"JEDI\",\"nested\":{\"bar\":\"2\",\"foo\":1}})");
   }
 
   private ResponseField createResponseField(String responseName, String fieldName) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NormalizedCacheTestCase.java
@@ -788,7 +788,7 @@ public class NormalizedCacheTestCase {
         "  }\n" +
         "\n" +
         "  \"QUERY_ROOT\" : {\n" +
-        "    \"hero(episode:NEWHOPE)\" : CacheRecordRef(2001)\n" +
+        "    \"hero({\"episode\":\"NEWHOPE\"})\" : CacheRecordRef(2001)\n" +
         "  }\n" +
         "\n" +
         "  \"1003\" : {\n" +

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseNormalizationTest.java
@@ -44,6 +44,8 @@ public class ResponseNormalizationTest {
   @Rule public final MockWebServer server = new MockWebServer();
   private NormalizedCache normalizedCache;
 
+  private static final String TEST_FIELD_KEY_JEDI = "hero({\"episode\":\"JEDI\"})";
+  public static final String TEST_FIELD_KEY_EMPIRE = "hero({\"episode\":\"EMPIRE\"})";
   private final String QUERY_ROOT_KEY = "QUERY_ROOT";
 
   @Before public void setUp() {
@@ -91,8 +93,8 @@ public class ResponseNormalizationTest {
     assertHasNoErrors("EpisodeHeroNameResponse.json", new EpisodeHeroNameQuery(Input.fromNullable(JEDI)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference reference = (CacheReference) record.field("hero(episode:JEDI)");
-    assertThat(reference).isEqualTo(new CacheReference("hero(episode:JEDI)"));
+    CacheReference reference = (CacheReference) record.field(TEST_FIELD_KEY_JEDI);
+    assertThat(reference).isEqualTo(new CacheReference(TEST_FIELD_KEY_JEDI));
 
     final Record heroRecord = normalizedCache.loadRecord(reference.key(), CacheHeaders.NONE);
     assertThat(heroRecord.field("name")).isEqualTo("R2-D2");
@@ -116,19 +118,20 @@ public class ResponseNormalizationTest {
     assertHasNoErrors("HeroAndFriendsNameResponse.json", new HeroAndFriendsNamesQuery(Input.fromNullable(JEDI)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:JEDI)");
-    assertThat(heroReference).isEqualTo(new CacheReference("hero(episode:JEDI)"));
+
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_JEDI);
+    assertThat(heroReference).isEqualTo(new CacheReference(TEST_FIELD_KEY_JEDI));
 
     final Record heroRecord = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
     assertThat(heroRecord.field("name")).isEqualTo("R2-D2");
 
     assertThat(heroRecord.field("friends")).isEqualTo(Arrays.asList(
-        new CacheReference("hero(episode:JEDI).friends.0"),
-        new CacheReference("hero(episode:JEDI).friends.1"),
-        new CacheReference("hero(episode:JEDI).friends.2")
+        new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.0"),
+        new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.1"),
+        new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.2")
     ));
 
-    final Record luke = normalizedCache.loadRecord("hero(episode:JEDI).friends.0", CacheHeaders.NONE);
+    final Record luke = normalizedCache.loadRecord(TEST_FIELD_KEY_JEDI + ".friends.0", CacheHeaders.NONE);
     assertThat(luke.field("name")).isEqualTo("Luke Skywalker");
   }
 
@@ -137,7 +140,7 @@ public class ResponseNormalizationTest {
     assertHasNoErrors("HeroAndFriendsNameWithIdsResponse.json", new HeroAndFriendsNamesWithIDsQuery(Input.fromNullable(JEDI)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:JEDI)");
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_JEDI);
     assertThat(heroReference).isEqualTo(new CacheReference("2001"));
 
     final Record heroRecord = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
@@ -159,7 +162,7 @@ public class ResponseNormalizationTest {
         new HeroAndFriendsNamesWithIDForParentOnlyQuery(Input.fromNullable(JEDI)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:JEDI)");
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_JEDI);
     assertThat(heroReference).isEqualTo(new CacheReference("2001"));
 
     final Record heroRecord = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
@@ -194,7 +197,7 @@ public class ResponseNormalizationTest {
         new HeroTypeDependentAliasedFieldQuery(Input.fromNullable(JEDI)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:JEDI)");
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_JEDI);
 
     final Record hero = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
     assertThat(hero.field("primaryFunction")).isEqualTo("Astromech");
@@ -207,7 +210,7 @@ public class ResponseNormalizationTest {
         new HeroTypeDependentAliasedFieldQuery(Input.fromNullable(EMPIRE)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:EMPIRE)");
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_EMPIRE);
 
     final Record hero = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
     assertThat(hero.field("homePlanet")).isEqualTo("Tatooine");
@@ -220,7 +223,7 @@ public class ResponseNormalizationTest {
         new HeroTypeDependentAliasedFieldQuery(Input.fromNullable(EMPIRE)));
 
     Record record = normalizedCache.loadRecord(QUERY_ROOT_KEY, CacheHeaders.NONE);
-    CacheReference heroReference = (CacheReference) record.field("hero(episode:EMPIRE)");
+    CacheReference heroReference = (CacheReference) record.field(TEST_FIELD_KEY_EMPIRE);
 
     final Record hero = normalizedCache.loadRecord(heroReference.key(), CacheHeaders.NONE);
     assertThat(hero.field("homePlanet")).isEqualTo("Tatooine");
@@ -233,15 +236,15 @@ public class ResponseNormalizationTest {
         new HeroParentTypeDependentFieldQuery(Input.fromNullable(JEDI)));
 
     Record lukeRecord = normalizedCache
-        .loadRecord("hero(episode:JEDI).friends.0", CacheHeaders.NONE);
+        .loadRecord(TEST_FIELD_KEY_JEDI + ".friends.0", CacheHeaders.NONE);
     assertThat(lukeRecord.field("name")).isEqualTo("Luke Skywalker");
-    assertThat(lukeRecord.field("height(unit:METER)")).isEqualTo(BigDecimal.valueOf(1.72));
+    assertThat(lukeRecord.field("height({\"unit\":\"METER\"})")).isEqualTo(BigDecimal.valueOf(1.72));
 
     final List<Object> friends = (List<Object>) normalizedCache
-        .loadRecord("hero(episode:JEDI)", CacheHeaders.NONE).field("friends");
-    assertThat(friends.get(0)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.0"));
-    assertThat(friends.get(1)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.1"));
-    assertThat(friends.get(2)).isEqualTo(new CacheReference("hero(episode:JEDI).friends.2"));
+        .loadRecord(TEST_FIELD_KEY_JEDI, CacheHeaders.NONE).field("friends");
+    assertThat(friends.get(0)).isEqualTo(new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.0"));
+    assertThat(friends.get(1)).isEqualTo(new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.1"));
+    assertThat(friends.get(2)).isEqualTo(new CacheReference(TEST_FIELD_KEY_JEDI + ".friends.2"));
   }
 
   @Test
@@ -250,24 +253,25 @@ public class ResponseNormalizationTest {
         new HeroParentTypeDependentFieldQuery(Input.fromNullable(EMPIRE)));
 
     Record lukeRecord = normalizedCache
-        .loadRecord("hero(episode:EMPIRE).friends.0", CacheHeaders.NONE);
+        .loadRecord(TEST_FIELD_KEY_EMPIRE + ".friends.0", CacheHeaders.NONE);
     assertThat(lukeRecord.field("name")).isEqualTo("Han Solo");
-    assertThat(lukeRecord.field("height(unit:FOOT)")).isEqualTo(BigDecimal.valueOf(5.905512));
+    assertThat(lukeRecord.field("height({\"unit\":\"FOOT\"})")).isEqualTo(BigDecimal.valueOf(5.905512));
   }
 
   @Test public void list_of_objects_with_null_object() throws Exception {
     assertHasNoErrors("AllPlanetsListOfObjectWithNullObject.json", new AllPlanetsQuery());
 
+    String fieldKey = "allPlanets({\"first\":\"300.0\"})";
     Record record = normalizedCache
-        .loadRecord("allPlanets(first:300.0).planets.0", CacheHeaders.NONE);
+        .loadRecord(fieldKey + ".planets.0", CacheHeaders.NONE);
     assertThat(record.field("filmConnection")).isNull();
 
     record = normalizedCache
-        .loadRecord("allPlanets(first:300.0).planets.0.filmConnection", CacheHeaders.NONE);
+        .loadRecord(fieldKey + ".planets.0.filmConnection", CacheHeaders.NONE);
     assertThat(record).isNull();
 
     record = normalizedCache
-        .loadRecord("allPlanets(first:300.0).planets.1.filmConnection", CacheHeaders.NONE);
+        .loadRecord(fieldKey + ".planets.1.filmConnection", CacheHeaders.NONE);
     assertThat(record).isNotNull();
   }
 


### PR DESCRIPTION
We have been working on sharing cache between android and react-native in a hybrid app but had some issues with different client libraries having separate approaches.There are some critical differences between `apollo-client` and `apollo-android` in terms of how they handle **CacheKey** in normalized cache. This PR aims to fix this issue by converting android cache key notation to json standards.

Apollo Client (JS) uses json notation while naming their cache keys in store, whereas apollo-android has its own structure without curly brackets or quotes. 

**Sample:**
apollo-client:
`hero({"color":"blue","episode":"JEDI"})`

apollo-android:
`hero(color:blue,episode:JEDI)`

With this PR, both platforms generates the cache key in the same manner. See updated tests for the new cache key formats.

cc @fourlastor who worked with me on this