### PR TITLE
Encode / decode custom type to JSON supported types.

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputFieldWriter.java
@@ -13,6 +13,8 @@ public interface InputFieldWriter {
 
   void writeDouble(@Nonnull String fieldName, Double value) throws IOException;
 
+  void writeNumber(@Nonnull String fieldName, Number value) throws IOException;
+
   void writeBoolean(@Nonnull String fieldName, Boolean value) throws IOException;
 
   void writeCustom(@Nonnull String fieldName, ScalarType scalarType, Object value) throws IOException;
@@ -33,6 +35,8 @@ public interface InputFieldWriter {
     void writeLong(Long value) throws IOException;
 
     void writeDouble(Double value) throws IOException;
+
+    void writeNumber(Number value) throws IOException;
 
     void writeBoolean(Boolean value) throws IOException;
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -12,6 +12,8 @@ import com.apollographql.apollo.integration.httpcache.AllPlanetsQuery;
 import com.apollographql.apollo.integration.httpcache.DroidDetailsQuery;
 import com.apollographql.apollo.integration.httpcache.type.CustomType;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 
 import org.junit.After;
@@ -53,16 +55,16 @@ public class HttpCacheTest {
 
   @Before public void setUp() {
     CustomTypeAdapter<Date> dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
-      @Override public Date decode(String value) {
+      @Override public Date decode(CustomTypeValue value) {
         try {
-          return DATE_FORMAT.parse(value);
+          return DATE_FORMAT.parse(value.value.toString());
         } catch (ParseException e) {
           throw new RuntimeException(e);
         }
       }
 
-      @Override public String encode(Date value) {
-        return DATE_FORMAT.format(value);
+      @Override public CustomTypeValue encode(Date value) {
+        return new CustomTypeValue.GraphQLString(DATE_FORMAT.format(value));
       }
     };
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -17,6 +17,8 @@ import com.apollographql.apollo.integration.httpcache.type.CustomType;
 import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery;
 import com.apollographql.apollo.integration.normalizer.HeroNameQuery;
 import com.apollographql.apollo.internal.json.JsonWriter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.response.OperationJsonWriter;
 import com.apollographql.apollo.response.OperationResponseParser;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
@@ -64,16 +66,16 @@ public class IntegrationTest {
 
   @Before public void setUp() {
     dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
-      @Override public Date decode(String value) {
+      @Override public Date decode(CustomTypeValue value) {
         try {
-          return DATE_FORMAT.parse(value);
+          return DATE_FORMAT.parse(value.value.toString());
         } catch (ParseException e) {
           throw new RuntimeException(e);
         }
       }
 
-      @Override public String encode(Date value) {
-        return DATE_FORMAT.format(value);
+      @Override public CustomTypeValue encode(Date value) {
+        return new CustomTypeValue.GraphQLString(DATE_FORMAT.format(value));
       }
     };
 
@@ -246,7 +248,7 @@ public class IntegrationTest {
                 .transform(new Function<AllFilmsQuery.Film, String>() {
                   @Override public String apply(AllFilmsQuery.Film film) {
                     Date releaseDate = film.releaseDate();
-                    return dateCustomTypeAdapter.encode(releaseDate);
+                    return dateCustomTypeAdapter.encode(releaseDate).value.toString();
                   }
                 }).copyInto(new ArrayList<String>());
             assertThat(dates).isEqualTo(Arrays.asList("1977-05-25", "1980-05-17", "1983-05-25", "1999-05-19",

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ResponseWriteTestCase.java
@@ -16,6 +16,8 @@ import com.apollographql.apollo.integration.normalizer.fragment.HeroWithFriendsF
 import com.apollographql.apollo.integration.normalizer.fragment.HumanWithIdFragment;
 import com.apollographql.apollo.integration.normalizer.type.CustomType;
 import com.apollographql.apollo.integration.normalizer.type.Episode;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeValue;
 
 import org.junit.After;
 import org.junit.Before;
@@ -56,16 +58,16 @@ public class ResponseWriteTestCase {
         .normalizedCache(new LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION), new IdFieldCacheKeyResolver())
         .dispatcher(Utils.immediateExecutor())
         .addCustomTypeAdapter(CustomType.DATE, new CustomTypeAdapter<Date>() {
-          @Override public Date decode(String value) {
+          @Override public Date decode(CustomTypeValue value) {
             try {
-              return DATE_TIME_FORMAT.parse(value);
+              return DATE_TIME_FORMAT.parse(value.value.toString());
             } catch (ParseException e) {
               throw new RuntimeException(e);
             }
           }
 
-          @Override public String encode(Date value) {
-            return DATE_TIME_FORMAT.format(value);
+          @Override public CustomTypeValue encode(Date value) {
+            return new CustomTypeValue.GraphQLString(DATE_TIME_FORMAT.format(value));
           }
         })
         .build();

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo.internal.interceptor;
 
 import com.google.common.base.Predicate;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.Logger;
 import com.apollographql.apollo.api.Input;
 import com.apollographql.apollo.api.ScalarType;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -29,6 +29,7 @@ import com.apollographql.apollo.internal.cache.normalized.RealApolloStore;
 import com.apollographql.apollo.internal.subscription.NoOpSubscriptionManager;
 import com.apollographql.apollo.internal.subscription.RealSubscriptionManager;
 import com.apollographql.apollo.internal.subscription.SubscriptionManager;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.subscription.SubscriptionTransport;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCacheFactory.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/NormalizedCacheFactory.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.cache.normalized;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Function;
 import com.apollographql.apollo.api.internal.Optional;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
@@ -1,13 +1,13 @@
 package com.apollographql.apollo.internal.response;
 
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.internal.field.FieldValueResolver;
-import com.apollographql.apollo.internal.json.Utils;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.math.BigDecimal;
@@ -190,7 +190,7 @@ import java.util.Map;
       result = null;
     } else {
       CustomTypeAdapter<T> typeAdapter = scalarTypeAdapters.adapterFor(field.scalarType());
-      result = typeAdapter.decode(normalizeCustomTypeValue(value));
+      result = typeAdapter.decode(CustomTypeValue.fromRawValue(value));
       checkValue(field, result);
       resolveDelegate.didResolveScalar(value);
     }
@@ -264,18 +264,6 @@ import java.util.Map;
     }
   }
 
-  @SuppressWarnings("unchecked") private static String normalizeCustomTypeValue(Object value) {
-    if (value instanceof Map || value instanceof List) {
-      try {
-        return Utils.toJsonString(value);
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    } else {
-      return value.toString();
-    }
-  }
-
   private class ListItemReader implements ResponseReader.ListItemReader {
     private final ResponseField field;
     private final Object value;
@@ -314,7 +302,7 @@ import java.util.Map;
     @Override public <T> T readCustomType(ScalarType scalarType) {
       CustomTypeAdapter<T> typeAdapter = scalarTypeAdapters.adapterFor(scalarType);
       resolveDelegate.didResolveScalar(value);
-      return typeAdapter.decode(normalizeCustomTypeValue(value));
+      return typeAdapter.decode(CustomTypeValue.fromRawValue(value));
     }
 
     @SuppressWarnings("unchecked")

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.response;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
@@ -48,9 +48,10 @@ public final class RealResponseWriter implements ResponseWriter {
     writeScalarFieldValue(field, value);
   }
 
+  @SuppressWarnings("unchecked")
   @Override public void writeCustom(@Nonnull ResponseField.CustomTypeField field, @Nullable Object value) {
     CustomTypeAdapter typeAdapter = scalarTypeAdapters.adapterFor(field.scalarType());
-    writeScalarFieldValue(field, value != null ? typeAdapter.encode(value) : null);
+    writeScalarFieldValue(field, value != null ? typeAdapter.encode(value).value : null);
   }
 
   @Override public void writeObject(@Nonnull ResponseField field, @Nullable ResponseFieldMarshaller marshaller) {
@@ -248,7 +249,7 @@ public final class RealResponseWriter implements ResponseWriter {
 
     @Override public void writeCustom(@Nonnull ScalarType scalarType, @Nullable Object value) {
       CustomTypeAdapter typeAdapter = scalarTypeAdapters.adapterFor(scalarType);
-      this.value = value != null ? typeAdapter.encode(value) : null;
+      this.value = value != null ? typeAdapter.encode(value).value : null;
     }
 
     @Override public void writeObject(ResponseFieldMarshaller marshaller) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeAdapter.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo;
+package com.apollographql.apollo.response;
 
 import javax.annotation.Nonnull;
 
@@ -67,7 +67,7 @@ public interface CustomTypeAdapter<T> {
    * @param value the value to de-serialize
    * @return custom scalar type
    */
-  T decode(@Nonnull String value);
+  T decode(@Nonnull CustomTypeValue value);
 
   /**
    * Serializes the custom scalar type to the corresponding string value. Usually used in serializing variables or input
@@ -76,5 +76,5 @@ public interface CustomTypeAdapter<T> {
    * @param value the custom scalar type to serialize
    * @return serialized string value
    */
-  @Nonnull String encode(@Nonnull T value);
+  @Nonnull CustomTypeValue encode(@Nonnull T value);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeValue.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeValue.java
@@ -1,0 +1,73 @@
+package com.apollographql.apollo.response;
+
+import com.apollographql.apollo.internal.json.Utils;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A wrapper class for representation of custom GraphQL type value, used in user provided {@link CustomTypeAdapter}
+ * encoding / decoding functions.
+ *
+ * @param <T> value type, one of the supported types <ul><li>{@link java.lang.String} <li>{@link
+ *            java.lang.Boolean}<li>{@link java.lang.Number}<li>{@link Map}<li>{@link List}<ul/>
+ */
+public abstract class CustomTypeValue<T> {
+  public final T value;
+
+  public static CustomTypeValue fromRawValue(Object value) {
+    if (value instanceof Map || value instanceof List) {
+      try {
+        return new GraphQLJsonString(Utils.toJsonString(value));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else if (value instanceof java.lang.Boolean) {
+      return new GraphQLBoolean((java.lang.Boolean) value);
+    } else if (value instanceof java.lang.Number) {
+      return new GraphQLNumber((java.lang.Number) value);
+    } else {
+      return new GraphQLString(value.toString());
+    }
+  }
+
+  private CustomTypeValue(T value) {
+    this.value = value;
+  }
+
+  /**
+   * Represents a {@code String} value
+   */
+  public static class GraphQLString extends CustomTypeValue<java.lang.String> {
+    public GraphQLString(java.lang.String value) {
+      super(value);
+    }
+  }
+
+  /**
+   * Represents a {@code Boolean} value
+   */
+  public static class GraphQLBoolean extends CustomTypeValue<java.lang.Boolean> {
+    public GraphQLBoolean(java.lang.Boolean value) {
+      super(value);
+    }
+  }
+
+  /**
+   * Represents a {@code Number} value
+   */
+  public static class GraphQLNumber extends CustomTypeValue<java.lang.Number> {
+    public GraphQLNumber(java.lang.Number value) {
+      super(value);
+    }
+  }
+
+  /**
+   * Represents a {@code JsonString} value
+   */
+  public static class GraphQLJsonString extends CustomTypeValue<java.lang.String> {
+    public GraphQLJsonString(java.lang.String value) {
+      super(value);
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.response;
 
-import com.apollographql.apollo.CustomTypeAdapter;
 import com.apollographql.apollo.api.ScalarType;
 
 import java.util.LinkedHashMap;
@@ -37,41 +36,71 @@ public final class ScalarTypeAdapters {
   private static Map<Class, CustomTypeAdapter> defaultAdapters() {
     Map<Class, CustomTypeAdapter> adapters = new LinkedHashMap<>();
     adapters.put(String.class, new DefaultCustomTypeAdapter<String>() {
-      @Nonnull @Override public String decode(@Nonnull String value) {
-        return value;
+      @Nonnull @Override public String decode(@Nonnull CustomTypeValue value) {
+        return value.value.toString();
       }
     });
     adapters.put(Boolean.class, new DefaultCustomTypeAdapter<Boolean>() {
-      @Nonnull @Override public Boolean decode(@Nonnull String value) {
-        return Boolean.parseBoolean(value);
+      @Nonnull @Override public Boolean decode(@Nonnull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLBoolean) {
+          return (Boolean) value.value;
+        } else if (value instanceof CustomTypeValue.GraphQLString) {
+          return Boolean.parseBoolean(((CustomTypeValue.GraphQLString) value).value);
+        } else {
+          throw new IllegalArgumentException("Can't map: " + value + " to Boolean");
+        }
       }
     });
     adapters.put(Integer.class, new DefaultCustomTypeAdapter<Integer>() {
-      @Nonnull @Override public Integer decode(@Nonnull String value) {
-        return Integer.parseInt(value);
+      @Nonnull @Override public Integer decode(@Nonnull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLNumber) {
+          return ((Number) value.value).intValue();
+        } else if (value instanceof CustomTypeValue.GraphQLString) {
+          return Integer.parseInt(((CustomTypeValue.GraphQLString) value).value);
+        } else {
+          throw new IllegalArgumentException("Can't map: " + value + " to Integer");
+        }
       }
     });
     adapters.put(Long.class, new DefaultCustomTypeAdapter<Long>() {
-      @Nonnull @Override public Long decode(@Nonnull String value) {
-        return Long.parseLong(value);
+      @Nonnull @Override public Long decode(@Nonnull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLNumber) {
+          return ((Number) value.value).longValue();
+        } else if (value instanceof CustomTypeValue.GraphQLString) {
+          return Long.parseLong(((CustomTypeValue.GraphQLString) value).value);
+        } else {
+          throw new IllegalArgumentException("Can't map: " + value + " to Long");
+        }
       }
     });
     adapters.put(Float.class, new DefaultCustomTypeAdapter<Float>() {
-      @Nonnull @Override public Float decode(@Nonnull String value) {
-        return Float.parseFloat(value);
+      @Nonnull @Override public Float decode(@Nonnull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLNumber) {
+          return ((Number) value.value).floatValue();
+        } else if (value instanceof CustomTypeValue.GraphQLString) {
+          return Float.parseFloat(((CustomTypeValue.GraphQLString) value).value);
+        } else {
+          throw new IllegalArgumentException("Can't map: " + value + " to Float");
+        }
       }
     });
     adapters.put(Double.class, new DefaultCustomTypeAdapter<Double>() {
-      @Nonnull @Override public Double decode(@Nonnull String value) {
-        return Double.parseDouble(value);
+      @Nonnull @Override public Double decode(@Nonnull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLNumber) {
+          return ((Number) value.value).doubleValue();
+        } else if (value instanceof CustomTypeValue.GraphQLString) {
+          return Double.parseDouble(((CustomTypeValue.GraphQLString) value).value);
+        } else {
+          throw new IllegalArgumentException("Can't map: " + value + " to Double");
+        }
       }
     });
     return adapters;
   }
 
   private abstract static class DefaultCustomTypeAdapter<T> implements CustomTypeAdapter<T> {
-    @Nonnull @Override public String encode(@Nonnull T value) {
-      return value.toString();
+    @Nonnull @Override public CustomTypeValue encode(@Nonnull T value) {
+      return CustomTypeValue.fromRawValue(value);
     }
   }
 }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapterTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapterTest.java
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.cache.normalized;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeValue;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,12 +22,13 @@ public class RecordFieldAdapterTest {
   @Before public void setUpAdapter() {
     customTypeAdapter = new CustomTypeAdapter<TestCustomScalar>() {
 
-      @Override public TestCustomScalar decode(String value) {
-        return new TestCustomScalar(value.substring(1, value.length()));
+      @Override public TestCustomScalar decode(CustomTypeValue value) {
+        String valueStr = value.value.toString();
+        return new TestCustomScalar(valueStr.substring(1, valueStr.length()));
       }
 
-      @Override public String encode(TestCustomScalar value) {
-        return "#" + value.fieldOne;
+      @Override public CustomTypeValue encode(TestCustomScalar value) {
+        return new CustomTypeValue.GraphQLString("#" + value.fieldOne);
       }
     };
     recordFieldAdapter = RecordFieldJsonAdapter.create();

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -2,7 +2,7 @@ package com.apollographql.apollo.internal.reader;
 
 import com.google.common.truth.Truth;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseField;
@@ -16,6 +16,7 @@ import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
 import com.apollographql.apollo.internal.field.MapFieldValueResolver;
 import com.apollographql.apollo.internal.response.RealResponseReader;
+import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import org.junit.Test;
@@ -770,33 +771,33 @@ public class ResponseReaderTest {
       Map<String, Object> recordSet) {
     Map<ScalarType, CustomTypeAdapter> customTypeAdapters = new HashMap<>();
     customTypeAdapters.put(DATE_CUSTOM_TYPE, new CustomTypeAdapter() {
-      @Override public Object decode(String value) {
+      @Override public Object decode(CustomTypeValue value) {
         try {
-          return DATE_TIME_FORMAT.parse(value);
+          return DATE_TIME_FORMAT.parse(value.value.toString());
         } catch (ParseException e) {
           throw new ClassCastException();
         }
       }
 
-      @Override public String encode(Object value) {
+      @Override public CustomTypeValue encode(Object value) {
         return null;
       }
     });
     customTypeAdapters.put(URL_CUSTOM_TYPE, new CustomTypeAdapter() {
-      @Override public Object decode(String value) {
+      @Override public Object decode(CustomTypeValue value) {
         return null;
       }
 
-      @Override public String encode(Object value) {
+      @Override public CustomTypeValue encode(Object value) {
         return null;
       }
     });
     customTypeAdapters.put(OBJECT_CUSTOM_TYPE, new CustomTypeAdapter() {
-      @Override public Object decode(String value) {
-        return value;
+      @Override public Object decode(CustomTypeValue value) {
+        return value.value.toString();
       }
 
-      @Override public String encode(Object value) {
+      @Override public CustomTypeValue encode(Object value) {
         return null;
       }
     });

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.internal.subscription;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Response;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.subscription;
 
-import com.apollographql.apollo.CustomTypeAdapter;
+import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseFieldMapper;


### PR DESCRIPTION
Allow user to decode / encode custom type value from / to JSON supported types, such as Number, String, Boolean. 

Closes https://github.com/apollographql/apollo-android/issues/828


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->