### PR TITLE
Fix issue with enum java reserved words

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
@@ -46,7 +46,7 @@ class InputFieldSpec(
 
   private fun writeEnumCode(writerParam: CodeBlock): CodeBlock {
     val valueCode = javaType.unwrapOptionalValue(name) {
-      CodeBlock.of("\$L.name()", it)
+      CodeBlock.of("\$L.rawValue()", it)
     }
     return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
   }
@@ -113,7 +113,7 @@ class InputFieldSpec(
     fun writeScalar(): CodeBlock {
       val writeMethod = SCALAR_LIST_ITEM_WRITE_METHODS[itemType] ?: "writeString"
       return if (itemType.isEnum(context)) {
-        CodeBlock.of("\$L.\$L(\$L != null ? \$L.name() : null);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam,
+        CodeBlock.of("\$L.\$L(\$L != null ? \$L.rawValue() : null);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam,
             itemParam)
       } else {
         CodeBlock.of("\$L.\$L(\$L);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -257,7 +257,7 @@ class ResponseFieldSpec(
 
   private fun writeEnumCode(writerParam: CodeBlock, fieldParam: CodeBlock): CodeBlock {
     val valueCode = fieldSpec.type.unwrapOptionalValue(fieldSpec.name) {
-      CodeBlock.of("\$L.name()", it)
+      CodeBlock.of("\$L.rawValue()", it)
     }
     return CodeBlock.of("\$L.\$L(\$L, \$L);\n", writerParam, WRITE_METHODS[responseFieldType],
         fieldParam, valueCode)
@@ -282,7 +282,7 @@ class ResponseFieldSpec(
       return CodeBlock.builder()
           .add(
               if (listItemType.isEnum(context)) {
-                CodeBlock.of("\$L.\$L(((\$L) \$L).name());\n", RESPONSE_LIST_ITEM_WRITER_PARAM.name, writeMethod,
+                CodeBlock.of("\$L.\$L(((\$L) \$L).rawValue());\n", RESPONSE_LIST_ITEM_WRITER_PARAM.name, writeMethod,
                     listItemType, OBJECT_VALUE_PARAM.name)
               } else {
                 CodeBlock.of("\$L.\$L(\$L);\n", RESPONSE_LIST_ITEM_WRITER_PARAM.name, writeMethod,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -25,32 +25,8 @@ data class TypeDeclaration(
   }
 
   private fun enumTypeToTypeSpec(): TypeSpec {
-    fun TypeSpec.Builder.addEnumConstants(): TypeSpec.Builder {
-      values?.forEach { value ->
-        val typeSpec = TypeSpec.anonymousClassBuilder("")
-            .apply {
-              if (!value.description.isNullOrEmpty()) {
-                addJavadoc("\$L\n", value.description)
-              }
-            }
-            .apply {
-              if (value.isDeprecated == true && !value.deprecationReason.isNullOrBlank()) {
-                addJavadoc("@deprecated \$L\n", value.deprecationReason)
-              }
-            }
-            .apply {
-              if (value.isDeprecated == true) {
-                addAnnotation(Annotations.DEPRECATED)
-              }
-            }
-            .build()
-        addEnumConstant(value.name, typeSpec)
-      }
-      return this
-    }
-
     val enumConstants = values?.map { value ->
-      value.name to TypeSpec.anonymousClassBuilder("")
+      value.name to TypeSpec.anonymousClassBuilder("\$S", value.name)
           .apply {
             if (!value.description.isNullOrEmpty()) {
               addJavadoc("\$L\n", value.description)
@@ -66,16 +42,16 @@ data class TypeDeclaration(
           }
           .build()
     }
-    val unknownConstantTypeSpec = TypeSpec.anonymousClassBuilder("")
+    val unknownConstantTypeSpec = TypeSpec.anonymousClassBuilder("\$S", "\$UNKNOWN")
         .addJavadoc("\$L\n", "Auto generated constant for unknown enum values")
         .build()
     val safeValueOfMethodSpec = MethodSpec.methodBuilder(ENUM_SAFE_VALUE_OF)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addParameter(ParameterSpec.builder(ClassNames.STRING, "value").build())
+        .addParameter(ParameterSpec.builder(ClassNames.STRING, "rawValue").build())
         .returns(ClassName.get("", name))
         .addCode(CodeBlock.builder()
             .beginControlFlow("for (\$L enumValue : values())", name)
-            .beginControlFlow("if (enumValue.name().equals(value))")
+            .beginControlFlow("if (enumValue.rawValue.equals(rawValue))")
             .addStatement("return enumValue")
             .endControlFlow()
             .endControlFlow()
@@ -87,9 +63,20 @@ data class TypeDeclaration(
     return TypeSpec.enumBuilder(name)
         .addAnnotation(Annotations.GENERATED_BY_APOLLO)
         .addModifiers(Modifier.PUBLIC)
+        .addField(FieldSpec.builder(ClassNames.STRING, "rawValue", Modifier.PRIVATE, Modifier.FINAL).build())
+        .addMethod(MethodSpec.constructorBuilder()
+            .addParameter(ParameterSpec.builder(ClassNames.STRING, "rawValue").build())
+            .addStatement("this.rawValue = rawValue")
+            .build()
+        )
+        .addMethod(MethodSpec.methodBuilder("rawValue")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ClassNames.STRING)
+            .addStatement("return rawValue")
+            .build())
         .apply {
           enumConstants?.forEach { (name, typeSpec) ->
-            addEnumConstant(name.escapeJavaReservedWord(), typeSpec)
+            addEnumConstant(name.escapeJavaReservedWord().toUpperCase(), typeSpec)
           }
         }
         .addEnumConstant(ENUM_UNKNOWN_CONSTANT, unknownConstantTypeSpec)

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -167,7 +167,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
           if (episode.defined) {
-            writer.writeString("episode", episode.value != null ? episode.value.name() : null);
+            writer.writeString("episode", episode.value != null ? episode.value.rawValue() : null);
           }
           writer.writeLong("stars", stars);
           writer.writeDouble("greenValue", greenValue);

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -151,7 +151,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
           if (episode.defined) {
-            writer.writeString("episode", episode.value != null ? episode.value.name() : null);
+            writer.writeString("episode", episode.value != null ? episode.value.rawValue() : null);
           }
           writer.writeBoolean("includeName", includeName);
         }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -137,7 +137,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
           if (episode.defined) {
-            writer.writeString("episode", episode.value != null ? episode.value.name() : null);
+            writer.writeString("episode", episode.value != null ? episode.value.rawValue() : null);
           }
         }
       };

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -235,10 +235,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeList($responseFields[2], appearsIn, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeString(((com.example.enum_type.type.Episode) value).name());
+              listItemWriter.writeString(((com.example.enum_type.type.Episode) value).rawValue());
             }
           });
-          writer.writeString($responseFields[3], firstAppearsIn.name());
+          writer.writeString($responseFields[3], firstAppearsIn.rawValue());
         }
       };
     }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.java
@@ -11,26 +11,36 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977. (with special symbol $S)
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983. (JEDI in lowercase)
    */
-  jedi,
+  JEDI("jedi"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -272,7 +272,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeList($responseFields[2], appearsIn, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeString(((com.example.fragment_with_inline_fragment.type.Episode) value).name());
+              listItemWriter.writeString(((com.example.fragment_with_inline_fragment.type.Episode) value).rawValue());
             }
           });
           fragments.marshaller().marshal(writer);

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -408,7 +408,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeList($responseFields[1], appearsIn, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeString(((com.example.inline_fragments_with_friends.type.Episode) value).name());
+              listItemWriter.writeString(((com.example.inline_fragments_with_friends.type.Episode) value).rawValue());
             }
           });
         }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -146,7 +146,7 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
       return new InputFieldMarshaller() {
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
-          writer.writeString("ep", ep.name());
+          writer.writeString("ep", ep.rawValue());
           writer.writeObject("review", review.marshaller());
         }
       };

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
@@ -70,7 +70,7 @@ public final class ColorInput {
         }
         writer.writeDouble("blue", blue);
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
       }
     };

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -205,10 +205,10 @@ public final class ReviewInput {
         }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
         if (nullableEnum.defined) {
-          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.rawValue() : null);
         }
         if (listOfCustomScalar.defined) {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
@@ -228,7 +228,7 @@ public final class ReviewInput {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
               for (Episode $item : listOfEnums.value) {
-                listItemWriter.writeString($item != null ? $item.name() : null);
+                listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
           } : null);
@@ -284,7 +284,7 @@ public final class ReviewInput {
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
                     for (Episode $$item : $item) {
-                      listItemWriter.writeString($$item != null ? $$item.name() : null);
+                      listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
                 } : null);

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -237,7 +237,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeList($responseFields[2], appearsIn, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeString(((com.example.java_beans_semantic_naming.type.Episode) value).name());
+              listItemWriter.writeString(((com.example.java_beans_semantic_naming.type.Episode) value).rawValue());
             }
           });
           fragments.marshaller().marshal(writer);

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -146,7 +146,7 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
       return new InputFieldMarshaller() {
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
-          writer.writeString("ep", ep.name());
+          writer.writeString("ep", ep.rawValue());
           writer.writeObject("review", review.marshaller());
         }
       };

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
@@ -70,7 +70,7 @@ public final class ColorInput {
         }
         writer.writeDouble("blue", blue);
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
       }
     };

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -205,10 +205,10 @@ public final class ReviewInput {
         }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
         if (nullableEnum.defined) {
-          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.rawValue() : null);
         }
         if (listOfCustomScalar.defined) {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
@@ -228,7 +228,7 @@ public final class ReviewInput {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
               for (Episode $item : listOfEnums.value) {
-                listItemWriter.writeString($item != null ? $item.name() : null);
+                listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
           } : null);
@@ -284,7 +284,7 @@ public final class ReviewInput {
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
                     for (Episode $$item : $item) {
-                      listItemWriter.writeString($$item != null ? $$item.name() : null);
+                      listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
                 } : null);

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -146,7 +146,7 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
       return new InputFieldMarshaller() {
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
-          writer.writeString("ep", ep.name());
+          writer.writeString("ep", ep.rawValue());
           writer.writeObject("review", review.marshaller());
         }
       };

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
@@ -70,7 +70,7 @@ public final class ColorInput {
         }
         writer.writeDouble("blue", blue);
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
       }
     };

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -205,10 +205,10 @@ public final class ReviewInput {
         }
         writer.writeObject("favoriteColor", favoriteColor.marshaller());
         if (enumWithDefaultValue.defined) {
-          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.name() : null);
+          writer.writeString("enumWithDefaultValue", enumWithDefaultValue.value != null ? enumWithDefaultValue.value.rawValue() : null);
         }
         if (nullableEnum.defined) {
-          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.name() : null);
+          writer.writeString("nullableEnum", nullableEnum.value != null ? nullableEnum.value.rawValue() : null);
         }
         if (listOfCustomScalar.defined) {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
@@ -228,7 +228,7 @@ public final class ReviewInput {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
               for (Episode $item : listOfEnums.value) {
-                listItemWriter.writeString($item != null ? $item.name() : null);
+                listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
           } : null);
@@ -284,7 +284,7 @@ public final class ReviewInput {
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
                     for (Episode $$item : $item) {
-                      listItemWriter.writeString($$item != null ? $$item.name() : null);
+                      listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
                 } : null);

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -156,7 +156,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(InputFieldWriter writer) throws IOException {
           if (episode.defined) {
-            writer.writeString("episode", episode.value != null ? episode.value.name() : null);
+            writer.writeString("episode", episode.value != null ? episode.value.rawValue() : null);
           }
         }
       };

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -621,7 +621,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeString($responseFields[1], firstAppearsIn.name());
+          writer.writeString($responseFields[1], firstAppearsIn.rawValue());
         }
       };
     }
@@ -1292,7 +1292,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeString($responseFields[1], firstAppearsIn.name());
+          writer.writeString($responseFields[1], firstAppearsIn.rawValue());
         }
       };
     }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -440,7 +440,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
           writer.writeList($responseFields[2], appearsIn, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeString(((com.example.unique_type_name.type.Episode) value).name());
+              listItemWriter.writeString(((com.example.unique_type_name.type.Episode) value).rawValue());
             }
           });
           writer.writeList($responseFields[3], friends.isPresent() ? friends.get() : null, new ResponseWriter.ListWriter() {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.java
@@ -12,40 +12,50 @@ public enum Episode {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE,
+  NEWHOPE("NEWHOPE"),
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE,
+  EMPIRE("EMPIRE"),
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI,
+  JEDI("JEDI"),
 
   /**
    * Test deprecated enum value
    * @deprecated For test purpose only
    */
   @Deprecated
-  DEPRECATED,
+  DEPRECATED("DEPRECATED"),
 
   /**
    * Test java reserved word
    * @deprecated For test purpose only
    */
   @Deprecated
-  new_,
+  NEW_("new"),
 
   /**
    * Auto generated constant for unknown enum values
    */
-  $UNKNOWN;
+  $UNKNOWN("$UNKNOWN");
 
-  public static Episode safeValueOf(String value) {
+  private final String rawValue;
+
+  Episode(String rawValue) {
+    this.rawValue = rawValue;
+  }
+
+  public String rawValue() {
+    return rawValue;
+  }
+
+  public static Episode safeValueOf(String rawValue) {
     for (Episode enumValue : values()) {
-      if (enumValue.name().equals(value)) {
+      if (enumValue.rawValue.equals(rawValue)) {
         return enumValue;
       }
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -30,8 +30,8 @@ import com.apollographql.apollo.internal.subscription.NoOpSubscriptionManager;
 import com.apollographql.apollo.internal.subscription.RealSubscriptionManager;
 import com.apollographql.apollo.internal.subscription.SubscriptionManager;
 import com.apollographql.apollo.response.CustomTypeAdapter;
-import com.apollographql.apollo.subscription.SubscriptionTransport;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
+import com.apollographql.apollo.subscription.SubscriptionTransport;
 
 import java.io.IOException;
 import java.util.ArrayList;


### PR DESCRIPTION
Make enum to backed by `rawValue` field that represents GraphQL enum value that defined in schema.

Closes https://github.com/apollographql/apollo-android/issues/842


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->