### PR TITLE
fix: memory leak due not closed SQLite cursors

### DIFF
--- a/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.java
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.java
@@ -156,10 +156,13 @@ public final class SqlNormalizedCache extends NormalizedCache {
     Cursor cursor = database.query(ApolloSqlHelper.TABLE_RECORDS,
         allColumns, ApolloSqlHelper.COLUMN_KEY + " = ?", new String[]{key},
         null, null, null);
-    if (cursor == null || !cursor.moveToFirst()) {
+    if (cursor == null) {
       return Optional.absent();
     }
     try {
+      if (!cursor.moveToFirst()) {
+        return Optional.absent();
+      }
       return Optional.of(cursorToRecord(cursor));
     } catch (IOException exception) {
       return Optional.absent();


### PR DESCRIPTION
The cause of the problem can be visible when activating strict mode:
```

03-26 17:22:07.420 21166-21176/com.aida.one.debug E/StrictMode: Finalizing a Cursor that has not been deactivated or closed. database = /data/user/0/com.aida.one.debug/databases/apollo_cache_db, table = records, query = SELECT _id, key, record FROM records WHERE key = ?
                                                                android.database.sqlite.DatabaseObjectNotClosedException: Application did not close the cursor or database object that was opened here
                                                                    at android.database.sqlite.SQLiteCursor.<init>(SQLiteCursor.java:98)
                                                                    at android.database.sqlite.SQLiteDirectCursorDriver.query(SQLiteDirectCursorDriver.java:50)
                                                                    at android.database.sqlite.SQLiteDatabase.rawQueryWithFactory(SQLiteDatabase.java:1318)
                                                                    at android.database.sqlite.SQLiteDatabase.queryWithFactory(SQLiteDatabase.java:1165)
                                                                    at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1036)
                                                                    at android.database.sqlite.SQLiteDatabase.query(SQLiteDatabase.java:1204)
                                                                    at com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCache.selectRecordForKey(SqlNormalizedCache.java:156)
```


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [X] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->