### PR TITLE
docs: Add `hexo-prism-plus` to enable Prism syntax highlighting.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "apollo-hexo-config": "1.0.6",
     "chexo": "1.0.4",
     "hexo": "3.7.0",
+    "hexo-prism-plus": "^1.0.0",
     "hexo-renderer-ejs": "0.3.1",
     "hexo-renderer-less": "0.2.0",
     "hexo-renderer-marked": "0.3.2",


### PR DESCRIPTION
The default syntax highlighting provided by Hexo uses highlight.js.  While there are a number of great syntax highlights provided by highlight.js, some of the more important ones to the Apollo project: `graphql`, `typescript`, and `jsx` are notably missing.

This uses the `hexo-prism-plus` plugin for Hexo, along with some upstream configuration to `apollo-hexo-config`[0] and `meteor-theme-hexo` (previously named `hexo-theme-meteor`)[1].  See refs for more information!

**The Netlify preview for this PR should be checked prior to merging!**

:crossed_fingers:

[0] https://github.com/apollographql/apollo-hexo-config/commit/547107b0
[1] https://github.com/meteor/meteor-theme-hexo/pull/61