### PR TITLE
Fix issue with inline fragment inside the root of regular fragment

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -143,8 +143,8 @@ class SchemaTypeSpecBuilder(
 
     fun isOptional(fragmentName: String): Boolean {
       return context.ir.fragments
-          .find { it.fragmentName == fragmentName }
-          ?.let { it.typeCondition != normalizeGraphQlType(schemaType) } ?: true
+          .first { it.fragmentName == fragmentName }
+          .let { it.inlineFragments.isNotEmpty() || it.typeCondition != normalizeGraphQlType(schemaType) }
     }
 
     fun fragmentFields(): List<FieldSpec> {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -340,7 +340,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final @Nonnull HeroDetails heroDetails;
+      final Optional<HeroDetails> heroDetails;
 
       private volatile String $toString;
 
@@ -348,11 +348,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nonnull HeroDetails heroDetails) {
-        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
+      public Fragments(@Nullable HeroDetails heroDetails) {
+        this.heroDetails = Optional.fromNullable(heroDetails);
       }
 
-      public @Nonnull HeroDetails heroDetails() {
+      public Optional<HeroDetails> heroDetails() {
         return this.heroDetails;
       }
 
@@ -360,7 +360,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final HeroDetails $heroDetails = heroDetails;
+            final HeroDetails $heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
             if ($heroDetails != null) {
               $heroDetails.marshaller().marshal(writer);
             }
@@ -404,7 +404,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public Builder toBuilder() {
         Builder builder = new Builder();
-        builder.heroDetails = heroDetails;
+        builder.heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
         return builder;
       }
 
@@ -421,23 +421,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (HeroDetails.POSSIBLE_TYPES.contains(conditionalType)) {
             heroDetails = heroDetailsFieldMapper.map(reader);
           }
-          return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
+          return new Fragments(heroDetails);
         }
       }
 
       public static final class Builder {
-        private @Nonnull HeroDetails heroDetails;
+        private @Nullable HeroDetails heroDetails;
 
         Builder() {
         }
 
-        public Builder heroDetails(@Nonnull HeroDetails heroDetails) {
+        public Builder heroDetails(@Nullable HeroDetails heroDetails) {
           this.heroDetails = heroDetails;
           return this;
         }
 
         public Fragments build() {
-          Utils.checkNotNull(heroDetails, "heroDetails == null");
           return new Fragments(heroDetails);
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -292,7 +292,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final @Nonnull HeroDetails heroDetails;
+      final Optional<HeroDetails> heroDetails;
 
       private volatile String $toString;
 
@@ -300,11 +300,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nonnull HeroDetails heroDetails) {
-        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
+      public Fragments(@Nullable HeroDetails heroDetails) {
+        this.heroDetails = Optional.fromNullable(heroDetails);
       }
 
-      public @Nonnull HeroDetails getHeroDetails() {
+      public Optional<HeroDetails> getHeroDetails() {
         return this.heroDetails;
       }
 
@@ -312,7 +312,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final HeroDetails $heroDetails = heroDetails;
+            final HeroDetails $heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
             if ($heroDetails != null) {
               $heroDetails.marshaller().marshal(writer);
             }
@@ -363,7 +363,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (HeroDetails.POSSIBLE_TYPES.contains(conditionalType)) {
             heroDetails = heroDetailsFieldMapper.map(reader);
           }
-          return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
+          return new Fragments(heroDetails);
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import javax.annotation.Generated;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
@@ -252,7 +253,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final @Nonnull TestSetting testSetting;
+      final Optional<TestSetting> testSetting;
 
       private volatile String $toString;
 
@@ -260,11 +261,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nonnull TestSetting testSetting) {
-        this.testSetting = Utils.checkNotNull(testSetting, "testSetting == null");
+      public Fragments(@Nullable TestSetting testSetting) {
+        this.testSetting = Optional.fromNullable(testSetting);
       }
 
-      public @Nonnull TestSetting testSetting() {
+      public Optional<TestSetting> testSetting() {
         return this.testSetting;
       }
 
@@ -272,7 +273,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final TestSetting $testSetting = testSetting;
+            final TestSetting $testSetting = testSetting.isPresent() ? testSetting.get() : null;
             if ($testSetting != null) {
               $testSetting.marshaller().marshal(writer);
             }
@@ -323,7 +324,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (TestSetting.POSSIBLE_TYPES.contains(conditionalType)) {
             testSetting = testSettingFieldMapper.map(reader);
           }
-          return new Fragments(Utils.checkNotNull(testSetting, "testSetting == null"));
+          return new Fragments(testSetting);
         }
       }
     }


### PR DESCRIPTION
If regular fragment has root inline fragment declaration make it optional for `Fragments` reference class. 

The issue is that for any usage of inline fragments the reference is optional. For regular fragments we generate synthetic class `Fragments` that enforce non-optional reference to fragment. But if the regular fragment has inline ones it automatically makes it to be optional.

Closes https://github.com/apollographql/apollo-android/issues/886


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->