### PR TITLE
Fix issue with query watcher for empty cache

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/Record.java
@@ -128,6 +128,17 @@ public final class Record {
   }
 
   /**
+   * @return A set of all field keys. A field key incorporates any GraphQL arguments in addition to the field name.
+   */
+  public Set<String> keys() {
+    Set<String> keys = new HashSet<>();
+    for (Map.Entry<String, Object> field : fields.entrySet()) {
+      keys.add(key() + "." + field.getKey());
+    }
+    return keys;
+  }
+
+  /**
    * @return A map of fieldName to fieldValue. Where fieldValue is a GraphQL Scalar or {@link CacheReference} if it is a
    * GraphQL Object type.
    */

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.java
@@ -117,7 +117,7 @@ public final class LruNormalizedCache extends NormalizedCache {
     final Record oldRecord = lruCache.getIfPresent(apolloRecord.key());
     if (oldRecord == null) {
       lruCache.put(apolloRecord.key(), apolloRecord);
-      return Collections.emptySet();
+      return apolloRecord.keys();
     } else {
       Set<String> changedKeys = oldRecord.mergeWith(apolloRecord);
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -37,7 +37,7 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
   private final ApolloCallTracker tracker;
   final ApolloStore.RecordChangeSubscriber recordChangeSubscriber = new ApolloStore.RecordChangeSubscriber() {
     @Override public void onCacheRecordsChanged(Set<String> changedRecordKeys) {
-      if (!Utils.areDisjoint(dependentKeys, changedRecordKeys)) {
+      if (dependentKeys.isEmpty() || !Utils.areDisjoint(dependentKeys, changedRecordKeys)) {
         refetch();
       }
     }


### PR DESCRIPTION
If cache is empty re-fetch any watcher that has empty dependent key set.

Closes https://github.com/apollographql/apollo-android/issues/822


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->