### PR TITLE
Do not escape input types too much

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
@@ -29,7 +29,7 @@ class InputFieldSpec(
     }.let {
       if (javaType.isOptional()) {
         CodeBlock.builder()
-            .beginControlFlow("if (\$L.defined)", name)
+            .beginControlFlow("if (\$L.defined)", name.escapeJavaReservedWord())
             .add(it)
             .endControlFlow()
             .build()
@@ -40,12 +40,12 @@ class InputFieldSpec(
   }
 
   private fun writeScalarCode(writerParam: CodeBlock): CodeBlock {
-    val valueCode = javaType.unwrapOptionalValue(varName = name, checkIfPresent = false)
+    val valueCode = javaType.unwrapOptionalValue(varName = name.escapeJavaReservedWord(), checkIfPresent = false)
     return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
   }
 
   private fun writeEnumCode(writerParam: CodeBlock): CodeBlock {
-    val valueCode = javaType.unwrapOptionalValue(name) {
+    val valueCode = javaType.unwrapOptionalValue(name.escapeJavaReservedWord()) {
       CodeBlock.of("\$L.rawValue()", it)
     }
     return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
@@ -54,22 +54,22 @@ class InputFieldSpec(
   private fun writeCustomCode(writerParam: CodeBlock): CodeBlock {
     val customScalarEnum = CustomEnumTypeSpecBuilder.className(context)
     val customScalarEnumConst = normalizeGraphQlType(graphQLType).toUpperCase(Locale.ENGLISH)
-    val valueCode = javaType.unwrapOptionalValue(name)
+    val valueCode = javaType.unwrapOptionalValue(name.escapeJavaReservedWord())
     return CodeBlock.of("\$L.\$L(\$S, \$L.\$L, \$L);\n", writerParam, WRITE_METHODS[type],
         name, customScalarEnum, customScalarEnumConst, valueCode)
   }
 
   private fun writeObjectCode(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
-    val valueCode = javaType.unwrapOptionalValue(name) {
+    val valueCode = javaType.unwrapOptionalValue(name.escapeJavaReservedWord()) {
       CodeBlock.of("\$L.\$L", it, marshaller)
     }
     return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[type], name, valueCode)
   }
 
   private fun writeList(writerParam: CodeBlock, marshaller: CodeBlock): CodeBlock {
-    val unwrappedListValue = javaType.unwrapOptionalValue(name, false)
+    val unwrappedListValue = javaType.unwrapOptionalValue(name.escapeJavaReservedWord(), false)
     val listParamType = with(javaType.unwrapOptionalType(true)) { if (isList()) listParamType() else this }
-    val listWriterCode = javaType.unwrapOptionalValue(name) {
+    val listWriterCode = javaType.unwrapOptionalValue(name.escapeJavaReservedWord()) {
       CodeBlock.of("\$L", listWriter(listParamType, unwrappedListValue, "\$item", marshaller))
     }
     return CodeBlock.of("\$L.\$L(\$S, \$L);\n", writerParam, WRITE_METHODS[Type.LIST], name, listWriterCode)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
@@ -74,7 +74,7 @@ class InputTypeSpecBuilder(
     val writeCode = fields
         .map {
           InputFieldSpec.build(
-              name = it.name.decapitalize().escapeJavaReservedWord(),
+              name = it.name.decapitalize(),
               graphQLType = it.type,
               context = context
           )

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/type/TestInputType.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/type/TestInputType.java
@@ -37,7 +37,7 @@ public final class TestInputType {
       @Override
       public void marshal(InputFieldWriter writer) throws IOException {
         if (private_.defined) {
-          writer.writeBoolean("private_", private_.value);
+          writer.writeBoolean("private", private_.value);
         }
       }
     };


### PR DESCRIPTION
It turns out I have been a bit agressive when trying to fix https://github.com/apollographql/apollo-android/issues/908. The actual marshaled parameter was escaped too making it rejected server-side.