### PR TITLE
Add support connection keep alive message (aka heartbeat)

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationServerMessage.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationServerMessage.java
@@ -58,6 +58,9 @@ public abstract class OperationServerMessage {
       case Complete.TYPE:
         return new Complete(id);
 
+      case ConnectionKeepAlive.TYPE:
+        return new ConnectionKeepAlive();
+
       default:
         throw new IOException("Unsupported message");
     }
@@ -114,6 +117,10 @@ public abstract class OperationServerMessage {
     public Complete(String id) {
       this.id = id;
     }
+  }
+
+  public static final class ConnectionKeepAlive extends OperationServerMessage {
+    public static final String TYPE = "ka";
   }
 
   public static final class Unsupported extends OperationServerMessage {

--- a/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
+++ b/apollo-sample/src/main/java/com/apollographql/apollo/sample/detail/GitHuntEntryDetailActivity.java
@@ -16,6 +16,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloSubscriptionCall;
@@ -165,14 +166,18 @@ public class GitHuntEntryDetailActivity extends AppCompatActivity {
             new DisposableSubscriber<Response<RepoCommentAddedSubscription.Data>>() {
               @Override public void onNext(Response<RepoCommentAddedSubscription.Data> response) {
                 commentsListViewAdapter.addItem(response.data().commentAdded().content());
+                Toast.makeText(GitHuntEntryDetailActivity.this, "Subscription response received", Toast.LENGTH_SHORT)
+                    .show();
               }
 
               @Override public void onError(Throwable e) {
                 Log.e(TAG, e.getMessage(), e);
+                Toast.makeText(GitHuntEntryDetailActivity.this, "Subscription failure", Toast.LENGTH_SHORT).show();
               }
 
               @Override public void onComplete() {
                 Log.d(TAG, "Subscription exhausted");
+                Toast.makeText(GitHuntEntryDetailActivity.this, "Subscription complete", Toast.LENGTH_SHORT).show();
               }
             }
         )


### PR DESCRIPTION
Add support of heartbeat messages sent by the subscription server.

Closes https://github.com/apollographql/apollo-android/issues/895


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->