### PR TITLE
Fix issue iterator is not final used in nested inner class

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
@@ -77,7 +77,7 @@ class InputFieldSpec(
 
   private fun listWriter(itemType: TypeName, listParam: CodeBlock, itemParam: String, marshaller: CodeBlock): TypeSpec {
     val writeStatement = CodeBlock.builder()
-        .beginControlFlow("for (\$T \$L : \$L)", itemType, itemParam, listParam)
+        .beginControlFlow("for (final \$T \$L : \$L)", itemType, itemParam, listParam)
         .add(writeListItemStatement(itemType, itemParam, marshaller))
         .endControlFlow()
         .build()

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -219,7 +219,7 @@ public final class ReviewInput {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Date $item : listOfCustomScalar.value) {
+              for (final Date $item : listOfCustomScalar.value) {
                 listItemWriter.writeCustom(CustomType.DATE, $item);
               }
             }
@@ -232,7 +232,7 @@ public final class ReviewInput {
           writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Episode $item : listOfEnums.value) {
+              for (final Episode $item : listOfEnums.value) {
                 listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
@@ -242,7 +242,7 @@ public final class ReviewInput {
           writer.writeList("listOfInt", listOfInt.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Integer $item : listOfInt.value) {
+              for (final Integer $item : listOfInt.value) {
                 listItemWriter.writeInt($item);
               }
             }
@@ -252,7 +252,7 @@ public final class ReviewInput {
           writer.writeList("listOfString", listOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (String $item : listOfString.value) {
+              for (final String $item : listOfString.value) {
                 listItemWriter.writeString($item);
               }
             }
@@ -265,12 +265,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfString", listOfListOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<String> $item : listOfListOfString.value) {
+              for (final List<String> $item : listOfListOfString.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (String $$item : $item) {
+                    for (final String $$item : $item) {
                       listItemWriter.writeString($$item);
                     }
                   }
@@ -283,12 +283,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfEnum", listOfListOfEnum.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Episode> $item : listOfListOfEnum.value) {
+              for (final List<Episode> $item : listOfListOfEnum.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Episode $$item : $item) {
+                    for (final Episode $$item : $item) {
                       listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
@@ -301,12 +301,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfCustom", listOfListOfCustom.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Date> $item : listOfListOfCustom.value) {
+              for (final List<Date> $item : listOfListOfCustom.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Date $$item : $item) {
+                    for (final Date $$item : $item) {
                       listItemWriter.writeCustom(CustomType.DATE, $$item);
                     }
                   }
@@ -319,12 +319,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfObject", listOfListOfObject.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<ColorInput> $item : listOfListOfObject.value) {
+              for (final List<ColorInput> $item : listOfListOfObject.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (ColorInput $$item : $item) {
+                    for (final ColorInput $$item : $item) {
                       listItemWriter.writeObject($$item != null ? $$item.marshaller() : null);
                     }
                   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -218,7 +218,7 @@ public final class ReviewInput {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Object $item : listOfCustomScalar.value) {
+              for (final Object $item : listOfCustomScalar.value) {
                 listItemWriter.writeCustom(CustomType.DATE, $item);
               }
             }
@@ -231,7 +231,7 @@ public final class ReviewInput {
           writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Episode $item : listOfEnums.value) {
+              for (final Episode $item : listOfEnums.value) {
                 listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
@@ -241,7 +241,7 @@ public final class ReviewInput {
           writer.writeList("listOfInt", listOfInt.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Integer $item : listOfInt.value) {
+              for (final Integer $item : listOfInt.value) {
                 listItemWriter.writeInt($item);
               }
             }
@@ -251,7 +251,7 @@ public final class ReviewInput {
           writer.writeList("listOfString", listOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (String $item : listOfString.value) {
+              for (final String $item : listOfString.value) {
                 listItemWriter.writeString($item);
               }
             }
@@ -264,12 +264,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfString", listOfListOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<String> $item : listOfListOfString.value) {
+              for (final List<String> $item : listOfListOfString.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (String $$item : $item) {
+                    for (final String $$item : $item) {
                       listItemWriter.writeString($$item);
                     }
                   }
@@ -282,12 +282,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfEnum", listOfListOfEnum.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Episode> $item : listOfListOfEnum.value) {
+              for (final List<Episode> $item : listOfListOfEnum.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Episode $$item : $item) {
+                    for (final Episode $$item : $item) {
                       listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
@@ -300,12 +300,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfCustom", listOfListOfCustom.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Object> $item : listOfListOfCustom.value) {
+              for (final List<Object> $item : listOfListOfCustom.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Object $$item : $item) {
+                    for (final Object $$item : $item) {
                       listItemWriter.writeCustom(CustomType.DATE, $$item);
                     }
                   }
@@ -318,12 +318,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfObject", listOfListOfObject.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<ColorInput> $item : listOfListOfObject.value) {
+              for (final List<ColorInput> $item : listOfListOfObject.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (ColorInput $$item : $item) {
+                    for (final ColorInput $$item : $item) {
                       listItemWriter.writeObject($$item != null ? $$item.marshaller() : null);
                     }
                   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -218,7 +218,7 @@ public final class ReviewInput {
           writer.writeList("listOfCustomScalar", listOfCustomScalar.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Object $item : listOfCustomScalar.value) {
+              for (final Object $item : listOfCustomScalar.value) {
                 listItemWriter.writeCustom(CustomType.DATE, $item);
               }
             }
@@ -231,7 +231,7 @@ public final class ReviewInput {
           writer.writeList("listOfEnums", listOfEnums.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Episode $item : listOfEnums.value) {
+              for (final Episode $item : listOfEnums.value) {
                 listItemWriter.writeString($item != null ? $item.rawValue() : null);
               }
             }
@@ -241,7 +241,7 @@ public final class ReviewInput {
           writer.writeList("listOfInt", listOfInt.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (Integer $item : listOfInt.value) {
+              for (final Integer $item : listOfInt.value) {
                 listItemWriter.writeInt($item);
               }
             }
@@ -251,7 +251,7 @@ public final class ReviewInput {
           writer.writeList("listOfString", listOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (String $item : listOfString.value) {
+              for (final String $item : listOfString.value) {
                 listItemWriter.writeString($item);
               }
             }
@@ -264,12 +264,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfString", listOfListOfString.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<String> $item : listOfListOfString.value) {
+              for (final List<String> $item : listOfListOfString.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (String $$item : $item) {
+                    for (final String $$item : $item) {
                       listItemWriter.writeString($$item);
                     }
                   }
@@ -282,12 +282,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfEnum", listOfListOfEnum.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Episode> $item : listOfListOfEnum.value) {
+              for (final List<Episode> $item : listOfListOfEnum.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Episode $$item : $item) {
+                    for (final Episode $$item : $item) {
                       listItemWriter.writeString($$item != null ? $$item.rawValue() : null);
                     }
                   }
@@ -300,12 +300,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfCustom", listOfListOfCustom.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<Object> $item : listOfListOfCustom.value) {
+              for (final List<Object> $item : listOfListOfCustom.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (Object $$item : $item) {
+                    for (final Object $$item : $item) {
                       listItemWriter.writeCustom(CustomType.DATE, $$item);
                     }
                   }
@@ -318,12 +318,12 @@ public final class ReviewInput {
           writer.writeList("listOfListOfObject", listOfListOfObject.value != null ? new InputFieldWriter.ListWriter() {
             @Override
             public void write(InputFieldWriter.ListItemWriter listItemWriter) throws IOException {
-              for (List<ColorInput> $item : listOfListOfObject.value) {
+              for (final List<ColorInput> $item : listOfListOfObject.value) {
                 listItemWriter.writeList($item != null ? new InputFieldWriter.ListWriter() {
                   @Override
                   public void write(InputFieldWriter.ListItemWriter listItemWriter) throws
                       IOException {
-                    for (ColorInput $$item : $item) {
+                    for (final ColorInput $$item : $item) {
                       listItemWriter.writeObject($$item != null ? $$item.marshaller() : null);
                     }
                   }


### PR DESCRIPTION
The issue is specific to Java7 and can't be reproduced on Java8. Apparently the iterator declared in for loop on Java7 must be with final keyword if it's going to be used inside the nested inner class.

Closes https://github.com/apollographql/apollo-android/issues/932


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->