### PR TITLE
Make IR generation workable anywhere

### DIFF
--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -14,6 +14,9 @@ class UpdateTestIRFilesTask extends DefaultTask {
       return
     }
 
+    // When this task runs from the Android Studio gradle task menu, it sets working
+    // directory to $project/apollo-compiler. When run from the command line, it
+    // sets working directory to $project.
     def apolloCompiler = "apollo-compiler"
     String currentDir = System.getProperty("user.dir")
     if (!currentDir.contains(apolloCompiler)) {

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -17,7 +17,7 @@ class UpdateTestIRFilesTask extends DefaultTask {
     // When this task runs from the Android Studio gradle task menu, it sets working
     // directory to $project/apollo-compiler. When run from the command line, it
     // sets working directory to $project.
-    apolloCompilerRelativeDirectory =
+    def apolloCompilerRelativeDirectory =
       System.getProperty("user.dir").endsWith("apollo-compiler") ?
               "../apollo-compiler" :
               "apollo-compiler"

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -75,7 +75,6 @@ class UpdateTestIRFilesTask extends DefaultTask {
           --schema ${schema.absoluteFile}
           --output ${outputFile.absoluteFile}
           --target json""".execute()
-
     apolloCodeGenProcess.waitFor()
     def error = apolloCodeGenProcess.err.text
     if (error != null && !error.isEmpty()) {

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -19,14 +19,14 @@ class UpdateTestIRFilesTask extends DefaultTask {
     // sets working directory to $project.
     def apolloCompiler = "apollo-compiler"
     String currentDir = System.getProperty("user.dir")
-    if (currentDir.contains(apolloCompiler)) {
-      currentDir = "../apollo-compiler/"
+    if (currentDir.endsWith(apolloCompiler)) {
+      currentDir = new File( "..", "apollo-compiler" )
     }
       else {
-      currentDir = "./apollo-compiler/"
+      currentDir = new File( "apollo-compiler" )
     }
 
-    def dir = new File("${currentDir}/src/test/graphql/com/example")
+    def dir = new File(currentDir, "src/test/graphql/com/example")
     dir.eachFile(FileType.DIRECTORIES) {
       testDir -> generateIRFile(testDir,currentDir)
     }
@@ -68,16 +68,14 @@ class UpdateTestIRFilesTask extends DefaultTask {
     idFileDir.mkdirs()
     def idFile = new File(idFileDir, "id.json")
 
-      def apolloCodeGenCommand = """apollo-codegen generate ${queryFile.absoluteFile}
+    def apolloCodeGenProcess = """apollo-codegen generate ${queryFile.absoluteFile}
           --add-typename
           --operation-ids-path ${idFile.toString()}
           --merge-in-fields-from-fragment-spreads false
           --schema ${schema.absoluteFile}
           --output ${outputFile.absoluteFile}
-          --target json"""
-    def apolloCodeGenProcess = apolloCodeGenCommand.execute()
+          --target json""".execute()
 
-      println( "CODEGEN: ${apolloCodeGenCommand}")
     apolloCodeGenProcess.waitFor()
     def error = apolloCodeGenProcess.err.text
     if (error != null && !error.isEmpty()) {

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -17,24 +17,20 @@ class UpdateTestIRFilesTask extends DefaultTask {
     // When this task runs from the Android Studio gradle task menu, it sets working
     // directory to $project/apollo-compiler. When run from the command line, it
     // sets working directory to $project.
-    def apolloCompiler = "apollo-compiler"
-    String currentDir = System.getProperty("user.dir")
-    if (currentDir.endsWith(apolloCompiler)) {
-      currentDir = new File( "..", "apollo-compiler" )
-    }
-      else {
-      currentDir = new File( "apollo-compiler" )
-    }
+    apolloCompilerRelativeDirectory =
+      System.getProperty("user.dir").endsWith("apollo-compiler") ?
+              "../apollo-compiler" :
+              "apollo-compiler"
 
-    def dir = new File(currentDir, "src/test/graphql/com/example")
+    def dir = new File(apolloCompilerRelativeDirectory, "src/test/graphql/com/example")
     dir.eachFile(FileType.DIRECTORIES) {
-      testDir -> generateIRFile(testDir,currentDir)
+      testDir -> generateIRFile(testDir,apolloCompilerRelativeDirectory)
     }
-    logApolloVersion(apolloVersion,currentDir)
+    logApolloVersion(apolloVersion,apolloCompilerRelativeDirectory)
   }
 
-  private static def logApolloVersion(apolloVersion, currentDir) {
-    File outputFile = new File("${currentDir}/src/test/graphql/apollo-codegen.properties")
+  private static def logApolloVersion(apolloVersion,apolloCompilerDirectory) {
+    File outputFile = new File("${apolloCompilerDirectory}/src/test/graphql/apollo-codegen.properties")
     outputFile.write("apollo-codegen version=${apolloVersion}")
   }
 
@@ -50,7 +46,7 @@ class UpdateTestIRFilesTask extends DefaultTask {
     return localCodeGenVersion
   }
 
-  def generateIRFile(testDir,currentDir) {
+  def generateIRFile(testDir,apolloCompilerDirectory) {
     logger.info("Generating IR file for: ${testDir.name}")
     def testOperationFileName = 'TestOperation.graphql'
     File queryFile = new File(testDir, testOperationFileName)
@@ -61,10 +57,10 @@ class UpdateTestIRFilesTask extends DefaultTask {
     File outputFile = new File(testDir, 'TestOperation.json')
     File schema = new File(testDir, 'schema.json') //Check for custom schema
     if (!schema.exists()) {
-      schema = new File("${currentDir}/src/test/graphql/schema.json")
+      schema = new File("${apolloCompilerDirectory}/src/test/graphql/schema.json")
     }
 
-    def idFileDir = new File("${currentDir}/build/apollo-codegen/${testDir.name}")
+    def idFileDir = new File("${apolloCompilerDirectory}/build/apollo-codegen/${testDir.name}")
     idFileDir.mkdirs()
     def idFile = new File(idFileDir, "id.json")
 

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -13,15 +13,22 @@ class UpdateTestIRFilesTask extends DefaultTask {
     if (apolloVersion == -1) {
       return
     }
-    def dir = new File("apollo-compiler/src/test/graphql/com/example")
-    dir.eachFile(FileType.DIRECTORIES) {
-      testDir -> generateIRFile(testDir)
+
+    def apolloCompiler = "apollo-compiler"
+    String currentDir = System.getProperty("user.dir")
+    if (!currentDir.contains(apolloCompiler)) {
+      currentDir = new File( currentDir, apolloCompiler )
     }
-    logApolloVersion(apolloVersion)
+
+    def dir = new File("${currentDir}/src/test/graphql/com/example")
+    dir.eachFile(FileType.DIRECTORIES) {
+      testDir -> generateIRFile(testDir,currentDir)
+    }
+    logApolloVersion(apolloVersion,currentDir)
   }
 
-  private static def logApolloVersion(apolloVersion) {
-    File outputFile = new File('apollo-compiler/src/test/graphql/apollo-codegen.properties')
+  private static def logApolloVersion(apolloVersion, currentDir) {
+    File outputFile = new File("${currentDir}/src/test/graphql/apollo-codegen.properties")
     outputFile.write("apollo-codegen version=${apolloVersion}")
   }
 
@@ -37,7 +44,7 @@ class UpdateTestIRFilesTask extends DefaultTask {
     return localCodeGenVersion
   }
 
-  def generateIRFile(testDir) {
+  def generateIRFile(testDir,currentDir) {
     logger.info("Generating IR file for: ${testDir.name}")
     def testOperationFileName = 'TestOperation.graphql'
     File queryFile = new File(testDir, testOperationFileName)
@@ -48,10 +55,10 @@ class UpdateTestIRFilesTask extends DefaultTask {
     File outputFile = new File(testDir, 'TestOperation.json')
     File schema = new File(testDir, 'schema.json') //Check for custom schema
     if (!schema.exists()) {
-      schema = new File('apollo-compiler/src/test/graphql/schema.json')
+      schema = new File("${currentDir}/src/test/graphql/schema.json")
     }
 
-    def idFileDir = new File("apollo-compiler/build/apollo-codegen/${testDir.name}")
+    def idFileDir = new File("${currentDir}/build/apollo-codegen/${testDir.name}")
     idFileDir.mkdirs()
     def idFile = new File(idFileDir, "id.json")
 

--- a/apollo-compiler/gradle/update-test-IR-files.gradle
+++ b/apollo-compiler/gradle/update-test-IR-files.gradle
@@ -19,8 +19,11 @@ class UpdateTestIRFilesTask extends DefaultTask {
     // sets working directory to $project.
     def apolloCompiler = "apollo-compiler"
     String currentDir = System.getProperty("user.dir")
-    if (!currentDir.contains(apolloCompiler)) {
-      currentDir = new File( currentDir, apolloCompiler )
+    if (currentDir.contains(apolloCompiler)) {
+      currentDir = "../apollo-compiler/"
+    }
+      else {
+      currentDir = "./apollo-compiler/"
     }
 
     def dir = new File("${currentDir}/src/test/graphql/com/example")
@@ -65,13 +68,16 @@ class UpdateTestIRFilesTask extends DefaultTask {
     idFileDir.mkdirs()
     def idFile = new File(idFileDir, "id.json")
 
-    def apolloCodeGenProcess = """apollo-codegen generate ${queryFile.absoluteFile}
+      def apolloCodeGenCommand = """apollo-codegen generate ${queryFile.absoluteFile}
           --add-typename
           --operation-ids-path ${idFile.toString()}
           --merge-in-fields-from-fragment-spreads false
           --schema ${schema.absoluteFile}
           --output ${outputFile.absoluteFile}
-          --target json""".execute()
+          --target json"""
+    def apolloCodeGenProcess = apolloCodeGenCommand.execute()
+
+      println( "CODEGEN: ${apolloCodeGenCommand}")
     apolloCodeGenProcess.waitFor()
     def error = apolloCodeGenProcess.err.text
     if (error != null && !error.isEmpty()) {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.Utils;
 import com.example.custom_scalar_type_warnings.type.CustomType;
 import java.lang.Object;
 import java.lang.Override;
@@ -16,15 +17,19 @@ import java.lang.String;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
-      + "  links\n"
+      + "  hero {\n"
+      + "    __typename\n"
+      + "    links\n"
+      + "  }\n"
       + "}";
 
-  public static final String OPERATION_ID = "261d102d2c930a0f9f444325bd349452a77a8c138cc1278825eb48971a8b88cf";
+  public static final String OPERATION_ID = "e85bc0b78c2cf20d9b02def60116c1d698ef6777720553e8f2f4507fad0eef35";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
@@ -86,10 +91,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
-      ResponseField.forList("links", "links", null, true, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
     };
 
-    final Optional<List<Object>> links;
+    final Optional<Hero> hero;
 
     private volatile String $toString;
 
@@ -97,24 +102,19 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private volatile boolean $hashCodeMemoized;
 
-    public Data(@Nullable List<Object> links) {
-      this.links = Optional.fromNullable(links);
+    public Data(@Nullable Hero hero) {
+      this.hero = Optional.fromNullable(hero);
     }
 
-    public Optional<List<Object>> links() {
-      return this.links;
+    public Optional<Hero> hero() {
+      return this.hero;
     }
 
     public ResponseFieldMarshaller marshaller() {
       return new ResponseFieldMarshaller() {
         @Override
         public void marshal(ResponseWriter writer) {
-          writer.writeList($responseFields[0], links.isPresent() ? links.get() : null, new ResponseWriter.ListWriter() {
-            @Override
-            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
-              listItemWriter.writeCustom(CustomType.URL, value);
-            }
-          });
+          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
         }
       };
     }
@@ -123,7 +123,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public String toString() {
       if ($toString == null) {
         $toString = "Data{"
-          + "links=" + links
+          + "hero=" + hero
           + "}";
       }
       return $toString;
@@ -136,7 +136,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
       if (o instanceof Data) {
         Data that = (Data) o;
-        return this.links.equals(that.links);
+        return this.hero.equals(that.hero);
       }
       return false;
     }
@@ -146,7 +146,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (!$hashCodeMemoized) {
         int h = 1;
         h *= 1000003;
-        h ^= links.hashCode();
+        h ^= hero.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -154,15 +154,117 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
+      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+
       @Override
       public Data map(ResponseReader reader) {
-        final List<Object> links = reader.readList($responseFields[0], new ResponseReader.ListReader<Object>() {
+        final Hero hero = reader.readObject($responseFields[0], new ResponseReader.ObjectReader<Hero>() {
+          @Override
+          public Hero read(ResponseReader reader) {
+            return heroFieldMapper.map(reader);
+          }
+        });
+        return new Data(hero);
+      }
+    }
+  }
+
+  public static class Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("links", "links", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull List<Object> links;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Hero(@NotNull String __typename, @NotNull List<Object> links) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.links = Utils.checkNotNull(links, "links == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * Links
+     */
+    public @NotNull List<Object> links() {
+      return this.links;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeList($responseFields[1], links, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeCustom(CustomType.URL, value);
+            }
+          });
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Hero{"
+          + "__typename=" + __typename + ", "
+          + "links=" + links
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Hero) {
+        Hero that = (Hero) o;
+        return this.__typename.equals(that.__typename)
+         && this.links.equals(that.links);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= links.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Hero> {
+      @Override
+      public Hero map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final List<Object> links = reader.readList($responseFields[1], new ResponseReader.ListReader<Object>() {
           @Override
           public Object read(ResponseReader.ListItemReader listItemReader) {
             return listItemReader.readCustomType(CustomType.URL);
           }
         });
-        return new Data(links);
+        return new Hero(__typename, links);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
@@ -9,7 +9,6 @@ import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
-import com.apollographql.apollo.api.internal.Utils;
 import com.example.custom_scalar_type_warnings.type.CustomType;
 import java.lang.Object;
 import java.lang.Override;
@@ -17,19 +16,15 @@ import java.lang.String;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Generated;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
   public static final String OPERATION_DEFINITION = "query TestQuery {\n"
-      + "  hero {\n"
-      + "    __typename\n"
-      + "    links\n"
-      + "  }\n"
+      + "  links\n"
       + "}";
 
-  public static final String OPERATION_ID = "e85bc0b78c2cf20d9b02def60116c1d698ef6777720553e8f2f4507fad0eef35";
+  public static final String OPERATION_ID = "261d102d2c930a0f9f444325bd349452a77a8c138cc1278825eb48971a8b88cf";
 
   public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
@@ -91,10 +86,10 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
-      ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forList("links", "links", null, true, Collections.<ResponseField.Condition>emptyList())
     };
 
-    final Optional<Hero> hero;
+    final Optional<List<Object>> links;
 
     private volatile String $toString;
 
@@ -102,102 +97,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private volatile boolean $hashCodeMemoized;
 
-    public Data(@Nullable Hero hero) {
-      this.hero = Optional.fromNullable(hero);
+    public Data(@Nullable List<Object> links) {
+      this.links = Optional.fromNullable(links);
     }
 
-    public Optional<Hero> hero() {
-      return this.hero;
-    }
-
-    public ResponseFieldMarshaller marshaller() {
-      return new ResponseFieldMarshaller() {
-        @Override
-        public void marshal(ResponseWriter writer) {
-          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
-        }
-      };
-    }
-
-    @Override
-    public String toString() {
-      if ($toString == null) {
-        $toString = "Data{"
-          + "hero=" + hero
-          + "}";
-      }
-      return $toString;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (o == this) {
-        return true;
-      }
-      if (o instanceof Data) {
-        Data that = (Data) o;
-        return this.hero.equals(that.hero);
-      }
-      return false;
-    }
-
-    @Override
-    public int hashCode() {
-      if (!$hashCodeMemoized) {
-        int h = 1;
-        h *= 1000003;
-        h ^= hero.hashCode();
-        $hashCode = h;
-        $hashCodeMemoized = true;
-      }
-      return $hashCode;
-    }
-
-    public static final class Mapper implements ResponseFieldMapper<Data> {
-      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
-
-      @Override
-      public Data map(ResponseReader reader) {
-        final Hero hero = reader.readObject($responseFields[0], new ResponseReader.ObjectReader<Hero>() {
-          @Override
-          public Hero read(ResponseReader reader) {
-            return heroFieldMapper.map(reader);
-          }
-        });
-        return new Data(hero);
-      }
-    }
-  }
-
-  public static class Hero {
-    static final ResponseField[] $responseFields = {
-      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
-      ResponseField.forList("links", "links", null, false, Collections.<ResponseField.Condition>emptyList())
-    };
-
-    final @NotNull String __typename;
-
-    final @NotNull List<Object> links;
-
-    private volatile String $toString;
-
-    private volatile int $hashCode;
-
-    private volatile boolean $hashCodeMemoized;
-
-    public Hero(@NotNull String __typename, @NotNull List<Object> links) {
-      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
-      this.links = Utils.checkNotNull(links, "links == null");
-    }
-
-    public @NotNull String __typename() {
-      return this.__typename;
-    }
-
-    /**
-     * Links
-     */
-    public @NotNull List<Object> links() {
+    public Optional<List<Object>> links() {
       return this.links;
     }
 
@@ -205,8 +109,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return new ResponseFieldMarshaller() {
         @Override
         public void marshal(ResponseWriter writer) {
-          writer.writeString($responseFields[0], __typename);
-          writer.writeList($responseFields[1], links, new ResponseWriter.ListWriter() {
+          writer.writeList($responseFields[0], links.isPresent() ? links.get() : null, new ResponseWriter.ListWriter() {
             @Override
             public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
               listItemWriter.writeCustom(CustomType.URL, value);
@@ -219,8 +122,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @Override
     public String toString() {
       if ($toString == null) {
-        $toString = "Hero{"
-          + "__typename=" + __typename + ", "
+        $toString = "Data{"
           + "links=" + links
           + "}";
       }
@@ -232,10 +134,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (o == this) {
         return true;
       }
-      if (o instanceof Hero) {
-        Hero that = (Hero) o;
-        return this.__typename.equals(that.__typename)
-         && this.links.equals(that.links);
+      if (o instanceof Data) {
+        Data that = (Data) o;
+        return this.links.equals(that.links);
       }
       return false;
     }
@@ -245,8 +146,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (!$hashCodeMemoized) {
         int h = 1;
         h *= 1000003;
-        h ^= __typename.hashCode();
-        h *= 1000003;
         h ^= links.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
@@ -254,17 +153,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return $hashCode;
     }
 
-    public static final class Mapper implements ResponseFieldMapper<Hero> {
+    public static final class Mapper implements ResponseFieldMapper<Data> {
       @Override
-      public Hero map(ResponseReader reader) {
-        final String __typename = reader.readString($responseFields[0]);
-        final List<Object> links = reader.readList($responseFields[1], new ResponseReader.ListReader<Object>() {
+      public Data map(ResponseReader reader) {
+        final List<Object> links = reader.readList($responseFields[0], new ResponseReader.ListReader<Object>() {
           @Override
           public Object read(ResponseReader.ListItemReader listItemReader) {
             return listItemReader.readCustomType(CustomType.URL);
           }
         });
-        return new Hero(__typename, links);
+        return new Data(links);
       }
     }
   }


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

If you run the task `./gradlew :apollo-compiler:updateTestIRFiles` from the command line, IR generation works fine.

If you run from the Android Studio gradle menu, the task fails because the working directory is mistakenly set to `apollo-compiler` (so paths look like `apollo-compiler/apollo-compiler/...` and IR fails). 

This PR makes it so that the task figures out its contextual working directory and does the right thing.