### PR TITLE
Fix issue with inline fragments mapped to null

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -244,7 +244,7 @@ fun TypeSpec.withHashCodeImplementation(): TypeSpec {
       .build()
 }
 
-fun ClassName.mapperFieldName(): String = "${simpleName().decapitalize()}FieldMapper"
+fun ClassName.mapperFieldName(): String = "${simpleName().decapitalize()}${Util.FIELD_MAPPER_SUFFIX}"
 
 fun TypeName.isNullable(): Boolean = isOptional() || annotations.contains(Annotations.NULLABLE)
 
@@ -431,7 +431,7 @@ fun TypeName.rawType(): TypeName {
       ?: this
 }
 
-fun TypeSpec.confirmToProtocol(protocolSpec: TypeSpec): TypeSpec {
+fun TypeSpec.conformToProtocol(protocolSpec: TypeSpec): TypeSpec {
   val nestedTypes = typeSpecs.map { it.name }
   val nestedTypeProtocols = methodSpecs
       .filter { it.returnType != null }
@@ -460,7 +460,7 @@ fun TypeSpec.confirmToProtocol(protocolSpec: TypeSpec): TypeSpec {
       .addMethods(methodSpecs)
       .addTypes(typeSpecs.map { typeSpec ->
         val protocol = nestedTypeProtocols[typeSpec.name]
-        protocol?.let { typeSpec.confirmToProtocol(it) } ?: typeSpec
+        protocol?.let { typeSpec.conformToProtocol(it) } ?: typeSpec
       })
       .also { if (!staticBlock.isEmpty) it.addStaticBlock(staticBlock) }
       .also { if (classBuilder && !initializerBlock.isEmpty) it.addInitializerBlock(initializerBlock) }
@@ -501,6 +501,7 @@ object Util {
   const val MEMOIZED_HASH_CODE_VAR: String = "\$hashCode"
   const val MEMOIZED_HASH_CODE_FLAG_VAR: String = "\$hashCodeMemoized"
   const val MEMOIZED_TO_STRING_VAR: String = "\$toString"
+  const val FIELD_MAPPER_SUFFIX: String = "FieldMapper"
   val SCALAR_TYPES = listOf(ClassNames.STRING, TypeName.INT, TypeName.INT.box(), TypeName.LONG,
       TypeName.LONG.box(), TypeName.DOUBLE, TypeName.DOUBLE.box(), TypeName.BOOLEAN, TypeName.BOOLEAN.box())
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -23,6 +23,7 @@ data class Fragment(
   override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec {
     return SchemaTypeSpecBuilder(
         typeName = formatClassName(),
+        schemaType = typeCondition,
         fields = fields,
         fragmentSpreads = fragmentSpreads,
         inlineFragments = inlineFragments,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -62,6 +62,8 @@ public interface HeroDetails extends GraphqlFragment {
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+    final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
     @Override
     public HeroDetails map(ResponseReader reader) {
       final AsDroid asDroid = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid")), new ResponseReader.ConditionalTypeReader<AsDroid>() {
@@ -73,7 +75,7 @@ public interface HeroDetails extends GraphqlFragment {
       if (asDroid != null) {
         return asDroid;
       }
-      return null;
+      return asCharacterFieldMapper.map(reader);
     }
   }
 
@@ -755,6 +757,625 @@ public interface HeroDetails extends GraphqlFragment {
         Utils.checkNotNull(__typename, "__typename == null");
         Utils.checkNotNull(name, "name == null");
         return new Node1(__typename, name);
+      }
+    }
+  }
+
+  class AsCharacter implements HeroDetails {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    final @NotNull FriendsConnection2 friendsConnection;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name,
+        @NotNull FriendsConnection2 friendsConnection) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    /**
+     * The friends of the character exposed as a connection with edges
+     */
+    public @NotNull FriendsConnection2 friendsConnection() {
+      return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
+          + "friendsConnection=" + friendsConnection
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
+         && this.friendsConnection.equals(that.friendsConnection);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
+        h ^= friendsConnection.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.name = name;
+      builder.friendsConnection = friendsConnection;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      final FriendsConnection2.Mapper friendsConnection2FieldMapper = new FriendsConnection2.Mapper();
+
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        final FriendsConnection2 friendsConnection = reader.readObject($responseFields[2], new ResponseReader.ObjectReader<FriendsConnection2>() {
+          @Override
+          public FriendsConnection2 read(ResponseReader reader) {
+            return friendsConnection2FieldMapper.map(reader);
+          }
+        });
+        return new AsCharacter(__typename, name, friendsConnection);
+      }
+    }
+
+    public static final class Builder {
+      private @NotNull String __typename;
+
+      private @NotNull String name;
+
+      private @NotNull FriendsConnection2 friendsConnection;
+
+      Builder() {
+      }
+
+      public Builder __typename(@NotNull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder name(@NotNull String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Builder friendsConnection(@NotNull FriendsConnection2 friendsConnection) {
+        this.friendsConnection = friendsConnection;
+        return this;
+      }
+
+      public Builder friendsConnection(@NotNull Mutator<FriendsConnection2.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        FriendsConnection2.Builder builder = this.friendsConnection != null ? this.friendsConnection.toBuilder() : FriendsConnection2.builder();
+        mutator.accept(builder);
+        this.friendsConnection = builder.build();
+        return this;
+      }
+
+      public AsCharacter build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        Utils.checkNotNull(name, "name == null");
+        Utils.checkNotNull(friendsConnection, "friendsConnection == null");
+        return new AsCharacter(__typename, name, friendsConnection);
+      }
+    }
+  }
+
+  class FriendsConnection2 implements FriendsConnection {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forInt("totalCount", "totalCount", null, true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("edges", "edges", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<Integer> totalCount;
+
+    final Optional<List<Edge2>> edges;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public FriendsConnection2(@NotNull String __typename, @Nullable Integer totalCount,
+        @Nullable List<Edge2> edges) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.totalCount = Optional.fromNullable(totalCount);
+      this.edges = Optional.fromNullable(edges);
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The total number of friends
+     */
+    public Optional<Integer> totalCount() {
+      return this.totalCount;
+    }
+
+    /**
+     * The edges for each of the character's friends.
+     */
+    public Optional<List<Edge2>> edges() {
+      return this.edges;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? edges.get() : null, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeObject(((Edge2) value).marshaller());
+            }
+          });
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "FriendsConnection2{"
+          + "__typename=" + __typename + ", "
+          + "totalCount=" + totalCount + ", "
+          + "edges=" + edges
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof FriendsConnection2) {
+        FriendsConnection2 that = (FriendsConnection2) o;
+        return this.__typename.equals(that.__typename)
+         && this.totalCount.equals(that.totalCount)
+         && this.edges.equals(that.edges);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= totalCount.hashCode();
+        h *= 1000003;
+        h ^= edges.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.totalCount = totalCount.isPresent() ? totalCount.get() : null;
+      builder.edges = edges.isPresent() ? edges.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<FriendsConnection2> {
+      final Edge2.Mapper edge2FieldMapper = new Edge2.Mapper();
+
+      @Override
+      public FriendsConnection2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Integer totalCount = reader.readInt($responseFields[1]);
+        final List<Edge2> edges = reader.readList($responseFields[2], new ResponseReader.ListReader<Edge2>() {
+          @Override
+          public Edge2 read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readObject(new ResponseReader.ObjectReader<Edge2>() {
+              @Override
+              public Edge2 read(ResponseReader reader) {
+                return edge2FieldMapper.map(reader);
+              }
+            });
+          }
+        });
+        return new FriendsConnection2(__typename, totalCount, edges);
+      }
+    }
+
+    public static final class Builder {
+      private @NotNull String __typename;
+
+      private @Nullable Integer totalCount;
+
+      private @Nullable List<Edge2> edges;
+
+      Builder() {
+      }
+
+      public Builder __typename(@NotNull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder totalCount(@Nullable Integer totalCount) {
+        this.totalCount = totalCount;
+        return this;
+      }
+
+      public Builder edges(@Nullable List<Edge2> edges) {
+        this.edges = edges;
+        return this;
+      }
+
+      public Builder edges(@NotNull Mutator<List<Edge2.Builder>> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        List<Edge2.Builder> builders = new ArrayList<>();
+        if (this.edges != null) {
+          for (Edge2 item : this.edges) {
+            builders.add(item != null ? item.toBuilder() : null);
+          }
+        }
+        mutator.accept(builders);
+        List<Edge2> edges = new ArrayList<>();
+        for (Edge2.Builder item : builders) {
+          edges.add(item != null ? item.build() : null);
+        }
+        this.edges = edges;
+        return this;
+      }
+
+      public FriendsConnection2 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        return new FriendsConnection2(__typename, totalCount, edges);
+      }
+    }
+  }
+
+  class Edge2 implements Edge {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("node", "node", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<Node2> node;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Edge2(@NotNull String __typename, @Nullable Node2 node) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.node = Optional.fromNullable(node);
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The character represented by this friendship edge
+     */
+    public Optional<Node2> node() {
+      return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Edge2{"
+          + "__typename=" + __typename + ", "
+          + "node=" + node
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Edge2) {
+        Edge2 that = (Edge2) o;
+        return this.__typename.equals(that.__typename)
+         && this.node.equals(that.node);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= node.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.node = node.isPresent() ? node.get() : null;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Edge2> {
+      final Node2.Mapper node2FieldMapper = new Node2.Mapper();
+
+      @Override
+      public Edge2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Node2 node = reader.readObject($responseFields[1], new ResponseReader.ObjectReader<Node2>() {
+          @Override
+          public Node2 read(ResponseReader reader) {
+            return node2FieldMapper.map(reader);
+          }
+        });
+        return new Edge2(__typename, node);
+      }
+    }
+
+    public static final class Builder {
+      private @NotNull String __typename;
+
+      private @Nullable Node2 node;
+
+      Builder() {
+      }
+
+      public Builder __typename(@NotNull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder node(@Nullable Node2 node) {
+        this.node = node;
+        return this;
+      }
+
+      public Builder node(@NotNull Mutator<Node2.Builder> mutator) {
+        Utils.checkNotNull(mutator, "mutator == null");
+        Node2.Builder builder = this.node != null ? this.node.toBuilder() : Node2.builder();
+        mutator.accept(builder);
+        this.node = builder.build();
+        return this;
+      }
+
+      public Edge2 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        return new Edge2(__typename, node);
+      }
+    }
+  }
+
+  class Node2 implements Node {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Node2(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Node2{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Node2) {
+        Node2 that = (Node2) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public Builder toBuilder() {
+      Builder builder = new Builder();
+      builder.__typename = __typename;
+      builder.name = name;
+      return builder;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Node2> {
+      @Override
+      public Node2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new Node2(__typename, name);
+      }
+    }
+
+    public static final class Builder {
+      private @NotNull String __typename;
+
+      private @NotNull String name;
+
+      Builder() {
+      }
+
+      public Builder __typename(@NotNull String __typename) {
+        this.__typename = __typename;
+        return this;
+      }
+
+      public Builder name(@NotNull String name) {
+        this.name = name;
+        return this;
+      }
+
+      public Node2 build() {
+        Utils.checkNotNull(__typename, "__typename == null");
+        Utils.checkNotNull(name, "name == null");
+        return new Node2(__typename, name);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -179,6 +179,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public Hero map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -190,7 +192,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asHuman != null) {
           return asHuman;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -281,6 +283,79 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String __typename = reader.readString($responseFields[0]);
         final Double height = reader.readDouble($responseFields[1]);
         return new AsHuman(__typename, height);
+      }
+    }
+  }
+
+  public static class AsCharacter implements Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        return new AsCharacter(__typename);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -201,6 +201,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public Hero map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -221,7 +223,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asDroid != null) {
           return asDroid;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -696,6 +698,96 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String __typename = reader.readString($responseFields[0]);
         final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
         return new Friend1(__typename, id);
+      }
+    }
+  }
+
+  public static class AsCharacter implements Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter(__typename, name);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
@@ -65,6 +65,8 @@ public interface HeroDetails extends GraphqlFragment {
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+    final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
     @Override
     public HeroDetails map(ResponseReader reader) {
       final AsDroid asDroid = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Droid")), new ResponseReader.ConditionalTypeReader<AsDroid>() {
@@ -76,7 +78,7 @@ public interface HeroDetails extends GraphqlFragment {
       if (asDroid != null) {
         return asDroid;
       }
-      return null;
+      return asCharacterFieldMapper.map(reader);
     }
   }
 
@@ -704,6 +706,561 @@ public interface HeroDetails extends GraphqlFragment {
         final String __typename = reader.readString($responseFields[0]);
         final boolean hasNextPage = reader.readBoolean($responseFields[1]);
         return new PageInfo1(__typename, hasNextPage);
+      }
+    }
+  }
+
+  class AsCharacter implements HeroDetails {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    final @NotNull FriendsConnection2 friendsConnection;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name,
+        @NotNull FriendsConnection2 friendsConnection) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friendsConnection = Utils.checkNotNull(friendsConnection, "friendsConnection == null");
+    }
+
+    public @NotNull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String getName() {
+      return this.name;
+    }
+
+    /**
+     * The friends of the character exposed as a connection with edges
+     */
+    public @NotNull FriendsConnection2 getFriendsConnection() {
+      return this.friendsConnection;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeObject($responseFields[2], friendsConnection.marshaller());
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
+          + "friendsConnection=" + friendsConnection
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
+         && this.friendsConnection.equals(that.friendsConnection);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
+        h ^= friendsConnection.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      final FriendsConnection2.Mapper friendsConnection2FieldMapper = new FriendsConnection2.Mapper();
+
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        final FriendsConnection2 friendsConnection = reader.readObject($responseFields[2], new ResponseReader.ObjectReader<FriendsConnection2>() {
+          @Override
+          public FriendsConnection2 read(ResponseReader reader) {
+            return friendsConnection2FieldMapper.map(reader);
+          }
+        });
+        return new AsCharacter(__typename, name, friendsConnection);
+      }
+    }
+  }
+
+  class FriendsConnection2 implements FriendsConnection {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forInt("totalCount", "totalCount", null, true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("edges", "edges", null, true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("pageInfo", "pageInfo", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forBoolean("isEmpty", "isEmpty", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<Integer> totalCount;
+
+    final Optional<List<Edge2>> edges;
+
+    final @NotNull PageInfo2 pageInfo;
+
+    final boolean isEmpty;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public FriendsConnection2(@NotNull String __typename, @Nullable Integer totalCount,
+        @Nullable List<Edge2> edges, @NotNull PageInfo2 pageInfo, boolean isEmpty) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.totalCount = Optional.fromNullable(totalCount);
+      this.edges = Optional.fromNullable(edges);
+      this.pageInfo = Utils.checkNotNull(pageInfo, "pageInfo == null");
+      this.isEmpty = isEmpty;
+    }
+
+    public @NotNull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The total number of friends
+     */
+    public Optional<Integer> getTotalCount() {
+      return this.totalCount;
+    }
+
+    /**
+     * The edges for each of the character's friends.
+     */
+    public Optional<List<Edge2>> getEdges() {
+      return this.edges;
+    }
+
+    /**
+     * Information for paginating this connection
+     */
+    public @NotNull PageInfo2 getPageInfo() {
+      return this.pageInfo;
+    }
+
+    /**
+     * For test java beans semantic naming only
+     */
+    public boolean isEmpty() {
+      return this.isEmpty;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeInt($responseFields[1], totalCount.isPresent() ? totalCount.get() : null);
+          writer.writeList($responseFields[2], edges.isPresent() ? edges.get() : null, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeObject(((Edge2) value).marshaller());
+            }
+          });
+          writer.writeObject($responseFields[3], pageInfo.marshaller());
+          writer.writeBoolean($responseFields[4], isEmpty);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "FriendsConnection2{"
+          + "__typename=" + __typename + ", "
+          + "totalCount=" + totalCount + ", "
+          + "edges=" + edges + ", "
+          + "pageInfo=" + pageInfo + ", "
+          + "isEmpty=" + isEmpty
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof FriendsConnection2) {
+        FriendsConnection2 that = (FriendsConnection2) o;
+        return this.__typename.equals(that.__typename)
+         && this.totalCount.equals(that.totalCount)
+         && this.edges.equals(that.edges)
+         && this.pageInfo.equals(that.pageInfo)
+         && this.isEmpty == that.isEmpty;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= totalCount.hashCode();
+        h *= 1000003;
+        h ^= edges.hashCode();
+        h *= 1000003;
+        h ^= pageInfo.hashCode();
+        h *= 1000003;
+        h ^= Boolean.valueOf(isEmpty).hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<FriendsConnection2> {
+      final Edge2.Mapper edge2FieldMapper = new Edge2.Mapper();
+
+      final PageInfo2.Mapper pageInfo2FieldMapper = new PageInfo2.Mapper();
+
+      @Override
+      public FriendsConnection2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Integer totalCount = reader.readInt($responseFields[1]);
+        final List<Edge2> edges = reader.readList($responseFields[2], new ResponseReader.ListReader<Edge2>() {
+          @Override
+          public Edge2 read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readObject(new ResponseReader.ObjectReader<Edge2>() {
+              @Override
+              public Edge2 read(ResponseReader reader) {
+                return edge2FieldMapper.map(reader);
+              }
+            });
+          }
+        });
+        final PageInfo2 pageInfo = reader.readObject($responseFields[3], new ResponseReader.ObjectReader<PageInfo2>() {
+          @Override
+          public PageInfo2 read(ResponseReader reader) {
+            return pageInfo2FieldMapper.map(reader);
+          }
+        });
+        final boolean isEmpty = reader.readBoolean($responseFields[4]);
+        return new FriendsConnection2(__typename, totalCount, edges, pageInfo, isEmpty);
+      }
+    }
+  }
+
+  class Edge2 implements Edge {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("node", "node", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<Node2> node;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Edge2(@NotNull String __typename, @Nullable Node2 node) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.node = Optional.fromNullable(node);
+    }
+
+    public @NotNull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The character represented by this friendship edge
+     */
+    public Optional<Node2> getNode() {
+      return this.node;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], node.isPresent() ? node.get().marshaller() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Edge2{"
+          + "__typename=" + __typename + ", "
+          + "node=" + node
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Edge2) {
+        Edge2 that = (Edge2) o;
+        return this.__typename.equals(that.__typename)
+         && this.node.equals(that.node);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= node.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Edge2> {
+      final Node2.Mapper node2FieldMapper = new Node2.Mapper();
+
+      @Override
+      public Edge2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Node2 node = reader.readObject($responseFields[1], new ResponseReader.ObjectReader<Node2>() {
+          @Override
+          public Node2 read(ResponseReader reader) {
+            return node2FieldMapper.map(reader);
+          }
+        });
+        return new Edge2(__typename, node);
+      }
+    }
+  }
+
+  class Node2 implements Node {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Node2(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String get__typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String getName() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Node2{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Node2) {
+        Node2 that = (Node2) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Node2> {
+      @Override
+      public Node2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new Node2(__typename, name);
+      }
+    }
+  }
+
+  class PageInfo2 implements PageInfo {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forBoolean("hasNextPage", "hasNextPage", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final boolean hasNextPage;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public PageInfo2(@NotNull String __typename, boolean hasNextPage) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.hasNextPage = hasNextPage;
+    }
+
+    public @NotNull String get__typename() {
+      return this.__typename;
+    }
+
+    public boolean isHasNextPage() {
+      return this.hasNextPage;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeBoolean($responseFields[1], hasNextPage);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "PageInfo2{"
+          + "__typename=" + __typename + ", "
+          + "hasNextPage=" + hasNextPage
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof PageInfo2) {
+        PageInfo2 that = (PageInfo2) o;
+        return this.__typename.equals(that.__typename)
+         && this.hasNextPage == that.hasNextPage;
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= Boolean.valueOf(hasNextPage).hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<PageInfo2> {
+      @Override
+      public PageInfo2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final boolean hasNextPage = reader.readBoolean($responseFields[1]);
+        return new PageInfo2(__typename, hasNextPage);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -263,6 +263,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+      final AsCharacter2.Mapper asCharacter2FieldMapper = new AsCharacter2.Mapper();
+
       @Override
       public Hero map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -283,7 +285,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asDroid != null) {
           return asDroid;
         }
-        return null;
+        return asCharacter2FieldMapper.map(reader);
       }
     }
   }
@@ -426,6 +428,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     final class Mapper implements ResponseFieldMapper<Friend> {
       final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public Friend map(ResponseReader reader) {
         final AsHuman1 asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman1>() {
@@ -437,7 +441,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asHuman != null) {
           return asHuman;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -547,6 +551,96 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String name = reader.readString($responseFields[1]);
         final Double height = reader.readDouble($responseFields[2]);
         return new AsHuman1(__typename, name, height);
+      }
+    }
+  }
+
+  public static class AsCharacter implements Friend {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter(__typename, name);
       }
     }
   }
@@ -689,6 +783,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     final class Mapper implements ResponseFieldMapper<Friend1> {
       final AsHuman2.Mapper asHuman2FieldMapper = new AsHuman2.Mapper();
 
+      final AsCharacter1.Mapper asCharacter1FieldMapper = new AsCharacter1.Mapper();
+
       @Override
       public Friend1 map(ResponseReader reader) {
         final AsHuman2 asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman2>() {
@@ -700,7 +796,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asHuman != null) {
           return asHuman;
         }
-        return null;
+        return asCharacter1FieldMapper.map(reader);
       }
     }
   }
@@ -810,6 +906,186 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String name = reader.readString($responseFields[1]);
         final Double height = reader.readDouble($responseFields[2]);
         return new AsHuman2(__typename, name, height);
+      }
+    }
+  }
+
+  public static class AsCharacter1 implements Friend1 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter1(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter1{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter1) {
+        AsCharacter1 that = (AsCharacter1) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter1> {
+      @Override
+      public AsCharacter1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter1(__typename, name);
+      }
+    }
+  }
+
+  public static class AsCharacter2 implements Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter2(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter2{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter2) {
+        AsCharacter2 that = (AsCharacter2) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter2> {
+      @Override
+      public AsCharacter2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter2(__typename, name);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
@@ -49,6 +49,8 @@ public interface TestSetting extends GraphqlFragment {
   final class Mapper implements ResponseFieldMapper<TestSetting> {
     final AsSelectSetting.Mapper asSelectSettingFieldMapper = new AsSelectSetting.Mapper();
 
+    final AsSetting.Mapper asSettingFieldMapper = new AsSetting.Mapper();
+
     @Override
     public TestSetting map(ResponseReader reader) {
       final AsSelectSetting asSelectSetting = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("SelectSetting")), new ResponseReader.ConditionalTypeReader<AsSelectSetting>() {
@@ -60,7 +62,7 @@ public interface TestSetting extends GraphqlFragment {
       if (asSelectSetting != null) {
         return asSelectSetting;
       }
-      return null;
+      return asSettingFieldMapper.map(reader);
     }
   }
 
@@ -71,6 +73,8 @@ public interface TestSetting extends GraphqlFragment {
 
     final class Mapper implements ResponseFieldMapper<Value> {
       final AsStringListSettingValue.Mapper asStringListSettingValueFieldMapper = new AsStringListSettingValue.Mapper();
+
+      final AsSettingValue.Mapper asSettingValueFieldMapper = new AsSettingValue.Mapper();
 
       @Override
       public Value map(ResponseReader reader) {
@@ -83,7 +87,7 @@ public interface TestSetting extends GraphqlFragment {
         if (asStringListSettingValue != null) {
           return asStringListSettingValue;
         }
-        return null;
+        return asSettingValueFieldMapper.map(reader);
       }
     }
   }
@@ -181,6 +185,79 @@ public interface TestSetting extends GraphqlFragment {
           }
         });
         return new AsStringListSettingValue(__typename, list);
+      }
+    }
+  }
+
+  class AsSettingValue implements Value {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsSettingValue(@NotNull String __typename) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsSettingValue{"
+          + "__typename=" + __typename
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsSettingValue) {
+        AsSettingValue that = (AsSettingValue) o;
+        return this.__typename.equals(that.__typename);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsSettingValue> {
+      @Override
+      public AsSettingValue map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        return new AsSettingValue(__typename);
       }
     }
   }
@@ -319,6 +396,8 @@ public interface TestSetting extends GraphqlFragment {
     final class Mapper implements ResponseFieldMapper<Value1> {
       final AsStringListSettingValue1.Mapper asStringListSettingValue1FieldMapper = new AsStringListSettingValue1.Mapper();
 
+      final AsSettingValue1.Mapper asSettingValue1FieldMapper = new AsSettingValue1.Mapper();
+
       @Override
       public Value1 map(ResponseReader reader) {
         final AsStringListSettingValue1 asStringListSettingValue = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("StringListSettingValue")), new ResponseReader.ConditionalTypeReader<AsStringListSettingValue1>() {
@@ -330,7 +409,7 @@ public interface TestSetting extends GraphqlFragment {
         if (asStringListSettingValue != null) {
           return asStringListSettingValue;
         }
-        return null;
+        return asSettingValue1FieldMapper.map(reader);
       }
     }
   }
@@ -428,6 +507,79 @@ public interface TestSetting extends GraphqlFragment {
           }
         });
         return new AsStringListSettingValue1(__typename, list);
+      }
+    }
+  }
+
+  class AsSettingValue1 implements Value1 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsSettingValue1(@NotNull String __typename) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsSettingValue1{"
+          + "__typename=" + __typename
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsSettingValue1) {
+        AsSettingValue1 that = (AsSettingValue1) o;
+        return this.__typename.equals(that.__typename);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsSettingValue1> {
+      @Override
+      public AsSettingValue1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        return new AsSettingValue1(__typename);
       }
     }
   }
@@ -544,6 +696,296 @@ public interface TestSetting extends GraphqlFragment {
         final String id = reader.readString($responseFields[2]);
         final String label = reader.readString($responseFields[3]);
         return new Option(__typename, allowFreeText, id, label);
+      }
+    }
+  }
+
+  class AsSetting implements TestSetting {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forObject("value", "value", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<Value2> value;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsSetting(@NotNull String __typename, @Nullable Value2 value) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.value = Optional.fromNullable(value);
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public Optional<Value2> value() {
+      return this.value;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeObject($responseFields[1], value.isPresent() ? value.get().marshaller() : null);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsSetting{"
+          + "__typename=" + __typename + ", "
+          + "value=" + value
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsSetting) {
+        AsSetting that = (AsSetting) o;
+        return this.__typename.equals(that.__typename)
+         && this.value.equals(that.value);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= value.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsSetting> {
+      final Value2.Mapper value2FieldMapper = new Value2.Mapper();
+
+      @Override
+      public AsSetting map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final Value2 value = reader.readObject($responseFields[1], new ResponseReader.ObjectReader<Value2>() {
+          @Override
+          public Value2 read(ResponseReader reader) {
+            return value2FieldMapper.map(reader);
+          }
+        });
+        return new AsSetting(__typename, value);
+      }
+    }
+  }
+
+  interface Value2 extends Value {
+    @NotNull String __typename();
+
+    ResponseFieldMarshaller marshaller();
+
+    final class Mapper implements ResponseFieldMapper<Value2> {
+      final AsStringListSettingValue2.Mapper asStringListSettingValue2FieldMapper = new AsStringListSettingValue2.Mapper();
+
+      final AsSettingValue2.Mapper asSettingValue2FieldMapper = new AsSettingValue2.Mapper();
+
+      @Override
+      public Value2 map(ResponseReader reader) {
+        final AsStringListSettingValue2 asStringListSettingValue = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("StringListSettingValue")), new ResponseReader.ConditionalTypeReader<AsStringListSettingValue2>() {
+          @Override
+          public AsStringListSettingValue2 read(String conditionalType, ResponseReader reader) {
+            return asStringListSettingValue2FieldMapper.map(reader);
+          }
+        });
+        if (asStringListSettingValue != null) {
+          return asStringListSettingValue;
+        }
+        return asSettingValue2FieldMapper.map(reader);
+      }
+    }
+  }
+
+  class AsStringListSettingValue2 implements Value2 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("list", "list", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final Optional<List<String>> list;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsStringListSettingValue2(@NotNull String __typename, @Nullable List<String> list) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.list = Optional.fromNullable(list);
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public Optional<List<String>> list() {
+      return this.list;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeList($responseFields[1], list.isPresent() ? list.get() : null, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeString(value);
+            }
+          });
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsStringListSettingValue2{"
+          + "__typename=" + __typename + ", "
+          + "list=" + list
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsStringListSettingValue2) {
+        AsStringListSettingValue2 that = (AsStringListSettingValue2) o;
+        return this.__typename.equals(that.__typename)
+         && this.list.equals(that.list);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= list.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsStringListSettingValue2> {
+      @Override
+      public AsStringListSettingValue2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final List<String> list = reader.readList($responseFields[1], new ResponseReader.ListReader<String>() {
+          @Override
+          public String read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readString();
+          }
+        });
+        return new AsStringListSettingValue2(__typename, list);
+      }
+    }
+  }
+
+  class AsSettingValue2 implements Value2 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsSettingValue2(@NotNull String __typename) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsSettingValue2{"
+          + "__typename=" + __typename
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsSettingValue2) {
+        AsSettingValue2 that = (AsSettingValue2) o;
+        return this.__typename.equals(that.__typename);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsSettingValue2> {
+      @Override
+      public AsSettingValue2 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        return new AsSettingValue2(__typename);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -190,6 +190,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public Hero map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -210,7 +212,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asDroid != null) {
           return asDroid;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -426,6 +428,96 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String name = reader.readString($responseFields[1]);
         final String primaryFunction = reader.readString($responseFields[2]);
         return new AsDroid(__typename, name, primaryFunction);
+      }
+    }
+  }
+
+  public static class AsCharacter implements Hero {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter(__typename, name);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -226,6 +226,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsStarship.Mapper asStarshipFieldMapper = new AsStarship.Mapper();
 
+      final AsSearchResult.Mapper asSearchResultFieldMapper = new AsSearchResult.Mapper();
+
       @Override
       public Search map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -255,7 +257,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asStarship != null) {
           return asStarship;
         }
-        return null;
+        return asSearchResultFieldMapper.map(reader);
       }
     }
   }
@@ -417,6 +419,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public Friend map(ResponseReader reader) {
         final AsHuman1 asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman1>() {
@@ -437,7 +441,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asDroid != null) {
           return asDroid;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -931,6 +935,96 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  public static class AsCharacter implements Friend {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter(__typename, name);
+      }
+    }
+  }
+
   public static class AsDroid1 implements Search {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1088,6 +1182,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       final AsDroid2.Mapper asDroid2FieldMapper = new AsDroid2.Mapper();
 
+      final AsCharacter1.Mapper asCharacter1FieldMapper = new AsCharacter1.Mapper();
+
       @Override
       public Friend3 map(ResponseReader reader) {
         final AsHuman2 asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman2>() {
@@ -1108,7 +1204,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         if (asDroid != null) {
           return asDroid;
         }
-        return null;
+        return asCharacter1FieldMapper.map(reader);
       }
     }
   }
@@ -1602,6 +1698,96 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  public static class AsCharacter1 implements Friend3 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter1(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter1{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter1) {
+        AsCharacter1 that = (AsCharacter1) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter1> {
+      @Override
+      public AsCharacter1 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter1(__typename, name);
+      }
+    }
+  }
+
   public static class AsStarship implements Search {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1688,6 +1874,79 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String __typename = reader.readString($responseFields[0]);
         final String name = reader.readString($responseFields[1]);
         return new AsStarship(__typename, name);
+      }
+    }
+  }
+
+  public static class AsSearchResult implements Search {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsSearchResult(@NotNull String __typename) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsSearchResult{"
+          + "__typename=" + __typename
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsSearchResult) {
+        AsSearchResult that = (AsSearchResult) o;
+        return this.__typename.equals(that.__typename);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsSearchResult> {
+      @Override
+      public AsSearchResult map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        return new AsSearchResult(__typename);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -207,6 +207,8 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     final class Mapper implements ResponseFieldMapper<HeroDetailQuery1> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
+      final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
+
       @Override
       public HeroDetailQuery1 map(ResponseReader reader) {
         final AsHuman asHuman = reader.readConditional(ResponseField.forInlineFragment("__typename", "__typename", Arrays.asList("Human")), new ResponseReader.ConditionalTypeReader<AsHuman>() {
@@ -218,7 +220,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
         if (asHuman != null) {
           return asHuman;
         }
-        return null;
+        return asCharacterFieldMapper.map(reader);
       }
     }
   }
@@ -696,6 +698,221 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
           }
         });
         return new Friend2(__typename, fragments);
+      }
+    }
+  }
+
+  public static class AsCharacter implements HeroDetailQuery1 {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("friends", "friends", null, true, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    final Optional<List<Friend3>> friends;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public AsCharacter(@NotNull String __typename, @NotNull String name,
+        @Nullable List<Friend3> friends) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+      this.friends = Optional.fromNullable(friends);
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    /**
+     * The friends of the character, or an empty list if they have none
+     */
+    public Optional<List<Friend3>> friends() {
+      return this.friends;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+          writer.writeList($responseFields[2], friends.isPresent() ? friends.get() : null, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(Object value, ResponseWriter.ListItemWriter listItemWriter) {
+              listItemWriter.writeObject(((Friend3) value).marshaller());
+            }
+          });
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "AsCharacter{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
+          + "friends=" + friends
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof AsCharacter) {
+        AsCharacter that = (AsCharacter) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
+         && this.friends.equals(that.friends);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
+        h ^= friends.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<AsCharacter> {
+      final Friend3.Mapper friend3FieldMapper = new Friend3.Mapper();
+
+      @Override
+      public AsCharacter map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        final List<Friend3> friends = reader.readList($responseFields[2], new ResponseReader.ListReader<Friend3>() {
+          @Override
+          public Friend3 read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readObject(new ResponseReader.ObjectReader<Friend3>() {
+              @Override
+              public Friend3 read(ResponseReader reader) {
+                return friend3FieldMapper.map(reader);
+              }
+            });
+          }
+        });
+        return new AsCharacter(__typename, name, friends);
+      }
+    }
+  }
+
+  public static class Friend3 implements Friend {
+    static final ResponseField[] $responseFields = {
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
+    };
+
+    final @NotNull String __typename;
+
+    final @NotNull String name;
+
+    private volatile String $toString;
+
+    private volatile int $hashCode;
+
+    private volatile boolean $hashCodeMemoized;
+
+    public Friend3(@NotNull String __typename, @NotNull String name) {
+      this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
+    }
+
+    public @NotNull String __typename() {
+      return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
+    }
+
+    public ResponseFieldMarshaller marshaller() {
+      return new ResponseFieldMarshaller() {
+        @Override
+        public void marshal(ResponseWriter writer) {
+          writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
+        }
+      };
+    }
+
+    @Override
+    public String toString() {
+      if ($toString == null) {
+        $toString = "Friend3{"
+          + "__typename=" + __typename + ", "
+          + "name=" + name
+          + "}";
+      }
+      return $toString;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o == this) {
+        return true;
+      }
+      if (o instanceof Friend3) {
+        Friend3 that = (Friend3) o;
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      if (!$hashCodeMemoized) {
+        int h = 1;
+        h *= 1000003;
+        h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
+        $hashCode = h;
+        $hashCodeMemoized = true;
+      }
+      return $hashCode;
+    }
+
+    public static final class Mapper implements ResponseFieldMapper<Friend3> {
+      @Override
+      public Friend3 map(ResponseReader reader) {
+        final String __typename = reader.readString($responseFields[0]);
+        final String name = reader.readString($responseFields[1]);
+        return new Friend3(__typename, name);
       }
     }
   }


### PR DESCRIPTION
If response is an instance of inline fragment that is not in the requested list we map it null.
These changes generates surrogate inline fragment class that mapper will fallback to if response typename doesn't match to requested inline fragment conditions.

Example: https://github.com/apollographql/apollo-android/pull/971/files#diff-4e9825e5c07ebb7d5462ee1ca6f79e46

Closes https://github.com/apollographql/apollo-android/issues/955


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->