### PR TITLE
Update Moshi version to 1.6.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,7 +32,7 @@ ext.dep = [
     compiletesting          : 'com.google.testing.compile:compile-testing:0.11',
     cache                   : "com.nytimes.android:cache:$versions.cacheVersion",
     javaPoet                : 'com.squareup:javapoet:1.8.0',
-    moshi                   : 'com.squareup.moshi:moshi:1.5.0',
+    moshi                   : 'com.squareup.moshi:moshi:1.6.0',
     rxjava                  : 'io.reactivex:rxjava:1.2.9',
     rxjava2                 : 'io.reactivex.rxjava2:rxjava:2.0.5',
     rxandroid               : 'io.reactivex.rxjava2:rxandroid:2.0.1',


### PR DESCRIPTION
The issue with `Nesting too deep error` was fixed in Moshi with 1.6.0 release.

Closes https://github.com/apollographql/apollo-android/issues/736


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->