### PR TITLE
Specify codegen version in README w/ example install

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ To enable usage of pre-installed `apollo-codegen` module, set gradle system prop
 systemProp.apollographql.useGlobalApolloCodegen=true
 ```
 
-Note that this requires exactly version `0.19.1` (not older, not newer). You can install this conventionall via `npm install -g apollo-codegen@0.19.1`.
+Note that this requires exactly version `0.19.1` (not older, not newer). You can install this conventionally via `npm install -g apollo-codegen@0.19.1`.
 
 ### Download
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,8 @@ To enable usage of pre-installed `apollo-codegen` module, set gradle system prop
 systemProp.apollographql.useGlobalApolloCodegen=true
 ```
 
+Note that this requires exactly version `0.19.1` (not older, not newer). You can install this conventionall via `npm install -g apollo-codegen@0.19.1`.
+
 ### Download
 
 RxJava1:


### PR DESCRIPTION
This was a bit confusing when I was first setting it up, and after talking with @digitalbuddha it seemed like a good thing to mention in the readme