### PR TITLE
docs: Add browser auto-reloading on source content changes.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "apollo-hexo-config": "1.0.8",
     "chexo": "1.0.5",
     "hexo": "3.7.1",
+    "hexo-browsersync": "0.3.0",
     "hexo-prism-plus": "1.0.0",
     "hexo-renderer-ejs": "0.3.1",
     "hexo-renderer-less": "0.2.0",


### PR DESCRIPTION
By virtue of a relatively simple `hexo-browsersync` package[0], which
implements BrowserSync[1] in Hexo, this change brings support for automatically
reloading the browser when the source content has changed.

No more pressing "Reload" in order to see the changes to the Markdown source
when working on documentation! :tada:

[0]: https://npm.im/hexo-browsersync
[1]: https://www.browsersync.io