### PR TITLE
docs: Update blog URLs to reference blog.apollographql.com.

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -5,13 +5,13 @@ order: 0
 
 ## Docs are on GitHub
 
-Apollo Android has been [launched](https://dev-blog.apollodata.com/launching-apollo-graphql-on-android-40ee0b5789bd) and is ready to try in your app today! For now, the docs for the project are hosted on GitHub, please look there: [apollographql/apollo-android](https://github.com/apollographql/apollo-android).
+Apollo Android has been [launched](https://blog.apollographql.com/launching-apollo-graphql-on-android-40ee0b5789bd) and is ready to try in your app today! For now, the docs for the project are hosted on GitHub, please look there: [apollographql/apollo-android](https://github.com/apollographql/apollo-android).
 
 ## Getting involved
 
-Apollo Android is a community-driven project with contributors from many companies. Check out the [blog post introducing the first public release of the project](https://dev-blog.apollodata.com/launching-apollo-graphql-on-android-40ee0b5789bd) and the [project's README](https://github.com/apollographql/apollo-android) to learn about the current progress.
+Apollo Android is a community-driven project with contributors from many companies. Check out the [blog post introducing the first public release of the project](https://blog.apollographql.com/launching-apollo-graphql-on-android-40ee0b5789bd) and the [project's README](https://github.com/apollographql/apollo-android) to learn about the current progress.
 
-We're excited about the idea of further [unifying the clients for JavaScript, iOS and Android](https://dev-blog.apollodata.com/one-graphql-client-for-javascript-ios-and-android-64993c1b7991), including sharing a cache between native and React Native.
+We're excited about the idea of further [unifying the clients for JavaScript, iOS and Android](https://blog.apollographql.com/one-graphql-client-for-javascript-ios-and-android-64993c1b7991), including sharing a cache between native and React Native.
 
 If you have questions or would like to contribute, please join the `#android` channel on [Slack](http://www.apollodata.com/#slack).
 


### PR DESCRIPTION
This updates all blog URLs in the documentation to use blog.apollographql.com
as the domain, rather than dev-blog.apollodata.com.