### PR TITLE
Update cache section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Raw HTTP Response Cache:
 
 ```java
 //Directory where cached responses will be stored
-File file = new File("/cache/");
+File file = new File(context.getApplicationInfo().dataDir.concat("/cache"));
 
 //Size in bytes of the cache
 int size = 1024*1024;

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Raw HTTP Response Cache:
 
 ```java
 //Directory where cached responses will be stored
-File file = new File(context.getApplicationInfo().dataDir.concat("/cache"));
+File file = new File(context.getApplicationContext().getCacheDir());
 
 //Size in bytes of the cache
 int size = 1024*1024;


### PR DESCRIPTION
## Motivation

Documentation snippets for HTTP cache using invalid directory. By default application do not have access to /cache directory. Caching will fail silently.
Common aproach for cache is to use application directory as this space is reserved for the application and it will be removed along with app. 

This simple suggestion to documentation will help developers to get cache working out of the box and with the most appropriate folder.

## Issue

AppolloHttpCache

<img width="714" alt="screen shot 2018-07-20 at 11 50 19 am" src="https://user-images.githubusercontent.com/981838/42998735-23b152b8-8c13-11e8-9165-97b18bccdc0c.png">

 