### PR TITLE
Fix race in subscription manager AutoReleaseTimer

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -405,9 +405,10 @@ public final class RealSubscriptionManager implements SubscriptionManager {
         if (timer == null) {
           timer = new Timer("Subscription SmartTimer", true);
         }
+
+        timer.schedule(timerTask, delay);
       }
 
-      timer.schedule(timerTask, delay);
     }
 
     void cancelTask(int taskId) {


### PR DESCRIPTION
We see lots of NPEs trying to call `timer.schedule()`
 and `TimerTask is canceled` errors running the subscription manager
in production. It looks like the call to `schedule()` needs to be
inside of the lock, or else the timer can be cancelled before it
is scheduled.


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->