### PR TITLE
Add LinkedHashMap type support to RecordFieldJsonAdapter

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
@@ -8,7 +8,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -85,9 +84,9 @@ public final class RecordFieldJsonAdapter {
         writeJsonValue(item, jsonWriter);
       }
       jsonWriter.endArray();
-    } else if (value instanceof LinkedHashMap) {
+    } else if (value instanceof Map) {
       //noinspection unchecked
-      LinkedHashMap<String, Object> fields = (LinkedHashMap) value;
+      Map<String, Object> fields = (Map) value;
       jsonWriter.beginObject();
       for (Map.Entry<String, Object> fieldEntry : fields.entrySet()) {
         jsonWriter.name(fieldEntry.getKey());

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/cache/normalized/RecordFieldJsonAdapter.java
@@ -3,13 +3,14 @@ package com.apollographql.apollo.cache.normalized;
 import com.apollographql.apollo.internal.json.CacheJsonStreamReader;
 import com.apollographql.apollo.internal.json.JsonWriter;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.jetbrains.annotations.NotNull;
 
 import okio.Buffer;
 import okio.BufferedSource;
@@ -84,6 +85,15 @@ public final class RecordFieldJsonAdapter {
         writeJsonValue(item, jsonWriter);
       }
       jsonWriter.endArray();
+    } else if (value instanceof LinkedHashMap) {
+      //noinspection unchecked
+      LinkedHashMap<String, Object> fields = (LinkedHashMap) value;
+      jsonWriter.beginObject();
+      for (Map.Entry<String, Object> fieldEntry : fields.entrySet()) {
+        jsonWriter.name(fieldEntry.getKey());
+        writeJsonValue(fieldEntry.getValue(), jsonWriter);
+      }
+      jsonWriter.endObject();
     } else {
       throw new RuntimeException("Unsupported record value type: " + value.getClass());
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapterTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/cache/normalized/RecordFieldAdapterTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -44,6 +45,9 @@ public class RecordFieldAdapterTest {
     List<CacheReference> expectedCacheReferenceList = Arrays.asList(new CacheReference("bar"), new CacheReference("baz"));
     List<Object> expectedScalarList = Arrays.<Object>asList("scalarOne", "scalarTwo");
     List<List<String>> expectedListOfScalarList = Arrays.asList(Arrays.asList("scalarOne", "scalarTwo"));
+    String expectedMapKey = "foo";
+    String expectedMapValue = "bar";
+    Map<String, String> expectedMap = Collections.singletonMap(expectedMapKey, expectedMapValue);
 
     recordBuilder.addField("bigDecimal", expectedBigDecimal);
     recordBuilder.addField("string", expectedStringValue);
@@ -53,6 +57,7 @@ public class RecordFieldAdapterTest {
     recordBuilder.addField("referenceList", expectedCacheReferenceList);
     recordBuilder.addField("nullValue", null);
     recordBuilder.addField("listOfScalarList", expectedListOfScalarList);
+    recordBuilder.addField("map", expectedMap);
     Record record = recordBuilder.build();
 
     String json = recordFieldAdapter.toJson(record.fields());
@@ -67,5 +72,6 @@ public class RecordFieldAdapterTest {
     assertThat(deserializedMap.get("nullValue")).isNull();
     assertThat((List) deserializedMap.get("listOfScalarList")).hasSize(1);
     assertThat((Iterable) ((List) deserializedMap.get("listOfScalarList")).get(0)).containsExactlyElementsIn(expectedScalarList).inOrder();
+    assertThat((Map) deserializedMap.get("map")).containsEntry(expectedMapKey, expectedMapValue);
   }
 }


### PR DESCRIPTION
See: https://github.com/apollographql/apollo-android/issues/1001

RecordFieldJsonAdapter does not support LinkedHashMap at the moment, so it's unable to parse json objects if no custom types are defined. This bug is blocking SqlNormalisedCache from persisting these objects to the database. 