### PR TITLE
Handle `ApolloCacheHeaders.DO_NOT_STORE` in http cache.

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/cache/http/HttpCache.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/cache/http/HttpCache.java
@@ -35,6 +35,10 @@ public interface HttpCache {
    * Expire cached response flag http header
    */
   String CACHE_EXPIRE_AFTER_READ_HEADER = "X-APOLLO-EXPIRE-AFTER-READ";
+  /**
+   * Do not store the http response
+   */
+  String CACHE_DO_NOT_STORE = "X-APOLLO-CACHE-DO-NOT-STORE";
 
   /**
    * Clear cached http responses

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
@@ -21,6 +21,7 @@ import okio.Source;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 import static com.apollographql.apollo.cache.http.Utils.copyResponseBody;
+import static com.apollographql.apollo.cache.http.Utils.skipStoreResponse;
 
 @SuppressWarnings("WeakerAccess")
 public final class ApolloHttpCache implements HttpCache {
@@ -99,6 +100,10 @@ public final class ApolloHttpCache implements HttpCache {
   }
 
   Response cacheProxy(@NotNull Response response, @NotNull String cacheKey) {
+    if (skipStoreResponse(response.request())) {
+      return response;
+    }
+
     HttpCacheRecordEditor cacheRecordEditor = null;
     try {
       cacheRecordEditor = cacheStore.cacheRecordEditor(cacheKey);

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/Utils.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/Utils.java
@@ -16,6 +16,7 @@ import okio.Okio;
 import okio.Sink;
 import okio.Source;
 
+import static com.apollographql.apollo.api.cache.http.HttpCache.CACHE_DO_NOT_STORE;
 import static com.apollographql.apollo.api.cache.http.HttpCache.CACHE_EXPIRE_AFTER_READ_HEADER;
 import static com.apollographql.apollo.api.cache.http.HttpCache.CACHE_EXPIRE_TIMEOUT_HEADER;
 import static com.apollographql.apollo.api.cache.http.HttpCache.CACHE_FETCH_STRATEGY_HEADER;
@@ -73,6 +74,10 @@ final class Utils {
 
   static boolean shouldExpireAfterRead(Request request) {
     return Boolean.TRUE.toString().equalsIgnoreCase(request.header(CACHE_EXPIRE_AFTER_READ_HEADER));
+  }
+
+  static boolean skipStoreResponse(Request request) {
+    return Boolean.TRUE.toString().equalsIgnoreCase(request.header(CACHE_DO_NOT_STORE));
   }
 
   static Response unsatisfiableCacheRequest(Request request) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
@@ -2,6 +2,8 @@ package com.apollographql.apollo.internal.interceptor;
 
 import com.google.common.base.Predicate;
 
+import com.apollographql.apollo.cache.ApolloCacheHeaders;
+import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.Logger;
 import com.apollographql.apollo.api.Input;
@@ -65,7 +67,7 @@ public class ApolloServerInterceptorTest {
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
         new ApolloLogger(Optional.<Logger>absent()), false);
 
-    interceptor.httpCall(query);
+    interceptor.httpCall(query, CacheHeaders.NONE);
   }
 
   @Test public void testCachedHttpCall() throws Exception {
@@ -78,6 +80,7 @@ public class ApolloServerInterceptorTest {
         assertThat(request.header(HttpCache.CACHE_EXPIRE_TIMEOUT_HEADER)).isEqualTo("10000");
         assertThat(request.header(HttpCache.CACHE_EXPIRE_AFTER_READ_HEADER)).isEqualTo("false");
         assertThat(request.header(HttpCache.CACHE_PREFETCH_HEADER)).isEqualTo("false");
+        assertThat(request.header(HttpCache.CACHE_DO_NOT_STORE)).isEqualTo("true");
         assertRequestBody(request);
         return true;
       }
@@ -89,7 +92,7 @@ public class ApolloServerInterceptorTest {
         false, new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
         new ApolloLogger(Optional.<Logger>absent()), false);
 
-    interceptor.httpCall(query);
+    interceptor.httpCall(query, CacheHeaders.builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "true").build());
   }
 
   private void assertDefaultRequestHeaders(Request request) {


### PR DESCRIPTION
If request has `ApolloCacheHeaders.DO_NOT_STORE` header then do not cache http response

Closes https://github.com/apollographql/apollo-android/issues/1026


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->