### PR TITLE
Handle lowercase enum as default value in input objects

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
@@ -31,7 +31,7 @@ class BuilderTypeSpecBuilder(
         val longType = (type == TypeName.LONG || type == TypeName.LONG.box())
         CodeBlock.of("\$L\$L", value.castTo(type), if (longType) "L" else "")
       }
-      type.isEnum(typeDeclarations) -> CodeBlock.of("\$T.\$L", type, value)
+      type.isEnum(typeDeclarations) -> CodeBlock.of("\$T.safeValueOf(\$S)", type, value)
       value !is String -> CodeBlock.of("\$L", value)
       else -> CodeBlock.of("\$S", value)
     }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestOperation.json
@@ -255,7 +255,7 @@
 					"name": "enumWithDefaultValue",
 					"type": "Episode",
 					"description": "for test purpose only",
-					"defaultValue": "JEDI"
+					"defaultValue": "new"
 				}
 			]
 		},

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.java
@@ -123,7 +123,7 @@ public final class ColorInput implements InputType {
 
     private double blue = 1.5;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("new"));
 
     Builder() {
     }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.java
@@ -433,7 +433,7 @@ public final class ReviewInput implements InputType {
 
     private @NotNull ColorInput favoriteColor;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("JEDI"));
 
     private Input<Episode> nullableEnum = Input.absent();
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.json
@@ -306,7 +306,7 @@
 					"name": "enumWithDefaultValue",
 					"type": "Episode",
 					"description": "for test purpose only",
-					"defaultValue": "JEDI"
+					"defaultValue": "new"
 				}
 			]
 		},

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.java
@@ -123,7 +123,7 @@ public final class ColorInput implements InputType {
 
     private double blue = 1.5;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("new"));
 
     Builder() {
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.java
@@ -433,7 +433,7 @@ public final class ReviewInput implements InputType {
 
     private @NotNull ColorInput favoriteColor;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("JEDI"));
 
     private Input<Episode> nullableEnum = Input.absent();
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/TestOperation.json
@@ -255,7 +255,7 @@
 					"name": "enumWithDefaultValue",
 					"type": "Episode",
 					"description": "for test purpose only",
-					"defaultValue": "JEDI"
+					"defaultValue": "new"
 				}
 			]
 		},

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.java
@@ -123,7 +123,7 @@ public final class ColorInput implements InputType {
 
     private double blue = 1.5;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("new"));
 
     Builder() {
     }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.java
@@ -432,7 +432,7 @@ public final class ReviewInput implements InputType {
 
     private @NotNull ColorInput favoriteColor;
 
-    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.JEDI);
+    private Input<Episode> enumWithDefaultValue = Input.fromNullable(Episode.safeValueOf("JEDI"));
 
     private Input<Episode> nullableEnum = Input.absent();
 

--- a/apollo-compiler/src/test/graphql/schema.json
+++ b/apollo-compiler/src/test/graphql/schema.json
@@ -2137,7 +2137,7 @@
                 "name": "Episode",
                 "ofType": null
               },
-              "defaultValue": "JEDI"
+              "defaultValue": "new"
             }
           ],
           "interfaces": null,


### PR DESCRIPTION
The issue appears with the enum that has lowercase enum values used as default in input objects


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->