### PR TITLE
[ISSUE-698] Added support for Instant Apps

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.gradle
 
 import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.InstantAppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.build.gradle.api.BaseVariant
 import com.apollographql.apollo.compiler.GraphQLCompiler
@@ -40,6 +41,7 @@ class ApolloPlugin implements Plugin<Project> {
   void apply(Project project) {
     this.project = project
     if (project.plugins.hasPlugin(AppPlugin)
+        || project.plugins.hasPlugin(InstantAppPlugin)
         || project.plugins.hasPlugin(LibraryPlugin)
         || project.plugins.hasPlugin(JavaPlugin)
         || project.plugins.hasPlugin(JavaLibraryPlugin)) {


### PR DESCRIPTION
Issue #698 

I started working with feature modules for my app, and Apollo not supporting it has become a blocker. As explained in https://developer.android.com/topic/google-play-instant/getting-started/feature-plugin, developers are expected to add `apply plugin: 'com.android.feature'` to the top of their feature's build.gradle. Currently, Apollo only recognizes `com.android.application` and the other java plugins.

Here is the suggested edit from that ticket.