### PR TITLE
Remove unused link to kotlin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Apollo-Android is designed primarily with Android in mind but you can use it in 
 **Table of Contents**
 
 - [Adding Apollo to your Project](#adding-apollo-to-your-project)
-  - [Kotlin](#kotlin)
 - [Generate Code using Apollo](#generate-code-using-apollo)
 - [Consuming Code](#consuming-code)
 - [Custom Scalar Types](#custom-scalar-types)


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->
As in title, remove Kotlin from README