### PR TITLE
Point to newer CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Note: There is nothing Android specific about this query, it can be shared with 
 
 3) You will also need to add a schema to the project. In the sample project you can find the schema `apollo-sample/src/main/graphql/com/apollographql/apollo/sample/schema.json`. 
 
-You can find instructions to download your schema using apollo-codegen [HERE](https://www.apollographql.com/docs/android/essentials/get-started.html#download-schema)
+You can find instructions to download your schema using the apollo CLI [HERE](https://github.com/apollographql/apollo-tooling#apollo-schemadownload-output)
 
 4) Compile your project to have Apollo generate the appropriate Java classes with nested classes for reading from the network response. In the sample project, a `FeedQuery` Java class is created here `apollo-sample/build/generated/source/apollo/com/apollographql/apollo/sample`.
 


### PR DESCRIPTION
The README still points users to the older `apollo-codegen` documentation, though it is now recommended to use the `apollo` command to download schemas.


- [ ] feature
- [ ] blocking
- [x] docs