### PR TITLE
Make plugin work with kotlin DSL/4.10.2

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -1,8 +1,6 @@
 package com.apollographql.apollo.gradle
 
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.InstantAppPlugin
-import com.android.build.gradle.LibraryPlugin
+
 import com.android.build.gradle.api.BaseVariant
 import com.apollographql.apollo.compiler.GraphQLCompiler
 import com.google.common.base.Joiner
@@ -15,8 +13,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.plugins.JavaLibraryPlugin
-import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
@@ -40,11 +36,14 @@ class ApolloPlugin implements Plugin<Project> {
   @Override
   void apply(Project project) {
     this.project = project
-    if (hasAndroidPlugin(project) || hasJavaPlugin(project)) {
+    project.plugins.withId("java-base") {
       applyApolloPlugin()
-    } else {
-      throw new IllegalArgumentException(
-          "Apollo plugin couldn't be applied. The Android or Java plugin must be configured first")
+    }
+    project.gradle.getTaskGraph().whenReady {
+      if (!project.plugins.hasPlugin("java-base")) {
+        throw new IllegalArgumentException(
+            "Apollo plugin couldn't be applied without Android or Java or Kotlin plugin.")
+      }
     }
   }
 
@@ -233,17 +232,4 @@ class ApolloPlugin implements Plugin<Project> {
       return false
     }
   }
-
-  private static boolean hasAndroidPlugin(Project project) {
-    return project.plugins.hasPlugin(AppPlugin) \
-        || project.plugins.hasPlugin(InstantAppPlugin) \
-        || project.plugins.hasPlugin(LibraryPlugin) \
-        || project.plugins.hasPlugin("com.android.feature")
-  }
-
-  private static boolean hasJavaPlugin(Project project) {
-    return project.plugins.hasPlugin(JavaPlugin) \
-        || project.plugins.hasPlugin(JavaLibraryPlugin)
-  }
-
 }


### PR DESCRIPTION
I hope this is what was discussed with gradle community #1066 to make the plugin immune to order of applying and what will enable `apollo-gradle-plugin` to work with Kotlin DSL gradle scripts (`build.gradle.kts`).

As it is commented in #1066, it requires some configuration in **root** `settings.gradle.kts` (or just `settings.gradle`) to indicate repository where plugin is available

```
pluginManagement {
    resolutionStrategy.eachPlugin {
        if (requested.id.namespace == "com.apollographql") {
            useModule("com.apollographql.apollo:apollo-gradle-plugin:$requested.version")
        }
    }

    repositories {
        gradlePluginPortal()
        jcenter()
    }
}
...
```

and then one can apply the plugin in submodule (e.g. `graphql/build.gradle.kts`) this way:

```
plugins {
    kotlin("jvm")
    id("com.apollographql.android") version "put-version-here"  // <<<
}

dependencies {
    implementation(kotlin("stdlib-jdk7"))
    implementation("com.apollographql.apollo:apollo-runtime:put-version-here") // <<<
    ...
}
...
```

Plugin should be used with any plugin that applies `java-base` plugin - those are: `java`, `java-library`, `kotlin`, all the android ones `com.android.application`, `com.android.library`, and more (instant app, feature, ...).
Otherwise it will fail with error `"Apollo plugin couldn't be applied without Android or Java or Kotlin plugin."`
