### PR TITLE
Fix using plugin with gradle-5.0-rc-x

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -38,6 +38,11 @@ class ApolloClassGenerationTask extends SourceTask {
     inputs.outOfDate(new Action<InputFileDetails>() {
       @Override
       void execute(@NotNull InputFileDetails inputFileDetails) {
+        File inputFile = inputFileDetails.getFile()
+        if (!inputFile.isFile()) {
+          // skip if input is not a file
+          return
+        }
         outputDir.asFile.get().delete()
 
         String outputPackageName = outputPackageName.get()
@@ -45,7 +50,7 @@ class ApolloClassGenerationTask extends SourceTask {
           outputPackageName = null
         }
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
-            inputFileDetails.getFile(), outputDir.get().asFile, customTypeMapping.get(),
+            inputFile, outputDir.get().asFile, customTypeMapping.get(),
             nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
             generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
             suppressRawTypesWarning.get()


### PR DESCRIPTION
Skip out-of-date directories/folders, process files only

With Gradle-5.0-RC, not only files but also enclosing directories for out-of-date files are reported in `SourceTask`. As `ApolloClassGenerationTask` is interested in files only, others are skipped.
(https://github.com/gradle/gradle/issues/7732#issuecomment-438678230)

Fixes #1106