### PR TITLE
Add support for Auto Persisted Queries

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -23,9 +23,11 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
 import okhttp3.internal.io.FileSystem;
 import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockWebServer;
+import okio.Buffer;
 
 import static com.apollographql.apollo.Utils.assertResponse;
 import static com.apollographql.apollo.Utils.enqueueAndAssertResponse;
@@ -127,7 +129,10 @@ public class ApolloPrefetchTest {
   }
 
   private void checkCachedResponse(String fileName) throws IOException {
-    String cacheKey = ApolloServerInterceptor.cacheKey(lastHttRequest.body());
+    RequestBody requestBody = lastHttRequest.body();
+    Buffer buffer = new Buffer();
+    requestBody.writeTo(buffer);
+    String cacheKey = buffer.readByteString().md5().hex();
     okhttp3.Response response = apolloClient.cachedHttpResponse(cacheKey);
     assertThat(response).isNotNull();
     assertThat(response.body().source().readUtf8()).isEqualTo(Utils.readFileToString(getClass(), "/" + fileName));

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -13,7 +13,6 @@ import com.apollographql.apollo.integration.httpcache.AllFilmsQuery;
 import com.apollographql.apollo.integration.httpcache.AllPlanetsQuery;
 import com.apollographql.apollo.integration.httpcache.DroidDetailsQuery;
 import com.apollographql.apollo.integration.httpcache.type.CustomType;
-import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.rx2.Rx2Apollo;
@@ -35,6 +34,7 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
+import okhttp3.RequestBody;
 import okhttp3.internal.io.FileSystem;
 import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockResponse;
@@ -656,7 +656,10 @@ public class HttpCacheTest {
   }
 
   private void checkCachedResponse(String fileName) throws IOException {
-    String cacheKey = ApolloServerInterceptor.cacheKey(lastHttRequest.body());
+    RequestBody requestBody = lastHttRequest.body();
+    Buffer buffer = new Buffer();
+    requestBody.writeTo(buffer);
+    String cacheKey = buffer.readByteString().md5().hex();
     okhttp3.Response response = apolloClient.cachedHttpResponse(cacheKey);
     assertThat(response).isNotNull();
     assertThat(response.body().source().readUtf8()).isEqualTo(Utils.readFileToString(getClass(), fileName));

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -124,7 +124,10 @@ public class IntegrationTest {
     );
 
     assertThat(server.takeRequest().getBody().readString(Charsets.UTF_8))
-        .isEqualTo("{\"query\":\"query AllPlanets {  "
+        .isEqualTo("{\"operationName\":\"AllPlanets\",\"variables\":{},"
+            + "\"extensions\":{\"persistedQuery\":{\"version\":1," +
+            "\"sha256Hash\":\"99f22cd11d5600fb2b0b15af15f263160815054bbcd7ea1d7e730ecfd1b04751\"}},"
+            + "\"query\":\"query AllPlanets {  "
             + "allPlanets(first: 300) {"
             + "    __typename"
             + "    planets {"
@@ -152,7 +155,7 @@ public class IntegrationTest {
             + "  name"
             + "  climates"
             + "  surfaceWater"
-            + "}\",\"operationName\":\"AllPlanets\",\"variables\":{}}");
+            + "}\"}");
   }
 
   @Test public void error_response() throws Exception {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
@@ -28,19 +28,20 @@ public class SendOperationIdentifiersTest {
     final HeroAndFriendsNamesQuery query = new HeroAndFriendsNamesQuery(Input.fromNullable(EMPIRE));
     ApolloClient apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
-        .sendOperationIdentifiers(true)
+        .enableAutoPersistedQueries(true)
         .build();
     apolloClient.query(query).enqueue(null);
 
     String serverRequest = server.takeRequest().getBody().readUtf8();
-    assertThat(serverRequest.contains(String.format("\"id\":\"%s\"", query.operationId()))).isTrue();
+    assertThat(serverRequest.contains(String.format("\"sha256Hash\":\"%s\"", query.operationId()))).isTrue();
+    assertThat(serverRequest.contains("\"query\":")).isFalse();
   }
 
   @Test public void doesNotSendOperationIdsWhenFalse() throws Exception {
     final HeroAndFriendsNamesQuery query = new HeroAndFriendsNamesQuery(Input.fromNullable(EMPIRE));
     ApolloClient apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
-        .sendOperationIdentifiers(false)
+        .enableAutoPersistedQueries(false)
         .build();
     apolloClient.query(query).enqueue(null);
 

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -4,14 +4,15 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
+  compile project(":apollo-api")
   compile dep.okHttp
   compile dep.cache
-  compile project(":apollo-api")
 
   testCompile dep.junit
   testCompile dep.truth
   testCompile dep.mockWebServer
   testCompile dep.okhttpTestSupport
+  testCompile dep.mockito
   testCompile project(':apollo-rx2-support')
 }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -89,7 +89,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   private final ApolloLogger logger;
   private final ApolloCallTracker tracker = new ApolloCallTracker();
   private final List<ApolloInterceptor> applicationInterceptors;
-  private final boolean sendOperationIdentifiers;
+  private final boolean enableAutoPersistedQueries;
   private final SubscriptionManager subscriptionManager;
 
   ApolloClient(HttpUrl serverUrl,
@@ -103,7 +103,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
       CacheHeaders defaultCacheHeaders,
       ApolloLogger logger,
       List<ApolloInterceptor> applicationInterceptors,
-      boolean sendOperationIdentifiers,
+      boolean enableAutoPersistedQueries,
       SubscriptionManager subscriptionManager) {
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
@@ -116,7 +116,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     this.defaultCacheHeaders = defaultCacheHeaders;
     this.logger = logger;
     this.applicationInterceptors = applicationInterceptors;
-    this.sendOperationIdentifiers = sendOperationIdentifiers;
+    this.enableAutoPersistedQueries = enableAutoPersistedQueries;
     this.subscriptionManager = subscriptionManager;
   }
 
@@ -143,7 +143,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   public <D extends Operation.Data, T, V extends Operation.Variables> ApolloPrefetch prefetch(
       @NotNull Operation<D, T, V> operation) {
     return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, scalarTypeAdapters, dispatcher, logger,
-        tracker, sendOperationIdentifiers);
+        tracker);
   }
 
   @Override
@@ -238,7 +238,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
         .tracker(tracker)
         .refetchQueries(Collections.<Query>emptyList())
         .refetchQueryNames(Collections.<OperationName>emptyList())
-        .sendOperationIdentifiers(sendOperationIdentifiers)
+        .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .build();
   }
 
@@ -256,7 +256,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     Executor dispatcher;
     Optional<Logger> logger = Optional.absent();
     final List<ApolloInterceptor> applicationInterceptors = new ArrayList<>();
-    boolean sendOperationIdentifiers;
+    boolean enableAutoPersistedQueries;
     Optional<SubscriptionTransport.Factory> subscriptionTransportFactory = Optional.absent();
     Optional<Map<String, Object>> subscriptionConnectionParams = Optional.absent();
     long subscriptionHeartbeatTimeout = -1;
@@ -424,12 +424,12 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
-     * @param sendOperationIdentifiers True if ApolloClient should send a operation identifier instead of the operation
-     *                                 definition. Default: false.
+     * @param enableAutoPersistedQueries True if ApolloClient should enable Automatic Persisted Queries support.
+     *                                   Default: false.
      * @return The {@link Builder} object to be used for chaining method calls
      */
-    public Builder sendOperationIdentifiers(boolean sendOperationIdentifiers) {
-      this.sendOperationIdentifiers = sendOperationIdentifiers;
+    public Builder enableAutoPersistedQueries(boolean enableAutoPersistedQueries) {
+      this.enableAutoPersistedQueries = enableAutoPersistedQueries;
       return this;
     }
 
@@ -531,7 +531,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
           defaultCacheHeaders,
           apolloLogger,
           applicationInterceptors,
-          sendOperationIdentifiers,
+          enableAutoPersistedQueries,
           subscriptionManager);
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -116,13 +116,15 @@ public interface ApolloInterceptor {
     public final CacheHeaders cacheHeaders;
     public final boolean fetchFromCache;
     public final Optional<Operation.Data> optimisticUpdates;
+    public final boolean sendQueryDocument;
 
     InterceptorRequest(Operation operation, CacheHeaders cacheHeaders, Optional<Operation.Data> optimisticUpdates,
-        boolean fetchFromCache) {
+        boolean fetchFromCache, boolean sendQueryDocument) {
       this.operation = operation;
       this.cacheHeaders = cacheHeaders;
       this.optimisticUpdates = optimisticUpdates;
       this.fetchFromCache = fetchFromCache;
+      this.sendQueryDocument = sendQueryDocument;
     }
 
     public Builder toBuilder() {
@@ -141,6 +143,7 @@ public interface ApolloInterceptor {
       private CacheHeaders cacheHeaders = CacheHeaders.NONE;
       private boolean fetchFromCache;
       private Optional<Operation.Data> optimisticUpdates = Optional.absent();
+      private boolean sendQueryDocument = true;
 
       Builder(@NotNull Operation operation) {
         this.operation = checkNotNull(operation, "operation == null");
@@ -166,8 +169,14 @@ public interface ApolloInterceptor {
         return this;
       }
 
+      public Builder sendQueryDocument(boolean sendQueryDocument) {
+        this.sendQueryDocument = sendQueryDocument;
+        return this;
+      }
+
       public InterceptorRequest build() {
-        return new InterceptorRequest(operation, cacheHeaders, optimisticUpdates, fetchFromCache);
+        return new InterceptorRequest(operation, cacheHeaders, optimisticUpdates, fetchFromCache,
+            sendQueryDocument);
       }
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -131,7 +131,8 @@ public interface ApolloInterceptor {
       return new Builder(operation)
           .cacheHeaders(cacheHeaders)
           .fetchFromCache(fetchFromCache)
-          .optimisticUpdates(optimisticUpdates.orNull());
+          .optimisticUpdates(optimisticUpdates.orNull())
+          .sendQueryDocument(sendQueryDocument);
     }
 
     public static Builder builder(@NotNull Operation operation) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -360,7 +360,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.addAll(applicationInterceptors);
     interceptors.add(responseFetcher.provideInterceptor(logger));
     interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
-    if (operation instanceof Query) {
+    if (operation instanceof Query && enableAutoPersistedQueries) {
       interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger));
     }
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -20,6 +20,7 @@ import com.apollographql.apollo.exception.ApolloParseException;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
+import com.apollographql.apollo.internal.interceptor.ApolloAutoPersistedQueryInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloCacheInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloParseInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
@@ -66,7 +67,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final List<OperationName> refetchQueryNames;
   final List<Query> refetchQueries;
   final Optional<QueryReFetcher> queryReFetcher;
-  final boolean sendOperationdIdentifiers;
+  final boolean enableAutoPersistedQueries;
   final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
   final AtomicReference<Callback<T>> originalCallback = new AtomicReference<>();
   final Optional<Operation.Data> optimisticUpdates;
@@ -110,7 +111,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
           .callTracker(builder.tracker)
           .build());
     }
-    sendOperationdIdentifiers = builder.sendOperationIdentifiers;
+    enableAutoPersistedQueries = builder.enableAutoPersistedQueries;
     interceptorChain = prepareInterceptorChain(operation);
     optimisticUpdates = builder.optimisticUpdates;
   }
@@ -293,7 +294,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .tracker(tracker)
         .refetchQueryNames(refetchQueryNames)
         .refetchQueries(refetchQueries)
-        .sendOperationIdentifiers(sendOperationdIdentifiers)
+        .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .optimisticUpdates(optimisticUpdates);
   }
 
@@ -359,10 +360,13 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.addAll(applicationInterceptors);
     interceptors.add(responseFetcher.provideInterceptor(logger));
     interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
+    if (operation instanceof Query) {
+      interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger));
+    }
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
         scalarTypeAdapters, logger));
-    interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false,
-        scalarTypeAdapters, logger, sendOperationdIdentifiers));
+    interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false, scalarTypeAdapters,
+        logger));
 
     return new RealApolloInterceptorChain(interceptors);
   }
@@ -385,7 +389,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     List<OperationName> refetchQueryNames = emptyList();
     List<Query> refetchQueries = emptyList();
     ApolloCallTracker tracker;
-    boolean sendOperationIdentifiers;
+    boolean enableAutoPersistedQueries;
     Optional<Operation.Data> optimisticUpdates = Optional.absent();
 
     public Builder<T> operation(Operation operation) {
@@ -469,8 +473,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
       return this;
     }
 
-    public Builder<T> sendOperationIdentifiers(boolean sendOperationIdentifiers) {
-      this.sendOperationIdentifiers = sendOperationIdentifiers;
+    public Builder<T> enableAutoPersistedQueries(boolean enableAutoPersistedQueries) {
+      this.enableAutoPersistedQueries = enableAutoPersistedQueries;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -39,13 +39,11 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
   final ApolloLogger logger;
   final ApolloCallTracker tracker;
   final ApolloInterceptorChain interceptorChain;
-  final boolean sendOperationIds;
   final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
   final AtomicReference<ApolloPrefetch.Callback> originalCallback = new AtomicReference<>();
 
   public RealApolloPrefetch(Operation operation, HttpUrl serverUrl, Call.Factory httpCallFactory,
-      ScalarTypeAdapters scalarTypeAdapters, Executor dispatcher, ApolloLogger logger, ApolloCallTracker callTracker,
-      boolean sendOperationIds) {
+      ScalarTypeAdapters scalarTypeAdapters, Executor dispatcher, ApolloLogger logger, ApolloCallTracker callTracker) {
     this.operation = operation;
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
@@ -53,10 +51,9 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
     this.dispatcher = dispatcher;
     this.logger = logger;
     this.tracker = callTracker;
-    this.sendOperationIds = sendOperationIds;
     interceptorChain = new RealApolloInterceptorChain(Collections.<ApolloInterceptor>singletonList(
-        new ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, true,
-            scalarTypeAdapters, logger, sendOperationIds)
+        new ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, true, scalarTypeAdapters,
+            logger)
     ));
   }
 
@@ -127,8 +124,8 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
   }
 
   @Override public ApolloPrefetch clone() {
-    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, scalarTypeAdapters, dispatcher,
-        logger, tracker, sendOperationIds);
+    return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, scalarTypeAdapters, dispatcher, logger,
+        tracker);
   }
 
   @Override public synchronized void cancel() {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
@@ -71,7 +71,7 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
             return Optional.of(request.toBuilder().sendQueryDocument(true).build());
           }
 
-          if (isPersistedQueryNotFound(response.errors()) || isPersistedQueryNotSupported(response.errors())) {
+          if (isPersistedQueryNotSupported(response.errors())) {
             // TODO how to disable Automatic Persisted Queries in future and how to notify user about this
             logger.e("GraphQL server doesn't support Automatic Persisted Queries");
             return Optional.of(request.toBuilder().sendQueryDocument(true).build());

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
@@ -1,0 +1,102 @@
+package com.apollographql.apollo.internal.interceptor;
+
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.internal.Function;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.interceptor.ApolloInterceptor;
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
+import com.apollographql.apollo.internal.ApolloLogger;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
+  private static final String PROTOCOL_NEGOTIATION_ERROR_QUERY_NOT_FOUND = "PersistedQueryNotFound";
+  private static final String PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED = "PersistedQueryNotSupported";
+
+  private final ApolloLogger logger;
+  private volatile boolean disposed;
+
+  public ApolloAutoPersistedQueryInterceptor(@NotNull ApolloLogger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void interceptAsync(@NotNull final InterceptorRequest request, @NotNull final ApolloInterceptorChain chain,
+      @NotNull final Executor dispatcher, @NotNull final CallBack callBack) {
+    InterceptorRequest newRequest = request.toBuilder().sendQueryDocument(false).build();
+    chain.proceedAsync(newRequest, dispatcher, new CallBack() {
+      @Override public void onResponse(@NotNull InterceptorResponse response) {
+        if (disposed) return;
+
+        Optional<InterceptorRequest> retryRequest = handleProtocolNegotiation(request, response);
+        if (retryRequest.isPresent()) {
+          chain.proceedAsync(retryRequest.get(), dispatcher, callBack);
+        } else {
+          callBack.onResponse(response);
+          callBack.onCompleted();
+        }
+      }
+
+      @Override public void onFetch(FetchSourceType sourceType) {
+        callBack.onFetch(sourceType);
+      }
+
+      @Override public void onFailure(@NotNull ApolloException e) {
+        callBack.onFailure(e);
+      }
+
+      @Override public void onCompleted() {
+        // call onCompleted in onResponse
+      }
+    });
+  }
+
+  @Override public void dispose() {
+    disposed = true;
+  }
+
+  Optional<InterceptorRequest> handleProtocolNegotiation(final InterceptorRequest request,
+      InterceptorResponse response) {
+    return response.parsedResponse.flatMap(new Function<Response, Optional<InterceptorRequest>>() {
+      @NotNull @Override public Optional<InterceptorRequest> apply(@NotNull Response response) {
+        if (response.hasErrors()) {
+          if (isPersistedQueryNotFound(response.errors())) {
+            logger.w("GraphQL server couldn't find Automatic Persisted Query for operation name: "
+                + request.operation.name().name() + " id: " + request.operation.operationId());
+            return Optional.of(request.toBuilder().sendQueryDocument(true).build());
+          }
+
+          if (isPersistedQueryNotFound(response.errors()) || isPersistedQueryNotSupported(response.errors())) {
+            // TODO how to disable Automatic Persisted Queries in future and how to notify user about this
+            logger.e("GraphQL server doesn't support Automatic Persisted Queries");
+            return Optional.of(request.toBuilder().sendQueryDocument(true).build());
+          }
+        }
+        return Optional.absent();
+      }
+    });
+  }
+
+  boolean isPersistedQueryNotFound(List<Error> errors) {
+    for (Error error : errors) {
+      if (PROTOCOL_NEGOTIATION_ERROR_QUERY_NOT_FOUND.equalsIgnoreCase(error.message())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  boolean isPersistedQueryNotSupported(List<Error> errors) {
+    for (Error error : errors) {
+      if (PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED.equalsIgnoreCase(error.message())) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -92,6 +92,7 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
             }
 
             @Override public void onCompleted() {
+              // call onCompleted in onResponse
             }
 
             @Override public void onFetch(FetchSourceType sourceType) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -28,6 +28,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okio.Buffer;
+import okio.ByteString;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
@@ -51,21 +52,18 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
   final boolean prefetch;
   final ApolloLogger logger;
   final ScalarTypeAdapters scalarTypeAdapters;
-  final boolean sendOperationIdentifiers;
   volatile Call httpCall;
   volatile boolean disposed;
 
   public ApolloServerInterceptor(@NotNull HttpUrl serverUrl, @NotNull Call.Factory httpCallFactory,
       @Nullable HttpCachePolicy.Policy cachePolicy, boolean prefetch,
-      @NotNull ScalarTypeAdapters scalarTypeAdapters, @NotNull ApolloLogger logger,
-      boolean sendOperationIdentifiers) {
+      @NotNull ScalarTypeAdapters scalarTypeAdapters, @NotNull ApolloLogger logger) {
     this.serverUrl = checkNotNull(serverUrl, "serverUrl == null");
     this.httpCallFactory = checkNotNull(httpCallFactory, "httpCallFactory == null");
     this.cachePolicy = Optional.fromNullable(cachePolicy);
     this.prefetch = prefetch;
     this.scalarTypeAdapters = checkNotNull(scalarTypeAdapters, "scalarTypeAdapters == null");
     this.logger = checkNotNull(logger, "logger == null");
-    this.sendOperationIdentifiers = sendOperationIdentifiers;
   }
 
   @Override
@@ -77,7 +75,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
         callBack.onFetch(FetchSourceType.NETWORK);
 
         try {
-          httpCall = httpCall(request.operation, request.cacheHeaders);
+          httpCall = httpCall(request.operation, request.cacheHeaders, request.sendQueryDocument);
         } catch (IOException e) {
           logger.e(e, "Failed to prepare http call for operation %s", request.operation.name().name());
           callBack.onFailure(new ApolloNetworkException("Failed to prepare http call", e));
@@ -110,8 +108,8 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     this.httpCall = null;
   }
 
-  Call httpCall(Operation operation, CacheHeaders cacheHeaders) throws IOException {
-    RequestBody requestBody = httpRequestBody(operation);
+  Call httpCall(Operation operation, CacheHeaders cacheHeaders, boolean writeQueryDocument) throws IOException {
+    RequestBody requestBody = RequestBody.create(MEDIA_TYPE, httpRequestBody(operation, writeQueryDocument));
     Request.Builder requestBuilder = new Request.Builder()
         .url(serverUrl)
         .post(requestBody)
@@ -125,7 +123,8 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
       HttpCachePolicy.Policy cachePolicy = this.cachePolicy.get();
       boolean skipCacheHttpResponse = "true".equalsIgnoreCase(cacheHeaders.headerValue(
           ApolloCacheHeaders.DO_NOT_STORE));
-      String cacheKey = cacheKey(requestBody);
+
+      String cacheKey = httpRequestBody(operation, true).md5().hex();
       requestBuilder = requestBuilder
           .header(HttpCache.CACHE_KEY_HEADER, cacheKey)
           .header(HttpCache.CACHE_FETCH_STRATEGY_HEADER, cachePolicy.fetchStrategy.name())
@@ -138,33 +137,28 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     return httpCallFactory.newCall(requestBuilder.build());
   }
 
-  private RequestBody httpRequestBody(Operation operation) throws IOException {
+  private ByteString httpRequestBody(Operation operation, boolean writeQueryDocument) throws IOException {
     Buffer buffer = new Buffer();
     JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);
     jsonWriter.beginObject();
-    if (sendOperationIdentifiers) {
-      jsonWriter.name("id").value(operation.operationId());
-    } else {
-      jsonWriter.name("query").value(operation.queryDocument().replaceAll("\\n", ""));
-    }
     jsonWriter.name("operationName").value(operation.name().name());
     jsonWriter.name("variables").beginObject();
     operation.variables().marshaller().marshal(new InputFieldJsonWriter(jsonWriter, scalarTypeAdapters));
     jsonWriter.endObject();
+    jsonWriter.name("extensions")
+        .beginObject()
+        .name("persistedQuery")
+        .beginObject()
+        .name("version").value(1)
+        .name("sha256Hash").value(operation.operationId())
+        .endObject()
+        .endObject();
+    if (writeQueryDocument) {
+      jsonWriter.name("query").value(operation.queryDocument().replaceAll("\\n", ""));
+    }
     jsonWriter.endObject();
     jsonWriter.close();
-    return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
-  }
-
-  public static String cacheKey(RequestBody requestBody) {
-    Buffer hashBuffer = new Buffer();
-    try {
-      requestBody.writeTo(hashBuffer);
-    } catch (IOException e) {
-      // should never happen
-      throw new RuntimeException(e);
-    }
-    return hashBuffer.readByteString().md5().hex();
+    return buffer.readByteString();
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -109,7 +109,8 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
   }
 
   Call httpCall(Operation operation, CacheHeaders cacheHeaders, boolean writeQueryDocument) throws IOException {
-    RequestBody requestBody = RequestBody.create(MEDIA_TYPE, httpRequestBody(operation, writeQueryDocument));
+    RequestBody requestBody = RequestBody.create(MEDIA_TYPE, httpRequestBody(operation, scalarTypeAdapters,
+        writeQueryDocument));
     Request.Builder requestBuilder = new Request.Builder()
         .url(serverUrl)
         .post(requestBody)
@@ -124,7 +125,7 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
       boolean skipCacheHttpResponse = "true".equalsIgnoreCase(cacheHeaders.headerValue(
           ApolloCacheHeaders.DO_NOT_STORE));
 
-      String cacheKey = httpRequestBody(operation, true).md5().hex();
+      String cacheKey = httpRequestBody(operation, scalarTypeAdapters, true).md5().hex();
       requestBuilder = requestBuilder
           .header(HttpCache.CACHE_KEY_HEADER, cacheKey)
           .header(HttpCache.CACHE_FETCH_STRATEGY_HEADER, cachePolicy.fetchStrategy.name())
@@ -137,7 +138,8 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     return httpCallFactory.newCall(requestBuilder.build());
   }
 
-  private ByteString httpRequestBody(Operation operation, boolean writeQueryDocument) throws IOException {
+  static ByteString httpRequestBody(Operation operation, ScalarTypeAdapters scalarTypeAdapters,
+      boolean writeQueryDocument) throws IOException {
     Buffer buffer = new Buffer();
     JsonWriter jsonWriter = JsonWriter.of(buffer);
     jsonWriter.setSerializeNulls(true);

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
@@ -1,0 +1,312 @@
+package com.apollographql.apollo.internal.interceptor;
+
+import com.apollographql.apollo.Logger;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.cache.normalized.Record;
+import com.apollographql.apollo.interceptor.ApolloInterceptor;
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
+import com.apollographql.apollo.internal.ApolloLogger;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class ApolloAutoPersistedQueryInterceptorTest {
+  private ApolloAutoPersistedQueryInterceptor interceptor =
+      new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(Optional.<Logger>absent()));
+  private ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(new MockOperation())
+      .build();
+
+  @Test
+  public void initialRequestWithoutQueryDocument() {
+    ApolloInterceptorChain chain = mock(ApolloInterceptorChain.class);
+
+    interceptor.interceptAsync(request, chain, new TrampolineExecutor(), mock(ApolloInterceptor.CallBack.class));
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorRequest> requestArgumentCaptor =
+        ArgumentCaptor.forClass(ApolloInterceptor.InterceptorRequest.class);
+    verify(chain).proceedAsync(requestArgumentCaptor.capture(), any(Executor.class),
+        any(ApolloInterceptor.CallBack.class));
+
+    assertThat(requestArgumentCaptor.getValue().sendQueryDocument).isFalse();
+  }
+
+  @Test
+  public void onPersistedQueryNotFoundErrorRequestWithQueryDocument() {
+    ApolloInterceptorChainAdapter chain = new ApolloInterceptorChainAdapter() {
+      @Override
+      public void proceedAsync(@NotNull ApolloInterceptor.InterceptorRequest request, @NotNull Executor dispatcher,
+          @NotNull ApolloInterceptor.CallBack callBack) {
+        super.proceedAsync(request, dispatcher, callBack);
+        if (proceedAsyncInvocationCount == 1) {
+          assertThat(request.sendQueryDocument).isFalse();
+          callBack.onResponse(
+              new ApolloInterceptor.InterceptorResponse(
+                  mockHttpResponse(),
+                  com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                      .errors(Collections.singletonList(new Error("PersistedQueryNotFound", null, null)))
+                      .build(),
+                  Collections.<Record>emptyList()
+              )
+          );
+        } else if (proceedAsyncInvocationCount == 2) {
+          assertThat(request.sendQueryDocument).isTrue();
+          callBack.onResponse(
+              new ApolloInterceptor.InterceptorResponse(
+                  mockHttpResponse(),
+                  com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                      .data(new MockOperation.Data())
+                      .build(),
+                  Collections.<Record>emptyList()
+              )
+          );
+        } else {
+          fail("expected only 2 invocation first without query document, second with it");
+        }
+      }
+    };
+    ApolloInterceptor.CallBack interceptorCallBack = mock(ApolloInterceptor.CallBack.class);
+
+    interceptor.interceptAsync(request, chain, new TrampolineExecutor(), interceptorCallBack);
+
+    assertThat(chain.proceedAsyncInvocationCount).isEqualTo(2);
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorResponse> interceptorResponseArgumentCaptor =
+        ArgumentCaptor.forClass(ApolloInterceptor.InterceptorResponse.class);
+    verify(interceptorCallBack).onResponse(interceptorResponseArgumentCaptor.capture());
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().hasErrors()).isFalse();
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().data()).isNotNull();
+  }
+
+  @Test
+  public void onPersistedQueryNotSupportedErrorRequestWithQueryDocument() {
+    ApolloInterceptorChainAdapter chain = new ApolloInterceptorChainAdapter() {
+      @Override
+      public void proceedAsync(@NotNull ApolloInterceptor.InterceptorRequest request, @NotNull Executor dispatcher,
+          @NotNull ApolloInterceptor.CallBack callBack) {
+        super.proceedAsync(request, dispatcher, callBack);
+        if (proceedAsyncInvocationCount == 1) {
+          assertThat(request.sendQueryDocument).isFalse();
+          callBack.onResponse(
+              new ApolloInterceptor.InterceptorResponse(
+                  mockHttpResponse(),
+                  com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                      .errors(Collections.singletonList(new Error("PersistedQueryNotSupported", null, null)))
+                      .build(),
+                  Collections.<Record>emptyList()
+              )
+          );
+        } else if (proceedAsyncInvocationCount == 2) {
+          assertThat(request.sendQueryDocument).isTrue();
+          callBack.onResponse(
+              new ApolloInterceptor.InterceptorResponse(
+                  mockHttpResponse(),
+                  com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                      .data(new MockOperation.Data())
+                      .build(),
+                  Collections.<Record>emptyList()
+              )
+          );
+        } else {
+          fail("expected only 2 invocation first without query document, second with it");
+        }
+      }
+    };
+    ApolloInterceptor.CallBack interceptorCallBack = mock(ApolloInterceptor.CallBack.class);
+
+    interceptor.interceptAsync(request, chain, new TrampolineExecutor(), interceptorCallBack);
+
+    assertThat(chain.proceedAsyncInvocationCount).isEqualTo(2);
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorResponse> interceptorResponseArgumentCaptor =
+        ArgumentCaptor.forClass(ApolloInterceptor.InterceptorResponse.class);
+    verify(interceptorCallBack).onResponse(interceptorResponseArgumentCaptor.capture());
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().hasErrors()).isFalse();
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().data()).isNotNull();
+  }
+
+  @Test
+  public void onNonPersistedQueryErrorOriginalCallbackCalled() {
+    ApolloInterceptorChain chain = mock(ApolloInterceptorChain.class);
+    doAnswer(new Answer() {
+      @Override public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((ApolloInterceptor.CallBack) invocation.getArguments()[2]).onResponse(
+            new ApolloInterceptor.InterceptorResponse(
+                mockHttpResponse(),
+                com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                    .errors(Collections.singletonList(new Error("SomeOtherError", null, null)))
+                    .build(),
+                Collections.<Record>emptyList()
+            )
+        );
+        return null;
+      }
+    }).when(chain).proceedAsync(
+        any(ApolloInterceptor.InterceptorRequest.class),
+        any(Executor.class),
+        any(ApolloInterceptor.CallBack.class)
+    );
+
+    ApolloInterceptor.CallBack interceptorCallBack = mock(ApolloInterceptor.CallBack.class);
+
+    interceptor.interceptAsync(request, chain, new TrampolineExecutor(), interceptorCallBack);
+
+    verify(chain).proceedAsync(any(ApolloInterceptor.InterceptorRequest.class), any(Executor.class),
+        any(ApolloInterceptor.CallBack.class));
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorResponse> interceptorResponseArgumentCaptor =
+        ArgumentCaptor.forClass(ApolloInterceptor.InterceptorResponse.class);
+    verify(interceptorCallBack).onResponse(interceptorResponseArgumentCaptor.capture());
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().hasErrors()).isTrue();
+  }
+
+  @Test
+  public void onPersistedQueryFoundCallbackCalled() {
+    ApolloInterceptorChain chain = mock(ApolloInterceptorChain.class);
+    doAnswer(new Answer() {
+      @Override public Object answer(InvocationOnMock invocation) throws Throwable {
+        ((ApolloInterceptor.CallBack) invocation.getArguments()[2]).onResponse(
+            new ApolloInterceptor.InterceptorResponse(
+                mockHttpResponse(),
+                com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
+                    .data(new MockOperation.Data())
+                    .build(),
+                Collections.<Record>emptyList()
+            )
+        );
+        return null;
+      }
+    }).when(chain).proceedAsync(
+        any(ApolloInterceptor.InterceptorRequest.class),
+        any(Executor.class),
+        any(ApolloInterceptor.CallBack.class)
+    );
+
+    ApolloInterceptor.CallBack interceptorCallBack = mock(ApolloInterceptor.CallBack.class);
+
+    interceptor.interceptAsync(request, chain, new TrampolineExecutor(), interceptorCallBack);
+
+    verify(chain).proceedAsync(any(ApolloInterceptor.InterceptorRequest.class), any(Executor.class),
+        any(ApolloInterceptor.CallBack.class));
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorResponse> interceptorResponseArgumentCaptor =
+        ArgumentCaptor.forClass(ApolloInterceptor.InterceptorResponse.class);
+    verify(interceptorCallBack).onResponse(interceptorResponseArgumentCaptor.capture());
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().data()).isNotNull();
+    assertThat(interceptorResponseArgumentCaptor.getValue().parsedResponse.get().hasErrors()).isFalse();
+  }
+
+  private Response mockHttpResponse() {
+    return new okhttp3.Response.Builder()
+        .request(new Request.Builder()
+            .url("https://localhost/")
+            .build())
+        .protocol(Protocol.HTTP_2)
+        .code(200)
+        .message("Intercepted")
+        .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
+        .build();
+  }
+
+  static class MockOperation implements Operation<MockOperation.Data, MockOperation.Data, Operation.Variables> {
+
+    @Override public String queryDocument() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Variables variables() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public ResponseFieldMapper<Data> responseFieldMapper() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override public Data wrapData(Data data) {
+      throw new UnsupportedOperationException();
+    }
+
+    @NotNull @Override public OperationName name() {
+      return new OperationName() {
+        @Override public String name() {
+          return "MockOperation";
+        }
+      };
+    }
+
+    @NotNull @Override public String operationId() {
+      return UUID.randomUUID().toString();
+    }
+
+    static class Data implements Operation.Data {
+      @Override public ResponseFieldMarshaller marshaller() {
+        throw new UnsupportedOperationException();
+      }
+    }
+  }
+
+  static class TrampolineExecutor extends AbstractExecutorService {
+    @Override public void shutdown() {
+    }
+
+    @Override public List<Runnable> shutdownNow() {
+      return null;
+    }
+
+    @Override public boolean isShutdown() {
+      return false;
+    }
+
+    @Override public boolean isTerminated() {
+      return false;
+    }
+
+    @Override public boolean awaitTermination(long l, TimeUnit timeUnit) {
+      return false;
+    }
+
+    @Override public void execute(Runnable runnable) {
+      runnable.run();
+    }
+  }
+
+  static class ApolloInterceptorChainAdapter implements ApolloInterceptorChain {
+    int proceedAsyncInvocationCount;
+
+    @Override
+    public void proceedAsync(@NotNull ApolloInterceptor.InterceptorRequest request, @NotNull Executor dispatcher,
+        @NotNull ApolloInterceptor.CallBack callBack) {
+      proceedAsyncInvocationCount++;
+    }
+
+    @Override public void dispose() {
+    }
+  }
+}


### PR DESCRIPTION
Add support of Auto Persisted Queries for Apollo Link protocol https://github.com/apollographql/apollo-link-persisted-queries#protocol

There are 2 features missing from the original issue:
- Use Get requests (will probably extracted as separate issue)
- Auto disable Auto Persisted Queries whenever server returns `PersistedQueryNotSupported`

Part of https://github.com/apollographql/apollo-android/issues/1055