### PR TITLE
Fix for Input class equal method

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -59,7 +59,7 @@ public final class Input<V> {
 
     Input<?> input = (Input<?>) o;
 
-    return defined == input.defined && value != null && value.equals(input.value);
+    return defined == input.defined && value == input.value;
   }
 
   @Override public int hashCode() {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -68,8 +68,8 @@ public final class Input<V> {
     }
 
     Input<?> input = (Input<?>) o;
-    return defined == input.defined && (value != null && value.equals(input.value) ||
-            value == null && input.value == null);
+    return defined == input.defined
+            && (value != null && value.equals(input.value) || value == null && input.value == null);
   }
 
   @Override

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -3,68 +3,79 @@ package com.apollographql.apollo.api;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * An immutable object that wraps reference to another object. Reference can be in two states: <i>defined</i> means
- * reference to another object is set explicitly and <i>undefined</i> means reference is not set. <br/> It provides a
- * convenience way to distinguish the case when value is provided explicitly and should be serialized (even if it's
+ * An immutable object that wraps reference to another object. Reference can be in two states:
+ * <i>defined</i> means
+ * reference to another object is set explicitly and <i>undefined</i> means reference is not set.
+ * <br/> It provides a
+ * convenience way to distinguish the case when value is provided explicitly and should be
+ * serialized (even if it's
  * null) and the case when value is undefined (means it won't be serialized).
  *
  * @param <V> the type of instance that can be contained
  */
 public final class Input<V> {
-  @Nullable public final V value;
-  public final boolean defined;
+    @Nullable
+    public final V value;
+    public final boolean defined;
 
-  private Input(V value, boolean defined) {
-    this.value = value;
-    this.defined = defined;
-  }
-
-  /**
-   * Creates a new {@link Input} instance that is defined in case if {@code value} is not-null and undefined otherwise.
-   *
-   * @param value to be wrapped
-   * @return a new {@link Input} instance
-   */
-  public static <V> Input<V> optional(@Nullable V value) {
-    if (value == null) {
-      return absent();
-    } else {
-      return fromNullable(value);
+    private Input(V value, boolean defined) {
+        this.value = value;
+        this.defined = defined;
     }
-  }
 
-  /**
-   * Creates a new {@link Input} instance that is always defined.
-   *
-   * @param value to be wrapped
-   * @return a new {@link Input} instance
-   */
-  public static <V> Input<V> fromNullable(@Nullable V value) {
-    return new Input<>(value, true);
-  }
+    /**
+     * Creates a new {@link Input} instance that is defined in case if {@code value} is not-null
+     * and undefined otherwise.
+     *
+     * @param value to be wrapped
+     * @return a new {@link Input} instance
+     */
+    public static <V> Input<V> optional(@Nullable V value) {
+        if (value == null) {
+            return absent();
+        } else {
+            return fromNullable(value);
+        }
+    }
 
-  /**
-   * Creates a new {@link Input} instance that is always undefined.
-   *
-   * @param value to be wrapped
-   * @return a new {@link Input} instance
-   */
-  public static <V> Input<V> absent() {
-    return new Input<>(null, false);
-  }
+    /**
+     * Creates a new {@link Input} instance that is always defined.
+     *
+     * @param value to be wrapped
+     * @return a new {@link Input} instance
+     */
+    public static <V> Input<V> fromNullable(@Nullable V value) {
+        return new Input<>(value, true);
+    }
 
-  @Override public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof Input)) return false;
+    /**
+     * Creates a new {@link Input} instance that is always undefined.
+     *
+     * @param value to be wrapped
+     * @return a new {@link Input} instance
+     */
+    public static <V> Input<V> absent() {
+        return new Input<>(null, false);
+    }
 
-    Input<?> input = (Input<?>) o;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Input)) {
+            return false;
+        }
 
-    return defined == input.defined && value == input.value;
-  }
+        Input<?> input = (Input<?>) o;
+        return defined == input.defined &&
+                (value != null && value.equals(input.value) || value == null && input.value == null);
+    }
 
-  @Override public int hashCode() {
-    int result = value != null ? value.hashCode() : 0;
-    result = 31 * result + (defined ? 1 : 0);
-    return result;
-  }
+    @Override
+    public int hashCode() {
+        int result = value != null ? value.hashCode() : 0;
+        result = 31 * result + (defined ? 1 : 0);
+        return result;
+    }
 }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -14,68 +14,68 @@ import org.jetbrains.annotations.Nullable;
  * @param <V> the type of instance that can be contained
  */
 public final class Input<V> {
-    @Nullable
-    public final V value;
-    public final boolean defined;
+  @Nullable
+  public final V value;
+  public final boolean defined;
 
-    private Input(V value, boolean defined) {
-        this.value = value;
-        this.defined = defined;
+  private Input(V value, boolean defined) {
+    this.value = value;
+    this.defined = defined;
+  }
+
+  /**
+   * Creates a new {@link Input} instance that is defined in case if {@code value} is not-null
+   * and undefined otherwise.
+   *
+   * @param value to be wrapped
+   * @return a new {@link Input} instance
+   */
+  public static <V> Input<V> optional(@Nullable V value) {
+    if (value == null) {
+      return absent();
+    } else {
+      return fromNullable(value);
+    }
+  }
+
+  /**
+   * Creates a new {@link Input} instance that is always defined.
+   *
+   * @param value to be wrapped
+   * @return a new {@link Input} instance
+   */
+  public static <V> Input<V> fromNullable(@Nullable V value) {
+    return new Input<>(value, true);
+  }
+
+  /**
+   * Creates a new {@link Input} instance that is always undefined.
+   *
+   * @param value to be wrapped
+   * @return a new {@link Input} instance
+   */
+  public static <V> Input<V> absent() {
+    return new Input<>(null, false);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Input)) {
+      return false;
     }
 
-    /**
-     * Creates a new {@link Input} instance that is defined in case if {@code value} is not-null
-     * and undefined otherwise.
-     *
-     * @param value to be wrapped
-     * @return a new {@link Input} instance
-     */
-    public static <V> Input<V> optional(@Nullable V value) {
-        if (value == null) {
-            return absent();
-        } else {
-            return fromNullable(value);
-        }
-    }
+    Input<?> input = (Input<?>) o;
+    return defined == input.defined && (value != null && value.equals(input.value) ||
+            value == null && input.value == null);
+  }
 
-    /**
-     * Creates a new {@link Input} instance that is always defined.
-     *
-     * @param value to be wrapped
-     * @return a new {@link Input} instance
-     */
-    public static <V> Input<V> fromNullable(@Nullable V value) {
-        return new Input<>(value, true);
-    }
-
-    /**
-     * Creates a new {@link Input} instance that is always undefined.
-     *
-     * @param value to be wrapped
-     * @return a new {@link Input} instance
-     */
-    public static <V> Input<V> absent() {
-        return new Input<>(null, false);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Input)) {
-            return false;
-        }
-
-        Input<?> input = (Input<?>) o;
-        return defined == input.defined &&
-                (value != null && value.equals(input.value) || value == null && input.value == null);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = value != null ? value.hashCode() : 0;
-        result = 31 * result + (defined ? 1 : 0);
-        return result;
-    }
+  @Override
+  public int hashCode() {
+    int result = value != null ? value.hashCode() : 0;
+    result = 31 * result + (defined ? 1 : 0);
+    return result;
+  }
 }

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.api;
 
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -44,6 +45,16 @@ public final class InputTest {
     }
 
     @Test
+    public void testInputEqualsOnEqualObjectsWithDifferentReferences() {
+
+        TestObject object1 = new TestObject("Hello world!");
+        TestObject object2 = new TestObject("Hello world!");
+        Input<TestObject> input1 = Input.fromNullable(object1);
+        Input<TestObject> input2 = Input.fromNullable(object2);
+        assertEquals(input1, input2);
+    }
+
+    @Test
     public void testInputNotEqualsOnDifferentObjects() {
         TestObject object = new TestObject("Hello world!");
         TestObject anotherObject = new TestObject("Bye world!");
@@ -70,14 +81,29 @@ public final class InputTest {
 
         assertNotEquals(aInput, anotherInput);
     }
+
     //==================================================================
     //==================================================================
     class TestObject {
 
         private String value;
 
-        TestObject(String  value) {
+        TestObject(String value) {
             this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof TestObject)) {
+                return false;
+            }
+
+            TestObject input = (TestObject) o;
+            return value != null && value.equals(input.value) ||
+                    value == null && input.value == null;
         }
     }
 }

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
@@ -102,8 +102,12 @@ public final class InputTest {
             }
 
             TestObject input = (TestObject) o;
-            return value != null && value.equals(input.value) ||
-                    value == null && input.value == null;
+            return value != null && value.equals(input.value) || value == null && input.value == null;
         }
+
+      @Override
+      public int hashCode() {
+        return super.hashCode();
+      }
     }
 }

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
@@ -1,0 +1,35 @@
+package com.apollographql.apollo.api;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public final class InputTest {
+
+    @Test
+    public void testInputEqualsOnNotNullValue() {
+        String value = "Hello world!";
+        Input<String> stringInput = Input.fromNullable(value);
+        Input<String> anotherStringInput = Input.fromNullable(value);
+
+        assertEquals(stringInput, anotherStringInput);
+    }
+
+    @Test
+    public void testInputNotEqualsOnDifferentValues() {
+        String value = "Hello world!";
+        String value2 = "Bye world!";
+        Input<String> stringInput = Input.fromNullable(value);
+        Input<String> anotherStringInput = Input.fromNullable(value2);
+
+        assertNotEquals(stringInput, anotherStringInput);
+    }
+
+    @Test
+    public void testInputEqualsOnNullValue() {
+        Input<String> stringInput = Input.fromNullable(null);
+        Input<String> anotherStringInput = Input.fromNullable(null);
+
+        assertEquals(stringInput, anotherStringInput);
+    }
+}

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/InputTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotEquals;
 
 public final class InputTest {
 
+
     @Test
     public void testInputEqualsOnNotNullValue() {
         String value = "Hello world!";
@@ -31,5 +32,52 @@ public final class InputTest {
         Input<String> anotherStringInput = Input.fromNullable(null);
 
         assertEquals(stringInput, anotherStringInput);
+    }
+
+    @Test
+    public void testInputEqualsOnNotNullObjects() {
+        TestObject object = new TestObject("Hello world!");
+        Input<TestObject> aInput = Input.fromNullable(object);
+        Input<TestObject> anotherInput = Input.fromNullable(object);
+
+        assertEquals(aInput, anotherInput);
+    }
+
+    @Test
+    public void testInputNotEqualsOnDifferentObjects() {
+        TestObject object = new TestObject("Hello world!");
+        TestObject anotherObject = new TestObject("Bye world!");
+        Input<TestObject> aInput = Input.fromNullable(object);
+        Input<TestObject> anotherInput = Input.fromNullable(anotherObject);
+
+        assertNotEquals(aInput, anotherInput);
+    }
+
+    @Test
+    public void testInputEqualsOnObjectsWithNullValue() {
+        TestObject object = new TestObject(null);
+        Input<TestObject> aInput = Input.fromNullable(object);
+        Input<TestObject> anotherInput = Input.fromNullable(object);
+
+        assertEquals(aInput, anotherInput);
+    }
+
+    @Test
+    public void testInputNotEqualsWhenAnObjectIsNull() {
+        TestObject object = new TestObject(null);
+        Input<TestObject> aInput = Input.fromNullable(object);
+        Input<TestObject> anotherInput = Input.fromNullable(null);
+
+        assertNotEquals(aInput, anotherInput);
+    }
+    //==================================================================
+    //==================================================================
+    class TestObject {
+
+        private String value;
+
+        TestObject(String  value) {
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
This is my idea to solve the issue I posted (#1134). Maybe I didn't get it right and the `Input` class is supposed to behave like that.

Anyway I hope anyone can confirm if this is indeed a bug or a feature.

Thanks!