### PR TITLE
Update android gradle plugin version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ android:
     - android-28
     - android-24 # needed for the emulator
     - sys-img-armeabi-v7a-android-24 # as of now, travis doesn't support x86 so we stick with armeabi
-    - sys-img-x86-android-28
   licenses:
     - android-sdk-preview-license-.+
     - android-sdk-license-.+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ android:
   components:
     - tools
     - platform-tools
-    - tools  # Upgrade again after upgrading platform-tools
     - build-tools-28.0.3
     - android-28
   licenses:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ jdk:
 
 android:
   components:
-    - tools-26.0.2
+    - tools
     - platform-tools
     - build-tools-28.0.3
     - android-28
-    - sys-img-armeabi-v7a-android-28
+    - android-24 # needed for the emulator
+    - sys-img-armeabi-v7a-android-24 # as of now, travis doesn't support x86 so we stick with armeabi
+    - sys-img-x86-android-28
   licenses:
     - android-sdk-preview-license-.+
     - android-sdk-license-.+
@@ -21,7 +23,7 @@ script:
 
 before_script:
   - android list target
-  - echo no | android create avd --force -n test -t android-28 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 
 android:
   components:
-    - tools
+    - tools-26.0.2
     - platform-tools
     - build-tools-28.0.3
     - android-28

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - .buildscript/integration_tests_composite.sh
 
 before_script:
+  - android list target
   - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
     - platform-tools
     - build-tools-28.0.3
     - android-28
+    - sys-img-armeabi-v7a-android-28
   licenses:
     - android-sdk-preview-license-.+
     - android-sdk-license-.+

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ android:
     - tools
     - platform-tools
     - tools  # Upgrade again after upgrading platform-tools
-    - build-tools-26.0.2
-    - android-22
-    - extra-google-m2repository
-    - extra-android-m2repository
+    - build-tools-28.0.3
+    - android-28
     - sys-img-armeabi-v7a-android-22
   licenses:
     - android-sdk-preview-license-.+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ android:
     - platform-tools
     - build-tools-28.0.3
     - android-28
-    - android-24 # needed for the emulator
-    - sys-img-armeabi-v7a-android-24 # as of now, travis doesn't support x86 so we stick with armeabi
+    - android-22 # needed for the emulator
+    - sys-img-armeabi-v7a-android-22 # as of now, travis doesn't support x86 so we stick with armeabi
   licenses:
     - android-sdk-preview-license-.+
     - android-sdk-license-.+
@@ -22,7 +22,7 @@ script:
 
 before_script:
   - android list target
-  - echo no | android create avd --force -n test -t android-24 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ android:
     - tools  # Upgrade again after upgrading platform-tools
     - build-tools-28.0.3
     - android-28
-    - sys-img-armeabi-v7a-android-22
   licenses:
     - android-sdk-preview-license-.+
     - android-sdk-license-.+
@@ -22,7 +21,7 @@ script:
 
 before_script:
   - android list target
-  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - echo no | android create avd --force -n test -t android-28 --abi armeabi-v7a
   - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82

--- a/apollo-android-support/build.gradle
+++ b/apollo-android-support/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7

--- a/apollo-espresso-support/build.gradle
+++ b/apollo-espresso-support/build.gradle
@@ -8,7 +8,6 @@ apply plugin: 'com.android.library'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_7
@@ -32,7 +31,7 @@ android {
 }
 
 dependencies {
-  provided project(":apollo-runtime")
+  implementation project(":apollo-runtime")
 
   compile dep.espressoIdlingResource
 

--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -2,9 +2,6 @@ apply plugin: 'groovy'
 apply plugin: 'idea'
 apply plugin: 'java-gradle-plugin'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
-
 sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDirs = ["src/main/java", "src/main/groovy"]
 

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
@@ -11,16 +11,15 @@ class ApolloPluginTestHelper {
   static def setupDefaultAndroidProject(Project project) {
     setupAndroidProject(project)
     project.android {
-      compileSdkVersion 25
-      buildToolsVersion "25.0.2"
+      compileSdkVersion 28
     }
   }
 
   static def setupAndroidProjectWithProductFlavours(Project project) {
     setupAndroidProject(project)
     project.android {
-      compileSdkVersion 25
-      buildToolsVersion "25.0.2"
+      compileSdkVersion 28
+      flavorDimensions "version"
       productFlavors {
         demo {
           applicationIdSuffix ".demo"

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -2,6 +2,7 @@ buildscript {
   apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
+    google()
   }
 
   dependencies {
@@ -16,7 +17,6 @@ plugins {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.example.apollographql.testProject.basic"
@@ -42,6 +42,7 @@ android {
 repositories {
   jcenter()
   maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  google()
 }
 
 dependencies {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -2,6 +2,7 @@ buildscript {
   apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
+    google()
   }
 
   dependencies {
@@ -16,7 +17,6 @@ plugins {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.example.apollographql.testProject.flavored"
@@ -31,6 +31,7 @@ android {
     abortOnError false
   }
 
+  flavorDimensions "version"
   productFlavors {
         demo {
             applicationIdSuffix ".demo"
@@ -53,6 +54,7 @@ android {
 repositories {
   jcenter()
   maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  google()
 }
 
 dependencies {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
@@ -2,6 +2,7 @@ buildscript {
   apply from: "../../../../gradle/testFixturesDeps.gradle"
   repositories {
     jcenter()
+    google()
   }
 
   dependencies {
@@ -16,7 +17,6 @@ plugins {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     minSdkVersion androidConfig.minSdkVersion
@@ -41,6 +41,7 @@ android {
 repositories {
   jcenter()
   maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  google()
 }
 
 dependencies {

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -10,7 +10,6 @@ apply plugin: 'com.apollographql.android'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.example.apollographql.integration"

--- a/apollo-sample/build.gradle
+++ b/apollo-sample/build.gradle
@@ -12,7 +12,6 @@ apply plugin: 'com.apollographql.android'
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.example.apollographql.sample"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
 
   repositories {
     maven { url "https://plugins.gradle.org/m2/" }
+    google()
   }
 
   dependencies {
@@ -17,6 +18,7 @@ subprojects {
     repositories {
       maven { url "https://plugins.gradle.org/m2/" }
       maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+      google()
     }
 
     dependencies {
@@ -28,6 +30,7 @@ subprojects {
   repositories {
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    google()
   }
 
   apply plugin: "net.ltgt.errorprone"

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -19,7 +19,6 @@ repositories {
 
 android {
   compileSdkVersion androidConfig.compileSdkVersion
-  buildToolsVersion androidConfig.buildToolsVersion
 
   defaultConfig {
     applicationId "com.example.apollographql.integration"

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -7,6 +7,7 @@ buildscript {
   dependencies {
     classpath dep.androidPlugin
     classpath dep.apolloPlugin
+    google()
   }
 }
 

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -3,11 +3,11 @@ buildscript {
   repositories {
     jcenter()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+    google()
   }
   dependencies {
     classpath dep.androidPlugin
     classpath dep.apolloPlugin
-    google()
   }
 }
 

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -16,6 +16,7 @@ apply plugin: 'com.apollographql.android'
 repositories {
   jcenter()
   maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
+  google()
 }
 
 android {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -13,14 +13,13 @@ def versions = [
 ext.isCi = "true" == System.getenv('CI')
 
 ext.androidConfig = [
-    compileSdkVersion: 25,
-    buildToolsVersion: '26.0.2',
+    compileSdkVersion: 28,
     minSdkVersion    : 15,
-    targetSdkVersion : 25
+    targetSdkVersion : 28
 ]
 
 ext.dep = [
-    androidPlugin           : 'com.android.tools.build:gradle:2.3.3',
+    androidPlugin           : 'com.android.tools.build:gradle:3.2.1',
     apolloPlugin            : "com.apollographql.apollo:apollo-gradle-plugin:$versions.apolloVersion",
     apolloAndroidSupport    : "com.apollographql.apollo:apollo-android-support:$versions.apolloVersion",
     apolloRuntime           : "com.apollographql.apollo:apollo-runtime:$versions.apolloVersion",


### PR DESCRIPTION
This pull request is related to https://github.com/apollographql/apollo-android/issues/1141

As part of this pull request, the apollo plugin gets compiled as java8. It seems ok to me but maybe I'm missing something.

This also compiles android code against SDK 28