### PR TITLE
Fix issue with operation id doesn't match query document

### DIFF
--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -29,17 +29,15 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode, $stars: Int!, $greenValue: Float!) {\n"
+  public static final String OPERATION_ID = "4905a0fccc07f97ecd6d660f5a68d4d49ffedc3f4688b76d17288dec1a1fdf93";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($episode: Episode, $stars: Int!, $greenValue: Float!) {\n"
       + "  heroWithReview(episode: $episode, review: {stars: $stars, favoriteColor: {red: 0, green: $greenValue, blue: 0}}) {\n"
       + "    __typename\n"
       + "    name\n"
       + "    height(unit: FOOT)\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "4905a0fccc07f97ecd6d660f5a68d4d49ffedc3f4688b76d17288dec1a1fdf93";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
@@ -22,17 +22,15 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "a6746506c2fb20405972e7e76920eec4aa2e5e02dc429cfbd1585a4f1787b0d9";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  reviews(episode: JEDI, starsInt: 10, starsFloat: 9.9) {\n"
       + "    __typename\n"
       + "    stars\n"
       + "    commentary\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "a6746506c2fb20405972e7e76920eec4aa2e5e02dc429cfbd1585a4f1787b0d9";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -29,16 +29,14 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode, $IncludeName: Boolean!) {\n"
+  public static final String OPERATION_ID = "8e8ef66a6e97a76a5579df7768bd4d2ac09df975bcadb51fc040ac98eb5e4e0f";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($episode: Episode, $IncludeName: Boolean!) {\n"
       + "  hero(episode: $episode) {\n"
       + "    __typename\n"
       + "    name @include(if: $IncludeName)\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "8e8ef66a6e97a76a5579df7768bd4d2ac09df975bcadb51fc040ac98eb5e4e0f";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -23,7 +23,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "97c3220729cb6b43bfbb66f24be53a88482515ea92d3ba9783fce882bc58fc53";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -34,10 +36,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    links\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "97c3220729cb6b43bfbb66f24be53a88482515ea92d3ba9783fce882bc58fc53";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
@@ -22,16 +22,14 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "e85bc0b78c2cf20d9b02def60116c1d698ef6777720553e8f2f4507fad0eef35";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    links\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "e85bc0b78c2cf20d9b02def60116c1d698ef6777720553e8f2f4507fad0eef35";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -29,7 +29,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode) {\n"
+  public static final String OPERATION_ID = "d62c8a7f6b24719252b8516389ca97a605b57cdebbbc523f4644847c5bf4efed";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($episode: Episode) {\n"
       + "  hero(episode: $episode) {\n"
       + "    __typename\n"
       + "    name\n"
@@ -37,10 +39,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    deprecatedBool\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "d62c8a7f6b24719252b8516389ca97a605b57cdebbbc523f4644847c5bf4efed";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -27,7 +27,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($includeName: Boolean!, $skipFriends: Boolean!) {\n"
+  public static final String OPERATION_ID = "330f0fe4baea1b2e41c551ea45b413502c32080fc6581ed3756890896a897ae9";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($includeName: Boolean!, $skipFriends: Boolean!) {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name @include(if: $includeName)\n"
@@ -37,10 +39,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "330f0fe4baea1b2e41c551ea45b413502c32080fc6581ed3756890896a897ae9";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "b21e7723eade7c2801671c52c5de16f21ea29cb902dd88d8ebf42c334a07e7c0";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -30,10 +32,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    firstAppearsIn\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "b21e7723eade7c2801671c52c5de16f21ea29cb902dd88d8ebf42c334a07e7c0";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -23,17 +23,29 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "04159f026f56177a5ffd90a08c365ebdae5d4775175c48f17bc9d82003e74b84";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    ...HeroDetails\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    __typename\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "04159f026f56177a5ffd90a08c365ebdae5d4775175c48f17bc9d82003e74b84";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HeroDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -12,7 +12,6 @@ import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
-import com.example.fragment_in_fragment.fragment.PilotFragment;
 import com.example.fragment_in_fragment.fragment.StarshipFragment;
 import java.lang.Object;
 import java.lang.Override;
@@ -26,7 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class AllStarships implements Query<AllStarships.Data, Optional<AllStarships.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query AllStarships {\n"
+  public static final String OPERATION_ID = "f3b63150118cfccd52140c4ca6aec578235d7ea99c5b905f14138c49f7f5fc7d";
+
+  public static final String QUERY_DOCUMENT = "query AllStarships {\n"
       + "  allStarships(first: 7) {\n"
       + "    __typename\n"
       + "    edges {\n"
@@ -37,13 +38,30 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
       + "      }\n"
       + "    }\n"
       + "  }\n"
+      + "}\n"
+      + "fragment starshipFragment on Starship {\n"
+      + "  __typename\n"
+      + "  id\n"
+      + "  name\n"
+      + "  pilotConnection {\n"
+      + "    __typename\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        ...pilotFragment\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
+      + "}\n"
+      + "fragment pilotFragment on Person {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  homeworld {\n"
+      + "    __typename\n"
+      + "    name\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "f3b63150118cfccd52140c4ca6aec578235d7ea99c5b905f14138c49f7f5fc7d";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + StarshipFragment.FRAGMENT_DEFINITION + "\n"
-   + PilotFragment.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -26,19 +26,35 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "82ed8ea1e7e7b7d0344905a747cc94a1228c7ea59c809e9feb9c9d3604ff07cd";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
       + "    ...HeroDetails\n"
       + "    appearsIn\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    __typename\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
+      + "  ... on Droid {\n"
+      + "    name\n"
+      + "    primaryFunction\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "82ed8ea1e7e7b7d0344905a747cc94a1228c7ea59c809e9feb9c9d3604ff07cd";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HeroDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "caec283b7a9499b14fe44cbe6e118fe4463bc96e7d186acafc10453fb30fbaa0";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
       + "    ...HumanDetails\n"
@@ -35,13 +37,17 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    ...HumanDetails\n"
       + "    ...DroidDetails\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HumanDetails on Human {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  height\n"
+      + "}\n"
+      + "fragment DroidDetails on Droid {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  primaryFunction\n"
       + "}";
-
-  public static final String OPERATION_ID = "caec283b7a9499b14fe44cbe6e118fe4463bc96e7d186acafc10453fb30fbaa0";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HumanDetails.FRAGMENT_DEFINITION + "\n"
-   + DroidDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
@@ -23,7 +23,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "caec283b7a9499b14fe44cbe6e118fe4463bc96e7d186acafc10453fb30fbaa0";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
       + "    ...HumanDetails\n"
@@ -34,13 +36,17 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       + "    ...HumanDetails\n"
       + "    ...DroidDetails\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HumanDetails on Human {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  height\n"
+      + "}\n"
+      + "fragment DroidDetails on Droid {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  primaryFunction\n"
       + "}";
-
-  public static final String OPERATION_ID = "caec283b7a9499b14fe44cbe6e118fe4463bc96e7d186acafc10453fb30fbaa0";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HumanDetails.FRAGMENT_DEFINITION + "\n"
-   + DroidDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroDetails.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query HeroDetails {\n"
+  public static final String OPERATION_ID = "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
+
+  public static final String QUERY_DOCUMENT = "query HeroDetails {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -39,10 +41,6 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -39,10 +41,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -39,10 +41,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -21,7 +21,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -38,10 +40,6 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "bd31d2946fb8bd87d560a73a4e14753bd9ea366bc94001f86d5a5fef0b459bee";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Optional<HeroDetailsQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query HeroDetails {\n"
+  public static final String OPERATION_ID = "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
+
+  public static final String QUERY_DOCUMENT = "query HeroDetails {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -39,10 +41,6 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "04c4c609078258b0ad954a88e05fb068e53815a35051bb61cde8cc14107583bc";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -20,16 +20,14 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "f28c106dcaca07eb2077c9bcf7c64af9b0aa81f85169af29f7b41808b168e468";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "f28c106dcaca07eb2077c9bcf7c64af9b0aa81f85169af29f7b41808b168e468";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "0f706e61c84de11e4cd87bd4096a4ff59705869a0b7e2a845ac0ac571b10a4e5";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    ... on Human {\n"
@@ -30,10 +32,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "0f706e61c84de11e4cd87bd4096a4ff59705869a0b7e2a845ac0ac571b10a4e5";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -25,7 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "3026923a1bf30eb616b31b5ff348bc1129472e73edf6a0c0c16e359e0900b088";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -45,10 +47,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "3026923a1bf30eb616b31b5ff348bc1129472e73edf6a0c0c16e359e0900b088";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -28,17 +28,15 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n"
+  public static final String OPERATION_ID = "557e9010a4f6274a5409cc73de928653c878c931099afa98357c530df729a448";
+
+  public static final String QUERY_DOCUMENT = "mutation TestQuery($ep: Episode!, $review: ReviewInput!) {\n"
       + "  createReview(episode: $ep, review: $review) {\n"
       + "    __typename\n"
       + "    stars\n"
       + "    commentary\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "557e9010a4f6274a5409cc73de928653c878c931099afa98357c530df729a448";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -25,19 +25,40 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "4141e194c5f3846dabfcb576e735c71968b03a940baf49cc5e647c5e50eda72a";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
       + "    ...HeroDetails\n"
       + "    appearsIn\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    __typename\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "    pageInfo {\n"
+      + "      __typename\n"
+      + "      hasNextPage\n"
+      + "    }\n"
+      + "    isEmpty\n"
+      + "  }\n"
+      + "  ... on Droid {\n"
+      + "    name\n"
+      + "    primaryFunction\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "4141e194c5f3846dabfcb576e735c71968b03a940baf49cc5e647c5e50eda72a";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HeroDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -31,7 +31,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpisode.Data, Optional<CreateReviewForEpisode.Data>, CreateReviewForEpisode.Variables> {
-  public static final String OPERATION_DEFINITION = "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n"
+  public static final String OPERATION_ID = "63f677799b4c5cfe580f133b71712c66179ea84077be680e999b0f1d1e66e0a1";
+
+  public static final String QUERY_DOCUMENT = "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n"
       + "  createReview(episode: $ep, review: $review) {\n"
       + "    __typename\n"
       + "    stars\n"
@@ -45,10 +47,6 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "63f677799b4c5cfe580f133b71712c66179ea84077be680e999b0f1d1e66e0a1";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -28,17 +28,15 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class CreateReviewForEpisodeMutation implements Mutation<CreateReviewForEpisodeMutation.Data, Optional<CreateReviewForEpisodeMutation.Data>, CreateReviewForEpisodeMutation.Variables> {
-  public static final String OPERATION_DEFINITION = "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n"
+  public static final String OPERATION_ID = "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f";
+
+  public static final String QUERY_DOCUMENT = "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n"
       + "  createReview(episode: $ep, review: $review) {\n"
       + "    __typename\n"
       + "    stars\n"
       + "    commentary\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "eb015fa9dd6e305a9228393e61579154ae22719f6a18df6d00b45659ee2e7f7f";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -31,7 +31,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($episode: Episode) {\n"
+  public static final String OPERATION_ID = "071e064b3415e8b92bed3befa46bf04501c7194cde77ede0ebf50429624796cc";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($episode: Episode) {\n"
       + "  hero(episode: $episode) {\n"
       + "    __typename\n"
       + "    name\n"
@@ -55,10 +57,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "071e064b3415e8b92bed3befa46bf04501c7194cde77ede0ebf50429624796cc";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
@@ -23,17 +23,31 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestOperation {\n"
+  public static final String OPERATION_ID = "c4e875b8b3292e1ca6a36e8dccd11c724ee40eed3a3b87a1107fceddb3186fd2";
+
+  public static final String QUERY_DOCUMENT = "query TestOperation {\n"
       + "  setting {\n"
       + "    __typename\n"
       + "    ...TestSetting\n"
       + "  }\n"
+      + "}\n"
+      + "fragment TestSetting on Setting {\n"
+      + "  __typename\n"
+      + "  value {\n"
+      + "    __typename\n"
+      + "    ... on StringListSettingValue {\n"
+      + "      list\n"
+      + "    }\n"
+      + "  }\n"
+      + "  ... on SelectSetting {\n"
+      + "    options {\n"
+      + "      __typename\n"
+      + "      allowFreeText\n"
+      + "      id\n"
+      + "      label\n"
+      + "    }\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "c4e875b8b3292e1ca6a36e8dccd11c724ee40eed3a3b87a1107fceddb3186fd2";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + TestSetting.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.java
@@ -25,11 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestMutation implements Mutation<TestMutation.Data, Optional<TestMutation.Data>, TestMutation.Variables> {
-  public static final String OPERATION_DEFINITION = "";
-
   public static final String OPERATION_ID = null;
 
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+  public static final String QUERY_DOCUMENT = null;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -25,11 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "";
-
   public static final String OPERATION_ID = null;
 
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
+  public static final String QUERY_DOCUMENT = null;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -23,17 +23,18 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "7824113c9abde76f3c8ffbee5d7065129bc5c47757f34dd5959d5cd16464d014";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    ...HeroDetails\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
       + "}";
-
-  public static final String OPERATION_ID = "7824113c9abde76f3c8ffbee5d7065129bc5c47757f34dd5959d5cd16464d014";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HeroDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "212ff92146147cf94d8e05687d2660c3ead0b054e92d86a52e24eb15880c6dfd";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -34,10 +36,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "212ff92146147cf94d8e05687d2660c3ead0b054e92d86a52e24eb15880c6dfd";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
@@ -29,7 +29,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery($id: ID!) {\n"
+  public static final String OPERATION_ID = "7e7fbeaf6d1978c07e66bb041e7022ad5a7b9b8ca84b28b4faadfb1950ae340c";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery($id: ID!) {\n"
       + "  starship(id: $id) {\n"
       + "    __typename\n"
       + "    id\n"
@@ -37,10 +39,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    coordinates\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "7e7fbeaf6d1978c07e66bb041e7022ad5a7b9b8ca84b28b4faadfb1950ae340c";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
@@ -26,17 +26,15 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestSubscription implements Subscription<TestSubscription.Data, Optional<TestSubscription.Data>, TestSubscription.Variables> {
-  public static final String OPERATION_DEFINITION = "subscription TestSubscription($repo: String!) {\n"
+  public static final String OPERATION_ID = "8f1972cf9af58c4659da0ae72d02b97faf5fa6e6b794070d2cbcb034e2881fb8";
+
+  public static final String QUERY_DOCUMENT = "subscription TestSubscription($repo: String!) {\n"
       + "  commentAdded(repoFullName: $repo) {\n"
       + "    __typename\n"
       + "    id\n"
       + "    content\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "8f1972cf9af58c4659da0ae72d02b97faf5fa6e6b794070d2cbcb034e2881fb8";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -22,7 +22,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "922160ff4bcf150d3b4a84e8b4d218dde7ff83f6a98145fc9d5237b54eb89e6d";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -33,10 +35,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    name\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "922160ff4bcf150d3b4a84e8b4d218dde7ff83f6a98145fc9d5237b54eb89e6d";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -24,7 +24,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "e8d7fac5e934be8f96520ce424ad3d9a447507405f3e43733873897b8ec27ec6";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  r2: hero {\n"
       + "    __typename\n"
       + "    name\n"
@@ -57,10 +59,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "e8d7fac5e934be8f96520ce424ad3d9a447507405f3e43733873897b8ec27ec6";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -26,7 +26,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query TestQuery {\n"
+  public static final String OPERATION_ID = "1c0af4394c45ee39ec1e3eba06044a9834637fdef3dcfde107b2c801a8b27fa9";
+
+  public static final String QUERY_DOCUMENT = "query TestQuery {\n"
       + "  search(text: \"test\") {\n"
       + "    __typename\n"
       + "    ... on Character {\n"
@@ -61,10 +63,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       + "    }\n"
       + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "1c0af4394c45ee39ec1e3eba06044a9834637fdef3dcfde107b2c801a8b27fa9";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -26,7 +26,9 @@ import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Optional<HeroDetailQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_DEFINITION = "query HeroDetailQuery {\n"
+  public static final String OPERATION_ID = "92a6f8d924f3a9768021c6685ce6648cc180aa1066a76cf0d7ed7240e22c67bd";
+
+  public static final String QUERY_DOCUMENT = "query HeroDetailQuery {\n"
       + "  heroDetailQuery {\n"
       + "    __typename\n"
       + "    name\n"
@@ -46,12 +48,22 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       + "      }\n"
       + "    }\n"
       + "  }\n"
+      + "}\n"
+      + "fragment HeroDetails on Character {\n"
+      + "  __typename\n"
+      + "  name\n"
+      + "  friendsConnection {\n"
+      + "    __typename\n"
+      + "    totalCount\n"
+      + "    edges {\n"
+      + "      __typename\n"
+      + "      node {\n"
+      + "        __typename\n"
+      + "        name\n"
+      + "      }\n"
+      + "    }\n"
+      + "  }\n"
       + "}";
-
-  public static final String OPERATION_ID = "92a6f8d924f3a9768021c6685ce6648cc180aa1066a76cf0d7ed7240e22c67bd";
-
-  public static final String QUERY_DOCUMENT = OPERATION_DEFINITION + "\n"
-   + HeroDetails.FRAGMENT_DEFINITION;
 
   public static final OperationName OPERATION_NAME = new OperationName() {
     @Override

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -145,16 +145,16 @@ public class IntegrationTest {
             + "    }"
             + "  }"
             + "}"
-            + "fragment FilmFragment on Film {"
-            + "  __typename"
-            + "  title"
-            + "  producers"
-            + "}"
             + "fragment PlanetFragment on Planet {"
             + "  __typename"
             + "  name"
             + "  climates"
             + "  surfaceWater"
+            + "}"
+            + "fragment FilmFragment on Film {"
+            + "  __typename"
+            + "  title"
+            + "  producers"
             + "}\"}");
   }
 


### PR DESCRIPTION
Operation id is generated by `codegen` that is based on `sourceWithFragments` our `QUERY_DOCUMENT` is a calculated field that appends query definition and all used fragment definitions. The issue is that in case of queries with fragments our calculated query document is different from what generation tool uses due to different order of how fragment definitions appended to the query definition. The proposal to replace runtime calculation of `QUERY_DOCUMENT` with `sourceWithFragments` that was used by `codegen`  tool.

- Remove `OPERATION_ID` generation
- Update `QUERY_DOCUMENT` generation with `sourceWithFragments` as a value

Closes https://github.com/apollographql/apollo-android/issues/1155