### PR TITLE
Remove forcing fragments with inline fragments to be always nullable

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -166,7 +166,7 @@ class SchemaTypeSpecBuilder(
     fun isOptional(fragmentName: String): Boolean {
       return context.ir.fragments
           .first { it.fragmentName == fragmentName }
-          .let { it.inlineFragments.isNotEmpty() || it.typeCondition != normalizeGraphQlType(schemaType) }
+          .let { it.typeCondition != normalizeGraphQlType(schemaType) }
     }
 
     fun fragmentFields(): List<FieldSpec> {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -342,7 +342,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final Optional<HeroDetails> heroDetails;
+      final @NotNull HeroDetails heroDetails;
 
       private transient volatile String $toString;
 
@@ -350,11 +350,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private transient volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nullable HeroDetails heroDetails) {
-        this.heroDetails = Optional.fromNullable(heroDetails);
+      public Fragments(@NotNull HeroDetails heroDetails) {
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
-      public Optional<HeroDetails> heroDetails() {
+      public @NotNull HeroDetails heroDetails() {
         return this.heroDetails;
       }
 
@@ -362,7 +362,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final HeroDetails $heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
+            final HeroDetails $heroDetails = heroDetails;
             if ($heroDetails != null) {
               $heroDetails.marshaller().marshal(writer);
             }
@@ -406,7 +406,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public Builder toBuilder() {
         Builder builder = new Builder();
-        builder.heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
+        builder.heroDetails = heroDetails;
         return builder;
       }
 
@@ -423,22 +423,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (HeroDetails.POSSIBLE_TYPES.contains(conditionalType)) {
             heroDetails = heroDetailsFieldMapper.map(reader);
           }
-          return new Fragments(heroDetails);
+          return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
         }
       }
 
       public static final class Builder {
-        private @Nullable HeroDetails heroDetails;
+        private @NotNull HeroDetails heroDetails;
 
         Builder() {
         }
 
-        public Builder heroDetails(@Nullable HeroDetails heroDetails) {
+        public Builder heroDetails(@NotNull HeroDetails heroDetails) {
           this.heroDetails = heroDetails;
           return this;
         }
 
         public Fragments build() {
+          Utils.checkNotNull(heroDetails, "heroDetails == null");
           return new Fragments(heroDetails);
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -294,7 +294,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final Optional<HeroDetails> heroDetails;
+      final @NotNull HeroDetails heroDetails;
 
       private transient volatile String $toString;
 
@@ -302,11 +302,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private transient volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nullable HeroDetails heroDetails) {
-        this.heroDetails = Optional.fromNullable(heroDetails);
+      public Fragments(@NotNull HeroDetails heroDetails) {
+        this.heroDetails = Utils.checkNotNull(heroDetails, "heroDetails == null");
       }
 
-      public Optional<HeroDetails> getHeroDetails() {
+      public @NotNull HeroDetails getHeroDetails() {
         return this.heroDetails;
       }
 
@@ -314,7 +314,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final HeroDetails $heroDetails = heroDetails.isPresent() ? heroDetails.get() : null;
+            final HeroDetails $heroDetails = heroDetails;
             if ($heroDetails != null) {
               $heroDetails.marshaller().marshal(writer);
             }
@@ -365,7 +365,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (HeroDetails.POSSIBLE_TYPES.contains(conditionalType)) {
             heroDetails = heroDetailsFieldMapper.map(reader);
           }
-          return new Fragments(heroDetails);
+          return new Fragments(Utils.checkNotNull(heroDetails, "heroDetails == null"));
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
@@ -19,7 +19,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import javax.annotation.Generated;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 @Generated("Apollo GraphQL")
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
@@ -253,7 +252,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static class Fragments {
-      final Optional<TestSetting> testSetting;
+      final @NotNull TestSetting testSetting;
 
       private transient volatile String $toString;
 
@@ -261,11 +260,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       private transient volatile boolean $hashCodeMemoized;
 
-      public Fragments(@Nullable TestSetting testSetting) {
-        this.testSetting = Optional.fromNullable(testSetting);
+      public Fragments(@NotNull TestSetting testSetting) {
+        this.testSetting = Utils.checkNotNull(testSetting, "testSetting == null");
       }
 
-      public Optional<TestSetting> testSetting() {
+      public @NotNull TestSetting testSetting() {
         return this.testSetting;
       }
 
@@ -273,7 +272,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            final TestSetting $testSetting = testSetting.isPresent() ? testSetting.get() : null;
+            final TestSetting $testSetting = testSetting;
             if ($testSetting != null) {
               $testSetting.marshaller().marshal(writer);
             }
@@ -324,7 +323,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           if (TestSetting.POSSIBLE_TYPES.contains(conditionalType)) {
             testSetting = testSettingFieldMapper.map(reader);
           }
-          return new Fragments(testSetting);
+          return new Fragments(Utils.checkNotNull(testSetting, "testSetting == null"));
         }
       }
     }


### PR DESCRIPTION
After merging https://github.com/apollographql/apollo-android/pull/971 we had to rollback this one https://github.com/apollographql/apollo-android/pull/899 that we forgot to do.

Closes https://github.com/apollographql/apollo-android/issues/1145