### PR TITLE
Notify subscription listener when connection is terminated

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
@@ -73,5 +73,11 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
      * Gets called when final GraphQL response is received.  It is considered a terminal event.
      */
     void onCompleted();
+
+    /**
+     * Gets called when GraphQL subscription server connection is closed unexpectedly. It is considered to re-try
+     * the subscription later.
+     */
+    void onTerminated();
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
@@ -140,11 +140,7 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
       if (callback != null) {
         callback.onFailure(error);
       }
-
-      RealApolloSubscriptionCall<T> delegate = this.delegate;
-      if (delegate != null) {
-        delegate.terminate();
-      }
+      terminate();
     }
 
     @Override
@@ -153,11 +149,7 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
       if (callback != null) {
         callback.onFailure(new ApolloNetworkException("Subscription failed", t));
       }
-
-      RealApolloSubscriptionCall<T> delegate = this.delegate;
-      if (delegate != null) {
-        delegate.terminate();
-      }
+      terminate();
     }
 
     @Override
@@ -166,7 +158,19 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
       if (callback != null) {
         callback.onCompleted();
       }
+      terminate();
+    }
 
+    @Override
+    public void onTerminated() {
+      Callback<T> callback = this.originalCallback;
+      if (callback != null) {
+        callback.onTerminated();
+      }
+      terminate();
+    }
+
+    void terminate() {
       RealApolloSubscriptionCall<T> delegate = this.delegate;
       if (delegate != null) {
         delegate.terminate();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/ApolloSubscriptionTerminatedException.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/ApolloSubscriptionTerminatedException.java
@@ -1,0 +1,14 @@
+package com.apollographql.apollo.internal.subscription;
+
+import com.apollographql.apollo.exception.ApolloException;
+
+public class ApolloSubscriptionTerminatedException extends ApolloException {
+
+  public ApolloSubscriptionTerminatedException(String message) {
+    super(message);
+  }
+
+  public ApolloSubscriptionTerminatedException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
@@ -19,5 +19,7 @@ public interface SubscriptionManager {
     void onNetworkError(@NotNull Throwable t);
 
     void onCompleted();
+
+    void onTerminated();
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/SubscriptionTransport.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/SubscriptionTransport.java
@@ -50,6 +50,11 @@ public interface SubscriptionTransport {
      * @param message new message received from the server.
      */
     void onMessage(OperationServerMessage message);
+
+    /**
+     * Gets called when connection with subscription server is closed.
+     */
+    void onClosed();
   }
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
@@ -73,6 +73,14 @@ public final class WebSocketSubscriptionTransport implements SubscriptionTranspo
     }
   }
 
+  void onClosed() {
+    try {
+      callback.onClosed();
+    } finally {
+      release();
+    }
+  }
+
   void release() {
     WebSocketListener socketListener = webSocketListener.getAndSet(null);
     if (socketListener != null) {
@@ -117,7 +125,7 @@ public final class WebSocketSubscriptionTransport implements SubscriptionTranspo
     public void onClosing(WebSocket webSocket, int code, String reason) {
       WebSocketSubscriptionTransport delegate = delegateRef.get();
       if (delegate != null) {
-        delegate.release();
+        delegate.onClosed();
       }
     }
 
@@ -125,7 +133,7 @@ public final class WebSocketSubscriptionTransport implements SubscriptionTranspo
     public void onClosed(WebSocket webSocket, int code, String reason) {
       WebSocketSubscriptionTransport delegate = delegateRef.get();
       if (delegate != null) {
-        delegate.release();
+        delegate.onClosed();
       }
     }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
@@ -36,7 +36,7 @@ public class SubscriptionManagerTest {
   private MockSubscription subscription2 = new MockSubscription("MockSubscription2");
   private SubscriptionManagerOnStateChangeListener onStateChangeListener = new SubscriptionManagerOnStateChangeListener();
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     subscriptionTransportFactory = new MockSubscriptionTransportFactory();
     subscriptionManager = new RealSubscriptionManager(new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
         subscriptionTransportFactory, Collections.<String, Object>emptyMap(), new MockExecutor(), connectionHeartbeatTimeoutMs);
@@ -135,7 +135,7 @@ public class SubscriptionManagerTest {
     assertThat(subscriptionManager.subscriptions).isEmpty();
   }
 
-  @Test public void disconnectedOnTransportFailure() throws Exception {
+  @Test public void disconnectedOnTransportFailure() {
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback1 = new SubscriptionManagerCallbackAdapter<>();
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1);
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback2 = new SubscriptionManagerCallbackAdapter<>();
@@ -151,7 +151,7 @@ public class SubscriptionManagerTest {
     assertThat(subscriptionManager.subscriptions).isEmpty();
   }
 
-  @Test public void unsubscribeOnComplete() throws Exception {
+  @Test public void unsubscribeOnComplete() {
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback1 = new SubscriptionManagerCallbackAdapter<>();
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1);
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback2 = new SubscriptionManagerCallbackAdapter<>();
@@ -167,7 +167,7 @@ public class SubscriptionManagerTest {
     assertThat(subscriptionManagerCallback2.completed).isFalse();
   }
 
-  @Test public void unsubscribeOnError() throws Exception {
+  @Test public void unsubscribeOnError() {
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback1 = new SubscriptionManagerCallbackAdapter<>();
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1);
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback2 = new SubscriptionManagerCallbackAdapter<>();
@@ -187,7 +187,7 @@ public class SubscriptionManagerTest {
     assertThat(subscriptionManagerCallback2.completed).isFalse();
   }
 
-  @Test public void notifyOnData() throws Exception {
+  @Test public void notifyOnData() {
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback1 = new SubscriptionManagerCallbackAdapter<>();
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1);
 
@@ -199,7 +199,7 @@ public class SubscriptionManagerTest {
     assertThat(subscriptionManagerCallback1.response).isNotNull();
   }
 
-  @Test public void duplicateSubscriptions() throws Exception {
+  @Test public void duplicateSubscriptions() {
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback1 = new SubscriptionManagerCallbackAdapter<>();
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1);
     SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback2 = new SubscriptionManagerCallbackAdapter<>();
@@ -220,6 +220,20 @@ public class SubscriptionManagerTest {
 
     onStateChangeListener.awaitState(RealSubscriptionManager.State.DISCONNECTED, connectionHeartbeatTimeoutMs + 800, TimeUnit.MILLISECONDS);
     onStateChangeListener.awaitState(RealSubscriptionManager.State.CONNECTING, 800, TimeUnit.MILLISECONDS);
+  }
+
+  @Test public void connectionTerminated() {
+    SubscriptionManagerCallbackAdapter<Operation.Data> subscriptionManagerCallback = new SubscriptionManagerCallbackAdapter<>();
+    subscriptionManager.subscribe(subscription1, subscriptionManagerCallback);
+
+    subscriptionTransportFactory.callback.onConnected();
+    subscriptionTransportFactory.callback.onMessage(new OperationServerMessage.ConnectionAcknowledge());
+
+    assertThat(subscriptionManager.state).isEqualTo(RealSubscriptionManager.State.ACTIVE);
+
+    subscriptionTransportFactory.callback.onClosed();
+    assertThat(subscriptionManager.state).isEqualTo(RealSubscriptionManager.State.DISCONNECTED);
+    assertThat(subscriptionManagerCallback.terminated).isTrue();
   }
 
   private static final class MockSubscriptionTransportFactory implements SubscriptionTransport.Factory {
@@ -331,6 +345,7 @@ public class SubscriptionManagerTest {
     volatile ApolloSubscriptionException error;
     volatile Throwable networkError;
     volatile boolean completed;
+    volatile boolean terminated;
 
     @Override public void onResponse(@NotNull Response<T> response) {
       this.response = response;
@@ -346,6 +361,10 @@ public class SubscriptionManagerTest {
 
     @Override public void onCompleted() {
       completed = true;
+    }
+
+    @Override public void onTerminated() {
+      terminated = true;
     }
   }
 }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -181,15 +181,16 @@ public class WebSocketSubscriptionTransportMessageTest {
     OperationServerMessage lastMessage;
 
     @Override public void onConnected() {
-
     }
 
     @Override public void onFailure(Throwable t) {
-
     }
 
     @Override public void onMessage(OperationServerMessage message) {
       lastMessage = message;
+    }
+
+    @Override public void onClosed() {
     }
   }
 

--- a/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -171,8 +171,8 @@ public final class RxApollo {
           }
 
           @Override public void onTerminated() {
-            onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated " +
-                "connection"));
+            onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated "
+                + "connection"));
           }
         });
       }

--- a/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
+++ b/apollo-rx-support/src/main/java/com/apollographql/apollo/rx/RxApollo.java
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
+import com.apollographql.apollo.internal.subscription.ApolloSubscriptionTerminatedException;
 import com.apollographql.apollo.internal.util.Cancelable;
 
 import org.jetbrains.annotations.NotNull;
@@ -168,6 +169,11 @@ public final class RxApollo {
               emitter.onCompleted();
             }
           }
+
+          @Override public void onTerminated() {
+            onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated " +
+                "connection"));
+          }
         });
       }
     }, backpressureMode);
@@ -176,8 +182,8 @@ public final class RxApollo {
   /**
    * Converts an {@link ApolloStoreOperation} to a Single.
    *
-   * @param operation        the ApolloStoreOperation to convert
-   * @param <T>              the value type
+   * @param operation the ApolloStoreOperation to convert
+   * @param <T>       the value type
    * @return the converted Single
    */
   @NotNull public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -7,6 +7,7 @@ import com.apollographql.apollo.ApolloSubscriptionCall;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.internal.subscription.ApolloSubscriptionTerminatedException;
 import com.apollographql.apollo.internal.util.Cancelable;
 
 import org.jetbrains.annotations.NotNull;
@@ -146,33 +147,38 @@ public class Rx2Apollo {
   }
 
   @NotNull public static <T> Flowable<Response<T>> from(@NotNull final ApolloSubscriptionCall<T> call,
-                                                        @NotNull BackpressureStrategy backpressureStrategy) {
+      @NotNull BackpressureStrategy backpressureStrategy) {
     checkNotNull(call, "originalCall == null");
     checkNotNull(backpressureStrategy, "backpressureStrategy == null");
     return Flowable.create(new FlowableOnSubscribe<Response<T>>() {
       @Override public void subscribe(final FlowableEmitter<Response<T>> emitter) throws Exception {
         cancelOnFlowableDisposed(emitter, call);
         call.execute(
-                new ApolloSubscriptionCall.Callback<T>() {
-                  @Override public void onResponse(@NotNull Response<T> response) {
-                    if (!emitter.isCancelled()) {
-                      emitter.onNext(response);
-                    }
-                  }
-
-                  @Override public void onFailure(@NotNull ApolloException e) {
-                    Exceptions.throwIfFatal(e);
-                    if (!emitter.isCancelled()) {
-                      emitter.onError(e);
-                    }
-                  }
-
-                  @Override public void onCompleted() {
-                    if (!emitter.isCancelled()) {
-                      emitter.onComplete();
-                    }
-                  }
+            new ApolloSubscriptionCall.Callback<T>() {
+              @Override public void onResponse(@NotNull Response<T> response) {
+                if (!emitter.isCancelled()) {
+                  emitter.onNext(response);
                 }
+              }
+
+              @Override public void onFailure(@NotNull ApolloException e) {
+                Exceptions.throwIfFatal(e);
+                if (!emitter.isCancelled()) {
+                  emitter.onError(e);
+                }
+              }
+
+              @Override public void onCompleted() {
+                if (!emitter.isCancelled()) {
+                  emitter.onComplete();
+                }
+              }
+
+              @Override public void onTerminated() {
+                onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated " +
+                    "connection"));
+              }
+            }
         );
       }
     }, backpressureStrategy);
@@ -181,8 +187,8 @@ public class Rx2Apollo {
   /**
    * Converts an {@link ApolloStoreOperation} to a Single.
    *
-   * @param operation        the ApolloStoreOperation to convert
-   * @param <T>              the value type
+   * @param operation the ApolloStoreOperation to convert
+   * @param <T>       the value type
    * @return the converted Single
    */
   @NotNull public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -175,8 +175,8 @@ public class Rx2Apollo {
               }
 
               @Override public void onTerminated() {
-                onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated " +
-                    "connection"));
+                onFailure(new ApolloSubscriptionTerminatedException("Subscription server unexpectedly terminated "
+                    + "connection"));
               }
             }
         );


### PR DESCRIPTION
If connection with subscription server terminated unexpectedly notify all active subscriptions via appropriated callback.
New `onTerminated` callback was added to the `ApolloSubscriptionCall` to be called whenever connection is terminated (due to several reasons networking issue, server reboot etc.)

Closes https://github.com/apollographql/apollo-android/issues/996