### PR TITLE
Squash @truongsinh PR in the upstream repository

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -49,8 +49,10 @@ class ApolloClassGenerationTask extends SourceTask {
         if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
           outputPackageName = null
         }
+        Map processedCustomTypeMapping = customTypeMapping.get()
+        processedCustomTypeMapping.putIfAbsent("Upload", "java.io.File")
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
-            inputFile, outputDir.get().asFile, customTypeMapping.get(),
+            inputFileDetails.getFile(), outputDir.get().asFile, processedCustomTypeMapping,
             nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
             generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
             suppressRawTypesWarning.get()

--- a/apollo-integration/build.gradle
+++ b/apollo-integration/build.gradle
@@ -1,7 +1,9 @@
 buildscript {
+  ext.kotlin_version = '1.3.11'
   dependencies {
     classpath dep.androidPlugin
     classpath dep.apolloPlugin
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }
 

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/UploadQuery.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/UploadQuery.graphql
@@ -1,0 +1,3 @@
+mutation uploadFileExample($topFile:Upload, $topFileList:[Upload], $nested: NestedObject) {
+  uploadFileExample(topFile: $topFile, topFileList: $topFileList, nested: $nested)
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/schema.json
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/schema.json
@@ -4,9 +4,69 @@
       "queryType": {
         "name": "Root"
       },
-      "mutationType": null,
+      "mutationType": {
+        "name": "Mutation"
+      },
       "subscriptionType": null,
       "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": null,
+          "fields": [
+            {
+              "name": "uploadFileExample",
+              "description": "",
+              "args": [
+                {
+                  "name": "topFile",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Upload",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "topFileList",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Upload",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "nested",
+                  "description": "",
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "NestedObject",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
         {
           "kind": "OBJECT",
           "name": "Root",
@@ -60,6 +120,29 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "FilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "uploadQuery",
+              "description": null,
+              "args": [
+                {
+                  "name": "file",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Upload",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -558,6 +641,89 @@
           ],
           "inputFields": null,
           "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Upload",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "NestedObject",
+          "description": "",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "recursiveNested",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NestedObject",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "text",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "file",
+              "description": "",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Upload",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fileList",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Upload",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "textList",
+              "description": "",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerUploadInterceptorTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerUploadInterceptorTest.kt
@@ -1,0 +1,199 @@
+package com.apollographql.apollo.internal.interceptor
+
+import com.apollographql.apollo.api.internal.Optional
+import com.apollographql.apollo.cache.CacheHeaders
+import com.apollographql.apollo.integration.interceptor.UploadFileExampleMutation
+import com.apollographql.apollo.integration.interceptor.type.NestedObject
+import com.apollographql.apollo.internal.ApolloLogger
+import com.apollographql.apollo.response.ScalarTypeAdapters
+import com.google.common.base.Predicate
+import com.google.common.truth.Truth.assertThat
+import junit.framework.Assert.fail
+import okhttp3.*
+import okio.Buffer
+import org.junit.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+import java.io.IOException
+
+fun createFile(fileName: String, content: String): File {
+    val tempDir = System.getProperty("java.io.tmpdir")
+    val filePath = tempDir + "/" + fileName
+    val f = File(filePath)
+    val bw = BufferedWriter(FileWriter(f))
+    bw.write(content)
+    bw.close()
+    return f
+}
+
+class ApolloServerUploadInterceptorTest {
+    private val serverUrl = HttpUrl.parse("http://google.com")
+    private val file0 = createFile("test0.txt", "content_testZero")
+    private val file1 = createFile("test1.png", "content_testOne")
+    private val file2 = createFile("test2.jpg", "content_test2")
+    private val nestedObject0 = NestedObject.builder()
+            .file(file0)
+            .fileList(listOf(file1, file2))
+            .build()
+    private val nestedObject1 = NestedObject.builder()
+            .file(file1)
+            .fileList(listOf(file0, file2))
+            .build()
+    private val nestedObject2 = NestedObject.builder()
+            .file(file2)
+            .fileList(listOf(file0, file1))
+            .recursiveNested(listOf(nestedObject0, nestedObject1))
+            .build()
+    private val query = UploadFileExampleMutation.builder()
+            .nested(nestedObject2)
+            .topFile(file2)
+            .topFileList(listOf(file1, file0))
+            .build()
+
+    @Test
+    fun testUploadWithGraphQL() {
+        val requestAssertPredicate = Predicate<Request> { request ->
+            assertThat(request!!.header(ApolloServerInterceptor.HEADER_CONTENT_TYPE)).isEqualTo("multipart/form-data; boundary=--graphql-multipart-upload-boundary-85763456--")
+            assertRequestBody(request, """
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="operations"
+Content-Type: application/json; charset=utf-8
+Content-Length: 419
+
+{"query":"mutation uploadFileExample(${'$'}topFile: Upload, ${'$'}topFileList: [Upload], ${'$'}nested: NestedObject) {  uploadFileExample(topFile: ${'$'}topFile, topFileList: ${'$'}topFileList, nested: ${'$'}nested)}","operationName":"uploadFileExample","variables":{"topFile":null,"topFileList":[null,null],"nested":{"recursiveNested":[{"file":null,"fileList":[null,null]},{"file":null,"fileList":[null,null]}],"file":null,"fileList":[null,null]}}}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="map"
+Content-Type: application/json; charset=utf-8
+Content-Length: 507
+
+{"0":["variables.topFile"],"11":["variables.nested.fileList.1"],"1":["variables.topFileList.0"],"2":["variables.topFileList.1"],"3":["variables.nested.recursiveNested.0.file"],"4":["variables.nested.recursiveNested.0.fileList.0"],"5":["variables.nested.recursiveNested.0.fileList.1"],"6":["variables.nested.recursiveNested.1.file"],"7":["variables.nested.recursiveNested.1.fileList.0"],"8":["variables.nested.recursiveNested.1.fileList.1"],"9":["variables.nested.file"],"10":["variables.nested.fileList.0"]}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="0"; filename="test2.jpg"
+Content-Type: image/jpeg
+Content-Length: 13
+
+content_test2
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="1"; filename="test1.png"
+Content-Type: image/png
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="2"; filename="test0.txt"
+Content-Type: text/plain
+Content-Length: 16
+
+content_testZero
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="3"; filename="test0.txt"
+Content-Type: text/plain
+Content-Length: 16
+
+content_testZero
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="4"; filename="test1.png"
+Content-Type: image/png
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="5"; filename="test2.jpg"
+Content-Type: image/jpeg
+Content-Length: 13
+
+content_test2
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="6"; filename="test1.png"
+Content-Type: image/png
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="7"; filename="test0.txt"
+Content-Type: text/plain
+Content-Length: 16
+
+content_testZero
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="8"; filename="test2.jpg"
+Content-Type: image/jpeg
+Content-Length: 13
+
+content_test2
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="9"; filename="test2.jpg"
+Content-Type: image/jpeg
+Content-Length: 13
+
+content_test2
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="10"; filename="test0.txt"
+Content-Type: text/plain
+Content-Length: 16
+
+content_testZero
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="11"; filename="test1.png"
+Content-Type: image/png
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456----
+    """.trimIndent())
+            true
+        }
+
+        val interceptor = ApolloServerInterceptor(serverUrl!!,
+                AssertHttpCallFactory(requestAssertPredicate), null, false,
+                ScalarTypeAdapters(emptyMap()),
+                ApolloLogger(Optional.absent()))
+
+        interceptor.httpCall(query, CacheHeaders.NONE, true)
+    }
+
+    private fun assertRequestBody(request: Request?, expectedRequestBody: String) {
+//            assertThat(request!!.body()!!.contentType()).isEqualTo("multipart/form-data; boundary=--graphql-multipart-upload-boundary-85763456--");
+        val bodyBuffer = Buffer()
+        request!!.body()!!.writeTo(bodyBuffer)
+        assertThat(bodyBuffer.readUtf8().trimIndent()).isEqualTo(expectedRequestBody)
+    }
+
+    private class AssertHttpCallFactory internal constructor(internal val predicate: Predicate<Request>) : Call.Factory {
+
+        override fun newCall(request: Request): Call {
+            if (!predicate.apply(request)) {
+                fail("Assertion failed")
+            }
+            return NoOpCall()
+        }
+    }
+
+    private class NoOpCall : Call {
+        override fun request(): Request? {
+            return null
+        }
+
+        @Throws(IOException::class)
+        override fun execute(): Response? {
+            return null
+        }
+
+        override fun enqueue(responseCallback: Callback) {}
+
+        override fun cancel() {}
+
+        override fun isExecuted(): Boolean {
+            return false
+        }
+
+        override fun isCanceled(): Boolean {
+            return false
+        }
+
+        override fun clone(): Call {
+            return this
+        }
+    }
+}

--- a/apollo-runtime/build.gradle
+++ b/apollo-runtime/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+  id 'org.jetbrains.kotlin.jvm' version '1.3.11'
+}
 apply plugin: 'java-library'
 
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -18,6 +21,7 @@ dependencies {
   testImplementation dep.mockWebServer
   testImplementation dep.okhttpTestSupport
   testImplementation project(':apollo-rx2-support')
+  compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
@@ -31,4 +35,17 @@ tasks.withType(Checkstyle) {
 
 javadoc {
   options.encoding = 'UTF-8'
+}
+repositories {
+  mavenCentral()
+}
+compileKotlin {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
+compileTestKotlin {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloFileUploadInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloFileUploadInterceptor.java
@@ -1,0 +1,133 @@
+package com.apollographql.apollo.internal.interceptor;
+
+import com.apollographql.apollo.api.Input;
+import com.apollographql.apollo.api.InputType;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.internal.json.JsonWriter;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+import static com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor.MEDIA_TYPE;
+
+
+class UploadData {
+    public ArrayList<File> allUploads = null;
+    public HashMap<String, String[]> filesMap = null;
+}
+
+
+public class ApolloFileUploadInterceptor {
+
+    private static void recursiveGetUploadData(
+            Object value,
+            String variableName,
+            ArrayList<File> allUploads,
+            HashMap<String,
+            String[]> filesMap
+    ) {
+        if (value instanceof InputType) {
+            try {
+                Field[] fields = value.getClass().getDeclaredFields();
+                for (Field field : fields) {
+                    field.setAccessible(true);
+                    Object subValue = field.get(value);
+                    String key = field.getName();
+                    recursiveGetUploadData(subValue, variableName + "." + key, allUploads, filesMap);
+                }
+            } catch (IllegalAccessException e) {
+                // never happen
+            }
+        } else if (value instanceof Input) {
+            Object unwrappedValue = ((Input) value).value;
+            recursiveGetUploadData(unwrappedValue, variableName, allUploads, filesMap);
+        } else if (value instanceof File) {
+            File upload = (File) value;
+            allUploads.add(upload);
+            filesMap.put("" + filesMap.size(), new String[]{variableName});
+        } else if (value instanceof File[]) {
+            int varFileIndex = 0;
+            File[] uploads = (File[]) value;
+            for (File upload : uploads) {
+                allUploads.add(upload);
+                filesMap.put("" + filesMap.size(), new String[]{variableName + "." + varFileIndex});
+                varFileIndex++;
+            }
+        } else if (value instanceof Collection) {
+            Object[] listData = ((Collection) value).toArray();
+            for (int i = 0; i < listData.length; i++) {
+                Object subValue = listData[i];
+                recursiveGetUploadData(subValue, variableName + "." + i, allUploads, filesMap);
+            }
+        }
+    }
+
+    public static UploadData getUploadData(Operation operation) {
+
+        ArrayList<File> allUploads = new ArrayList<>();
+        HashMap<String, String[]> filesMap = new HashMap<>();
+        for (String variableName : operation.variables().valueMap().keySet()) {
+            Object value = operation.variables().valueMap().get(variableName);
+            recursiveGetUploadData(value, "variables." + variableName, allUploads, filesMap);
+        }
+
+        final ArrayList<File> allUploadsRef = allUploads;
+        final HashMap<String, String[]> filesMapRef = filesMap;
+
+        return new UploadData() {{
+            allUploads = allUploadsRef;
+            filesMap = filesMapRef;
+        }};
+    }
+
+    public static RequestBody httpMultipartRequestBody(RequestBody mainBody, Operation operation) throws IOException {
+
+        UploadData uploadData = getUploadData(operation);
+        if (uploadData.allUploads.isEmpty()) {
+            return mainBody;
+        }
+
+
+        HashMap<String, String[]> filesMap = uploadData.filesMap;
+        File[] uploads = uploadData.allUploads.toArray(new File[0]);
+
+
+        Buffer buffer = new Buffer();
+        JsonWriter jsonWriter = JsonWriter.of(buffer);
+        jsonWriter.setSerializeNulls(true);
+        jsonWriter.beginObject();
+        for (String key : filesMap.keySet()) {
+            jsonWriter.name(key).beginArray();
+            jsonWriter.value((filesMap.get(key))[0]);
+            jsonWriter.endArray();
+        }
+        jsonWriter.endObject();
+        jsonWriter.close();
+        MultipartBody.Builder multipartBodyBuilder = new MultipartBody
+                .Builder("--graphql-multipart-upload-boundary-85763456--")
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("operations", null, mainBody)
+                .addFormDataPart("map", null, RequestBody.create(MEDIA_TYPE, buffer.readByteString()));
+        int index = 0;
+        for (File upload : uploads) {
+            String fileName = upload.getName();
+            MediaType mimetype =  MediaType.parse(URLConnection.guessContentTypeFromName(fileName));
+
+            multipartBodyBuilder.addFormDataPart("" + index, fileName,
+                    RequestBody.create(mimetype, upload));
+            index++;
+        }
+        return multipartBodyBuilder.build();
+    }
+
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -24,6 +24,7 @@ import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
 import okhttp3.MediaType;
+import okhttp3.MultipartBody;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -31,6 +32,7 @@ import okio.Buffer;
 import okio.ByteString;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+import static com.apollographql.apollo.internal.interceptor.ApolloFileUploadInterceptor.httpMultipartRequestBody;
 
 /**
  * ApolloServerInterceptor is a concrete {@link ApolloInterceptor} responsible for making the network calls to the
@@ -109,16 +111,24 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
   }
 
   Call httpCall(Operation operation, CacheHeaders cacheHeaders, boolean writeQueryDocument) throws IOException {
-    RequestBody requestBody = RequestBody.create(MEDIA_TYPE, httpRequestBody(operation, scalarTypeAdapters,
+    RequestBody requestBodyOriginal = RequestBody.create(MEDIA_TYPE, httpRequestBody(operation, scalarTypeAdapters,
         writeQueryDocument));
+    RequestBody requestBody = httpMultipartRequestBody(requestBodyOriginal, operation);
     Request.Builder requestBuilder = new Request.Builder()
         .url(serverUrl)
         .post(requestBody)
         .header(HEADER_ACCEPT_TYPE, ACCEPT_TYPE)
-        .header(HEADER_CONTENT_TYPE, CONTENT_TYPE)
         .header(HEADER_APOLLO_OPERATION_ID, operation.operationId())
         .header(HEADER_APOLLO_OPERATION_NAME, operation.name().name())
         .tag(operation.operationId());
+
+    // @todo untested
+    if (requestBody instanceof MultipartBody) {
+      String boundary = ((MultipartBody) requestBody).boundary();
+      requestBuilder = requestBuilder.header(HEADER_CONTENT_TYPE, "multipart/form-data; boundary=" + boundary);
+    } else {
+      requestBuilder = requestBuilder.header(HEADER_CONTENT_TYPE, CONTENT_TYPE);
+    }
 
     if (cachePolicy.isPresent()) {
       HttpCachePolicy.Policy cachePolicy = this.cachePolicy.get();
@@ -161,6 +171,17 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
     }
     jsonWriter.endObject();
     jsonWriter.close();
-    return buffer.readByteString();
+    return RequestBody.create(MEDIA_TYPE, buffer.readByteString());
+  }
+
+  public static String cacheKey(RequestBody requestBody) {
+    Buffer hashBuffer = new Buffer();
+    try {
+      requestBody.writeTo(hashBuffer);
+    } catch (IOException e) {
+      // should never happen
+      throw new RuntimeException(e);
+    }
+    return hashBuffer.readByteString().md5().hex();
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -2,6 +2,7 @@ package com.apollographql.apollo.response;
 
 import com.apollographql.apollo.api.ScalarType;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -93,6 +94,17 @@ public final class ScalarTypeAdapters {
         } else {
           throw new IllegalArgumentException("Can't map: " + value + " to Double");
         }
+      }
+    });
+    adapters.put(File.class, new DefaultCustomTypeAdapter<File>() {
+      @Override public File decode(@NotNull CustomTypeValue value) {
+        return null;
+      }
+
+      @NotNull
+      @Override
+      public CustomTypeValue encode(@NotNull File value) {
+        return new CustomTypeValue.GraphQLString(null);
       }
     });
     return adapters;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloFileUploadInterceptorTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloFileUploadInterceptorTest.kt
@@ -1,0 +1,387 @@
+package com.apollographql.apollo.internal.interceptor
+
+import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy
+import com.apollographql.apollo.api.internal.Optional
+import com.apollographql.apollo.cache.CacheHeaders
+import com.apollographql.apollo.internal.ApolloLogger
+import com.apollographql.apollo.response.ScalarTypeAdapters
+import com.google.common.truth.Truth.assertThat
+import okhttp3.*
+import okhttp3.Response
+import okio.Buffer
+import okio.BufferedSink
+import okio.Okio
+import org.junit.Test
+import java.io.BufferedWriter
+import java.io.File
+import java.io.FileWriter
+import java.nio.file.Files
+import java.nio.file.Paths
+
+fun createFile(fileName: String, content: String): File {
+    val tempDir = Files.createTempDirectory("graphql-tmp-test-dir")
+    val filePath = Paths.get(tempDir.toString(), fileName)
+    val f = filePath.toFile()
+    val bw = BufferedWriter(FileWriter(f))
+    bw.write(content)
+    bw.close()
+    return f
+}
+
+val serverUrl = HttpUrl.parse("http://localhost") as HttpUrl
+val httpCallFactory = object : Call.Factory {
+    override fun newCall(request: Request): Call {
+        return object : Call {
+            override fun enqueue(responseCallback: Callback) {
+                TODO("not implemented")
+            }
+
+            override fun cancel() {
+                TODO("not implemented")
+            }
+
+            override fun clone(): Call {
+                TODO("not implemented")
+            }
+
+            override fun execute(): Response {
+                TODO("not implemented")
+            }
+
+            override fun isCanceled(): Boolean {
+                TODO("not implemented")
+            }
+
+            override fun isExecuted(): Boolean {
+                TODO("not implemented")
+            }
+
+            override fun request(): Request {
+                return request
+            }
+        }
+    }
+}
+val scalarTypeAdapters = ScalarTypeAdapters(HashMap())
+val logger = ApolloLogger(Optional.fromNullable(null))
+
+val apolloServerInterceptor = ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, false,
+        scalarTypeAdapters, logger, false)
+
+fun readRequestBody(body: RequestBody): String {
+    val limited: BufferedSink = Buffer()
+    val source = Okio.buffer(limited)
+
+    body.writeTo(source)
+    source.flush()
+    return limited.buffer().readUtf8()
+}
+
+
+internal var file1 = createFile("test1.txt", "content_testOne")
+internal var file2 = createFile("test2.jpg", "content_testTwo")
+internal var file3 = createFile("test3.pdf", "content_testThree")
+
+class ApolloFileUploadInterceptorTest {
+
+    @Test
+    fun noUpload() {
+        val operation = object : Mutation<Operation.Data, Void, Operation.Variables> {
+
+            override fun variables(): Operation.Variables {
+                return object : Operation.Variables() {
+                    override fun valueMap(): Map<String, Any> {
+                        return object : HashMap<String, Any>() {
+                            init {
+                                put("k1", "v1")
+                                put("k2", "v2")
+                            }
+                        }
+                    }
+                }
+            }
+
+            override fun queryDocument(): String? {
+                return "dummy request body"
+            }
+
+            override fun responseFieldMapper(): ResponseFieldMapper<Operation.Data>? {
+                return null
+            }
+
+            override fun wrapData(data: Operation.Data): Void? {
+                return null
+            }
+
+            override fun name(): OperationName {
+                return OperationName { "" }
+            }
+
+            override fun operationId(): String {
+                return ""
+            }
+        }
+
+
+        val httpRequest = apolloServerInterceptor.httpCall(operation, CacheHeaders.NONE).request()
+
+        assertThat(httpRequest.headers("Content-Type")[0]).isEqualTo("application/json")
+
+        val body = httpRequest.body() as RequestBody
+        val bodyString = readRequestBody(body)
+        assertThat(bodyString.trimIndent()).isEqualTo("""
+{"query":"dummy request body","operationName":"","variables":{}}
+        """.trimIndent())
+
+    }
+
+    @Test
+    fun singleSimpleUpload() {
+        val operation = object : Mutation<Operation.Data, Void, Operation.Variables> {
+
+            override fun variables(): Operation.Variables {
+                return object : Operation.Variables() {
+                    override fun valueMap(): Map<String, Any> {
+                        return object : HashMap<String, Any>() {
+                            init {
+                                put("k1", "v1")
+                                put("k2", file1)
+                            }
+                        }
+                    }
+                }
+            }
+
+            override fun queryDocument(): String? {
+                return "dummy request body"
+            }
+
+            override fun responseFieldMapper(): ResponseFieldMapper<Operation.Data>? {
+                return null
+            }
+
+            override fun wrapData(data: Operation.Data): Void? {
+                return null
+            }
+
+            override fun name(): OperationName {
+                return OperationName { "" }
+            }
+
+            override fun operationId(): String {
+                return ""
+            }
+        }
+
+
+        val httpRequest = apolloServerInterceptor.httpCall(operation, CacheHeaders.NONE).request()
+
+        assertThat(httpRequest.headers("Content-Type")[0]).isEqualTo("multipart/form-data; boundary=--graphql-multipart-upload-boundary-85763456--")
+
+        val body = httpRequest.body() as RequestBody
+        val bodyString = readRequestBody(body)
+        assertThat(bodyString.trimIndent()).isEqualTo("""
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="operations"
+Content-Type: application/json; charset=utf-8
+Content-Length: 64
+
+{"query":"dummy request body","operationName":"","variables":{}}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="map"
+Content-Type: application/json; charset=utf-8
+Content-Length: 22
+
+{"0":["variables.k2"]}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="0"; filename="test1.txt"
+Content-Type: text/plain
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456----
+        """.trimIndent())
+
+    }
+
+    @Test
+    fun singleNestedMapUpload() {
+        val nestedObject = object : InputType {
+            override fun marshaller(): InputFieldMarshaller {
+                TODO("not implemented")
+            }
+
+            private val k1Lev2 = "v1"
+            private val k2Lev2 = object : InputType {
+                override fun marshaller(): InputFieldMarshaller {
+                    TODO("not implemented")
+                }
+
+                private val k1Lev3 = "v1"
+                private val k2Lev3 = file1
+                private val k3Lev3 = "v3"
+            }
+            private val k3Lev2 = "v3"
+        }
+        val operation = object : Mutation<Operation.Data, Void, Operation.Variables> {
+            override fun variables(): Operation.Variables {
+                return object : Operation.Variables() {
+                    override fun valueMap(): Map<String, Any> {
+                        return object : HashMap<String, Any>() {
+                            init {
+                                put("k1Lev1", "v1")
+                                put("k2Lev1", nestedObject)
+                                put("k3Lev1", "v2")
+                            }
+                        }
+                    }
+                }
+            }
+
+            override fun queryDocument(): String? {
+                return "any dummy"
+            }
+
+            override fun responseFieldMapper(): ResponseFieldMapper<Operation.Data>? {
+                return null
+            }
+
+            override fun wrapData(data: Operation.Data): Void? {
+                return null
+            }
+
+            override fun name(): OperationName {
+                return OperationName { "" }
+            }
+
+            override fun operationId(): String {
+                return ""
+            }
+        }
+        val httpRequest = apolloServerInterceptor.httpCall(operation, CacheHeaders.NONE).request()
+        val body = httpRequest.body() as RequestBody
+
+        assertThat(httpRequest.headers("Content-Type")[0]).isEqualTo("multipart/form-data; boundary=--graphql-multipart-upload-boundary-85763456--")
+
+        val bodyString = readRequestBody(body)
+        assertThat(bodyString.trimIndent()).isEqualTo("""
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="operations"
+Content-Type: application/json; charset=utf-8
+Content-Length: 55
+
+{"query":"any dummy","operationName":"","variables":{}}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="map"
+Content-Type: application/json; charset=utf-8
+Content-Length: 40
+
+{"0":["variables.k2Lev1.k2Lev2.k2Lev3"]}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="0"; filename="test1.txt"
+Content-Type: text/plain
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456----
+        """.trimIndent())
+    }
+
+    @Test
+    fun singleNestedMapListUpload() {
+        val nestedObject = object : InputType {
+            override fun marshaller(): InputFieldMarshaller {
+                TODO("not implemented")
+            }
+
+            private val choices = arrayListOf(object : InputType {
+                override fun marshaller(): InputFieldMarshaller {
+                    TODO("not implemented")
+                }
+
+                private val inputFiles = arrayListOf(file1, file2)
+            }, object : InputType {
+                override fun marshaller(): InputFieldMarshaller {
+                    TODO("not implemented")
+                }
+
+                private val inputFiles = arrayListOf(file3)
+            })
+        }
+        val operation = object : Mutation<Operation.Data, Void, Operation.Variables> {
+            override fun variables(): Operation.Variables {
+                return object : Operation.Variables() {
+                    override fun valueMap(): Map<String, Any> {
+                        return object : HashMap<String, Any>() {
+                            init {
+                                put("answer", nestedObject)
+                            }
+                        }
+                    }
+                }
+            }
+
+            override fun queryDocument(): String? {
+                return "singleNestedMapListUpload"
+            }
+
+            override fun responseFieldMapper(): ResponseFieldMapper<Operation.Data>? {
+                return null
+            }
+
+            override fun wrapData(data: Operation.Data): Void? {
+                return null
+            }
+
+            override fun name(): OperationName {
+                return OperationName { "" }
+            }
+
+            override fun operationId(): String {
+                return ""
+            }
+        }
+
+
+        val httpRequest = apolloServerInterceptor.httpCall(operation, CacheHeaders.NONE).request()
+        val body = httpRequest.body() as RequestBody
+
+        assertThat(httpRequest.headers("Content-Type")[0]).isEqualTo("multipart/form-data; boundary=--graphql-multipart-upload-boundary-85763456--")
+
+        val bodyString = readRequestBody(body)
+        assertThat(bodyString.trimIndent()).isEqualTo("""
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="operations"
+Content-Type: application/json; charset=utf-8
+Content-Length: 71
+
+{"query":"singleNestedMapListUpload","operationName":"","variables":{}}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="map"
+Content-Type: application/json; charset=utf-8
+Content-Length: 145
+
+{"0":["variables.answer.choices.0.inputFiles.0"],"1":["variables.answer.choices.0.inputFiles.1"],"2":["variables.answer.choices.1.inputFiles.0"]}
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="0"; filename="test1.txt"
+Content-Type: text/plain
+Content-Length: 15
+
+content_testOne
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="1"; filename="test2.jpg"
+Content-Type: image/jpeg
+Content-Length: 15
+
+content_testTwo
+----graphql-multipart-upload-boundary-85763456--
+Content-Disposition: form-data; name="2"; filename="test3.pdf"
+Content-Type: application/pdf
+Content-Length: 17
+
+content_testThree
+----graphql-multipart-upload-boundary-85763456----
+        """.trimIndent())
+    }
+}

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -45,7 +47,11 @@ public class ApolloCallTrackerTest {
     }
 
     @Override public Variables variables() {
-      return EMPTY_VARIABLES;
+      return new Variables() {
+          @Override public Map<String, Object> valueMap() {
+              return new HashMap<>();
+      }
+      };
     }
 
     @Override public ResponseFieldMapper<Data> responseFieldMapper() {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ subprojects {
 
   buildscript {
     repositories {
+      maven { url "https://dl.bintray.com/truongsinh/android" }
       maven { url "https://plugins.gradle.org/m2/" }
       maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
       google()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    apolloVersion                : '1.0.0-alpha3',
+    apolloVersion                : '1.0.0-alpha3.inspectorio22',
     cacheVersion                 : '2.0.2',
     okHttpVersion                : '3.11.0',
     kotlinVersion                : '1.3.0',
@@ -30,8 +30,8 @@ ext.dep = [
     recyclerView            : "com.android.support:recyclerview-v7:$versions.supportLibVersion",
     compiletesting          : 'com.google.testing.compile:compile-testing:0.15',
     cache                   : "com.nytimes.android:cache:$versions.cacheVersion",
-    javaPoet                : 'com.squareup:javapoet:1.9.0',
-    moshi                   : 'com.squareup.moshi:moshi:1.8.0',
+    javaPoet                : 'com.squareup:javapoet:1.11.1',
+    moshi                   : 'com.squareup.moshi:moshi:1.7.0',
     rxjava                  : 'io.reactivex:rxjava:1.2.9',
     rxjava2                 : 'io.reactivex.rxjava2:rxjava:2.0.5',
     rxandroid               : 'io.reactivex.rxjava2:rxandroid:2.0.1',


### PR DESCRIPTION
Experiment code for apollo-upload-client using multipart form data

with test file

handle `map` and `collection` type (recursively)

cleanup

Experiment code for apollo-upload-client using multipart form data

with test file

handle `map` and `collection` type (recursively)

cleanup

more test

integration test

handle nested structure using reflection

better integration test

properly unitest

cover more case in integration test

auto detect mimtype from extension

simplify API

tmp

change dependency to pass test in compiler https://github.com/square/moshi/issues/740

compiler Upload scalar

compiler Upload scalar

configure `Upload` to be handled by class `java.io.File` by default

fix style

fix test