### PR TITLE
use separate packageNames for separate modules.

### DIFF
--- a/apollo-android-support/src/main/AndroidManifest.xml
+++ b/apollo-android-support/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.apollographql.apollo">
+  package="com.apollographql.apollo.android.support">
   <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/apollo-espresso-support/src/main/AndroidManifest.xml
+++ b/apollo-espresso-support/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.apollographql.apollo"></manifest>
+<manifest package="com.apollographql.apollo.espresso.support" />


### PR DESCRIPTION
Else, I ended up have a duplicate BuildConfig class.
See this link for a discussion on the problem: https://stackoverflow.com/questions/50717588/program-type-already-present-buildconfig