### PR TITLE
Added null check for response 'data' field before parsing payload

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -49,8 +49,8 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
     checkNotNull(payload, "payload == null");
 
     D data = null;
-    if (payload.containsKey("data")) {
-      Map<String, Object> buffer = (Map<String, Object>) payload.get("data");
+    Map<String, Object> buffer = (Map<String, Object>) payload.get("data");
+    if (buffer!=null) {
       RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(operation.variables(),
           buffer, new MapFieldValueResolver(), scalarTypeAdapters, responseNormalizer);
       data = (D) responseFieldMapper.map(realResponseReader);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -50,7 +50,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
 
     D data = null;
     Map<String, Object> buffer = (Map<String, Object>) payload.get("data");
-    if (buffer!=null) {
+    if (buffer != null) {
       RealResponseReader<Map<String, Object>> realResponseReader = new RealResponseReader<>(operation.variables(),
           buffer, new MapFieldValueResolver(), scalarTypeAdapters, responseNormalizer);
       data = (D) responseFieldMapper.map(realResponseReader);

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/response/OperationResponseParserTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/response/OperationResponseParserTest.java
@@ -1,0 +1,33 @@
+package com.apollographql.apollo.response;
+
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ScalarType;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+
+public class OperationResponseParserTest {
+
+    abstract class TestOperation implements Operation<Operation.Data, String, Operation.Variables> {
+    }
+
+    @Test
+    public void validateNullDataFieldInPayload() {
+        OperationResponseParser<Operation.Data, String> parser = new OperationResponseParser<>(
+                mock(TestOperation.class),
+                mock(ResponseFieldMapper.class),
+                new ScalarTypeAdapters(new HashMap<ScalarType, CustomTypeAdapter>())
+        );
+
+        Map<String, Object> payload = new HashMap<>();
+        parser.parse(payload);
+
+        payload.put("data", null);
+        parser.parse(payload);
+    }
+}


### PR DESCRIPTION
https://github.com/apollographql/apollo-android/issues/1215

According to https://facebook.github.io/graphql/draft/#sec-Data
null data value is a valid value and can be present in the response.