### PR TITLE
Make Mutations documentation accessible

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ sidebar_categories:
   Essentials:
       - essentials/get-started
       - essentials/queries
+      - essentials/mutations
 github_repo: apollographql/apollo-android
 content_root: docs/source
 


### PR DESCRIPTION
Mutations documentation cannot be found in the documentation website. By adding it here, it will now be accessible.

Here is how it looks like: 

![image](https://user-images.githubusercontent.com/763339/54930178-195edc00-4f17-11e9-98a6-ddfc04f800ee.png)
