### PR TITLE
Adding support for per-request headers

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -126,7 +126,7 @@ public class IntegrationTest {
     assertThat(server.takeRequest().getBody().readString(Charsets.UTF_8))
         .isEqualTo("{\"operationName\":\"AllPlanets\",\"variables\":{},"
             + "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-            "\"sha256Hash\":\"c4d45ee8b7464957320775df69251c9bba2f1eea82ef9f64146e71eb6e074930\"}},"
+            "\"sha256Hash\":\"" + AllPlanetsQuery.OPERATION_ID + "\"}},"
             + "\"query\":\"query AllPlanets {  "
             + "allPlanets(first: 300) {"
             + "    __typename"

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -30,6 +30,16 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
 
   @NotNull @Override ApolloMutationCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
+  /**
+   * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
+   * it is issued. These headers will be applied after any headers applied by application-level interceptors
+   * and will override those if necessary.
+   *
+   * @param requestHeaders The {@link RequestHeaders} to use for this request.
+   * @return The ApolloCall object with the provided {@link RequestHeaders}.
+   */
+  @NotNull ApolloMutationCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+
   @NotNull @Override ApolloMutationCall<T> clone();
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.request.RequestHeaders;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.api.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
+import com.apollographql.apollo.request.RequestHeaders;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -46,6 +47,16 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    * @return The ApolloCall object with the provided CacheControl strategy
    */
   @NotNull ApolloQueryCall<T> responseFetcher(@NotNull ResponseFetcher fetcher);
+
+  /**
+   * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
+   * it is issued. These headers will be applied after any headers applied by application-level interceptors
+   * and will override those if necessary.
+   *
+   * @param requestHeaders The {@link RequestHeaders} to use for this request.
+   * @return The ApolloCall object with the provided {@link RequestHeaders}.
+   */
+  @NotNull ApolloQueryCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
   @NotNull @Override ApolloQueryCall<T> clone();
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -6,6 +6,7 @@ import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.exception.ApolloException;
+import com.apollographql.apollo.request.RequestHeaders;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -114,14 +115,17 @@ public interface ApolloInterceptor {
     public final UUID uniqueId = UUID.randomUUID();
     public final Operation operation;
     public final CacheHeaders cacheHeaders;
+    public final RequestHeaders requestHeaders;
     public final boolean fetchFromCache;
     public final Optional<Operation.Data> optimisticUpdates;
     public final boolean sendQueryDocument;
 
-    InterceptorRequest(Operation operation, CacheHeaders cacheHeaders, Optional<Operation.Data> optimisticUpdates,
-        boolean fetchFromCache, boolean sendQueryDocument) {
+    InterceptorRequest(Operation operation, CacheHeaders cacheHeaders, RequestHeaders requestHeaders,
+        Optional<Operation.Data> optimisticUpdates, boolean fetchFromCache,
+        boolean sendQueryDocument) {
       this.operation = operation;
       this.cacheHeaders = cacheHeaders;
+      this.requestHeaders = requestHeaders;
       this.optimisticUpdates = optimisticUpdates;
       this.fetchFromCache = fetchFromCache;
       this.sendQueryDocument = sendQueryDocument;
@@ -130,6 +134,7 @@ public interface ApolloInterceptor {
     public Builder toBuilder() {
       return new Builder(operation)
           .cacheHeaders(cacheHeaders)
+          .requestHeaders(requestHeaders)
           .fetchFromCache(fetchFromCache)
           .optimisticUpdates(optimisticUpdates.orNull())
           .sendQueryDocument(sendQueryDocument);
@@ -142,6 +147,7 @@ public interface ApolloInterceptor {
     public static final class Builder {
       private final Operation operation;
       private CacheHeaders cacheHeaders = CacheHeaders.NONE;
+      private RequestHeaders requestHeaders = RequestHeaders.NONE;
       private boolean fetchFromCache;
       private Optional<Operation.Data> optimisticUpdates = Optional.absent();
       private boolean sendQueryDocument = true;
@@ -152,6 +158,11 @@ public interface ApolloInterceptor {
 
       public Builder cacheHeaders(@NotNull CacheHeaders cacheHeaders) {
         this.cacheHeaders = checkNotNull(cacheHeaders, "cacheHeaders == null");
+        return this;
+      }
+
+      public Builder requestHeaders(@NotNull RequestHeaders requestHeaders) {
+        this.requestHeaders = checkNotNull(requestHeaders, "requestHeaders == null");
         return this;
       }
 
@@ -176,8 +187,8 @@ public interface ApolloInterceptor {
       }
 
       public InterceptorRequest build() {
-        return new InterceptorRequest(operation, cacheHeaders, optimisticUpdates, fetchFromCache,
-            sendQueryDocument);
+        return new InterceptorRequest(operation, cacheHeaders, requestHeaders, optimisticUpdates,
+            fetchFromCache, sendQueryDocument);
       }
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -25,6 +25,7 @@ import com.apollographql.apollo.internal.interceptor.ApolloCacheInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloParseInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.internal.interceptor.RealApolloInterceptorChain;
+import com.apollographql.apollo.request.RequestHeaders;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
 
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final ScalarTypeAdapters scalarTypeAdapters;
   final ApolloStore apolloStore;
   final CacheHeaders cacheHeaders;
+  final RequestHeaders requestHeaders;
   final ResponseFetcher responseFetcher;
   final ApolloInterceptorChain interceptorChain;
   final Executor dispatcher;
@@ -87,6 +89,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     apolloStore = builder.apolloStore;
     responseFetcher = builder.responseFetcher;
     cacheHeaders = builder.cacheHeaders;
+    requestHeaders = builder.requestHeaders;
     dispatcher = builder.dispatcher;
     logger = builder.logger;
     applicationInterceptors = builder.applicationInterceptors;
@@ -130,6 +133,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(operation)
         .cacheHeaders(cacheHeaders)
+        .requestHeaders(requestHeaders)
         .fetchFromCache(false)
         .optimisticUpdates(optimisticUpdates)
         .build();
@@ -158,6 +162,13 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
     return toBuilder()
         .cacheHeaders(checkNotNull(cacheHeaders, "cacheHeaders == null"))
+        .build();
+  }
+
+  @NotNull @Override public RealApolloCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders) {
+    if (state.get() != IDLE) throw new IllegalStateException("Already Executed");
+    return toBuilder()
+        .requestHeaders(checkNotNull(requestHeaders, "requestHeaders == null"))
         .build();
   }
 
@@ -287,6 +298,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .scalarTypeAdapters(scalarTypeAdapters)
         .apolloStore(apolloStore)
         .cacheHeaders(cacheHeaders)
+        .requestHeaders(requestHeaders)
         .responseFetcher(responseFetcher)
         .dispatcher(dispatcher)
         .logger(logger)
@@ -382,6 +394,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     ApolloStore apolloStore;
     ResponseFetcher responseFetcher;
     CacheHeaders cacheHeaders;
+    RequestHeaders requestHeaders = RequestHeaders.NONE;
     ApolloInterceptorChain interceptorChain;
     Executor dispatcher;
     ApolloLogger logger;
@@ -439,6 +452,11 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     public Builder<T> cacheHeaders(CacheHeaders cacheHeaders) {
       this.cacheHeaders = cacheHeaders;
+      return this;
+    }
+
+    public Builder<T> requestHeaders(RequestHeaders requestHeaders) {
+      this.requestHeaders = requestHeaders;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/request/RequestHeaders.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/request/RequestHeaders.java
@@ -1,0 +1,66 @@
+package com.apollographql.apollo.request;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A key/value collection of HTTP headers which are added to a request.
+ */
+public final class RequestHeaders {
+  private final Map<String, String> headerMap;
+
+  public static RequestHeaders.Builder builder() {
+    return new Builder();
+  }
+
+  public static final RequestHeaders NONE = new RequestHeaders(Collections.<String, String>emptyMap());
+
+  public static final class Builder {
+
+    private final Map<String, String> headerMap = new LinkedHashMap<>();
+
+    public Builder addHeader(String headerName, String headerValue) {
+      headerMap.put(headerName, headerValue);
+      return this;
+    }
+
+    public Builder addHeaders(Map<String, String> headerMap) {
+      this.headerMap.putAll(headerMap);
+      return this;
+    }
+
+    public RequestHeaders build() {
+      return new RequestHeaders(headerMap);
+    }
+  }
+
+  /**
+   * @return A {@link RequestHeaders.Builder} with a copy of this {@link RequestHeaders} values.
+   */
+  public RequestHeaders.Builder toBuilder() {
+    RequestHeaders.Builder builder = builder();
+    builder.addHeaders(headerMap);
+    return builder;
+  }
+
+  RequestHeaders(Map<String, String> headerMap) {
+    this.headerMap = headerMap;
+  }
+
+  public Set<String> headers() {
+    return headerMap.keySet();
+  }
+
+  @Nullable
+  public String headerValue(String header) {
+    return headerMap.get(header);
+  }
+
+  public boolean hasHeader(String headerName) {
+    return headerMap.containsKey(headerName);
+  }
+}


### PR DESCRIPTION
This PR adds support for the concept of per-request headers. These are introduced by adding a RequestHeaders structure which is similar to the existing CacheHeaders structure. These are configured on ApolloQueryCalls and provided to a new interceptor which adds the specified headers to the call when executed.

This PR also fixes an issue with the integration tests - SHA hashes can be different on different file systems based on encoding. On my local machine, at least, these hashes were different than the hard-coded values. So replacing the integration test SHAs with constants worked better. (Note - the tests don't seem to fully pass for me with `./gradlew check`, with some lint errors in files I didn't touch)

This should help to address https://github.com/apollographql/apollo-android/issues/1183.