### PR TITLE
Try to fix issue with local Apollo codegen CLI not found error

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloLocalCodegenGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloLocalCodegenGenerationTask.groovy
@@ -21,12 +21,7 @@ class ApolloLocalCodegenGenerationTask extends NodeTask {
 
   @Override
   void exec() {
-    File apolloScript = new File(getProject().getBuildDir(), APOLLO_CODEGEN)
-    if (!apolloScript.isFile()) {
-      throw new GradleException(
-          "Apollo-codegen was not found in node_modules. Please run the installApolloCodegen task.")
-    }
-    setScript(apolloScript)
+    setScript(new File(getProject().getBuildDir(), APOLLO_CODEGEN))
 
     List<CodegenGenerationTaskCommandArgsBuilder.CommandArgs> args = new CodegenGenerationTaskCommandArgsBuilder(
         this, schemaFilePath.get(), outputPackageName.get(), outputDir.get().asFile, variant, sourceSetNames


### PR DESCRIPTION
It's not really a fix but a workaround to avoid throwing exception on checking if local codegen is file. Hopefully this issue will go away after migration to new Apollo CLI.

Part of https://github.com/apollographql/apollo-android/issues/1265