### PR TITLE
Consolidated data source flow into a repository pattern for #1277.

### DIFF
--- a/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCallbackService.kt
+++ b/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCallbackService.kt
@@ -1,0 +1,90 @@
+package com.apollographql.apollo.kotlinsample.data
+
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
+import com.apollographql.apollo.kotlinsample.type.OrderDirection
+import com.apollographql.apollo.kotlinsample.type.PullRequestState
+import com.apollographql.apollo.kotlinsample.type.RepositoryOrderField
+
+/**
+ * An implementation of a [GitHubDataSource] that shows how to fetch data using callbacks.
+ */
+class ApolloCallbackService(apolloClient: ApolloClient) : GitHubDataSource(apolloClient) {
+  override fun fetchRepositories() {
+    val repositoriesQuery = GithubRepositoriesQuery.builder()
+        .repositoriesCount(50)
+        .orderBy(RepositoryOrderField.UPDATED_AT)
+        .orderDirection(OrderDirection.DESC)
+        .build()
+
+    val callback = object : ApolloCall.Callback<GithubRepositoriesQuery.Data>() {
+      override fun onFailure(e: ApolloException) {
+        exceptionSubject.onNext(e)
+      }
+
+      override fun onResponse(response: Response<GithubRepositoriesQuery.Data>) {
+        repositoriesSubject.onNext(mapRepositoriesResponseToRepositories(response))
+      }
+    }
+
+    apolloClient
+        .query(repositoriesQuery)
+        .httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
+        .enqueue(callback)
+  }
+
+  override fun fetchRepositoryDetail(repositoryName: String) {
+    val repositoryDetailQuery = GithubRepositoryDetailQuery.builder()
+        .name(repositoryName)
+        .pullRequestStates(listOf(PullRequestState.OPEN))
+        .build()
+
+    val callback = object : ApolloCall.Callback<GithubRepositoryDetailQuery.Data>() {
+      override fun onFailure(e: ApolloException) {
+        exceptionSubject.onNext(e)
+      }
+
+      override fun onResponse(response: Response<GithubRepositoryDetailQuery.Data>) {
+        repositoryDetailSubject.onNext(response)
+      }
+    }
+
+    apolloClient
+        .query(repositoryDetailQuery)
+        .httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
+        .enqueue(callback)
+  }
+
+  override fun fetchCommits(repositoryName: String) {
+    val commitsQuery = GithubRepositoryCommitsQuery.builder()
+        .name(repositoryName)
+        .build()
+
+    val callback = object : ApolloCall.Callback<GithubRepositoryCommitsQuery.Data>() {
+      override fun onFailure(e: ApolloException) {
+        exceptionSubject.onNext(e)
+      }
+
+      override fun onResponse(response: Response<GithubRepositoryCommitsQuery.Data>) {
+        val headCommit = response.data()?.viewer()?.repository()?.ref()?.target() as? GithubRepositoryCommitsQuery.AsCommit
+        val commits = headCommit?.history()?.edges().orEmpty()
+        commitsSubject.onNext(commits)
+      }
+    }
+
+    apolloClient
+        .query(commitsQuery)
+        .httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
+        .enqueue(callback)
+  }
+
+  override fun cancelFetching() {
+    //TODO: Determine how to cancel this when there's callbacks
+  }
+}

--- a/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
+++ b/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
@@ -1,0 +1,85 @@
+package com.apollographql.apollo.kotlinsample.data
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.coroutines.toDeferred
+import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
+import com.apollographql.apollo.kotlinsample.type.OrderDirection
+import com.apollographql.apollo.kotlinsample.type.PullRequestState
+import com.apollographql.apollo.kotlinsample.type.RepositoryOrderField
+import kotlinx.coroutines.*
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * An implementation of a [GitHubDataSource] that shows how we can use coroutines to make our apollo requests.
+ */
+class ApolloCoroutinesService(
+    apolloClient: ApolloClient,
+    private val processContext: CoroutineContext = Dispatchers.IO,
+    private val resultContext: CoroutineContext = Dispatchers.Main
+) : GitHubDataSource(apolloClient) {
+  private var job: Job? = null
+
+  override fun fetchRepositories() {
+    val repositoriesQuery = GithubRepositoriesQuery.builder()
+        .repositoriesCount(50)
+        .orderBy(RepositoryOrderField.UPDATED_AT)
+        .orderDirection(OrderDirection.DESC)
+        .build()
+
+    job = CoroutineScope(processContext).launch {
+      try {
+        val response = apolloClient.query(repositoriesQuery).toDeferred().await()
+        withContext(resultContext) {
+          repositoriesSubject.onNext(mapRepositoriesResponseToRepositories(response))
+        }
+      } catch (e: Exception) {
+        exceptionSubject.onNext(e)
+      }
+    }
+  }
+
+  override fun fetchRepositoryDetail(repositoryName: String) {
+    val repositoryDetailQuery = GithubRepositoryDetailQuery.builder()
+        .name(repositoryName)
+        .pullRequestStates(listOf(PullRequestState.OPEN))
+        .build()
+
+    job = CoroutineScope(processContext).launch {
+      try {
+        val response = apolloClient.query(repositoryDetailQuery).toDeferred().await()
+
+        withContext(resultContext) {
+          repositoryDetailSubject.onNext(response)
+        }
+      } catch (e: Exception) {
+        exceptionSubject.onNext(e)
+      }
+    }
+  }
+
+  override fun fetchCommits(repositoryName: String) {
+    val commitsQuery = GithubRepositoryCommitsQuery.builder()
+        .name(repositoryName)
+        .build()
+
+    job = CoroutineScope(processContext).launch {
+      try {
+        val response = apolloClient.query(commitsQuery).toDeferred().await()
+        val headCommit = response.data()?.viewer()?.repository()?.ref()?.target() as? GithubRepositoryCommitsQuery.AsCommit
+        val commits = headCommit?.history()?.edges().orEmpty()
+
+        withContext(resultContext) {
+          commitsSubject.onNext(commits)
+        }
+      } catch (e: Exception) {
+        exceptionSubject.onNext(e)
+      }
+    }
+  }
+
+  override fun cancelFetching() {
+    job?.cancel()
+  }
+}

--- a/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
+++ b/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
@@ -1,0 +1,90 @@
+package com.apollographql.apollo.kotlinsample.data
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
+import com.apollographql.apollo.kotlinsample.type.OrderDirection
+import com.apollographql.apollo.kotlinsample.type.PullRequestState
+import com.apollographql.apollo.kotlinsample.type.RepositoryOrderField
+import com.apollographql.apollo.rx2.Rx2Apollo
+import io.reactivex.Scheduler
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+
+/**
+ * An implementation of a [GitHubDataSource] that shows how we can use RxJava to make our apollo requests.
+ */
+class ApolloRxService(
+    apolloClient: ApolloClient,
+    private val compositeDisposable: CompositeDisposable = CompositeDisposable(),
+    private val processScheduler: Scheduler = Schedulers.io(),
+    private val resultScheduler: Scheduler = AndroidSchedulers.mainThread()
+) : GitHubDataSource(apolloClient) {
+  override fun fetchRepositories() {
+    val repositoriesQuery = GithubRepositoriesQuery.builder()
+        .repositoriesCount(50)
+        .orderBy(RepositoryOrderField.UPDATED_AT)
+        .orderDirection(OrderDirection.DESC)
+        .build()
+
+    val call = apolloClient.query(repositoriesQuery)
+
+    val disposable = Rx2Apollo.from(call)
+        .subscribeOn(processScheduler)
+        .observeOn(resultScheduler)
+        .map(this::mapRepositoriesResponseToRepositories)
+        .subscribe(
+            repositoriesSubject::onNext,
+            exceptionSubject::onNext
+        )
+
+    compositeDisposable.add(disposable)
+  }
+
+  override fun fetchRepositoryDetail(repositoryName: String) {
+    val repositoryDetailQuery = GithubRepositoryDetailQuery.builder()
+        .name(repositoryName)
+        .pullRequestStates(listOf(PullRequestState.OPEN))
+        .build()
+
+    val call = apolloClient.query(repositoryDetailQuery)
+
+    val disposable = Rx2Apollo.from(call)
+        .subscribeOn(processScheduler)
+        .observeOn(resultScheduler)
+        .subscribe(
+            repositoryDetailSubject::onNext,
+            exceptionSubject::onNext
+        )
+
+    compositeDisposable.add(disposable)
+  }
+
+  override fun fetchCommits(repositoryName: String) {
+    val commitsQuery = GithubRepositoryCommitsQuery.builder()
+        .name(repositoryName)
+        .build()
+
+    val call = apolloClient.query(commitsQuery)
+
+    val disposable = Rx2Apollo.from(call)
+        .subscribeOn(processScheduler)
+        .observeOn(resultScheduler)
+        .map { response ->
+          val headCommit = response.data()?.viewer()?.repository()?.ref()?.target() as? GithubRepositoryCommitsQuery.AsCommit
+          headCommit?.history()?.edges().orEmpty()
+        }
+        .subscribe(
+            commitsSubject::onNext,
+            exceptionSubject::onNext
+        )
+
+    compositeDisposable.add(disposable)
+  }
+
+  override fun cancelFetching() {
+    compositeDisposable.dispose()
+  }
+}

--- a/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/GitHubDataSource.kt
+++ b/apollo-kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/GitHubDataSource.kt
@@ -1,0 +1,36 @@
+package com.apollographql.apollo.kotlinsample.data
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
+import com.apollographql.apollo.kotlinsample.fragment.RepositoryFragment
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
+
+/**
+ * This is a base class defining the required behavior for a data source of GitHub information. We don't care if that data
+ * is fetched via RxJava, coroutines, etc. Any implementations of this can fetch data however they want, and post that result
+ * to the public Observables that activities can subscribe to for information.
+ */
+abstract class  GitHubDataSource(protected val apolloClient: ApolloClient) {
+  protected val repositoriesSubject: PublishSubject<List<RepositoryFragment>> = PublishSubject.create()
+  protected val repositoryDetailSubject: PublishSubject<Response<GithubRepositoryDetailQuery.Data>> = PublishSubject.create()
+  protected val commitsSubject: PublishSubject<List<GithubRepositoryCommitsQuery.Edge>> = PublishSubject.create()
+  protected val exceptionSubject: PublishSubject<Throwable> = PublishSubject.create()
+
+  val repositories: Observable<List<RepositoryFragment>> = repositoriesSubject.hide()
+  val repositoryDetail: Observable<Response<GithubRepositoryDetailQuery.Data>> = repositoryDetailSubject.hide()
+  val commits: Observable<List<GithubRepositoryCommitsQuery.Edge>> = commitsSubject.hide()
+  val error: Observable<Throwable> = exceptionSubject.hide()
+
+  abstract fun fetchRepositories()
+  abstract fun fetchRepositoryDetail(repositoryName: String)
+  abstract fun fetchCommits(repositoryName: String)
+  abstract fun cancelFetching()
+
+  protected fun mapRepositoriesResponseToRepositories(response: Response<GithubRepositoriesQuery.Data>): List<RepositoryFragment> {
+    return response.data()?.viewer()?.repositories()?.nodes()?.map { it.fragments().repositoryFragment() } ?: emptyList()
+  }
+}


### PR DESCRIPTION
# Summary

Previously the kotlin sample app was fetching data three different ways for all three activities. As someone new coming into the app, this can be pretty confusing. I sought out to consolidate that flow into something more understandable.

I created an abstract class called `GitHubDataSource` which defines our contract for fetching and exposing data. Our activities reference this data source, and it's created inside our application class. 

I made three implementations of this class, one using callbacks, one using RxJava, and one using coroutines. People who are implementing Apollo can pick their favorite, but at least they'll have a guiding reference now, no matter which they choose.

# How this was tested

Manually switched the data source type in `KotlinSampleApp` and ran the app for all data source types. Clicked into the app accordingly, and make sure they all fetched data without error. 