### PR TITLE
Fix issue with wrong operation name generated for Kotlin models

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
@@ -38,6 +38,7 @@ internal sealed class FieldType {
 internal data class OperationType(
     val name: String,
     val type: Type,
+    val operationName: String,
     val operationId: String,
     val queryDocument: String,
     val variables: InputType,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
@@ -26,6 +26,7 @@ internal fun Operation.ast(
   return OperationType(
       name = operationClassName,
       type = operationType,
+      operationName = operationName,
       operationId = (sourceWithFragments ?: "").filter { it != '\n' }.sha256(),
       queryDocument = sourceWithFragments!!,
       variables = InputType(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -88,7 +88,7 @@ internal fun OperationType.typeSpec(targetPackage: String) =
                 .build()
             )
             .addProperty(PropertySpec.builder("OPERATION_NAME", OperationName::class)
-                .initializer("%T { %S }", OperationName::class, name)
+                .initializer("%T { %S }", OperationName::class, operationName)
                 .build())
             .build()
         )

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -224,6 +224,6 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
                 |}
                 """.trimMargin()
 
-        val OPERATION_NAME: OperationName = OperationName { "HeroDetailsQuery" }
+        val OPERATION_NAME: OperationName = OperationName { "HeroDetails" }
     }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -128,6 +128,6 @@ data class CreateReviewForEpisodeMutation(val ep: Episode, val review: ReviewInp
                 |}
                 """.trimMargin()
 
-        val OPERATION_NAME: OperationName = OperationName { "CreateReviewForEpisodeMutation" }
+        val OPERATION_NAME: OperationName = OperationName { "CreateReviewForEpisode" }
     }
 }


### PR DESCRIPTION
Part of https://github.com/apollographql/apollo-android/issues/1300