### PR TITLE
Don't send extensions in query payload when auto persistence disabled

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -7,7 +7,6 @@ import com.apollographql.apollo.cache.http.ApolloHttpCache;
 import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.integration.httpcache.AllPlanetsQuery;
-import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 
 import org.junit.After;
@@ -23,11 +22,9 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.RequestBody;
 import okhttp3.internal.io.FileSystem;
 import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockWebServer;
-import okio.Buffer;
 
 import static com.apollographql.apollo.Utils.assertResponse;
 import static com.apollographql.apollo.Utils.enqueueAndAssertResponse;
@@ -129,10 +126,7 @@ public class ApolloPrefetchTest {
   }
 
   private void checkCachedResponse(String fileName) throws IOException {
-    RequestBody requestBody = lastHttRequest.body();
-    Buffer buffer = new Buffer();
-    requestBody.writeTo(buffer);
-    String cacheKey = buffer.readByteString().md5().hex();
+    String cacheKey = lastHttRequest.headers(HttpCache.CACHE_KEY_HEADER).get(0);
     okhttp3.Response response = apolloClient.cachedHttpResponse(cacheKey);
     assertThat(response).isNotNull();
     assertThat(response.body().source().readUtf8()).isEqualTo(Utils.readFileToString(getClass(), "/" + fileName));

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -34,7 +34,6 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.RequestBody;
 import okhttp3.internal.io.FileSystem;
 import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockResponse;
@@ -656,10 +655,7 @@ public class HttpCacheTest {
   }
 
   private void checkCachedResponse(String fileName) throws IOException {
-    RequestBody requestBody = lastHttRequest.body();
-    Buffer buffer = new Buffer();
-    requestBody.writeTo(buffer);
-    String cacheKey = buffer.readByteString().md5().hex();
+    String cacheKey = lastHttRequest.headers(HttpCache.CACHE_KEY_HEADER).get(0);
     okhttp3.Response response = apolloClient.cachedHttpResponse(cacheKey);
     assertThat(response).isNotNull();
     assertThat(response.body().source().readUtf8()).isEqualTo(Utils.readFileToString(getClass(), fileName));

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -125,8 +125,6 @@ public class IntegrationTest {
 
     assertThat(server.takeRequest().getBody().readString(Charsets.UTF_8))
         .isEqualTo("{\"operationName\":\"AllPlanets\",\"variables\":{},"
-            + "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-            "\"sha256Hash\":\"" + AllPlanetsQuery.OPERATION_ID + "\"}},"
             + "\"query\":\"query AllPlanets {  "
             + "allPlanets(first: 300) {"
             + "    __typename"

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SendOperationIdentifiersTest.java
@@ -33,6 +33,8 @@ public class SendOperationIdentifiersTest {
     apolloClient.query(query).enqueue(null);
 
     String serverRequest = server.takeRequest().getBody().readUtf8();
+    assertThat(serverRequest.contains("extensions")).isTrue();
+    assertThat(serverRequest.contains("persistedQuery")).isTrue();
     assertThat(serverRequest.contains(String.format("\"sha256Hash\":\"%s\"", query.operationId()))).isTrue();
     assertThat(serverRequest.contains("\"query\":")).isFalse();
   }
@@ -46,7 +48,9 @@ public class SendOperationIdentifiersTest {
     apolloClient.query(query).enqueue(null);
 
     String serverRequest = server.takeRequest().getBody().readUtf8();
-    assertThat(serverRequest.contains("\"id\":\"")).isFalse();
+    assertThat(serverRequest.contains("extensions")).isFalse();
+    assertThat(serverRequest.contains("persistedQuery")).isFalse();
+    assertThat(serverRequest.contains("sha256Hash")).isFalse();
     assertThat(serverRequest.contains("\"query\":")).isTrue();
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.java
@@ -72,8 +72,6 @@ public class ApolloServerInterceptorFileUploadTest {
 
   private final String expectedOperationsPartBodySingle = "{\"operationName\":\"SingleUpload\"," +
       "\"variables\":{\"file\":null}," +
-      "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-      "\"sha256Hash\":\"" + SingleUploadMutation.OPERATION_ID + "\"}}," +
       "\"query\":\"mutation SingleUpload($file: Upload!) {  " +
       "singleUpload(file: $file) {    __typename    id    path    filename    mimetype  }}\"}";
   private final String expectedMapPartBodySingle = "{\"0\":[\"variables.file\"]}";
@@ -84,8 +82,6 @@ public class ApolloServerInterceptorFileUploadTest {
       .build();
   private final String expectedOperationsPartBodyTwice = "{\"operationName\":\"SingleUploadTwice\"," +
       "\"variables\":{\"file1\":null,\"file2\":null}," +
-      "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-      "\"sha256Hash\":\"" + SingleUploadTwiceMutation.OPERATION_ID + "\"}}," +
       "\"query\":\"mutation SingleUploadTwice($file1: Upload!, $file2: Upload!) {  " +
       "file1: singleUpload(file: $file1) {    __typename    id    path    filename    mimetype  }  " +
       "file2: singleUpload(file: $file2) {    __typename    id    path    filename    mimetype  }}\"}";
@@ -94,8 +90,6 @@ public class ApolloServerInterceptorFileUploadTest {
   private MultipleUploadMutation mutationMultiple = null;
   private final String expectedOperationsPartBodyMultiple = "{\"operationName\":\"MultipleUpload\"," +
       "\"variables\":{\"files\":[null,null]}," +
-      "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-      "\"sha256Hash\":\"" + MultipleUploadMutation.OPERATION_ID + "\"}}," +
       "\"query\":\"mutation MultipleUpload($files: [Upload!]!) {  " +
       "multipleUpload(files: $files) {    __typename    id    path    filename    mimetype  }}\"}";
   private final String expectedMapPartBodyMultiple = "{\"0\":[\"variables.files.0\"],\"1\":[\"variables.files.1\"]}";
@@ -108,8 +102,6 @@ public class ApolloServerInterceptorFileUploadTest {
   private final String expectedOperationsPartBodyNested = "{\"operationName\":\"NestedUpload\"," +
       "\"variables\":{\"topFile\":null,\"topFileList\":[null,null],\"nested\":{\"recursiveNested\":[" +
       "{\"file\":null,\"fileList\":[null,null]},{\"file\":null,\"fileList\":[null,null]}],\"file\":null,\"fileList\":[null,null]}}," +
-      "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-      "\"sha256Hash\":\"" + NestedUploadMutation.OPERATION_ID + "\"}}," +
       "\"query\":\"mutation NestedUpload($topFile: Upload, $topFileList: [Upload], $nested: NestedObject) {  " +
       "nestedUpload(topFile: $topFile, topFileList: $topFileList, nested: $nested)}\"}";
   private final String expectedMapPartBodyNested = "{\"0\":[\"variables.topFile\"],\"1\":[\"variables.topFileList.0\"]," +
@@ -159,10 +151,9 @@ public class ApolloServerInterceptorFileUploadTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, RequestHeaders.NONE, true, false);
   }
 
   @Test public void testDefaultHttpCallWithUploadTwice() throws Exception {
@@ -183,10 +174,9 @@ public class ApolloServerInterceptorFileUploadTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(mutationTwice, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpPostCall(mutationTwice, CacheHeaders.NONE, RequestHeaders.NONE, true, false);
   }
 
   @Test public void testDefaultHttpCallWithUploadMultiple() throws Exception {
@@ -207,10 +197,9 @@ public class ApolloServerInterceptorFileUploadTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(mutationMultiple, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpPostCall(mutationMultiple, CacheHeaders.NONE, RequestHeaders.NONE, true, false);
   }
 
   @Test public void testDefaultHttpCallWithUploadNested() throws Exception {
@@ -228,10 +217,9 @@ public class ApolloServerInterceptorFileUploadTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(mutationNested, CacheHeaders.NONE, RequestHeaders.NONE,true);
+    interceptor.httpPostCall(mutationNested, CacheHeaders.NONE, RequestHeaders.NONE,true, false);
   }
 
   @Test public void testAdditionalHeaders() throws Exception {
@@ -268,10 +256,9 @@ public class ApolloServerInterceptorFileUploadTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, requestHeaders, true);
+    interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, requestHeaders, true, false);
   }
 
   private void assertDefaultRequestHeaders(Request request, Operation mutation) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorTest.java
@@ -44,13 +44,6 @@ public class ApolloServerInterceptorTest {
       .firstInput(Input.<Integer>fromNullable(null))
       .last(100)
       .build();
-  private final String expectedRequestBody = "{\"operationName\":\"AllFilms\"," +
-      "\"variables\":{\"after\":\"some cursor\",\"first\":null,\"last\":100}," +
-      "\"extensions\":{\"persistedQuery\":{\"version\":1," +
-      "\"sha256Hash\":\"" + AllFilmsQuery.OPERATION_ID + "\"}}," +
-      "\"query\":\"query AllFilms($after: String, $first: Int, $before: String, $last: Int) {  " +
-      "allFilms(after: $after, first: $first, before: $before, last: $last) {    " +
-      "__typename    totalCount    films {      __typename      title      releaseDate    }  }}\"}";
 
   @Test public void testDefaultHttpCall() throws Exception {
     Predicate<Request> requestAssertPredicate = new Predicate<Request>() {
@@ -72,9 +65,9 @@ public class ApolloServerInterceptorTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()), false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpPostCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true, false);
   }
 
   @Test public void testDefaultHttpCall1() throws Exception {
@@ -95,10 +88,9 @@ public class ApolloServerInterceptorTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()),
-        false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpPostCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true, false);
   }
 
   @Test public void testCachedHttpCall() throws Exception {
@@ -125,10 +117,10 @@ public class ApolloServerInterceptorTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate),
         HttpCachePolicy.NETWORK_FIRST.expireAfter(10, TimeUnit.SECONDS), false,
-        scalarTypeAdapters, new ApolloLogger(Optional.<Logger>absent()), false);
+        scalarTypeAdapters, new ApolloLogger(Optional.<Logger>absent()));
 
     interceptor.httpPostCall(query, CacheHeaders.builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "true").build(),
-        RequestHeaders.NONE, true);
+        RequestHeaders.NONE, true, false);
   }
 
   @Test public void testAdditionalHeaders() throws Exception {
@@ -167,9 +159,9 @@ public class ApolloServerInterceptorTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()), false);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpPostCall(query, CacheHeaders.NONE, requestHeaders, true);
+    interceptor.httpPostCall(query, CacheHeaders.NONE, requestHeaders, true, false);
   }
 
   @Test public void testUseHttpGetForQueries() throws IOException {
@@ -195,9 +187,9 @@ public class ApolloServerInterceptorTest {
     ApolloServerInterceptor interceptor = new ApolloServerInterceptor(serverUrl,
         new AssertHttpCallFactory(requestAssertPredicate), null, false,
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
-        new ApolloLogger(Optional.<Logger>absent()), true);
+        new ApolloLogger(Optional.<Logger>absent()));
 
-    interceptor.httpGetCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true);
+    interceptor.httpGetCall(query, CacheHeaders.NONE, RequestHeaders.NONE, true, true);
   }
 
   private void assertDefaultRequestHeaders(Request request) {
@@ -216,6 +208,11 @@ public class ApolloServerInterceptorTest {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+    String expectedRequestBody = "{\"operationName\":\"AllFilms\"," +
+        "\"variables\":{\"after\":\"some cursor\",\"first\":null,\"last\":100}," +
+        "\"query\":\"query AllFilms($after: String, $first: Int, $before: String, $last: Int) {  " +
+        "allFilms(after: $after, first: $first, before: $before, last: $last) {    " +
+        "__typename    totalCount    films {      __typename      title      releaseDate    }  }}\"}";
     assertThat(bodyBuffer.readUtf8()).isEqualTo(expectedRequestBody);
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptor.java
@@ -119,16 +119,20 @@ public interface ApolloInterceptor {
     public final boolean fetchFromCache;
     public final Optional<Operation.Data> optimisticUpdates;
     public final boolean sendQueryDocument;
+    public final boolean useHttpGetMethodForQueries;
+    public final boolean autoPersistQueries;
 
     InterceptorRequest(Operation operation, CacheHeaders cacheHeaders, RequestHeaders requestHeaders,
         Optional<Operation.Data> optimisticUpdates, boolean fetchFromCache,
-        boolean sendQueryDocument) {
+        boolean sendQueryDocument, boolean useHttpGetMethodForQueries, boolean autoPersistQueries) {
       this.operation = operation;
       this.cacheHeaders = cacheHeaders;
       this.requestHeaders = requestHeaders;
       this.optimisticUpdates = optimisticUpdates;
       this.fetchFromCache = fetchFromCache;
       this.sendQueryDocument = sendQueryDocument;
+      this.useHttpGetMethodForQueries = useHttpGetMethodForQueries;
+      this.autoPersistQueries = autoPersistQueries;
     }
 
     public Builder toBuilder() {
@@ -137,7 +141,9 @@ public interface ApolloInterceptor {
           .requestHeaders(requestHeaders)
           .fetchFromCache(fetchFromCache)
           .optimisticUpdates(optimisticUpdates.orNull())
-          .sendQueryDocument(sendQueryDocument);
+          .sendQueryDocument(sendQueryDocument)
+          .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
+          .autoPersistQueries(autoPersistQueries);
     }
 
     public static Builder builder(@NotNull Operation operation) {
@@ -151,6 +157,8 @@ public interface ApolloInterceptor {
       private boolean fetchFromCache;
       private Optional<Operation.Data> optimisticUpdates = Optional.absent();
       private boolean sendQueryDocument = true;
+      private boolean useHttpGetMethodForQueries;
+      private boolean autoPersistQueries;
 
       Builder(@NotNull Operation operation) {
         this.operation = checkNotNull(operation, "operation == null");
@@ -186,9 +194,19 @@ public interface ApolloInterceptor {
         return this;
       }
 
+      public Builder useHttpGetMethodForQueries(boolean useHttpGetMethodForQueries) {
+        this.useHttpGetMethodForQueries = useHttpGetMethodForQueries;
+        return this;
+      }
+
+      public Builder autoPersistQueries(boolean autoPersistQueries) {
+        this.autoPersistQueries = autoPersistQueries;
+        return this;
+      }
+
       public InterceptorRequest build() {
         return new InterceptorRequest(operation, cacheHeaders, requestHeaders, optimisticUpdates,
-            fetchFromCache, sendQueryDocument);
+            fetchFromCache, sendQueryDocument, useHttpGetMethodForQueries, autoPersistQueries);
       }
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -139,6 +139,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .requestHeaders(requestHeaders)
         .fetchFromCache(false)
         .optimisticUpdates(optimisticUpdates)
+        .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
+        .autoPersistQueries(enableAutoPersistedQueries)
         .build();
     interceptorChain.proceedAsync(request, dispatcher, interceptorCallbackProxy());
   }
@@ -368,11 +370,10 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   }
 
   private ApolloInterceptorChain prepareInterceptorChain(Operation operation) {
-    List<ApolloInterceptor> interceptors = new ArrayList<>();
     HttpCachePolicy.Policy httpCachePolicy = operation instanceof Query ? this.httpCachePolicy : null;
     ResponseFieldMapper responseFieldMapper = responseFieldMapperFactory.create(operation);
 
-    interceptors.addAll(applicationInterceptors);
+    List<ApolloInterceptor> interceptors = new ArrayList<>(applicationInterceptors);
     interceptors.add(responseFetcher.provideInterceptor(logger));
     interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
     if (operation instanceof Query && enableAutoPersistedQueries) {
@@ -381,7 +382,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
         scalarTypeAdapters, logger));
     interceptors.add(new ApolloServerInterceptor(serverUrl, httpCallFactory, httpCachePolicy, false, scalarTypeAdapters,
-        logger, useHttpGetMethodForQueries));
+        logger));
 
     return new RealApolloInterceptorChain(interceptors);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloPrefetch.java
@@ -53,7 +53,7 @@ import static com.apollographql.apollo.internal.CallState.TERMINATED;
     this.tracker = callTracker;
     interceptorChain = new RealApolloInterceptorChain(Collections.<ApolloInterceptor>singletonList(
         new ApolloServerInterceptor(serverUrl, httpCallFactory, HttpCachePolicy.NETWORK_ONLY, true, scalarTypeAdapters,
-            logger, false)
+            logger)
     ));
   }
 


### PR DESCRIPTION
Don't send `extensions` section with query sha if query auto persistence feature is disabled.

Closes https://github.com/apollographql/apollo-android/issues/1322