### PR TITLE
Fix usages of internal OkHttp APIs

### DIFF
--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/DiskLruHttpCacheStore.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/DiskLruHttpCacheStore.java
@@ -3,18 +3,15 @@ package com.apollographql.apollo.cache.http;
 import com.apollographql.apollo.api.cache.http.HttpCacheRecord;
 import com.apollographql.apollo.api.cache.http.HttpCacheRecordEditor;
 import com.apollographql.apollo.api.cache.http.HttpCacheStore;
-
-import org.jetbrains.annotations.NotNull;
-
+import com.apollographql.apollo.cache.http.internal.DiskLruCache;
+import com.apollographql.apollo.cache.http.internal.FileSystem;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import okhttp3.internal.cache.DiskLruCache;
-import okhttp3.internal.io.FileSystem;
 import okio.Sink;
 import okio.Source;
+import org.jetbrains.annotations.NotNull;
 
 public final class DiskLruHttpCacheStore implements HttpCacheStore {
   private static final int VERSION = 99991;

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseBodyProxy.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseBodyProxy.java
@@ -17,9 +17,9 @@ import okio.Source;
 import okio.Timeout;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+import static com.apollographql.apollo.cache.http.Utils.closeQuietly;
+import static com.apollographql.apollo.cache.http.Utils.discard;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static okhttp3.internal.Util.closeQuietly;
-import static okhttp3.internal.Util.discard;
 
 final class ResponseBodyProxy extends ResponseBody {
   private final String contentType;

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseHeaderRecord.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ResponseHeaderRecord.java
@@ -15,6 +15,7 @@
  */
 package com.apollographql.apollo.cache.http;
 
+import com.apollographql.apollo.cache.http.internal.StatusLine;
 import java.io.IOException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
@@ -23,7 +24,6 @@ import java.security.cert.CertificateFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import okhttp3.CipherSuite;
 import okhttp3.Handshake;
 import okhttp3.Headers;
@@ -33,9 +33,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.TlsVersion;
-import okhttp3.internal.http.HttpHeaders;
-import okhttp3.internal.http.StatusLine;
-import okhttp3.internal.platform.Platform;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.BufferedSource;
@@ -44,15 +41,17 @@ import okio.Okio;
 import okio.Sink;
 import okio.Source;
 
+import static com.apollographql.apollo.cache.http.Utils.varyHeaders;
+
 /**
  * Class was copied and modified from {@link okhttp3.Cache.Entry}
  */
 final class ResponseHeaderRecord {
   /** Synthetic response header: the local time when the request was sent. */
-  private static final String SENT_MILLIS = Platform.get().getPrefix() + "-Sent-Millis";
+  private static final String SENT_MILLIS = "OkHttp-Sent-Millis";
 
   /** Synthetic response header: the local time when the response was received. */
-  private static final String RECEIVED_MILLIS = Platform.get().getPrefix() + "-Received-Millis";
+  private static final String RECEIVED_MILLIS = "OkHttp-Received-Millis";
 
   private final String url;
   private final Headers varyHeaders;
@@ -169,7 +168,7 @@ final class ResponseHeaderRecord {
 
   ResponseHeaderRecord(Response response) {
     this.url = response.request().url().toString();
-    this.varyHeaders = HttpHeaders.varyHeaders(response);
+    this.varyHeaders = varyHeaders(response);
     this.requestMethod = response.request().method();
     this.protocol = response.protocol();
     this.code = response.code();

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
@@ -1,0 +1,1068 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.Flushable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Sink;
+import okio.Source;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A cache that uses a bounded amount of space on a filesystem. Each cache entry has a string key
+ * and a fixed number of values. Each key must match the regex <strong>[a-z0-9_-]{1,64}</strong>.
+ * Values are byte sequences, accessible as streams or files. Each value must be between {@code 0}
+ * and {@code Integer.MAX_VALUE} bytes in length.
+ *
+ * <p>The cache stores its data in a directory on the filesystem. This directory must be exclusive
+ * to the cache; the cache may delete or overwrite files from its directory. It is an error for
+ * multiple processes to use the same cache directory at the same time.
+ *
+ * <p>This cache limits the number of bytes that it will store on the filesystem. When the number of
+ * stored bytes exceeds the limit, the cache will remove entries in the background until the limit
+ * is satisfied. The limit is not strict: the cache may temporarily exceed it while waiting for
+ * files to be deleted. The limit does not include filesystem overhead or the cache journal so
+ * space-sensitive applications should set a conservative limit.
+ *
+ * <p>Clients call {@link #edit} to create or update the values of an entry. An entry may have only
+ * one editor at one time; if a value is not available to be edited then {@link #edit} will return
+ * null.
+ *
+ * <ul>
+ *     <li>When an entry is being <strong>created</strong> it is necessary to supply a full set of
+ *         values; the empty value should be used as a placeholder if necessary.
+ *     <li>When an entry is being <strong>edited</strong>, it is not necessary to supply data for
+ *         every value; values default to their previous value.
+ * </ul>
+ *
+ * <p>Every {@link #edit} call must be matched by a call to {@link Editor#commit} or {@link
+ * Editor#abort}. Committing is atomic: a read observes the full set of values as they were before
+ * or after the commit, but never a mix of values.
+ *
+ * <p>Clients call {@link #get} to read a snapshot of an entry. The read will observe the value at
+ * the time that {@link #get} was called. Updates and removals after the call do not impact ongoing
+ * reads.
+ *
+ * <p>This class is tolerant of some I/O errors. If files are missing from the filesystem, the
+ * corresponding entries will be dropped from the cache. If an error occurs while writing a cache
+ * value, the edit will fail silently. Callers should handle other problems by catching {@code
+ * IOException} and responding appropriately.
+ *
+ * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
+ */
+@SuppressWarnings("ConstantConditions")
+public final class DiskLruCache implements Closeable, Flushable {
+  static final String JOURNAL_FILE = "journal";
+  static final String JOURNAL_FILE_TEMP = "journal.tmp";
+  static final String JOURNAL_FILE_BACKUP = "journal.bkp";
+  static final String MAGIC = "libcore.io.DiskLruCache";
+  static final String VERSION_1 = "1";
+  static final long ANY_SEQUENCE_NUMBER = -1;
+  static final Pattern LEGAL_KEY_PATTERN = Pattern.compile("[a-z0-9_-]{1,120}");
+  private static final String CLEAN = "CLEAN";
+  private static final String DIRTY = "DIRTY";
+  private static final String REMOVE = "REMOVE";
+  private static final String READ = "READ";
+
+    /*
+     * This cache uses a journal file named "journal". A typical journal file
+     * looks like this:
+     *     libcore.io.DiskLruCache
+     *     1
+     *     100
+     *     2
+     *
+     *     CLEAN 3400330d1dfc7f3f7f4b8d4d803dfcf6 832 21054
+     *     DIRTY 335c4c6028171cfddfbaae1a9c313c52
+     *     CLEAN 335c4c6028171cfddfbaae1a9c313c52 3934 2342
+     *     REMOVE 335c4c6028171cfddfbaae1a9c313c52
+     *     DIRTY 1ab96a171faeeee38496d8b330771a7a
+     *     CLEAN 1ab96a171faeeee38496d8b330771a7a 1600 234
+     *     READ 335c4c6028171cfddfbaae1a9c313c52
+     *     READ 3400330d1dfc7f3f7f4b8d4d803dfcf6
+     *
+     * The first five lines of the journal form its header. They are the
+     * constant string "libcore.io.DiskLruCache", the disk cache's version,
+     * the application's version, the value count, and a blank line.
+     *
+     * Each of the subsequent lines in the file is a record of the state of a
+     * cache entry. Each line contains space-separated values: a state, a key,
+     * and optional state-specific values.
+     *   o DIRTY lines track that an entry is actively being created or updated.
+     *     Every successful DIRTY action should be followed by a CLEAN or REMOVE
+     *     action. DIRTY lines without a matching CLEAN or REMOVE indicate that
+     *     temporary files may need to be deleted.
+     *   o CLEAN lines track a cache entry that has been successfully published
+     *     and may be read. A publish line is followed by the lengths of each of
+     *     its values.
+     *   o READ lines track accesses for LRU.
+     *   o REMOVE lines track entries that have been deleted.
+     *
+     * The journal file is appended to as cache operations occur. The journal may
+     * occasionally be compacted by dropping redundant lines. A temporary file named
+     * "journal.tmp" will be used during compaction; that file should be deleted if
+     * it exists when the cache is opened.
+     */
+
+  final FileSystem fileSystem;
+  final File directory;
+  private final File journalFile;
+  private final File journalFileTmp;
+  private final File journalFileBackup;
+  private final int appVersion;
+  private long maxSize;
+  final int valueCount;
+  private long size = 0;
+  BufferedSink journalWriter;
+  final LinkedHashMap<String, Entry> lruEntries = new LinkedHashMap<>(0, 0.75f, true);
+  int redundantOpCount;
+  boolean hasJournalErrors;
+
+  // Must be read and written when synchronized on 'this'.
+  boolean initialized;
+  boolean closed;
+  boolean mostRecentTrimFailed;
+  boolean mostRecentRebuildFailed;
+
+  /**
+   * To differentiate between old and current snapshots, each entry is given a sequence number each
+   * time an edit is committed. A snapshot is stale if its sequence number is not equal to its
+   * entry's sequence number.
+   */
+  private long nextSequenceNumber = 0;
+
+  /** Used to run 'cleanupRunnable' for journal rebuilds. */
+  private final Executor executor;
+  private final Runnable cleanupRunnable = new Runnable() {
+    public void run() {
+      synchronized (DiskLruCache.this) {
+        if (!initialized | closed) {
+          return; // Nothing to do
+        }
+
+        try {
+          trimToSize();
+        } catch (IOException ignored) {
+          mostRecentTrimFailed = true;
+        }
+
+        try {
+          if (journalRebuildRequired()) {
+            rebuildJournal();
+            redundantOpCount = 0;
+          }
+        } catch (IOException e) {
+          mostRecentRebuildFailed = true;
+          journalWriter = Okio.buffer(Okio.blackhole());
+        }
+      }
+    }
+  };
+
+  DiskLruCache(FileSystem fileSystem, File directory, int appVersion, int valueCount, long maxSize,
+      Executor executor) {
+    this.fileSystem = fileSystem;
+    this.directory = directory;
+    this.appVersion = appVersion;
+    this.journalFile = new File(directory, JOURNAL_FILE);
+    this.journalFileTmp = new File(directory, JOURNAL_FILE_TEMP);
+    this.journalFileBackup = new File(directory, JOURNAL_FILE_BACKUP);
+    this.valueCount = valueCount;
+    this.maxSize = maxSize;
+    this.executor = executor;
+  }
+
+  public synchronized void initialize() throws IOException {
+    assert Thread.holdsLock(this);
+
+    if (initialized) {
+      return; // Already initialized.
+    }
+
+    // If a bkp file exists, use it instead.
+    if (fileSystem.exists(journalFileBackup)) {
+      // If journal file also exists just delete backup file.
+      if (fileSystem.exists(journalFile)) {
+        fileSystem.delete(journalFileBackup);
+      } else {
+        fileSystem.rename(journalFileBackup, journalFile);
+      }
+    }
+
+    // Prefer to pick up where we left off.
+    if (fileSystem.exists(journalFile)) {
+      try {
+        readJournal();
+        processJournal();
+        initialized = true;
+        return;
+      } catch (IOException journalIsCorrupt) {
+        //logger.w("DiskLruCache " + directory + " is corrupt: "
+        //    + journalIsCorrupt.getMessage() + ", removing", journalIsCorrupt);
+      }
+
+      // The cache is corrupted, attempt to delete the contents of the directory. This can throw and
+      // we'll let that propagate out as it likely means there is a severe filesystem problem.
+      try {
+        delete();
+      } finally {
+        closed = false;
+      }
+    }
+
+    rebuildJournal();
+
+    initialized = true;
+  }
+
+  /**
+   * Create a cache which will reside in {@code directory}. This cache is lazily initialized on
+   * first access and will be created if it does not exist.
+   *
+   * @param directory a writable directory
+   * @param valueCount the number of values per cache entry. Must be positive.
+   * @param maxSize the maximum number of bytes this cache should use to store
+   */
+  public static DiskLruCache create(FileSystem fileSystem, File directory, int appVersion,
+      int valueCount, long maxSize) {
+    if (maxSize <= 0) {
+      throw new IllegalArgumentException("maxSize <= 0");
+    }
+    if (valueCount <= 0) {
+      throw new IllegalArgumentException("valueCount <= 0");
+    }
+
+    // Use a single background thread to evict entries.
+    Executor executor = new ThreadPoolExecutor(
+        0,
+        1,
+        60L,
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        new ThreadFactory() {
+          @Override public Thread newThread(@NotNull Runnable runnable) {
+            Thread result = new Thread(runnable, "OkHttp DiskLruCache");
+            result.setDaemon(true);
+            return result;
+          }
+        });
+
+    return new DiskLruCache(fileSystem, directory, appVersion, valueCount, maxSize, executor);
+  }
+
+  private void readJournal() throws IOException {
+    try (BufferedSource source = Okio.buffer(fileSystem.source(journalFile))) {
+      String magic = source.readUtf8LineStrict();
+      String version = source.readUtf8LineStrict();
+      String appVersionString = source.readUtf8LineStrict();
+      String valueCountString = source.readUtf8LineStrict();
+      String blank = source.readUtf8LineStrict();
+      if (!MAGIC.equals(magic)
+          || !VERSION_1.equals(version)
+          || !Integer.toString(appVersion).equals(appVersionString)
+          || !Integer.toString(valueCount).equals(valueCountString)
+          || !"".equals(blank)) {
+        throw new IOException("unexpected journal header: [" + magic + ", " + version + ", "
+            + valueCountString + ", " + blank + "]");
+      }
+
+      int lineCount = 0;
+      while (true) {
+        try {
+          readJournalLine(source.readUtf8LineStrict());
+          lineCount++;
+        } catch (EOFException endOfJournal) {
+          break;
+        }
+      }
+      redundantOpCount = lineCount - lruEntries.size();
+
+      // If we ended on a truncated line, rebuild the journal before appending to it.
+      if (!source.exhausted()) {
+        rebuildJournal();
+      } else {
+        journalWriter = newJournalWriter();
+      }
+    }
+  }
+
+  private BufferedSink newJournalWriter() throws FileNotFoundException {
+    Sink fileSink = fileSystem.appendingSink(journalFile);
+    Sink faultHidingSink = new FaultHidingSink(fileSink) {
+      @Override protected void onException(IOException e) {
+        assert (Thread.holdsLock(DiskLruCache.this));
+        hasJournalErrors = true;
+      }
+    };
+    return Okio.buffer(faultHidingSink);
+  }
+
+  private void readJournalLine(String line) throws IOException {
+    int firstSpace = line.indexOf(' ');
+    if (firstSpace == -1) {
+      throw new IOException("unexpected journal line: " + line);
+    }
+
+    int keyBegin = firstSpace + 1;
+    int secondSpace = line.indexOf(' ', keyBegin);
+    final String key;
+    if (secondSpace == -1) {
+      key = line.substring(keyBegin);
+      if (firstSpace == REMOVE.length() && line.startsWith(REMOVE)) {
+        lruEntries.remove(key);
+        return;
+      }
+    } else {
+      key = line.substring(keyBegin, secondSpace);
+    }
+
+    Entry entry = lruEntries.get(key);
+    if (entry == null) {
+      entry = new Entry(key);
+      lruEntries.put(key, entry);
+    }
+
+    if (secondSpace != -1 && firstSpace == CLEAN.length() && line.startsWith(CLEAN)) {
+      String[] parts = line.substring(secondSpace + 1).split(" ");
+      entry.readable = true;
+      entry.currentEditor = null;
+      entry.setLengths(parts);
+    } else if (secondSpace == -1 && firstSpace == DIRTY.length() && line.startsWith(DIRTY)) {
+      entry.currentEditor = new Editor(entry);
+    } else if (secondSpace == -1 && firstSpace == READ.length() && line.startsWith(READ)) {
+      // This work was already done by calling lruEntries.get().
+    } else {
+      throw new IOException("unexpected journal line: " + line);
+    }
+  }
+
+  /**
+   * Computes the initial size and collects garbage as a part of opening the cache. Dirty entries
+   * are assumed to be inconsistent and will be deleted.
+   */
+  private void processJournal() throws IOException {
+    fileSystem.delete(journalFileTmp);
+    for (Iterator<Entry> i = lruEntries.values().iterator(); i.hasNext(); ) {
+      Entry entry = i.next();
+      if (entry.currentEditor == null) {
+        for (int t = 0; t < valueCount; t++) {
+          size += entry.lengths[t];
+        }
+      } else {
+        entry.currentEditor = null;
+        for (int t = 0; t < valueCount; t++) {
+          fileSystem.delete(entry.cleanFiles[t]);
+          fileSystem.delete(entry.dirtyFiles[t]);
+        }
+        i.remove();
+      }
+    }
+  }
+
+  /**
+   * Creates a new journal that omits redundant information. This replaces the current journal if it
+   * exists.
+   */
+  synchronized void rebuildJournal() throws IOException {
+    if (journalWriter != null) {
+      journalWriter.close();
+    }
+
+    try (BufferedSink writer = Okio.buffer(fileSystem.sink(journalFileTmp))) {
+      writer.writeUtf8(MAGIC).writeByte('\n');
+      writer.writeUtf8(VERSION_1).writeByte('\n');
+      writer.writeDecimalLong(appVersion).writeByte('\n');
+      writer.writeDecimalLong(valueCount).writeByte('\n');
+      writer.writeByte('\n');
+
+      for (Entry entry : lruEntries.values()) {
+        if (entry.currentEditor != null) {
+          writer.writeUtf8(DIRTY).writeByte(' ');
+          writer.writeUtf8(entry.key);
+          writer.writeByte('\n');
+        } else {
+          writer.writeUtf8(CLEAN).writeByte(' ');
+          writer.writeUtf8(entry.key);
+          entry.writeLengths(writer);
+          writer.writeByte('\n');
+        }
+      }
+    }
+
+    if (fileSystem.exists(journalFile)) {
+      fileSystem.rename(journalFile, journalFileBackup);
+    }
+    fileSystem.rename(journalFileTmp, journalFile);
+    fileSystem.delete(journalFileBackup);
+
+    journalWriter = newJournalWriter();
+    hasJournalErrors = false;
+    mostRecentRebuildFailed = false;
+  }
+
+  /**
+   * Returns a snapshot of the entry named {@code key}, or null if it doesn't exist is not currently
+   * readable. If a value is returned, it is moved to the head of the LRU queue.
+   */
+  public synchronized Snapshot get(String key) throws IOException {
+    initialize();
+
+    checkNotClosed();
+    validateKey(key);
+    Entry entry = lruEntries.get(key);
+    if (entry == null || !entry.readable) return null;
+
+    Snapshot snapshot = entry.snapshot();
+    if (snapshot == null) return null;
+
+    redundantOpCount++;
+    journalWriter.writeUtf8(READ).writeByte(' ').writeUtf8(key).writeByte('\n');
+    if (journalRebuildRequired()) {
+      executor.execute(cleanupRunnable);
+    }
+
+    return snapshot;
+  }
+
+  /**
+   * Returns an editor for the entry named {@code key}, or null if another edit is in progress.
+   */
+  public @Nullable Editor edit(String key) throws IOException {
+    return edit(key, ANY_SEQUENCE_NUMBER);
+  }
+
+  synchronized Editor edit(String key, long expectedSequenceNumber) throws IOException {
+    initialize();
+
+    checkNotClosed();
+    validateKey(key);
+    Entry entry = lruEntries.get(key);
+    if (expectedSequenceNumber != ANY_SEQUENCE_NUMBER && (entry == null
+        || entry.sequenceNumber != expectedSequenceNumber)) {
+      return null; // Snapshot is stale.
+    }
+    if (entry != null && entry.currentEditor != null) {
+      return null; // Another edit is in progress.
+    }
+    if (mostRecentTrimFailed || mostRecentRebuildFailed) {
+      // The OS has become our enemy! If the trim job failed, it means we are storing more data than
+      // requested by the user. Do not allow edits so we do not go over that limit any further. If
+      // the journal rebuild failed, the journal writer will not be active, meaning we will not be
+      // able to record the edit, causing file leaks. In both cases, we want to retry the clean up
+      // so we can get out of this state!
+      executor.execute(cleanupRunnable);
+      return null;
+    }
+
+    // Flush the journal before creating files to prevent file leaks.
+    journalWriter.writeUtf8(DIRTY).writeByte(' ').writeUtf8(key).writeByte('\n');
+    journalWriter.flush();
+
+    if (hasJournalErrors) {
+      return null; // Don't edit; the journal can't be written.
+    }
+
+    if (entry == null) {
+      entry = new Entry(key);
+      lruEntries.put(key, entry);
+    }
+    Editor editor = new Editor(entry);
+    entry.currentEditor = editor;
+    return editor;
+  }
+
+  /** Returns the directory where this cache stores its data. */
+  public File getDirectory() {
+    return directory;
+  }
+
+  /**
+   * Returns the maximum number of bytes that this cache should use to store its data.
+   */
+  public synchronized long getMaxSize() {
+    return maxSize;
+  }
+
+  /**
+   * Changes the maximum number of bytes the cache can store and queues a job to trim the existing
+   * store, if necessary.
+   */
+  public synchronized void setMaxSize(long maxSize) {
+    this.maxSize = maxSize;
+    if (initialized) {
+      executor.execute(cleanupRunnable);
+    }
+  }
+
+  /**
+   * Returns the number of bytes currently being used to store the values in this cache. This may be
+   * greater than the max size if a background deletion is pending.
+   */
+  public synchronized long size() throws IOException {
+    initialize();
+    return size;
+  }
+
+  synchronized void completeEdit(Editor editor, boolean success) throws IOException {
+    Entry entry = editor.entry;
+    if (entry.currentEditor != editor) {
+      throw new IllegalStateException();
+    }
+
+    // If this edit is creating the entry for the first time, every index must have a value.
+    if (success && !entry.readable) {
+      for (int i = 0; i < valueCount; i++) {
+        if (!editor.written[i]) {
+          editor.abort();
+          throw new IllegalStateException("Newly created entry didn't create value for index " + i);
+        }
+        if (!fileSystem.exists(entry.dirtyFiles[i])) {
+          editor.abort();
+          return;
+        }
+      }
+    }
+
+    for (int i = 0; i < valueCount; i++) {
+      File dirty = entry.dirtyFiles[i];
+      if (success) {
+        if (fileSystem.exists(dirty)) {
+          File clean = entry.cleanFiles[i];
+          fileSystem.rename(dirty, clean);
+          long oldLength = entry.lengths[i];
+          long newLength = fileSystem.size(clean);
+          entry.lengths[i] = newLength;
+          size = size - oldLength + newLength;
+        }
+      } else {
+        fileSystem.delete(dirty);
+      }
+    }
+
+    redundantOpCount++;
+    entry.currentEditor = null;
+    if (entry.readable | success) {
+      entry.readable = true;
+      journalWriter.writeUtf8(CLEAN).writeByte(' ');
+      journalWriter.writeUtf8(entry.key);
+      entry.writeLengths(journalWriter);
+      journalWriter.writeByte('\n');
+      if (success) {
+        entry.sequenceNumber = nextSequenceNumber++;
+      }
+    } else {
+      lruEntries.remove(entry.key);
+      journalWriter.writeUtf8(REMOVE).writeByte(' ');
+      journalWriter.writeUtf8(entry.key);
+      journalWriter.writeByte('\n');
+    }
+    journalWriter.flush();
+
+    if (size > maxSize || journalRebuildRequired()) {
+      executor.execute(cleanupRunnable);
+    }
+  }
+
+  /**
+   * We only rebuild the journal when it will halve the size of the journal and eliminate at least
+   * 2000 ops.
+   */
+  boolean journalRebuildRequired() {
+    final int redundantOpCompactThreshold = 2000;
+    return redundantOpCount >= redundantOpCompactThreshold
+        && redundantOpCount >= lruEntries.size();
+  }
+
+  /**
+   * Drops the entry for {@code key} if it exists and can be removed. If the entry for {@code key}
+   * is currently being edited, that edit will complete normally but its value will not be stored.
+   *
+   * @return true if an entry was removed.
+   */
+  public synchronized boolean remove(String key) throws IOException {
+    initialize();
+
+    checkNotClosed();
+    validateKey(key);
+    Entry entry = lruEntries.get(key);
+    if (entry == null) return false;
+    boolean removed = removeEntry(entry);
+    if (removed && size <= maxSize) mostRecentTrimFailed = false;
+    return removed;
+  }
+
+  boolean removeEntry(Entry entry) throws IOException {
+    if (entry.currentEditor != null) {
+      entry.currentEditor.detach(); // Prevent the edit from completing normally.
+    }
+
+    for (int i = 0; i < valueCount; i++) {
+      fileSystem.delete(entry.cleanFiles[i]);
+      size -= entry.lengths[i];
+      entry.lengths[i] = 0;
+    }
+
+    redundantOpCount++;
+    journalWriter.writeUtf8(REMOVE).writeByte(' ').writeUtf8(entry.key).writeByte('\n');
+    lruEntries.remove(entry.key);
+
+    if (journalRebuildRequired()) {
+      executor.execute(cleanupRunnable);
+    }
+
+    return true;
+  }
+
+  /** Returns true if this cache has been closed. */
+  public synchronized boolean isClosed() {
+    return closed;
+  }
+
+  private synchronized void checkNotClosed() {
+    if (isClosed()) {
+      throw new IllegalStateException("cache is closed");
+    }
+  }
+
+  /** Force buffered operations to the filesystem. */
+  @Override public synchronized void flush() throws IOException {
+    if (!initialized) return;
+
+    checkNotClosed();
+    trimToSize();
+    journalWriter.flush();
+  }
+
+  /** Closes this cache. Stored values will remain on the filesystem. */
+  @Override public synchronized void close() throws IOException {
+    if (!initialized || closed) {
+      closed = true;
+      return;
+    }
+    // Copying for safe iteration.
+    for (Entry entry : lruEntries.values().toArray(new Entry[lruEntries.size()])) {
+      if (entry.currentEditor != null) {
+        entry.currentEditor.abort();
+      }
+    }
+    trimToSize();
+    journalWriter.close();
+    journalWriter = null;
+    closed = true;
+  }
+
+  void trimToSize() throws IOException {
+    while (size > maxSize) {
+      Entry toEvict = lruEntries.values().iterator().next();
+      removeEntry(toEvict);
+    }
+    mostRecentTrimFailed = false;
+  }
+
+  /**
+   * Closes the cache and deletes all of its stored values. This will delete all files in the cache
+   * directory including files that weren't created by the cache.
+   */
+  public void delete() throws IOException {
+    close();
+    fileSystem.deleteContents(directory);
+  }
+
+  /**
+   * Deletes all stored values from the cache. In-flight edits will complete normally but their
+   * values will not be stored.
+   */
+  public synchronized void evictAll() throws IOException {
+    initialize();
+    // Copying for safe iteration.
+    for (Entry entry : lruEntries.values().toArray(new Entry[lruEntries.size()])) {
+      removeEntry(entry);
+    }
+    mostRecentTrimFailed = false;
+  }
+
+  private void validateKey(String key) {
+    Matcher matcher = LEGAL_KEY_PATTERN.matcher(key);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          "keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\"");
+    }
+  }
+
+  /**
+   * Returns an iterator over the cache's current entries. This iterator doesn't throw {@code
+   * ConcurrentModificationException}, but if new entries are added while iterating, those new
+   * entries will not be returned by the iterator. If existing entries are removed during iteration,
+   * they will be absent (unless they were already returned).
+   *
+   * <p>If there are I/O problems during iteration, this iterator fails silently. For example, if
+   * the hosting filesystem becomes unreachable, the iterator will omit elements rather than
+   * throwing exceptions.
+   *
+   * <p><strong>The caller must {@link Snapshot#close close}</strong> each snapshot returned by
+   * {@link Iterator#next}. Failing to do so leaks open files!
+   *
+   * <p>The returned iterator supports {@link Iterator#remove}.
+   */
+  public synchronized Iterator<Snapshot> snapshots() throws IOException {
+    initialize();
+    return new Iterator<Snapshot>() {
+      /** Iterate a copy of the entries to defend against concurrent modification errors. */
+      final Iterator<Entry> delegate = new ArrayList<>(lruEntries.values()).iterator();
+
+      /** The snapshot to return from {@link #next}. Null if we haven't computed that yet. */
+      Snapshot nextSnapshot;
+
+      /** The snapshot to remove with {@link #remove}. Null if removal is illegal. */
+      Snapshot removeSnapshot;
+
+      @Override public boolean hasNext() {
+        if (nextSnapshot != null) return true;
+
+        synchronized (DiskLruCache.this) {
+          // If the cache is closed, truncate the iterator.
+          if (closed) return false;
+
+          while (delegate.hasNext()) {
+            Entry entry = delegate.next();
+            Snapshot snapshot = entry.snapshot();
+            if (snapshot == null) continue; // Evicted since we copied the entries.
+            nextSnapshot = snapshot;
+            return true;
+          }
+        }
+
+        return false;
+      }
+
+      @Override public Snapshot next() {
+        if (!hasNext()) throw new NoSuchElementException();
+        removeSnapshot = nextSnapshot;
+        nextSnapshot = null;
+        return removeSnapshot;
+      }
+
+      @Override public void remove() {
+        if (removeSnapshot == null) throw new IllegalStateException("remove() before next()");
+        try {
+          DiskLruCache.this.remove(removeSnapshot.key);
+        } catch (IOException ignored) {
+          // Nothing useful to do here. We failed to remove from the cache. Most likely that's
+          // because we couldn't update the journal, but the cached entry will still be gone.
+        } finally {
+          removeSnapshot = null;
+        }
+      }
+    };
+  }
+
+  void closeQuietly(Closeable closeable, String name) {
+    try {
+      if (closeable != null) {
+        closeable.close();
+      }
+    } catch (Exception e) {
+      //logger.w(e, "Failed to close " + name);
+    }
+  }
+
+  /** A snapshot of the values for an entry. */
+  public final class Snapshot implements Closeable {
+    private final String key;
+    private final long sequenceNumber;
+    private final Source[] sources;
+    private final long[] lengths;
+
+    Snapshot(String key, long sequenceNumber, Source[] sources, long[] lengths) {
+      this.key = key;
+      this.sequenceNumber = sequenceNumber;
+      this.sources = sources;
+      this.lengths = lengths;
+    }
+
+    public String key() {
+      return key;
+    }
+
+    /**
+     * Returns an editor for this snapshot's entry, or null if either the entry has changed since
+     * this snapshot was created or if another edit is in progress.
+     */
+    public @Nullable Editor edit() throws IOException {
+      return DiskLruCache.this.edit(key, sequenceNumber);
+    }
+
+    /** Returns the unbuffered stream with the value for {@code index}. */
+    public Source getSource(int index) {
+      return sources[index];
+    }
+
+    /** Returns the byte length of the value for {@code index}. */
+    public long getLength(int index) {
+      return lengths[index];
+    }
+
+    public void close() {
+      for (Source in : sources) {
+        closeQuietly(in, "source");
+      }
+    }
+  }
+
+  /** Edits the values for an entry. */
+  public final class Editor {
+    final Entry entry;
+    final boolean[] written;
+    private boolean done;
+
+    Editor(Entry entry) {
+      this.entry = entry;
+      this.written = (entry.readable) ? null : new boolean[valueCount];
+    }
+
+    /**
+     * Prevents this editor from completing normally. This is necessary either when the edit causes
+     * an I/O error, or if the target entry is evicted while this editor is active. In either case
+     * we delete the editor's created files and prevent new files from being created. Note that once
+     * an editor has been detached it is possible for another editor to edit the entry.
+     */
+    void detach() {
+      if (entry.currentEditor == this) {
+        for (int i = 0; i < valueCount; i++) {
+          try {
+            fileSystem.delete(entry.dirtyFiles[i]);
+          } catch (IOException e) {
+            // This file is potentially leaked. Not much we can do about that.
+          }
+        }
+        entry.currentEditor = null;
+      }
+    }
+
+    /**
+     * Returns an unbuffered input stream to read the last committed value, or null if no value has
+     * been committed.
+     */
+    public Source newSource(int index) {
+      synchronized (DiskLruCache.this) {
+        if (done) {
+          throw new IllegalStateException();
+        }
+        if (!entry.readable || entry.currentEditor != this) {
+          return null;
+        }
+        try {
+          return fileSystem.source(entry.cleanFiles[index]);
+        } catch (FileNotFoundException e) {
+          return null;
+        }
+      }
+    }
+
+    /**
+     * Returns a new unbuffered output stream to write the value at {@code index}. If the underlying
+     * output stream encounters errors when writing to the filesystem, this edit will be aborted
+     * when {@link #commit} is called. The returned output stream does not throw IOExceptions.
+     */
+    public Sink newSink(int index) {
+      synchronized (DiskLruCache.this) {
+        if (done) {
+          throw new IllegalStateException();
+        }
+        if (entry.currentEditor != this) {
+          return Okio.blackhole();
+        }
+        if (!entry.readable) {
+          written[index] = true;
+        }
+        File dirtyFile = entry.dirtyFiles[index];
+        Sink sink;
+        try {
+          sink = fileSystem.sink(dirtyFile);
+        } catch (FileNotFoundException e) {
+          return Okio.blackhole();
+        }
+        return new FaultHidingSink(sink) {
+          @Override protected void onException(IOException e) {
+            synchronized (DiskLruCache.this) {
+              detach();
+            }
+          }
+        };
+      }
+    }
+
+    /**
+     * Commits this edit so it is visible to readers.  This releases the edit lock so another edit
+     * may be started on the same key.
+     */
+    public void commit() throws IOException {
+      synchronized (DiskLruCache.this) {
+        if (done) {
+          throw new IllegalStateException();
+        }
+        if (entry.currentEditor == this) {
+          completeEdit(this, true);
+        }
+        done = true;
+      }
+    }
+
+    /**
+     * Aborts this edit. This releases the edit lock so another edit may be started on the same
+     * key.
+     */
+    public void abort() throws IOException {
+      synchronized (DiskLruCache.this) {
+        if (done) {
+          throw new IllegalStateException();
+        }
+        if (entry.currentEditor == this) {
+          completeEdit(this, false);
+        }
+        done = true;
+      }
+    }
+
+    public void abortUnlessCommitted() {
+      synchronized (DiskLruCache.this) {
+        if (!done && entry.currentEditor == this) {
+          try {
+            completeEdit(this, false);
+          } catch (IOException ignored) {
+          }
+        }
+      }
+    }
+  }
+
+  private final class Entry {
+    final String key;
+
+    /** Lengths of this entry's files. */
+    final long[] lengths;
+    final File[] cleanFiles;
+    final File[] dirtyFiles;
+
+    /** True if this entry has ever been published. */
+    boolean readable;
+
+    /** The ongoing edit or null if this entry is not being edited. */
+    Editor currentEditor;
+
+    /** The sequence number of the most recently committed edit to this entry. */
+    long sequenceNumber;
+
+    Entry(String key) {
+      this.key = key;
+
+      lengths = new long[valueCount];
+      cleanFiles = new File[valueCount];
+      dirtyFiles = new File[valueCount];
+
+      // The names are repetitive so re-use the same builder to avoid allocations.
+      StringBuilder fileBuilder = new StringBuilder(key).append('.');
+      int truncateTo = fileBuilder.length();
+      for (int i = 0; i < valueCount; i++) {
+        fileBuilder.append(i);
+        cleanFiles[i] = new File(directory, fileBuilder.toString());
+        fileBuilder.append(".tmp");
+        dirtyFiles[i] = new File(directory, fileBuilder.toString());
+        fileBuilder.setLength(truncateTo);
+      }
+    }
+
+    /** Set lengths using decimal numbers like "10123". */
+    void setLengths(String[] strings) throws IOException {
+      if (strings.length != valueCount) {
+        throw invalidLengths(strings);
+      }
+
+      try {
+        for (int i = 0; i < strings.length; i++) {
+          lengths[i] = Long.parseLong(strings[i]);
+        }
+      } catch (NumberFormatException e) {
+        throw invalidLengths(strings);
+      }
+    }
+
+    /** Append space-prefixed lengths to {@code writer}. */
+    void writeLengths(BufferedSink writer) throws IOException {
+      for (long length : lengths) {
+        writer.writeByte(' ').writeDecimalLong(length);
+      }
+    }
+
+    private IOException invalidLengths(String[] strings) throws IOException {
+      throw new IOException("unexpected journal line: " + Arrays.toString(strings));
+    }
+
+    /**
+     * Returns a snapshot of this entry. This opens all streams eagerly to guarantee that we see a
+     * single published snapshot. If we opened streams lazily then the streams could come from
+     * different edits.
+     */
+    Snapshot snapshot() {
+      if (!Thread.holdsLock(DiskLruCache.this)) throw new AssertionError();
+
+      Source[] sources = new Source[valueCount];
+      long[] lengths = this.lengths.clone(); // Defensive copy since these can be zeroed out.
+      try {
+        for (int i = 0; i < valueCount; i++) {
+          sources[i] = fileSystem.source(cleanFiles[i]);
+        }
+        return new Snapshot(key, sequenceNumber, sources, lengths);
+      } catch (FileNotFoundException e) {
+        // A file must have been deleted manually!
+        for (int i = 0; i < valueCount; i++) {
+          if (sources[i] != null) {
+            closeQuietly(sources[i], "file");
+          } else {
+            break;
+          }
+        }
+        // Since the entry is no longer valid, remove it so the metadata is accurate (i.e. the cache
+        // size.)
+        try {
+          removeEntry(this);
+        } catch (IOException ignored) {
+        }
+        return null;
+      }
+    }
+  }
+}

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
@@ -167,9 +167,9 @@ public final class DiskLruCache implements Closeable, Flushable {
   /** Used to run 'cleanupRunnable' for journal rebuilds. */
   private final Executor executor;
   private final Runnable cleanupRunnable = new Runnable() {
-    public void run() {
+    @Override public void run() {
       synchronized (DiskLruCache.this) {
-        if (!initialized | closed) {
+        if (!initialized || closed) {
           return; // Nothing to do
         }
 
@@ -574,7 +574,7 @@ public final class DiskLruCache implements Closeable, Flushable {
 
     redundantOpCount++;
     entry.currentEditor = null;
-    if (entry.readable | success) {
+    if (entry.readable || success) {
       entry.readable = true;
       journalWriter.writeUtf8(CLEAN).writeByte(' ');
       journalWriter.writeUtf8(entry.key);

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
@@ -835,7 +835,7 @@ public final class DiskLruCache implements Closeable, Flushable {
       return lengths[index];
     }
 
-    public void close() {
+    @Override public void close() {
       for (Source in : sources) {
         closeQuietly(in, "source");
       }

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/DiskLruCache.java
@@ -81,7 +81,9 @@ import org.jetbrains.annotations.Nullable;
  * value, the edit will fail silently. Callers should handle other problems by catching {@code
  * IOException} and responding appropriately.
  *
- * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
+ * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/
+ * b8b6ee831c65208940c741f8e091ff02425566d5/
+ * okhttp/src/main/java/okhttp3/internal/cache/DiskLruCache.java
  */
 @SuppressWarnings("ConstantConditions")
 public final class DiskLruCache implements Closeable, Flushable {
@@ -375,7 +377,7 @@ public final class DiskLruCache implements Closeable, Flushable {
    */
   private void processJournal() throws IOException {
     fileSystem.delete(journalFileTmp);
-    for (Iterator<Entry> i = lruEntries.values().iterator(); i.hasNext(); ) {
+    for (Iterator<Entry> i = lruEntries.values().iterator(); i.hasNext();) {
       Entry entry = i.next();
       if (entry.currentEditor == null) {
         for (int t = 0; t < valueCount; t++) {

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FaultHidingSink.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FaultHidingSink.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.IOException;
+import okio.Buffer;
+import okio.ForwardingSink;
+import okio.Sink;
+
+/** A sink that never throws IOExceptions, even if the underlying sink does. */
+class FaultHidingSink extends ForwardingSink {
+  private boolean hasErrors;
+
+  FaultHidingSink(Sink delegate) {
+    super(delegate);
+  }
+
+  @Override public void write(Buffer source, long byteCount) throws IOException {
+    if (hasErrors) {
+      source.skip(byteCount);
+      return;
+    }
+    try {
+      super.write(source, byteCount);
+    } catch (IOException e) {
+      hasErrors = true;
+      onException(e);
+    }
+  }
+
+  @Override public void flush() throws IOException {
+    if (hasErrors) return;
+    try {
+      super.flush();
+    } catch (IOException e) {
+      hasErrors = true;
+      onException(e);
+    }
+  }
+
+  @Override public void close() throws IOException {
+    if (hasErrors) return;
+    try {
+      super.close();
+    } catch (IOException e) {
+      hasErrors = true;
+      onException(e);
+    }
+  }
+
+  protected void onException(IOException e) {
+  }
+}

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FileSystem.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FileSystem.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import okio.Okio;
+import okio.Sink;
+import okio.Source;
+
+/**
+ * Access to read and write files on a hierarchical data store. Most callers should use the {@link
+ * #SYSTEM} implementation, which uses the host machine's local file system. Alternate
+ * implementations may be used to inject faults (for testing) or to transform stored data (to add
+ * encryption, for example).
+ *
+ * <p>All operations on a file system are racy. For example, guarding a call to {@link #source} with
+ * {@link #exists} does not guarantee that {@link FileNotFoundException} will not be thrown. The
+ * file may be moved between the two calls!
+ *
+ * <p>This interface is less ambitious than {@link java.nio.file.FileSystem} introduced in Java 7.
+ * It lacks important features like file watching, metadata, permissions, and disk space
+ * information. In exchange for these limitations, this interface is easier to implement and works
+ * on all versions of Java and Android.
+ *
+ * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp/src/main/java/okhttp3/internal/io/FileSystem.java
+ */
+public interface FileSystem {
+  /** The host machine's local file system. */
+  FileSystem SYSTEM = new FileSystem() {
+    @Override public Source source(File file) throws FileNotFoundException {
+      return Okio.source(file);
+    }
+
+    @Override public Sink sink(File file) throws FileNotFoundException {
+      try {
+        return Okio.sink(file);
+      } catch (FileNotFoundException e) {
+        // Maybe the parent directory doesn't exist? Try creating it first.
+        file.getParentFile().mkdirs();
+        return Okio.sink(file);
+      }
+    }
+
+    @Override public Sink appendingSink(File file) throws FileNotFoundException {
+      try {
+        return Okio.appendingSink(file);
+      } catch (FileNotFoundException e) {
+        // Maybe the parent directory doesn't exist? Try creating it first.
+        file.getParentFile().mkdirs();
+        return Okio.appendingSink(file);
+      }
+    }
+
+    @Override public void delete(File file) throws IOException {
+      // If delete() fails, make sure it's because the file didn't exist!
+      if (!file.delete() && file.exists()) {
+        throw new IOException("failed to delete " + file);
+      }
+    }
+
+    @Override public boolean exists(File file) {
+      return file.exists();
+    }
+
+    @Override public long size(File file) {
+      return file.length();
+    }
+
+    @Override public void rename(File from, File to) throws IOException {
+      delete(to);
+      if (!from.renameTo(to)) {
+        throw new IOException("failed to rename " + from + " to " + to);
+      }
+    }
+
+    @Override public void deleteContents(File directory) throws IOException {
+      File[] files = directory.listFiles();
+      if (files == null) {
+        throw new IOException("not a readable directory: " + directory);
+      }
+      for (File file : files) {
+        if (file.isDirectory()) {
+          deleteContents(file);
+        }
+        if (!file.delete()) {
+          throw new IOException("failed to delete " + file);
+        }
+      }
+    }
+  };
+
+  /** Reads from {@code file}. */
+  Source source(File file) throws FileNotFoundException;
+
+  /**
+   * Writes to {@code file}, discarding any data already present. Creates parent directories if
+   * necessary.
+   */
+  Sink sink(File file) throws FileNotFoundException;
+
+  /**
+   * Writes to {@code file}, appending if data is already present. Creates parent directories if
+   * necessary.
+   */
+  Sink appendingSink(File file) throws FileNotFoundException;
+
+  /** Deletes {@code file} if it exists. Throws if the file exists and cannot be deleted. */
+  void delete(File file) throws IOException;
+
+  /** Returns true if {@code file} exists on the file system. */
+  boolean exists(File file);
+
+  /** Returns the number of bytes stored in {@code file}, or 0 if it does not exist. */
+  long size(File file);
+
+  /** Renames {@code from} to {@code to}. Throws if the file cannot be renamed. */
+  void rename(File from, File to) throws IOException;
+
+  /**
+   * Recursively delete the contents of {@code directory}. Throws an IOException if any file could
+   * not be deleted, or if {@code dir} is not a readable directory.
+   */
+  void deleteContents(File directory) throws IOException;
+}

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FileSystem.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/FileSystem.java
@@ -37,7 +37,8 @@ import okio.Source;
  * information. In exchange for these limitations, this interface is easier to implement and works
  * on all versions of Java and Android.
  *
- * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp/src/main/java/okhttp3/internal/io/FileSystem.java
+ * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/
+ * b8b6ee831c65208940c741f8e091ff02425566d5/okhttp/src/main/java/okhttp3/internal/io/FileSystem.java
  */
 public interface FileSystem {
   /** The host machine's local file system. */

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/HttpDate.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/HttpDate.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.text.DateFormat;
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import static okhttp3.internal.Util.UTC;
+
+/**
+ * Best-effort parser for HTTP dates.
+ *
+ * <p>Copied from OkHttp.
+ */
+public final class HttpDate {
+  /** The last four-digit year: "Fri, 31 Dec 9999 23:59:59 GMT". */
+  public static final long MAX_DATE = 253402300799999L;
+
+  /**
+   * Most websites serve cookies in the blessed format. Eagerly create the parser to ensure such
+   * cookies are on the fast path.
+   */
+  private static final ThreadLocal<DateFormat> STANDARD_DATE_FORMAT =
+      new ThreadLocal<DateFormat>() {
+        @Override protected DateFormat initialValue() {
+          // Date format specified by RFC 7231 section 7.1.1.1.
+          DateFormat rfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US);
+          rfc1123.setLenient(false);
+          rfc1123.setTimeZone(UTC);
+          return rfc1123;
+        }
+      };
+
+  /** If we fail to parse a date in a non-standard format, try each of these formats in sequence. */
+  private static final String[] BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS = new String[] {
+      // HTTP formats required by RFC2616 but with any timezone.
+      "EEE, dd MMM yyyy HH:mm:ss zzz", // RFC 822, updated by RFC 1123 with any TZ
+      "EEEE, dd-MMM-yy HH:mm:ss zzz", // RFC 850, obsoleted by RFC 1036 with any TZ.
+      "EEE MMM d HH:mm:ss yyyy", // ANSI C's asctime() format
+      // Alternative formats.
+      "EEE, dd-MMM-yyyy HH:mm:ss z",
+      "EEE, dd-MMM-yyyy HH-mm-ss z",
+      "EEE, dd MMM yy HH:mm:ss z",
+      "EEE dd-MMM-yyyy HH:mm:ss z",
+      "EEE dd MMM yyyy HH:mm:ss z",
+      "EEE dd-MMM-yyyy HH-mm-ss z",
+      "EEE dd-MMM-yy HH:mm:ss z",
+      "EEE dd MMM yy HH:mm:ss z",
+      "EEE,dd-MMM-yy HH:mm:ss z",
+      "EEE,dd-MMM-yyyy HH:mm:ss z",
+      "EEE, dd-MM-yyyy HH:mm:ss z",
+
+      /* RI bug 6641315 claims a cookie of this format was once served by www.yahoo.com */
+      "EEE MMM d yyyy HH:mm:ss z",
+  };
+
+  private static final DateFormat[] BROWSER_COMPATIBLE_DATE_FORMATS =
+      new DateFormat[BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS.length];
+
+  /** Returns the date for {@code value}. Returns null if the value couldn't be parsed. */
+  public static Date parse(String value) {
+    if (value.length() == 0) {
+      return null;
+    }
+
+    ParsePosition position = new ParsePosition(0);
+    Date result = STANDARD_DATE_FORMAT.get().parse(value, position);
+    if (position.getIndex() == value.length()) {
+      // STANDARD_DATE_FORMAT must match exactly; all text must be consumed, e.g. no ignored
+      // non-standard trailing "+01:00". Those cases are covered below.
+      return result;
+    }
+    synchronized (BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS) {
+      for (int i = 0, count = BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS.length; i < count; i++) {
+        DateFormat format = BROWSER_COMPATIBLE_DATE_FORMATS[i];
+        if (format == null) {
+          format = new SimpleDateFormat(BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS[i], Locale.US);
+          // Set the timezone to use when interpreting formats that don't have a timezone. GMT is
+          // specified by RFC 7231.
+          format.setTimeZone(UTC);
+          BROWSER_COMPATIBLE_DATE_FORMATS[i] = format;
+        }
+        position.setIndex(0);
+        result = format.parse(value, position);
+        if (position.getIndex() != 0) {
+          // Something was parsed. It's possible the entire string was not consumed but we ignore
+          // that. If any of the BROWSER_COMPATIBLE_DATE_FORMAT_STRINGS ended in "'GMT'" we'd have
+          // to also check that position.getIndex() == value.length() otherwise parsing might have
+          // terminated early, ignoring things like "+01:00". Leaving this as != 0 means that any
+          // trailing junk is ignored.
+          return result;
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Returns the string for {@code value}. */
+  public static String format(Date value) {
+    return STANDARD_DATE_FORMAT.get().format(value);
+  }
+
+  private HttpDate() {
+  }
+}

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/StatusLine.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/internal/StatusLine.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import okhttp3.Protocol;
+import okhttp3.Response;
+
+/**
+ * An HTTP response status line like "HTTP/1.1 200 OK".
+ *
+ * <p>Copied from OkHttp.
+ */
+public final class StatusLine {
+  /** Numeric status code, 307: Temporary Redirect. */
+  public static final int HTTP_TEMP_REDIRECT = 307;
+  public static final int HTTP_PERM_REDIRECT = 308;
+  public static final int HTTP_CONTINUE = 100;
+
+  public final Protocol protocol;
+  public final int code;
+  public final String message;
+
+  public StatusLine(Protocol protocol, int code, String message) {
+    this.protocol = protocol;
+    this.code = code;
+    this.message = message;
+  }
+
+  public static StatusLine get(Response response) {
+    return new StatusLine(response.protocol(), response.code(), response.message());
+  }
+
+  public static StatusLine parse(String statusLine) throws IOException {
+    // H T T P / 1 . 1   2 0 0   T e m p o r a r y   R e d i r e c t
+    // 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
+
+    // Parse protocol like "HTTP/1.1" followed by a space.
+    int codeStart;
+    Protocol protocol;
+    if (statusLine.startsWith("HTTP/1.")) {
+      if (statusLine.length() < 9 || statusLine.charAt(8) != ' ') {
+        throw new ProtocolException("Unexpected status line: " + statusLine);
+      }
+      int httpMinorVersion = statusLine.charAt(7) - '0';
+      codeStart = 9;
+      if (httpMinorVersion == 0) {
+        protocol = Protocol.HTTP_1_0;
+      } else if (httpMinorVersion == 1) {
+        protocol = Protocol.HTTP_1_1;
+      } else {
+        throw new ProtocolException("Unexpected status line: " + statusLine);
+      }
+    } else if (statusLine.startsWith("ICY ")) {
+      // Shoutcast uses ICY instead of "HTTP/1.0".
+      protocol = Protocol.HTTP_1_0;
+      codeStart = 4;
+    } else {
+      throw new ProtocolException("Unexpected status line: " + statusLine);
+    }
+
+    // Parse response code like "200". Always 3 digits.
+    if (statusLine.length() < codeStart + 3) {
+      throw new ProtocolException("Unexpected status line: " + statusLine);
+    }
+    int code;
+    try {
+      code = Integer.parseInt(statusLine.substring(codeStart, codeStart + 3));
+    } catch (NumberFormatException e) {
+      throw new ProtocolException("Unexpected status line: " + statusLine);
+    }
+
+    // Parse an optional response message like "OK" or "Not Modified". If it
+    // exists, it is separated from the response code by a space.
+    String message = "";
+    if (statusLine.length() > codeStart + 3) {
+      if (statusLine.charAt(codeStart + 3) != ' ') {
+        throw new ProtocolException("Unexpected status line: " + statusLine);
+      }
+      message = statusLine.substring(codeStart + 4);
+    }
+
+    return new StatusLine(protocol, code, message);
+  }
+
+  @Override public String toString() {
+    StringBuilder result = new StringBuilder();
+    result.append(protocol == Protocol.HTTP_1_0 ? "HTTP/1.0" : "HTTP/1.1");
+    result.append(' ').append(code);
+    if (message != null) {
+      result.append(' ').append(message);
+    }
+    return result.toString();
+  }
+}

--- a/apollo-http-cache/src/test/java/com/apollographql/apollo/cache/http/internal/DiskLruCacheTest.java
+++ b/apollo-http-cache/src/test/java/com/apollographql/apollo/cache/http/internal/DiskLruCacheTest.java
@@ -1,0 +1,1817 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Executor;
+import okio.BufferedSink;
+import okio.BufferedSource;
+import okio.Okio;
+import okio.Source;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.apollographql.apollo.cache.http.internal.DiskLruCache.JOURNAL_FILE;
+import static com.apollographql.apollo.cache.http.internal.DiskLruCache.JOURNAL_FILE_BACKUP;
+import static com.apollographql.apollo.cache.http.internal.DiskLruCache.MAGIC;
+import static com.apollographql.apollo.cache.http.internal.DiskLruCache.VERSION_1;
+import static org.junit.Assert.fail;
+
+/**
+ * Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp-tests/src/test/java/okhttp3/internal/cache/DiskLruCacheTest.java
+ */
+public final class DiskLruCacheTest {
+  @Rule public final TemporaryFolder tempDir = new TemporaryFolder();
+  @Rule public final Timeout timeout = new Timeout(60 * 1000);
+
+  private final FaultyFileSystem fileSystem = new FaultyFileSystem(FileSystem.SYSTEM);
+  private final int appVersion = 100;
+  private File cacheDir;
+  private File journalFile;
+  private File journalBkpFile;
+  private final TestExecutor executor = new TestExecutor();
+
+  private DiskLruCache cache;
+  private final Deque<DiskLruCache> toClose = new ArrayDeque<>();
+
+  private void createNewCache() throws IOException {
+    createNewCacheWithSize(Integer.MAX_VALUE);
+  }
+
+  private void createNewCacheWithSize(int maxSize) throws IOException {
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, maxSize, executor);
+    synchronized (cache) {
+      cache.initialize();
+    }
+    toClose.add(cache);
+  }
+
+  @Before public void setUp() throws Exception {
+    cacheDir = tempDir.getRoot();
+    journalFile = new File(cacheDir, JOURNAL_FILE);
+    journalBkpFile = new File(cacheDir, JOURNAL_FILE_BACKUP);
+    createNewCache();
+  }
+
+  @After public void tearDown() throws Exception {
+    while (!toClose.isEmpty()) {
+      toClose.pop().close();
+    }
+  }
+
+  @Test public void emptyCache() throws Exception {
+    cache.close();
+    assertJournalEquals();
+  }
+
+  @Test public void recoverFromInitializationFailure() throws IOException {
+    // Add an uncommitted entry. This will get detected on initialization, and the cache will
+    // attempt to delete the file. Do not explicitly close the cache here so the entry is left as
+    // incomplete.
+    DiskLruCache.Editor creator = cache.edit("k1");
+    BufferedSink sink = Okio.buffer(creator.newSink(0));
+    sink.writeUtf8("Hello");
+    sink.close();
+
+    // Simulate a severe filesystem failure on the first initialization.
+    fileSystem.setFaultyDelete(new File(cacheDir, "k1.0.tmp"), true);
+    fileSystem.setFaultyDelete(cacheDir, true);
+
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    toClose.add(cache);
+
+    try {
+      cache.get("k1");
+      fail();
+    } catch (IOException expected) {
+    }
+
+    // Now let it operate normally.
+    fileSystem.setFaultyDelete(new File(cacheDir, "k1.0.tmp"), false);
+    fileSystem.setFaultyDelete(cacheDir, false);
+
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertThat(snapshot).isNull();
+  }
+
+  @Test public void validateKey() throws Exception {
+    String key = null;
+    try {
+      key = "has_space ";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was invalid.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+    try {
+      key = "has_CR\r";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was invalid.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+    try {
+      key = "has_LF\n";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was invalid.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+    try {
+      key = "has_invalid/";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was invalid.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+    try {
+      key = "has_invalid\u2603";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was invalid.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+    try {
+      key = "this_is_way_too_long_this_is_way_too_long_this_is_way_too_long_"
+          + "this_is_way_too_long_this_is_way_too_long_this_is_way_too_long";
+      cache.edit(key);
+      fail("Expecting an IllegalArgumentException as the key was too long.");
+    } catch (IllegalArgumentException iae) {
+      assertThat(iae.getMessage()).isEqualTo(
+          ("keys must match regex [a-z0-9_-]{1,120}: \"" + key + "\""));
+    }
+
+    // Test valid cases.
+
+    // Exactly 120.
+    key = "0123456789012345678901234567890123456789012345678901234567890123456789"
+        + "01234567890123456789012345678901234567890123456789";
+    cache.edit(key).abort();
+    // Contains all valid characters.
+    key = "abcdefghijklmnopqrstuvwxyz_0123456789";
+    cache.edit(key).abort();
+    // Contains dash.
+    key = "-20384573948576";
+    cache.edit(key).abort();
+  }
+
+  @Test public void writeAndReadEntry() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "ABC");
+    setString(creator, 1, "DE");
+    assertThat(creator.newSource(0)).isNull();
+    assertThat(creator.newSource(1)).isNull();
+    creator.commit();
+
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertSnapshotValue(snapshot, 0, "ABC");
+    assertSnapshotValue(snapshot, 1, "DE");
+  }
+
+  @Test public void readAndWriteEntryAcrossCacheOpenAndClose() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "A");
+    setString(creator, 1, "B");
+    creator.commit();
+    cache.close();
+
+    createNewCache();
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertSnapshotValue(snapshot, 0, "A");
+    assertSnapshotValue(snapshot, 1, "B");
+    snapshot.close();
+  }
+
+  @Test public void readAndWriteEntryWithoutProperClose() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "A");
+    setString(creator, 1, "B");
+    creator.commit();
+
+    // Simulate a dirty close of 'cache' by opening the cache directory again.
+    createNewCache();
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertSnapshotValue(snapshot, 0, "A");
+    assertSnapshotValue(snapshot, 1, "B");
+    snapshot.close();
+  }
+
+  @Test public void journalWithEditAndPublish() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    assertJournalEquals("DIRTY k1"); // DIRTY must always be flushed.
+    setString(creator, 0, "AB");
+    setString(creator, 1, "C");
+    creator.commit();
+    cache.close();
+    assertJournalEquals("DIRTY k1", "CLEAN k1 2 1");
+  }
+
+  @Test public void revertedNewFileIsRemoveInJournal() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    assertJournalEquals("DIRTY k1"); // DIRTY must always be flushed.
+    setString(creator, 0, "AB");
+    setString(creator, 1, "C");
+    creator.abort();
+    cache.close();
+    assertJournalEquals("DIRTY k1", "REMOVE k1");
+  }
+
+  @Test public void unterminatedEditIsRevertedOnClose() throws Exception {
+    cache.edit("k1");
+    cache.close();
+    assertJournalEquals("DIRTY k1", "REMOVE k1");
+  }
+
+  @Test public void journalDoesNotIncludeReadOfYetUnpublishedValue() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    assertThat(cache.get("k1")).isNull();
+    setString(creator, 0, "A");
+    setString(creator, 1, "BC");
+    creator.commit();
+    cache.close();
+    assertJournalEquals("DIRTY k1", "CLEAN k1 1 2");
+  }
+
+  @Test public void journalWithEditAndPublishAndRead() throws Exception {
+    DiskLruCache.Editor k1Creator = cache.edit("k1");
+    setString(k1Creator, 0, "AB");
+    setString(k1Creator, 1, "C");
+    k1Creator.commit();
+    DiskLruCache.Editor k2Creator = cache.edit("k2");
+    setString(k2Creator, 0, "DEF");
+    setString(k2Creator, 1, "G");
+    k2Creator.commit();
+    DiskLruCache.Snapshot k1Snapshot = cache.get("k1");
+    k1Snapshot.close();
+    cache.close();
+    assertJournalEquals("DIRTY k1", "CLEAN k1 2 1", "DIRTY k2", "CLEAN k2 3 1", "READ k1");
+  }
+
+  @Test public void cannotOperateOnEditAfterPublish() throws Exception {
+    DiskLruCache.Editor editor = cache.edit("k1");
+    setString(editor, 0, "A");
+    setString(editor, 1, "B");
+    editor.commit();
+    assertInoperable(editor);
+  }
+
+  @Test public void cannotOperateOnEditAfterRevert() throws Exception {
+    DiskLruCache.Editor editor = cache.edit("k1");
+    setString(editor, 0, "A");
+    setString(editor, 1, "B");
+    editor.abort();
+    assertInoperable(editor);
+  }
+
+  @Test public void explicitRemoveAppliedToDiskImmediately() throws Exception {
+    DiskLruCache.Editor editor = cache.edit("k1");
+    setString(editor, 0, "ABC");
+    setString(editor, 1, "B");
+    editor.commit();
+    File k1 = getCleanFile("k1", 0);
+    assertThat(readFile(k1)).isEqualTo("ABC");
+    cache.remove("k1");
+    assertThat(fileSystem.exists(k1)).isFalse();
+  }
+
+  @Test public void removePreventsActiveEditFromStoringAValue() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Editor a = cache.edit("a");
+    setString(a, 0, "a1");
+    assertThat(cache.remove("a")).isTrue();
+    setString(a, 1, "a2");
+    a.commit();
+    assertAbsent("a");
+  }
+
+  /**
+   * Each read sees a snapshot of the file at the time read was called. This means that two reads of
+   * the same key can see different data.
+   */
+  @Test public void readAndWriteOverlapsMaintainConsistency() throws Exception {
+    DiskLruCache.Editor v1Creator = cache.edit("k1");
+    setString(v1Creator, 0, "AAaa");
+    setString(v1Creator, 1, "BBbb");
+    v1Creator.commit();
+
+    DiskLruCache.Snapshot snapshot1 = cache.get("k1");
+    BufferedSource inV1 = Okio.buffer(snapshot1.getSource(0));
+    assertThat(inV1.readByte()).isEqualTo((byte) 'A');
+    assertThat(inV1.readByte()).isEqualTo((byte) 'A');
+
+    DiskLruCache.Editor v1Updater = cache.edit("k1");
+    setString(v1Updater, 0, "CCcc");
+    setString(v1Updater, 1, "DDdd");
+    v1Updater.commit();
+
+    DiskLruCache.Snapshot snapshot2 = cache.get("k1");
+    assertSnapshotValue(snapshot2, 0, "CCcc");
+    assertSnapshotValue(snapshot2, 1, "DDdd");
+    snapshot2.close();
+
+    assertThat(inV1.readByte()).isEqualTo((byte) 'a');
+    assertThat(inV1.readByte()).isEqualTo((byte) 'a');
+    assertSnapshotValue(snapshot1, 1, "BBbb");
+    snapshot1.close();
+  }
+
+  @Test public void openWithDirtyKeyDeletesAllFilesForThatKey() throws Exception {
+    cache.close();
+    File cleanFile0 = getCleanFile("k1", 0);
+    File cleanFile1 = getCleanFile("k1", 1);
+    File dirtyFile0 = getDirtyFile("k1", 0);
+    File dirtyFile1 = getDirtyFile("k1", 1);
+    writeFile(cleanFile0, "A");
+    writeFile(cleanFile1, "B");
+    writeFile(dirtyFile0, "C");
+    writeFile(dirtyFile1, "D");
+    createJournal("CLEAN k1 1 1", "DIRTY   k1");
+    createNewCache();
+    assertThat(fileSystem.exists(cleanFile0)).isFalse();
+    assertThat(fileSystem.exists(cleanFile1)).isFalse();
+    assertThat(fileSystem.exists(dirtyFile0)).isFalse();
+    assertThat(fileSystem.exists(dirtyFile1)).isFalse();
+    assertThat(cache.get("k1")).isNull();
+  }
+
+  @Test public void openWithInvalidVersionClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournalWithHeader(MAGIC, "0", "100", "2", "");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+  }
+
+  @Test public void openWithInvalidAppVersionClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournalWithHeader(MAGIC, "1", "101", "2", "");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+  }
+
+  @Test public void openWithInvalidValueCountClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournalWithHeader(MAGIC, "1", "100", "1", "");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+  }
+
+  @Test public void openWithInvalidBlankLineClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournalWithHeader(MAGIC, "1", "100", "2", "x");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+  }
+
+  @Test public void openWithInvalidJournalLineClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournal("CLEAN k1 1 1", "BOGUS");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+    assertThat(cache.get("k1")).isNull();
+  }
+
+  @Test public void openWithInvalidFileSizeClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournal("CLEAN k1 0000x001 1");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+    assertThat(cache.get("k1")).isNull();
+  }
+
+  @Test public void openWithTruncatedLineDiscardsThatLine() throws Exception {
+    cache.close();
+    writeFile(getCleanFile("k1", 0), "A");
+    writeFile(getCleanFile("k1", 1), "B");
+
+    BufferedSink sink = Okio.buffer(fileSystem.sink(journalFile));
+    sink.writeUtf8(MAGIC + "\n" + VERSION_1 + "\n100\n2\n\nCLEAN k1 1 1"); // no trailing newline
+    sink.close();
+    createNewCache();
+    assertThat(cache.get("k1")).isNull();
+
+    // The journal is not corrupt when editing after a truncated line.
+    set("k1", "C", "D");
+
+    cache.close();
+    createNewCache();
+    assertValue("k1", "C", "D");
+  }
+
+  @Test public void openWithTooManyFileSizesClearsDirectory() throws Exception {
+    cache.close();
+    generateSomeGarbageFiles();
+    createJournal("CLEAN k1 1 1 1");
+    createNewCache();
+    assertGarbageFilesAllDeleted();
+    assertThat(cache.get("k1")).isNull();
+  }
+
+  @Test public void keyWithSpaceNotPermitted() throws Exception {
+    try {
+      cache.edit("my key");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void keyWithNewlineNotPermitted() throws Exception {
+    try {
+      cache.edit("my\nkey");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void keyWithCarriageReturnNotPermitted() throws Exception {
+    try {
+      cache.edit("my\rkey");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void nullKeyThrows() throws Exception {
+    try {
+      cache.edit(null);
+      fail();
+    } catch (NullPointerException expected) {
+    }
+  }
+
+  @Test public void createNewEntryWithTooFewValuesFails() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 1, "A");
+    try {
+      creator.commit();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+
+    assertThat(fileSystem.exists(getCleanFile("k1", 0))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile("k1", 1))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile("k1", 0))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile("k1", 1))).isFalse();
+    assertThat(cache.get("k1")).isNull();
+
+    DiskLruCache.Editor creator2 = cache.edit("k1");
+    setString(creator2, 0, "B");
+    setString(creator2, 1, "C");
+    creator2.commit();
+  }
+
+  @Test public void revertWithTooFewValues() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 1, "A");
+    creator.abort();
+    assertThat(fileSystem.exists(getCleanFile("k1", 0))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile("k1", 1))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile("k1", 0))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile("k1", 1))).isFalse();
+    assertThat(cache.get("k1")).isNull();
+  }
+
+  @Test public void updateExistingEntryWithTooFewValuesReusesPreviousValues() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "A");
+    setString(creator, 1, "B");
+    creator.commit();
+
+    DiskLruCache.Editor updater = cache.edit("k1");
+    setString(updater, 0, "C");
+    updater.commit();
+
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertSnapshotValue(snapshot, 0, "C");
+    assertSnapshotValue(snapshot, 1, "B");
+    snapshot.close();
+  }
+
+  @Test public void growMaxSize() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "a", "aaa"); // size 4
+    set("b", "bb", "bbbb"); // size 6
+    cache.setMaxSize(20);
+    set("c", "c", "c"); // size 12
+    assertThat(cache.size()).isEqualTo(12);
+  }
+
+  @Test public void shrinkMaxSizeEvicts() throws Exception {
+    cache.close();
+    createNewCacheWithSize(20);
+    set("a", "a", "aaa"); // size 4
+    set("b", "bb", "bbbb"); // size 6
+    set("c", "c", "c"); // size 12
+    cache.setMaxSize(10);
+    assertThat(executor.jobs.size()).isEqualTo(1);
+  }
+
+  @Test public void evictOnInsert() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+
+    set("a", "a", "aaa"); // size 4
+    set("b", "bb", "bbbb"); // size 6
+    assertThat(cache.size()).isEqualTo(10);
+
+    // Cause the size to grow to 12 should evict 'A'.
+    set("c", "c", "c");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(8);
+    assertAbsent("a");
+    assertValue("b", "bb", "bbbb");
+    assertValue("c", "c", "c");
+
+    // Causing the size to grow to 10 should evict nothing.
+    set("d", "d", "d");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(10);
+    assertAbsent("a");
+    assertValue("b", "bb", "bbbb");
+    assertValue("c", "c", "c");
+    assertValue("d", "d", "d");
+
+    // Causing the size to grow to 18 should evict 'B' and 'C'.
+    set("e", "eeee", "eeee");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(10);
+    assertAbsent("a");
+    assertAbsent("b");
+    assertAbsent("c");
+    assertValue("d", "d", "d");
+    assertValue("e", "eeee", "eeee");
+  }
+
+  @Test public void evictOnUpdate() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+
+    set("a", "a", "aa"); // size 3
+    set("b", "b", "bb"); // size 3
+    set("c", "c", "cc"); // size 3
+    assertThat(cache.size()).isEqualTo(9);
+
+    // Causing the size to grow to 11 should evict 'A'.
+    set("b", "b", "bbbb");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(8);
+    assertAbsent("a");
+    assertValue("b", "b", "bbbb");
+    assertValue("c", "c", "cc");
+  }
+
+  @Test public void evictionHonorsLruFromCurrentSession() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "a", "a");
+    set("b", "b", "b");
+    set("c", "c", "c");
+    set("d", "d", "d");
+    set("e", "e", "e");
+    cache.get("b").close(); // 'B' is now least recently used.
+
+    // Causing the size to grow to 12 should evict 'A'.
+    set("f", "f", "f");
+    // Causing the size to grow to 12 should evict 'C'.
+    set("g", "g", "g");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(10);
+    assertAbsent("a");
+    assertValue("b", "b", "b");
+    assertAbsent("c");
+    assertValue("d", "d", "d");
+    assertValue("e", "e", "e");
+    assertValue("f", "f", "f");
+  }
+
+  @Test public void evictionHonorsLruFromPreviousSession() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+    set("c", "c", "c");
+    set("d", "d", "d");
+    set("e", "e", "e");
+    set("f", "f", "f");
+    cache.get("b").close(); // 'B' is now least recently used.
+    assertThat(cache.size()).isEqualTo(12);
+    cache.close();
+    createNewCacheWithSize(10);
+
+    set("g", "g", "g");
+    cache.flush();
+    assertThat(cache.size()).isEqualTo(10);
+    assertAbsent("a");
+    assertValue("b", "b", "b");
+    assertAbsent("c");
+    assertValue("d", "d", "d");
+    assertValue("e", "e", "e");
+    assertValue("f", "f", "f");
+    assertValue("g", "g", "g");
+  }
+
+  @Test public void cacheSingleEntryOfSizeGreaterThanMaxSize() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "aaaaa", "aaaaaa"); // size=11
+    cache.flush();
+    assertAbsent("a");
+  }
+
+  @Test public void cacheSingleValueOfSizeGreaterThanMaxSize() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "aaaaaaaaaaa", "a"); // size=12
+    cache.flush();
+    assertAbsent("a");
+  }
+
+  @Test public void constructorDoesNotAllowZeroCacheSize() throws Exception {
+    try {
+      DiskLruCache.create(fileSystem, cacheDir, appVersion, 2, 0);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void constructorDoesNotAllowZeroValuesPerEntry() throws Exception {
+    try {
+      DiskLruCache.create(fileSystem, cacheDir, appVersion, 0, 10);
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
+  @Test public void removeAbsentElement() throws Exception {
+    cache.remove("a");
+  }
+
+  @Test public void readingTheSameStreamMultipleTimes() throws Exception {
+    set("a", "a", "b");
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    assertThat(snapshot.getSource(0)).isSameAs(snapshot.getSource(0));
+    snapshot.close();
+  }
+
+  @Test public void rebuildJournalOnRepeatedReads() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+    while (executor.jobs.isEmpty()) {
+      assertValue("a", "a", "a");
+      assertValue("b", "b", "b");
+    }
+  }
+
+  @Test public void rebuildJournalOnRepeatedEdits() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+    executor.jobs.removeFirst().run();
+
+    // Sanity check that a rebuilt journal behaves normally.
+    assertValue("a", "a", "a");
+    assertValue("b", "b", "b");
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/28">Issue #28</a> */
+  @Test public void rebuildJournalOnRepeatedReadsWithOpenAndClose() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+    while (executor.jobs.isEmpty()) {
+      assertValue("a", "a", "a");
+      assertValue("b", "b", "b");
+      cache.close();
+      createNewCache();
+    }
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/28">Issue #28</a> */
+  @Test public void rebuildJournalOnRepeatedEditsWithOpenAndClose() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+      cache.close();
+      createNewCache();
+    }
+  }
+
+  @Test public void rebuildJournalFailurePreventsEditors() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    // Don't allow edits under any circumstances.
+    assertThat(cache.edit("a")).isNull();
+    assertThat(cache.edit("c")).isNull();
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    assertThat(snapshot.edit()).isNull();
+    snapshot.close();
+  }
+
+  @Test public void rebuildJournalFailureIsRetried() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    // The rebuild is retried on cache hits and on cache edits.
+    DiskLruCache.Snapshot snapshot = cache.get("b");
+    snapshot.close();
+    assertThat(cache.edit("d")).isNull();
+    assertThat(executor.jobs.size()).isEqualTo(2);
+
+    // On cache misses, no retry job is queued.
+    assertThat(cache.get("c")).isNull();
+    assertThat(executor.jobs.size()).isEqualTo(2);
+
+    // Let the rebuild complete successfully.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), false);
+    executor.jobs.removeFirst().run();
+    assertJournalEquals("CLEAN a 1 1", "CLEAN b 1 1");
+  }
+
+  @Test public void rebuildJournalFailureWithInFlightEditors() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+    DiskLruCache.Editor commitEditor = cache.edit("c");
+    DiskLruCache.Editor abortEditor = cache.edit("d");
+    cache.edit("e"); // Grab an editor, but don't do anything with it.
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    // In-flight editors can commit and have their values retained.
+    setString(commitEditor, 0, "c");
+    setString(commitEditor, 1, "c");
+    commitEditor.commit();
+    assertValue("c", "c", "c");
+
+    abortEditor.abort();
+
+    // Let the rebuild complete successfully.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), false);
+    executor.jobs.removeFirst().run();
+    assertJournalEquals("CLEAN a 1 1", "CLEAN b 1 1", "DIRTY e", "CLEAN c 1 1");
+  }
+
+  @Test public void rebuildJournalFailureWithEditorsInFlightThenClose() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+    DiskLruCache.Editor commitEditor = cache.edit("c");
+    DiskLruCache.Editor abortEditor = cache.edit("d");
+    cache.edit("e"); // Grab an editor, but don't do anything with it.
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    setString(commitEditor, 0, "c");
+    setString(commitEditor, 1, "c");
+    commitEditor.commit();
+    assertValue("c", "c", "c");
+
+    abortEditor.abort();
+
+    cache.close();
+    createNewCache();
+
+    // Although 'c' successfully committed above, the journal wasn't available to issue a CLEAN op.
+    // Because the last state of 'c' was DIRTY before the journal failed, it should be removed
+    // entirely on a subsequent open.
+    assertThat(cache.size()).isEqualTo(4);
+    assertAbsent("c");
+    assertAbsent("d");
+    assertAbsent("e");
+  }
+
+  @Test public void rebuildJournalFailureAllowsRemovals() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    assertThat(cache.remove("a")).isTrue();
+    assertAbsent("a");
+
+    // Let the rebuild complete successfully.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), false);
+    executor.jobs.removeFirst().run();
+
+    assertJournalEquals("CLEAN b 1 1");
+  }
+
+  @Test public void rebuildJournalFailureWithRemovalThenClose() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    assertThat(cache.remove("a")).isTrue();
+    assertAbsent("a");
+
+    cache.close();
+    createNewCache();
+
+    // The journal will have no record that 'a' was removed. It will have an entry for 'a', but when
+    // it tries to read the cache files, it will find they were deleted. Once it encounters an entry
+    // with missing cache files, it should remove it from the cache entirely.
+    assertThat(cache.size()).isEqualTo(4);
+    assertThat(cache.get("a")).isNull();
+    assertThat(cache.size()).isEqualTo(2);
+  }
+
+  @Test public void rebuildJournalFailureAllowsEvictAll() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "a", "a");
+      set("b", "b", "b");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    cache.evictAll();
+
+    assertThat(cache.size()).isEqualTo(0);
+    assertAbsent("a");
+    assertAbsent("b");
+
+    cache.close();
+    createNewCache();
+
+    // The journal has no record that 'a' and 'b' were removed. It will have an entry for both, but
+    // when it tries to read the cache files for either entry, it will discover the cache files are
+    // missing and remove the entries from the cache.
+    assertThat(cache.size()).isEqualTo(4);
+    assertThat(cache.get("a")).isNull();
+    assertThat(cache.get("b")).isNull();
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test public void rebuildJournalFailureWithCacheTrim() throws Exception {
+    while (executor.jobs.isEmpty()) {
+      set("a", "aa", "aa");
+      set("b", "bb", "bb");
+    }
+
+    // Cause the rebuild action to fail.
+    fileSystem.setFaultyRename(new File(cacheDir, DiskLruCache.JOURNAL_FILE_BACKUP), true);
+    executor.jobs.removeFirst().run();
+
+    // Trigger a job to trim the cache.
+    cache.setMaxSize(4);
+    executor.jobs.removeFirst().run();
+
+    assertAbsent("a");
+    assertValue("b", "bb", "bb");
+  }
+
+  @Test public void restoreBackupFile() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "ABC");
+    setString(creator, 1, "DE");
+    creator.commit();
+    cache.close();
+
+    fileSystem.rename(journalFile, journalBkpFile);
+    assertThat(fileSystem.exists(journalFile)).isFalse();
+
+    createNewCache();
+
+    DiskLruCache.Snapshot snapshot = cache.get("k1");
+    assertSnapshotValue(snapshot, 0, "ABC");
+    assertSnapshotValue(snapshot, 1, "DE");
+
+    assertThat(fileSystem.exists(journalBkpFile)).isFalse();
+    assertThat(fileSystem.exists(journalFile)).isTrue();
+  }
+
+  @Test public void journalFileIsPreferredOverBackupFile() throws Exception {
+    DiskLruCache.Editor creator = cache.edit("k1");
+    setString(creator, 0, "ABC");
+    setString(creator, 1, "DE");
+    creator.commit();
+    cache.flush();
+
+    copyFile(journalFile, journalBkpFile);
+
+    creator = cache.edit("k2");
+    setString(creator, 0, "F");
+    setString(creator, 1, "GH");
+    creator.commit();
+    cache.close();
+
+    assertThat(fileSystem.exists(journalFile)).isTrue();
+    assertThat(fileSystem.exists(journalBkpFile)).isTrue();
+
+    createNewCache();
+
+    DiskLruCache.Snapshot snapshotA = cache.get("k1");
+    assertSnapshotValue(snapshotA, 0, "ABC");
+    assertSnapshotValue(snapshotA, 1, "DE");
+
+    DiskLruCache.Snapshot snapshotB = cache.get("k2");
+    assertSnapshotValue(snapshotB, 0, "F");
+    assertSnapshotValue(snapshotB, 1, "GH");
+
+    assertThat(fileSystem.exists(journalBkpFile)).isFalse();
+    assertThat(fileSystem.exists(journalFile)).isTrue();
+  }
+
+  @Test public void openCreatesDirectoryIfNecessary() throws Exception {
+    cache.close();
+    File dir = tempDir.newFolder("testOpenCreatesDirectoryIfNecessary");
+    cache = DiskLruCache.create(fileSystem, dir, appVersion, 2, Integer.MAX_VALUE);
+    set("a", "a", "a");
+    assertThat(fileSystem.exists(new File(dir, "a.0"))).isTrue();
+    assertThat(fileSystem.exists(new File(dir, "a.1"))).isTrue();
+    assertThat(fileSystem.exists(new File(dir, "journal"))).isTrue();
+  }
+
+  @Test public void fileDeletedExternally() throws Exception {
+    set("a", "a", "a");
+    fileSystem.delete(getCleanFile("a", 1));
+    assertThat(cache.get("a")).isNull();
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test public void editSameVersion() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    DiskLruCache.Editor editor = snapshot.edit();
+    setString(editor, 1, "a2");
+    editor.commit();
+    assertValue("a", "a", "a2");
+  }
+
+  @Test public void editSnapshotAfterChangeAborted() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    DiskLruCache.Editor toAbort = snapshot.edit();
+    setString(toAbort, 0, "b");
+    toAbort.abort();
+    DiskLruCache.Editor editor = snapshot.edit();
+    setString(editor, 1, "a2");
+    editor.commit();
+    assertValue("a", "a", "a2");
+  }
+
+  @Test public void editSnapshotAfterChangeCommitted() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    DiskLruCache.Editor toAbort = snapshot.edit();
+    setString(toAbort, 0, "b");
+    toAbort.commit();
+    assertThat(snapshot.edit()).isNull();
+  }
+
+  @Test public void editSinceEvicted() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "aa", "aaa"); // size 5
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    set("b", "bb", "bbb"); // size 5
+    set("c", "cc", "ccc"); // size 5; will evict 'A'
+    cache.flush();
+    assertThat(snapshot.edit()).isNull();
+  }
+
+  @Test public void editSinceEvictedAndRecreated() throws Exception {
+    cache.close();
+    createNewCacheWithSize(10);
+    set("a", "aa", "aaa"); // size 5
+    DiskLruCache.Snapshot snapshot = cache.get("a");
+    set("b", "bb", "bbb"); // size 5
+    set("c", "cc", "ccc"); // size 5; will evict 'A'
+    set("a", "a", "aaaa"); // size 5; will evict 'B'
+    cache.flush();
+    assertThat(snapshot.edit()).isNull();
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/2">Issue #2</a> */
+  @Test public void aggressiveClearingHandlesWrite() throws Exception {
+    fileSystem.deleteContents(tempDir.getRoot());
+    set("a", "a", "a");
+    assertValue("a", "a", "a");
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/2">Issue #2</a> */
+  @Test public void aggressiveClearingHandlesEdit() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Editor a = cache.get("a").edit();
+    fileSystem.deleteContents(tempDir.getRoot());
+    setString(a, 1, "a2");
+    a.commit();
+  }
+
+  @Test public void removeHandlesMissingFile() throws Exception {
+    set("a", "a", "a");
+    getCleanFile("a", 0).delete();
+    cache.remove("a");
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/2">Issue #2</a> */
+  @Test public void aggressiveClearingHandlesPartialEdit() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+    DiskLruCache.Editor a = cache.get("a").edit();
+    setString(a, 0, "a1");
+    fileSystem.deleteContents(tempDir.getRoot());
+    setString(a, 1, "a2");
+    a.commit();
+    assertThat(cache.get("a")).isNull();
+  }
+
+  /** @see <a href="https://github.com/JakeWharton/DiskLruCache/issues/2">Issue #2</a> */
+  @Test public void aggressiveClearingHandlesRead() throws Exception {
+    fileSystem.deleteContents(tempDir.getRoot());
+    assertThat(cache.get("a")).isNull();
+  }
+
+  /**
+   * We had a long-lived bug where {@link DiskLruCache#trimToSize} could infinite loop if entries
+   * being edited required deletion for the operation to complete.
+   */
+  @Test public void trimToSizeWithActiveEdit() throws Exception {
+    set("a", "a1234", "a1234");
+    DiskLruCache.Editor a = cache.edit("a");
+    setString(a, 0, "a123");
+
+    cache.setMaxSize(8); // Smaller than the sum of active edits!
+    cache.flush(); // Force trimToSize().
+    assertThat(cache.size()).isEqualTo(0);
+    assertThat(cache.get("a")).isNull();
+
+    // After the edit is completed, its entry is still gone.
+    setString(a, 1, "a1");
+    a.commit();
+    assertAbsent("a");
+    assertThat(cache.size()).isEqualTo(0);
+  }
+
+  @Test public void evictAll() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+    cache.evictAll();
+    assertThat(cache.size()).isEqualTo(0);
+    assertAbsent("a");
+    assertAbsent("b");
+  }
+
+  @Test public void evictAllWithPartialCreate() throws Exception {
+    DiskLruCache.Editor a = cache.edit("a");
+    setString(a, 0, "a1");
+    setString(a, 1, "a2");
+    cache.evictAll();
+    assertThat(cache.size()).isEqualTo(0);
+    a.commit();
+    assertAbsent("a");
+  }
+
+  @Test public void evictAllWithPartialEditDoesNotStoreAValue() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Editor a = cache.edit("a");
+    setString(a, 0, "a1");
+    setString(a, 1, "a2");
+    cache.evictAll();
+    assertThat(cache.size()).isEqualTo(0);
+    a.commit();
+    assertAbsent("a");
+  }
+
+  @Test public void evictAllDoesntInterruptPartialRead() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Snapshot a = cache.get("a");
+    assertSnapshotValue(a, 0, "a");
+    cache.evictAll();
+    assertThat(cache.size()).isEqualTo(0);
+    assertAbsent("a");
+    assertSnapshotValue(a, 1, "a");
+    a.close();
+  }
+
+  @Test public void editSnapshotAfterEvictAllReturnsNullDueToStaleValue() throws Exception {
+    set("a", "a", "a");
+    DiskLruCache.Snapshot a = cache.get("a");
+    cache.evictAll();
+    assertThat(cache.size()).isEqualTo(0);
+    assertAbsent("a");
+    assertThat(a.edit()).isNull();
+    a.close();
+  }
+
+  @Test public void iterator() throws Exception {
+    set("a", "a1", "a2");
+    set("b", "b1", "b2");
+    set("c", "c1", "c2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    assertThat(iterator.hasNext()).isTrue();
+    DiskLruCache.Snapshot a = iterator.next();
+    assertThat(a.key()).isEqualTo("a");
+    assertSnapshotValue(a, 0, "a1");
+    assertSnapshotValue(a, 1, "a2");
+    a.close();
+
+    assertThat(iterator.hasNext()).isTrue();
+    DiskLruCache.Snapshot b = iterator.next();
+    assertThat(b.key()).isEqualTo("b");
+    assertSnapshotValue(b, 0, "b1");
+    assertSnapshotValue(b, 1, "b2");
+    b.close();
+
+    assertThat(iterator.hasNext()).isTrue();
+    DiskLruCache.Snapshot c = iterator.next();
+    assertThat(c.key()).isEqualTo("c");
+    assertSnapshotValue(c, 0, "c1");
+    assertSnapshotValue(c, 1, "c2");
+    c.close();
+
+    assertThat(iterator.hasNext()).isFalse();
+    try {
+      iterator.next();
+      fail();
+    } catch (NoSuchElementException expected) {
+    }
+  }
+
+  @Test public void iteratorElementsAddedDuringIterationAreOmitted() throws Exception {
+    set("a", "a1", "a2");
+    set("b", "b1", "b2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    DiskLruCache.Snapshot a = iterator.next();
+    assertThat(a.key()).isEqualTo("a");
+    a.close();
+
+    set("c", "c1", "c2");
+
+    DiskLruCache.Snapshot b = iterator.next();
+    assertThat(b.key()).isEqualTo("b");
+    b.close();
+
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test public void iteratorElementsUpdatedDuringIterationAreUpdated() throws Exception {
+    set("a", "a1", "a2");
+    set("b", "b1", "b2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    DiskLruCache.Snapshot a = iterator.next();
+    assertThat(a.key()).isEqualTo("a");
+    a.close();
+
+    set("b", "b3", "b4");
+
+    DiskLruCache.Snapshot b = iterator.next();
+    assertThat(b.key()).isEqualTo("b");
+    assertSnapshotValue(b, 0, "b3");
+    assertSnapshotValue(b, 1, "b4");
+    b.close();
+  }
+
+  @Test public void iteratorElementsRemovedDuringIterationAreOmitted() throws Exception {
+    set("a", "a1", "a2");
+    set("b", "b1", "b2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    cache.remove("b");
+
+    DiskLruCache.Snapshot a = iterator.next();
+    assertThat(a.key()).isEqualTo("a");
+    a.close();
+
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test public void iteratorRemove() throws Exception {
+    set("a", "a1", "a2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    DiskLruCache.Snapshot a = iterator.next();
+    a.close();
+    iterator.remove();
+
+    assertThat(cache.get("a")).isNull();
+  }
+
+  @Test public void iteratorRemoveBeforeNext() throws Exception {
+    set("a", "a1", "a2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+    try {
+      iterator.remove();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void iteratorRemoveOncePerCallToNext() throws Exception {
+    set("a", "a1", "a2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+
+    DiskLruCache.Snapshot a = iterator.next();
+    iterator.remove();
+    a.close();
+
+    try {
+      iterator.remove();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void cacheClosedTruncatesIterator() throws Exception {
+    set("a", "a1", "a2");
+    Iterator<DiskLruCache.Snapshot> iterator = cache.snapshots();
+    cache.close();
+    assertThat(iterator.hasNext()).isFalse();
+  }
+
+  @Test public void isClosed_uninitializedCache() throws Exception {
+    // Create an uninitialized cache.
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    toClose.add(cache);
+
+    assertThat(cache.isClosed()).isFalse();
+    cache.close();
+    assertThat(cache.isClosed()).isTrue();
+  }
+
+  @Test public void journalWriteFailsDuringEdit() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+
+    // We can't begin the edit if writing 'DIRTY' fails.
+    fileSystem.setFaultyWrite(journalFile, true);
+    assertThat(cache.edit("c")).isNull();
+
+    // Once the journal has a failure, subsequent writes aren't permitted.
+    fileSystem.setFaultyWrite(journalFile, false);
+    assertThat(cache.edit("d")).isNull();
+
+    // Confirm that the fault didn't corrupt entries stored before the fault was introduced.
+    cache.close();
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    assertValue("a", "a", "a");
+    assertValue("b", "b", "b");
+    assertAbsent("c");
+    assertAbsent("d");
+  }
+
+  /**
+   * We had a bug where the cache was left in an inconsistent state after a journal write failed.
+   * https://github.com/square/okhttp/issues/1211
+   */
+  @Test public void journalWriteFailsDuringEditorCommit() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+
+    // Create an entry that fails to write to the journal during commit.
+    DiskLruCache.Editor editor = cache.edit("c");
+    setString(editor, 0, "c");
+    setString(editor, 1, "c");
+    fileSystem.setFaultyWrite(journalFile, true);
+    editor.commit();
+
+    // Once the journal has a failure, subsequent writes aren't permitted.
+    fileSystem.setFaultyWrite(journalFile, false);
+    assertThat(cache.edit("d")).isNull();
+
+    // Confirm that the fault didn't corrupt entries stored before the fault was introduced.
+    cache.close();
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    assertValue("a", "a", "a");
+    assertValue("b", "b", "b");
+    assertAbsent("c");
+    assertAbsent("d");
+  }
+
+  @Test public void journalWriteFailsDuringEditorAbort() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+
+    // Create an entry that fails to write to the journal during abort.
+    DiskLruCache.Editor editor = cache.edit("c");
+    setString(editor, 0, "c");
+    setString(editor, 1, "c");
+    fileSystem.setFaultyWrite(journalFile, true);
+    editor.abort();
+
+    // Once the journal has a failure, subsequent writes aren't permitted.
+    fileSystem.setFaultyWrite(journalFile, false);
+    assertThat(cache.edit("d")).isNull();
+
+    // Confirm that the fault didn't corrupt entries stored before the fault was introduced.
+    cache.close();
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    assertValue("a", "a", "a");
+    assertValue("b", "b", "b");
+    assertAbsent("c");
+    assertAbsent("d");
+  }
+
+  @Test public void journalWriteFailsDuringRemove() throws Exception {
+    set("a", "a", "a");
+    set("b", "b", "b");
+
+    // Remove, but the journal write will fail.
+    fileSystem.setFaultyWrite(journalFile, true);
+    assertThat(cache.remove("a")).isTrue();
+
+    // Confirm that the entry was still removed.
+    fileSystem.setFaultyWrite(journalFile, false);
+    cache.close();
+    cache = new DiskLruCache(fileSystem, cacheDir, appVersion, 2, Integer.MAX_VALUE, executor);
+    assertAbsent("a");
+    assertValue("b", "b", "b");
+  }
+
+  @Test public void cleanupTrimFailurePreventsNewEditors() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm that edits are prevented after a cache trim failure.
+    assertThat(cache.edit("a")).isNull();
+    assertThat(cache.edit("b")).isNull();
+    assertThat(cache.edit("c")).isNull();
+
+    // Allow the test to clean up.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+  }
+
+  @Test public void cleanupTrimFailureRetriedOnEditors() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // An edit should now add a job to clean up if the most recent trim failed.
+    assertThat(cache.edit("b")).isNull();
+    executor.jobs.pop().run();
+
+    // Confirm a successful cache trim now allows edits.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+    assertThat(cache.edit("c")).isNull();
+    executor.jobs.pop().run();
+    set("c", "cc", "cc");
+    assertValue("c", "cc", "cc");
+  }
+
+  @Test public void cleanupTrimFailureWithInFlightEditor() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aaa");
+    set("b", "bb", "bb");
+    DiskLruCache.Editor inFlightEditor = cache.edit("c");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // The in-flight editor can still write after a trim failure.
+    setString(inFlightEditor, 0, "cc");
+    setString(inFlightEditor, 1, "cc");
+    inFlightEditor.commit();
+
+    // Confirm the committed values are present after a successful cache trim.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+    executor.jobs.pop().run();
+    assertValue("c", "cc", "cc");
+  }
+
+  @Test public void cleanupTrimFailureAllowsSnapshotReads() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm we still allow snapshot reads after a trim failure.
+    assertValue("a", "aa", "aa");
+    assertValue("b", "bb", "bbb");
+
+    // Allow the test to clean up.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+  }
+
+  @Test public void cleanupTrimFailurePreventsSnapshotWrites() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm snapshot writes are prevented after a trim failure.
+    DiskLruCache.Snapshot snapshot1 = cache.get("a");
+    assertThat(snapshot1.edit()).isNull();
+    snapshot1.close();
+    DiskLruCache.Snapshot snapshot2 = cache.get("b");
+    assertThat(snapshot2.edit()).isNull();
+    snapshot2.close();
+
+    // Allow the test to clean up.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+  }
+
+  @Test public void evictAllAfterCleanupTrimFailure() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm we prevent edits after a trim failure.
+    assertThat(cache.edit("c")).isNull();
+
+    // A successful eviction should allow new writes.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+    cache.evictAll();
+    set("c", "cc", "cc");
+    assertValue("c", "cc", "cc");
+  }
+
+  @Test public void manualRemovalAfterCleanupTrimFailure() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm we prevent edits after a trim failure.
+    assertThat(cache.edit("c")).isNull();
+
+    // A successful removal which trims the cache should allow new writes.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+    cache.remove("a");
+    set("c", "cc", "cc");
+    assertValue("c", "cc", "cc");
+  }
+
+  @Test public void flushingAfterCleanupTrimFailure() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim job to fail.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), true);
+    executor.jobs.pop().run();
+
+    // Confirm we prevent edits after a trim failure.
+    assertThat(cache.edit("c")).isNull();
+
+    // A successful flush trims the cache and should allow new writes.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.0"), false);
+    cache.flush();
+    set("c", "cc", "cc");
+    assertValue("c", "cc", "cc");
+  }
+
+  @Test public void cleanupTrimFailureWithPartialSnapshot() throws Exception {
+    cache.setMaxSize(8);
+    executor.jobs.pop();
+    set("a", "aa", "aa");
+    set("b", "bb", "bbb");
+
+    // Cause the cache trim to fail on the second value leaving a partial snapshot.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.1"), true);
+    executor.jobs.pop().run();
+
+    // Confirm the partial snapshot is not returned.
+    assertThat(cache.get("a")).isNull();
+
+    // Confirm we prevent edits after a trim failure.
+    assertThat(cache.edit("a")).isNull();
+
+    // Confirm the partial snapshot is not returned after a successful trim.
+    fileSystem.setFaultyDelete(new File(cacheDir, "a.1"), false);
+    executor.jobs.pop().run();
+    assertThat(cache.get("a")).isNull();
+  }
+
+  @Test public void noSizeCorruptionAfterCreatorDetached() throws Exception {
+    // Create an editor for k1. Detach it by clearing the cache.
+    DiskLruCache.Editor editor = cache.edit("k1");
+    setString(editor, 0, "a");
+    setString(editor, 1, "a");
+    cache.evictAll();
+
+    // Create a new value in its place.
+    set("k1", "bb", "bb");
+    assertThat(cache.size()).isEqualTo(4);
+
+    // Committing the detached editor should not change the cache's size.
+    editor.commit();
+    assertThat(cache.size()).isEqualTo(4);
+    assertValue("k1", "bb", "bb");
+  }
+
+  @Test public void noSizeCorruptionAfterEditorDetached() throws Exception {
+    set("k1", "a", "a");
+
+    // Create an editor for k1. Detach it by clearing the cache.
+    DiskLruCache.Editor editor = cache.edit("k1");
+    setString(editor, 0, "bb");
+    setString(editor, 1, "bb");
+    cache.evictAll();
+
+    // Create a new value in its place.
+    set("k1", "ccc", "ccc");
+    assertThat(cache.size()).isEqualTo(6);
+
+    // Committing the detached editor should not change the cache's size.
+    editor.commit();
+    assertThat(cache.size()).isEqualTo(6);
+    assertValue("k1", "ccc", "ccc");
+  }
+
+  @Test public void noNewSourceAfterEditorDetached() throws Exception {
+    set("k1", "a", "a");
+
+    DiskLruCache.Editor editor = cache.edit("k1");
+    cache.evictAll();
+
+    assertThat(editor.newSource(0)).isNull();
+  }
+
+  @Test public void editsDiscardedAfterEditorDetached() throws Exception {
+    set("k1", "a", "a");
+
+    // Create an editor, then detach it.
+    DiskLruCache.Editor editor = cache.edit("k1");
+    BufferedSink sink = Okio.buffer(editor.newSink(0));
+    cache.evictAll();
+
+    // Create another value in its place.
+    set("k1", "ccc", "ccc");
+
+    // Complete the original edit. It goes into a black hole.
+    sink.writeUtf8("bb");
+    sink.close();
+
+    assertValue("k1", "ccc", "ccc");
+  }
+
+  @Test public void abortAfterDetach() throws Exception {
+    set("k1", "a", "a");
+
+    DiskLruCache.Editor editor = cache.edit("k1");
+    cache.evictAll();
+
+    editor.abort();
+    assertThat(cache.size()).isEqualTo(0);
+    assertAbsent("k1");
+  }
+
+  private void assertJournalEquals(String... expectedBodyLines) throws Exception {
+    List<String> expectedLines = new ArrayList<>();
+    expectedLines.add(MAGIC);
+    expectedLines.add(VERSION_1);
+    expectedLines.add("100");
+    expectedLines.add("2");
+    expectedLines.add("");
+    expectedLines.addAll(Arrays.asList(expectedBodyLines));
+    assertThat(readJournalLines()).isEqualTo(expectedLines);
+  }
+
+  private void createJournal(String... bodyLines) throws Exception {
+    createJournalWithHeader(MAGIC, VERSION_1, "100", "2", "", bodyLines);
+  }
+
+  private void createJournalWithHeader(String magic, String version, String appVersion,
+      String valueCount, String blank, String... bodyLines) throws Exception {
+    BufferedSink sink = Okio.buffer(fileSystem.sink(journalFile));
+    sink.writeUtf8(magic + "\n");
+    sink.writeUtf8(version + "\n");
+    sink.writeUtf8(appVersion + "\n");
+    sink.writeUtf8(valueCount + "\n");
+    sink.writeUtf8(blank + "\n");
+    for (String line : bodyLines) {
+      sink.writeUtf8(line);
+      sink.writeUtf8("\n");
+    }
+    sink.close();
+  }
+
+  private List<String> readJournalLines() throws Exception {
+    List<String> result = new ArrayList<>();
+    BufferedSource source = Okio.buffer(fileSystem.source(journalFile));
+    for (String line; (line = source.readUtf8Line()) != null; ) {
+      result.add(line);
+    }
+    source.close();
+    return result;
+  }
+
+  private File getCleanFile(String key, int index) {
+    return new File(cacheDir, key + "." + index);
+  }
+
+  private File getDirtyFile(String key, int index) {
+    return new File(cacheDir, key + "." + index + ".tmp");
+  }
+
+  private String readFile(File file) throws Exception {
+    BufferedSource source = Okio.buffer(fileSystem.source(file));
+    String result = source.readUtf8();
+    source.close();
+    return result;
+  }
+
+  public void writeFile(File file, String content) throws Exception {
+    BufferedSink sink = Okio.buffer(fileSystem.sink(file));
+    sink.writeUtf8(content);
+    sink.close();
+  }
+
+  private static void assertInoperable(DiskLruCache.Editor editor) throws Exception {
+    try {
+      setString(editor, 0, "A");
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      editor.newSource(0);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      editor.newSink(0);
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      editor.commit();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      editor.abort();
+      fail();
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  private void generateSomeGarbageFiles() throws Exception {
+    File dir1 = new File(cacheDir, "dir1");
+    File dir2 = new File(dir1, "dir2");
+    writeFile(getCleanFile("g1", 0), "A");
+    writeFile(getCleanFile("g1", 1), "B");
+    writeFile(getCleanFile("g2", 0), "C");
+    writeFile(getCleanFile("g2", 1), "D");
+    writeFile(getCleanFile("g2", 1), "D");
+    writeFile(new File(cacheDir, "otherFile0"), "E");
+    writeFile(new File(dir2, "otherFile1"), "F");
+  }
+
+  private void assertGarbageFilesAllDeleted() {
+    assertThat(fileSystem.exists(getCleanFile("g1", 0))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile("g1", 1))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile("g2", 0))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile("g2", 1))).isFalse();
+    assertThat(fileSystem.exists(new File(cacheDir, "otherFile0"))).isFalse();
+    assertThat(fileSystem.exists(new File(cacheDir, "dir1"))).isFalse();
+  }
+
+  private void set(String key, String value0, String value1) throws Exception {
+    DiskLruCache.Editor editor = cache.edit(key);
+    setString(editor, 0, value0);
+    setString(editor, 1, value1);
+    editor.commit();
+  }
+
+  public static void setString(DiskLruCache.Editor editor, int index, String value)
+      throws IOException {
+    BufferedSink writer = Okio.buffer(editor.newSink(index));
+    writer.writeUtf8(value);
+    writer.close();
+  }
+
+  private void assertAbsent(String key) throws Exception {
+    DiskLruCache.Snapshot snapshot = cache.get(key);
+    if (snapshot != null) {
+      snapshot.close();
+      fail();
+    }
+    assertThat(fileSystem.exists(getCleanFile(key, 0))).isFalse();
+    assertThat(fileSystem.exists(getCleanFile(key, 1))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile(key, 0))).isFalse();
+    assertThat(fileSystem.exists(getDirtyFile(key, 1))).isFalse();
+  }
+
+  private void assertValue(String key, String value0, String value1) throws Exception {
+    DiskLruCache.Snapshot snapshot = cache.get(key);
+    assertSnapshotValue(snapshot, 0, value0);
+    assertSnapshotValue(snapshot, 1, value1);
+    assertThat(fileSystem.exists(getCleanFile(key, 0))).isTrue();
+    assertThat(fileSystem.exists(getCleanFile(key, 1))).isTrue();
+    snapshot.close();
+  }
+
+  private void assertSnapshotValue(DiskLruCache.Snapshot snapshot, int index, String value)
+      throws IOException {
+    assertThat(sourceAsString(snapshot.getSource(index))).isEqualTo(value);
+    assertThat(snapshot.getLength(index)).isEqualTo(value.length());
+  }
+
+  private String sourceAsString(Source source) throws IOException {
+    return source != null ? Okio.buffer(source).readUtf8() : null;
+  }
+
+  private void copyFile(File from, File to) throws IOException {
+    Source source = fileSystem.source(from);
+    BufferedSink sink = Okio.buffer(fileSystem.sink(to));
+    sink.writeAll(source);
+    source.close();
+    sink.close();
+  }
+
+  private static class TestExecutor implements Executor {
+    final Deque<Runnable> jobs = new ArrayDeque<>();
+
+    @Override public void execute(Runnable command) {
+      jobs.addLast(command);
+    }
+  }
+}

--- a/apollo-http-cache/src/test/java/com/apollographql/apollo/cache/http/internal/FaultyFileSystem.java
+++ b/apollo-http-cache/src/test/java/com/apollographql/apollo/cache/http/internal/FaultyFileSystem.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2011 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.cache.http.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import okio.Buffer;
+import okio.ForwardingSink;
+import okio.Sink;
+import okio.Source;
+
+/**
+ * Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp-tests/src/test/java/okhttp3/internal/io/FaultyFileSystem.java
+ */
+public final class FaultyFileSystem implements FileSystem {
+  private final FileSystem delegate;
+  private final Set<File> writeFaults = new LinkedHashSet<>();
+  private final Set<File> deleteFaults = new LinkedHashSet<>();
+  private final Set<File> renameFaults = new LinkedHashSet<>();
+
+  public FaultyFileSystem(FileSystem delegate) {
+    this.delegate = delegate;
+  }
+
+  public void setFaultyWrite(File file, boolean faulty) {
+    if (faulty) {
+      writeFaults.add(file);
+    } else {
+      writeFaults.remove(file);
+    }
+  }
+
+  public void setFaultyDelete(File file, boolean faulty) {
+    if (faulty) {
+      deleteFaults.add(file);
+    } else {
+      deleteFaults.remove(file);
+    }
+  }
+
+  public void setFaultyRename(File file, boolean faulty) {
+    if (faulty) {
+      renameFaults.add(file);
+    } else {
+      renameFaults.remove(file);
+    }
+  }
+
+  @Override public Source source(File file) throws FileNotFoundException {
+    return delegate.source(file);
+  }
+
+  @Override public Sink sink(File file) throws FileNotFoundException {
+    return new FaultySink(delegate.sink(file), file);
+  }
+
+  @Override public Sink appendingSink(File file) throws FileNotFoundException {
+    return new FaultySink(delegate.appendingSink(file), file);
+  }
+
+  @Override public void delete(File file) throws IOException {
+    if (deleteFaults.contains(file)) throw new IOException("boom!");
+    delegate.delete(file);
+  }
+
+  @Override public boolean exists(File file) {
+    return delegate.exists(file);
+  }
+
+  @Override public long size(File file) {
+    return delegate.size(file);
+  }
+
+  @Override public void rename(File from, File to) throws IOException {
+    if (renameFaults.contains(from) || renameFaults.contains(to)) throw new IOException("boom!");
+    delegate.rename(from, to);
+  }
+
+  @Override public void deleteContents(File directory) throws IOException {
+    if (deleteFaults.contains(directory)) throw new IOException("boom!");
+    delegate.deleteContents(directory);
+  }
+
+  private class FaultySink extends ForwardingSink {
+    private final File file;
+
+    public FaultySink(Sink delegate, File file) {
+      super(delegate);
+      this.file = file;
+    }
+
+    @Override public void write(Buffer source, long byteCount) throws IOException {
+      if (writeFaults.contains(file)) throw new IOException("boom!");
+      super.write(source, byteCount);
+    }
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -22,8 +22,6 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.internal.io.FileSystem;
-import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockWebServer;
 
 import static com.apollographql.apollo.Utils.assertResponse;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloPrefetchTest.java
@@ -5,24 +5,22 @@ import com.apollographql.apollo.api.cache.http.HttpCache;
 import com.apollographql.apollo.api.cache.http.HttpCachePolicy;
 import com.apollographql.apollo.cache.http.ApolloHttpCache;
 import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore;
+import com.apollographql.apollo.cache.http.internal.FileSystem;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.integration.httpcache.AllPlanetsQuery;
 import com.apollographql.apollo.rx2.Rx2Apollo;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import io.reactivex.functions.Predicate;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-
-import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static com.apollographql.apollo.Utils.assertResponse;
 import static com.apollographql.apollo.Utils.enqueueAndAssertResponse;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/FaultyHttpCacheStore.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/FaultyHttpCacheStore.java
@@ -3,18 +3,15 @@ package com.apollographql.apollo;
 import com.apollographql.apollo.api.cache.http.HttpCacheRecord;
 import com.apollographql.apollo.api.cache.http.HttpCacheRecordEditor;
 import com.apollographql.apollo.api.cache.http.HttpCacheStore;
-
+import com.apollographql.apollo.cache.http.internal.DiskLruCache;
+import com.apollographql.apollo.cache.http.internal.FileSystem;
 import java.io.File;
 import java.io.IOException;
-
-import org.jetbrains.annotations.NotNull;
-
-import okhttp3.internal.cache.DiskLruCache;
-import okhttp3.internal.io.FileSystem;
 import okio.Buffer;
 import okio.Sink;
 import okio.Source;
 import okio.Timeout;
+import org.jetbrains.annotations.NotNull;
 
 class FaultyHttpCacheStore implements HttpCacheStore {
   private static final int VERSION = 99991;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -34,8 +34,6 @@ import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
-import okhttp3.internal.io.FileSystem;
-import okhttp3.internal.io.InMemoryFileSystem;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okio.Buffer;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTest.java
@@ -7,6 +7,7 @@ import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.CacheHeaders;
 import com.apollographql.apollo.cache.http.ApolloHttpCache;
 import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore;
+import com.apollographql.apollo.cache.http.internal.FileSystem;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.exception.ApolloHttpException;
 import com.apollographql.apollo.integration.httpcache.AllFilmsQuery;
@@ -16,12 +17,7 @@ import com.apollographql.apollo.integration.httpcache.type.CustomType;
 import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.rx2.Rx2Apollo;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
+import io.reactivex.functions.Predicate;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
@@ -29,14 +25,16 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-
-import io.reactivex.functions.Predicate;
 import okhttp3.Dispatcher;
 import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okio.Buffer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/InMemoryFileSystem.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/InMemoryFileSystem.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo;
+
+import com.apollographql.apollo.cache.http.internal.FileSystem;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import okio.Buffer;
+import okio.ForwardingSink;
+import okio.ForwardingSource;
+import okio.Sink;
+import okio.Source;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A simple file system where all files are held in memory. Not safe for concurrent use.
+ *
+ * <p>Copied from OkHttp 3.14.2: https://github.com/square/okhttp/blob/b8b6ee831c65208940c741f8e091ff02425566d5/okhttp-testing-support/src/main/java/okhttp3/internal/io/InMemoryFileSystem.java
+ */
+public final class InMemoryFileSystem implements FileSystem, TestRule {
+  private final Map<File, Buffer> files = new LinkedHashMap<>();
+  private final Map<Source, File> openSources = new IdentityHashMap<>();
+  private final Map<Sink, File> openSinks = new IdentityHashMap<>();
+
+  @Override public Statement apply(final Statement base, Description description) {
+    return new Statement() {
+      @Override public void evaluate() throws Throwable {
+        base.evaluate();
+        ensureResourcesClosed();
+      }
+    };
+  }
+
+  public void ensureResourcesClosed() {
+    List<String> openResources = new ArrayList<>();
+    for (File file : openSources.values()) {
+      openResources.add("Source for " + file);
+    }
+    for (File file : openSinks.values()) {
+      openResources.add("Sink for " + file);
+    }
+    if (!openResources.isEmpty()) {
+      StringBuilder builder = new StringBuilder("Resources acquired but not closed:");
+      for (String resource : openResources) {
+        builder.append("\n * ").append(resource);
+      }
+      throw new IllegalStateException(builder.toString());
+    }
+  }
+
+  @Override public Source source(File file) throws FileNotFoundException {
+    Buffer result = files.get(file);
+    if (result == null) throw new FileNotFoundException();
+
+    final Source source = result.clone();
+    openSources.put(source, file);
+
+    return new ForwardingSource(source) {
+      @Override public void close() throws IOException {
+        openSources.remove(source);
+        super.close();
+      }
+    };
+  }
+
+  @Override public Sink sink(File file) throws FileNotFoundException {
+    return sink(file, false);
+  }
+
+  @Override public Sink appendingSink(File file) throws FileNotFoundException {
+    return sink(file, true);
+  }
+
+  private Sink sink(File file, boolean appending) {
+    Buffer result = null;
+    if (appending) {
+      result = files.get(file);
+    }
+    if (result == null) {
+      result = new Buffer();
+    }
+    files.put(file, result);
+
+    final Sink sink = result;
+    openSinks.put(sink, file);
+
+    return new ForwardingSink(sink) {
+      @Override public void close() throws IOException {
+        openSinks.remove(sink);
+        super.close();
+      }
+    };
+  }
+
+  @Override public void delete(File file) throws IOException {
+    files.remove(file);
+  }
+
+  @Override public boolean exists(File file) {
+    return files.containsKey(file);
+  }
+
+  @Override public long size(File file) {
+    Buffer buffer = files.get(file);
+    return buffer != null ? buffer.size() : 0L;
+  }
+
+  @Override public void rename(File from, File to) throws IOException {
+    Buffer buffer = files.remove(from);
+    if (buffer == null) throw new FileNotFoundException();
+    files.put(to, buffer);
+  }
+
+  @Override public void deleteContents(File directory) throws IOException {
+    String prefix = directory.toString() + "/";
+    for (Iterator<File> i = files.keySet().iterator(); i.hasNext(); ) {
+      File file = i.next();
+      if (file.toString().startsWith(prefix)) i.remove();
+    }
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/NoFileSystem.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/NoFileSystem.java
@@ -1,10 +1,9 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.cache.http.internal.FileSystem;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-
-import okhttp3.internal.io.FileSystem;
 import okio.Sink;
 import okio.Source;
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.java
@@ -1,7 +1,5 @@
 package com.apollographql.apollo.internal.interceptor;
 
-import com.google.common.base.Predicate;
-
 import com.apollographql.apollo.Logger;
 import com.apollographql.apollo.api.FileUpload;
 import com.apollographql.apollo.api.Operation;
@@ -18,19 +16,14 @@ import com.apollographql.apollo.internal.ApolloLogger;
 import com.apollographql.apollo.request.RequestHeaders;
 import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Before;
-import org.junit.Test;
-
+import com.google.common.base.Predicate;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.HttpUrl;
@@ -40,6 +33,10 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okio.Buffer;
 import okio.Timeout;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Before;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.fail;
@@ -116,7 +113,7 @@ public class ApolloServerInterceptorFileUploadTest {
     String filePath = tempDir + "/" + fileName;
     File f = new File(filePath);
     try {
-      BufferedWriter bw = new BufferedWriter(new FileWriter(f));
+      BufferedWriter bw = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8);
       bw.write(content);
       bw.close();
     } catch (Exception e) {


### PR DESCRIPTION
Resolves #1347. Doesn't entirely remove everything (some internal usages still in tests), but makes the prod code not use them anymore. This is using sources from OkHttp 3.14.2