### PR TITLE
Support send HttpGetMethod for Persisted Queries

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -92,6 +92,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   private final boolean enableAutoPersistedQueries;
   private final SubscriptionManager subscriptionManager;
   private final boolean useHttpGetMethodForQueries;
+  private final boolean useHttpGetMethodForPersistedQueries;
 
   ApolloClient(HttpUrl serverUrl,
       Call.Factory httpCallFactory,
@@ -106,7 +107,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
       List<ApolloInterceptor> applicationInterceptors,
       boolean enableAutoPersistedQueries,
       SubscriptionManager subscriptionManager,
-      boolean useHttpGetMethodForQueries) {
+      boolean useHttpGetMethodForQueries,
+      boolean useHttpGetMethodForPersistedQueries) {
     this.serverUrl = serverUrl;
     this.httpCallFactory = httpCallFactory;
     this.httpCache = httpCache;
@@ -121,6 +123,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     this.enableAutoPersistedQueries = enableAutoPersistedQueries;
     this.subscriptionManager = subscriptionManager;
     this.useHttpGetMethodForQueries = useHttpGetMethodForQueries;
+    this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries;
   }
 
   @Override
@@ -269,6 +272,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
         .refetchQueryNames(Collections.<OperationName>emptyList())
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
+        .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
         .build();
   }
 
@@ -291,6 +295,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     Optional<Map<String, Object>> subscriptionConnectionParams = Optional.absent();
     long subscriptionHeartbeatTimeout = -1;
     boolean useHttpGetMethodForQueries;
+    boolean useHttpGetMethodForPersistedQueries;
 
     Builder() {
     }
@@ -517,6 +522,18 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
 
     /**
+     * Sets flag whether GraphQL Persisted queries should be sent via HTTP GET requests.
+     *
+     * @param useHttpGetMethodForPersistedQueries {@code true} if HTTP GET requests should be used,
+     * {@code false} otherwise.
+     * @return The {@link Builder} object to be used for chaining method calls
+     */
+    public Builder useHttpGetMethodForPersistedQueries(boolean useHttpGetMethodForPersistedQueries) {
+      this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries;
+      return this;
+    }
+
+    /**
      * Builds the {@link ApolloClient} instance using the configured values.
      *
      * Note that if the {@link #dispatcher} is not called, then a default {@link Executor} is used.
@@ -575,7 +592,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
           applicationInterceptors,
           enableAutoPersistedQueries,
           subscriptionManager,
-          useHttpGetMethodForQueries);
+          useHttpGetMethodForQueries,
+          useHttpGetMethodForPersistedQueries);
     }
 
     private Executor defaultDispatcher() {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -74,6 +74,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final AtomicReference<Callback<T>> originalCallback = new AtomicReference<>();
   final Optional<Operation.Data> optimisticUpdates;
   final boolean useHttpGetMethodForQueries;
+  final boolean useHttpGetMethodForPersistedQueries;
 
   public static <T> Builder<T> builder() {
     return new Builder<>();
@@ -117,6 +118,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     }
     useHttpGetMethodForQueries = builder.useHttpGetMethodForQueries;
     enableAutoPersistedQueries = builder.enableAutoPersistedQueries;
+    useHttpGetMethodForPersistedQueries = builder.useHttpGetMethodForPersistedQueries;
     interceptorChain = prepareInterceptorChain(operation);
     optimisticUpdates = builder.optimisticUpdates;
 
@@ -312,6 +314,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .refetchQueryNames(refetchQueryNames)
         .refetchQueries(refetchQueries)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
+        .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
         .optimisticUpdates(optimisticUpdates);
   }
 
@@ -377,7 +380,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.add(responseFetcher.provideInterceptor(logger));
     interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
     if (operation instanceof Query && enableAutoPersistedQueries) {
-      interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger));
+      interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger, useHttpGetMethodForPersistedQueries));
     }
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
         scalarTypeAdapters, logger));
@@ -409,6 +412,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     boolean enableAutoPersistedQueries;
     Optional<Operation.Data> optimisticUpdates = Optional.absent();
     boolean useHttpGetMethodForQueries;
+    boolean useHttpGetMethodForPersistedQueries;
 
     public Builder<T> operation(Operation operation) {
       this.operation = operation;
@@ -508,6 +512,11 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     public Builder<T> useHttpGetMethodForQueries(boolean useHttpGetMethodForQueries) {
       this.useHttpGetMethodForQueries = useHttpGetMethodForQueries;
+      return this;
+    }
+
+    public Builder<T> useHttpGetMethodForPersistedQueries(boolean useHttpGetMethodForPersistedQueries) {
+      this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
@@ -41,7 +41,6 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
             .autoPersistQueries(true)
             .useHttpGetMethodForQueries(useHttpGetMethodForQueries || useHttpGetMethodForPersistedQueries)
             .build();
-            
     chain.proceedAsync(newRequest, dispatcher, new CallBack() {
       @Override public void onResponse(@NotNull InterceptorResponse response) {
         if (disposed) return;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -44,8 +44,9 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 /**
  * ApolloServerInterceptor is a concrete {@link ApolloInterceptor} responsible for making the network calls to the
- * server. It is the last interceptor in the chain of interceptors and hence doesn't call {@link
- * ApolloInterceptorChain#proceed(FetchOptions)} on the interceptor chain.
+ * server. It is the last interceptor in the chain of interceptors and hence doesn't call
+ * {@link ApolloInterceptorChain#proceedAsync(InterceptorRequest, Executor, CallBack)}
+ * on the interceptor chain.
  */
 @SuppressWarnings("WeakerAccess") public final class ApolloServerInterceptor implements ApolloInterceptor {
   static final String HEADER_ACCEPT_TYPE = "Accept";

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
@@ -46,7 +46,8 @@ public class ApolloAutoPersistedQueryInterceptorTest {
           new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(Optional.<Logger>absent()), true);
 
   private ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(new MockOperation())
-      .build();
+          .autoPersistQueries(true)
+          .build();
 
   @Test
   public void initialRequestWithoutQueryDocument() {
@@ -60,6 +61,8 @@ public class ApolloAutoPersistedQueryInterceptorTest {
         any(ApolloInterceptor.CallBack.class));
 
     assertThat(requestArgumentCaptor.getValue().sendQueryDocument).isFalse();
+    assertThat(requestArgumentCaptor.getValue().useHttpGetMethodForQueries).isFalse();
+    assertThat(requestArgumentCaptor.getValue().autoPersistQueries).isTrue();
   }
 
   @Test
@@ -73,7 +76,9 @@ public class ApolloAutoPersistedQueryInterceptorTest {
     verify(chain).proceedAsync(requestArgumentCaptor.capture(), any(Executor.class),
             any(ApolloInterceptor.CallBack.class));
 
+    assertThat(requestArgumentCaptor.getValue().sendQueryDocument).isFalse();
     assertThat(requestArgumentCaptor.getValue().useHttpGetMethodForQueries).isTrue();
+    assertThat(requestArgumentCaptor.getValue().autoPersistQueries).isTrue();
   }
 
   @Test
@@ -85,6 +90,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
         super.proceedAsync(request, dispatcher, callBack);
         if (proceedAsyncInvocationCount == 1) {
           assertThat(request.sendQueryDocument).isFalse();
+          assertThat(request.autoPersistQueries).isTrue();
           callBack.onResponse(
               new ApolloInterceptor.InterceptorResponse(
                   mockHttpResponse(),
@@ -96,6 +102,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
           );
         } else if (proceedAsyncInvocationCount == 2) {
           assertThat(request.sendQueryDocument).isTrue();
+          assertThat(request.autoPersistQueries).isTrue();
           callBack.onResponse(
               new ApolloInterceptor.InterceptorResponse(
                   mockHttpResponse(),
@@ -132,6 +139,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
         super.proceedAsync(request, dispatcher, callBack);
         if (proceedAsyncInvocationCount == 1) {
           assertThat(request.sendQueryDocument).isFalse();
+          assertThat(request.autoPersistQueries).isTrue();
           callBack.onResponse(
               new ApolloInterceptor.InterceptorResponse(
                   mockHttpResponse(),
@@ -143,6 +151,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
           );
         } else if (proceedAsyncInvocationCount == 2) {
           assertThat(request.sendQueryDocument).isTrue();
+          assertThat(request.autoPersistQueries).isTrue();
           callBack.onResponse(
               new ApolloInterceptor.InterceptorResponse(
                   mockHttpResponse(),

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
@@ -40,7 +40,11 @@ import static org.mockito.Mockito.verify;
 
 public class ApolloAutoPersistedQueryInterceptorTest {
   private ApolloAutoPersistedQueryInterceptor interceptor =
-      new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(Optional.<Logger>absent()));
+      new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(Optional.<Logger>absent()), false);
+
+  private ApolloAutoPersistedQueryInterceptor interceptorWithGetMethod =
+          new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(Optional.<Logger>absent()), true);
+
   private ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(new MockOperation())
       .build();
 
@@ -56,6 +60,20 @@ public class ApolloAutoPersistedQueryInterceptorTest {
         any(ApolloInterceptor.CallBack.class));
 
     assertThat(requestArgumentCaptor.getValue().sendQueryDocument).isFalse();
+  }
+
+  @Test
+  public void initialRequestWithGetMethodForPersistedQueries() {
+    ApolloInterceptorChain chain = mock(ApolloInterceptorChain.class);
+
+    interceptorWithGetMethod.interceptAsync(request, chain, new TrampolineExecutor(), mock(ApolloInterceptor.CallBack.class));
+
+    ArgumentCaptor<ApolloInterceptor.InterceptorRequest> requestArgumentCaptor =
+            ArgumentCaptor.forClass(ApolloInterceptor.InterceptorRequest.class);
+    verify(chain).proceedAsync(requestArgumentCaptor.capture(), any(Executor.class),
+            any(ApolloInterceptor.CallBack.class));
+
+    assertThat(requestArgumentCaptor.getValue().useHttpGetMethodForQueries).isTrue();
   }
 
   @Test


### PR DESCRIPTION
- Support APQs with CDN through useHttpGetMethodForPersistedQueries

Ref. [Integrate APQs with CDN](https://www.apollographql.com/docs/apollo-server/features/apq/#cdn)

Implemented `useHttpGetMethodForPersistedQueries` which sends with HttpGetMethod when it's a persisted query request, otherwise send HttpGetMethod  or HttpPostMethod depends on global setting of `useHttpGetMethodForQueries`.

**Example**
```
ApolloClient.builder()
.enableAutoPersistedQueries(true)
.useHttpGetMethodForPersistedQueries(true)
.build()
```

ref. #1317 #1055