### PR TITLE
Add visitor spec to generate visitor interface and compatible visitor method for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,14 @@ systemProp.apollographql.useGlobalApolloCodegen=true
 
 Note that this requires exactly version `0.19.1` (not older, not newer). You can install this conventionally via `npm install -g apollo-codegen@0.19.1`.
 
+### Visitor generation for polymorphic datatypes
+Apollo Gradle plugin also supports generating visitors for compile-time safe handling of polymorphic datatypes. By default the feature is turned off since it requires source/target compatibility with Java 1.8. To opt into visitor generation:
+```groovy
+apollo {
+  generateVisitorForPolymorphicDatatypes = true
+}
+```
+
 ### Kotlin model generation (experimental)
 By default Apollo Gradle plugin generates Java models but you can configure it to generate Kotlin models instead:
 ```groovy

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -31,8 +31,9 @@ class GraphQLCompiler {
         useSemanticNaming = args.useSemanticNaming,
         generateModelBuilder = args.generateModelBuilder,
         useJavaBeansSemanticNaming = args.useJavaBeansSemanticNaming,
-        suppressRawTypesWarning = args.suppressRawTypesWarning
-    )
+        suppressRawTypesWarning = args.suppressRawTypesWarning,
+        generateVisitorForPolymorphicDatatypes = args.generateVisitorForPolymorphicDatatypes
+      )
 
     if (irPackageName.isNotEmpty()) {
       File(args.outputDir, irPackageName.replace('.', File.separatorChar)).deleteRecursively()
@@ -126,6 +127,7 @@ class GraphQLCompiler {
       val useJavaBeansSemanticNaming: Boolean,
       val outputPackageName: String?,
       val suppressRawTypesWarning: Boolean,
-      val generateKotlinModels: Boolean = false
+      val generateKotlinModels: Boolean = false,
+      val generateVisitorForPolymorphicDatatypes: Boolean = false
   )
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.compiler
 
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.ResponseFieldMapper
+import com.apollographql.apollo.compiler.VisitorSpec.VISITOR_CLASSNAME
 import com.apollographql.apollo.compiler.ir.*
 import com.squareup.javapoet.*
 import javax.lang.model.element.Modifier
@@ -30,6 +31,7 @@ class OperationTypeSpecBuilder(
         .addOperationName()
         .build()
         .flatten(excludeTypeNames = listOf(
+            VISITOR_CLASSNAME,
             Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
             (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
             ClassNames.BUILDER.simpleName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -70,9 +70,11 @@ class SchemaTypeSpecBuilder(
         .addTypes(nestedTypeSpecs.map { it.second })
         .apply {
           if (inlineFragments.isNotEmpty()) {
-            addType(inlineFragmentsVisitorInterfaceSpec(nameOverrideMap, surrogateInlineFragmentType!!))
-            addMethod(inlineFragmentsVisitorMethodSpec(nameOverrideMap, surrogateInlineFragmentType))
-            addType(inlineFragmentsResponseMapperSpec(nameOverrideMap, surrogateInlineFragmentType))
+            addType(inlineFragmentsResponseMapperSpec(nameOverrideMap, surrogateInlineFragmentType!!))
+            if (context.generateVisitorForPolymorphicDatatypes) {
+              addType(inlineFragmentsVisitorInterfaceSpec(nameOverrideMap, surrogateInlineFragmentType))
+              addMethod(inlineFragmentsVisitorMethodSpec(nameOverrideMap, surrogateInlineFragmentType))
+            }
           }
         }
         .build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -353,7 +353,7 @@ fun TypeSpec.removeNestedTypeSpecs(excludeTypeNames: List<String>): TypeSpec {
 
 fun TypeSpec.flatNestedTypeSpecs(excludeTypeNames: List<String>): List<TypeSpec> =
     typeSpecs
-        .filter { !excludeTypeNames.contains(it.name) }
+        .filterNot { excludeTypeNames.contains(it.name) }
         .flatMap { listOf(it.removeNestedTypeSpecs(excludeTypeNames)) + it.flatNestedTypeSpecs(excludeTypeNames) }
 
 fun TypeSpec.flatten(excludeTypeNames: List<String>): TypeSpec {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VisitorSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VisitorSpec.kt
@@ -1,0 +1,93 @@
+package com.apollographql.apollo.compiler
+
+import com.apollographql.apollo.compiler.VisitorSpec.DEFAULT_VISITOR_METHOD_NAME
+import com.apollographql.apollo.compiler.VisitorSpec.VISITOR_CLASSNAME
+import com.apollographql.apollo.compiler.VisitorSpec.VISITOR_METHOD_NAME
+import com.apollographql.apollo.compiler.VisitorSpec.VISITOR_TYPE_VARIABLE
+import com.squareup.javapoet.*
+import javax.lang.model.element.Modifier
+
+class VisitorInterfaceSpec(
+  private val schemaType: ClassName,
+  private val implementations: List<ClassName>
+) {
+
+  fun createVisitorInterface(): TypeSpec {
+    val visitDefaultMethod = MethodSpec.methodBuilder(DEFAULT_VISITOR_METHOD_NAME)
+      .returns(VISITOR_TYPE_VARIABLE)
+      .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+      .addParameter(ParameterSpec.builder(
+        ClassName.get("", schemaType.simpleName()),
+        schemaType.simpleName().decapitalize()
+      ).addAnnotation(Annotations.NONNULL).build())
+      .build()
+
+    val visitMethods = implementations.map { classNames ->
+      MethodSpec.methodBuilder(VISITOR_METHOD_NAME)
+        .returns(VISITOR_TYPE_VARIABLE)
+        .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+        .addParameter(ParameterSpec.builder(
+          ClassName.get("", classNames.simpleName()),
+          classNames.simpleName().decapitalize()
+        ).addAnnotation(Annotations.NONNULL).build())
+        .build()
+    }
+
+    return TypeSpec.interfaceBuilder(VISITOR_CLASSNAME)
+      .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+      .addMethod(visitDefaultMethod)
+      .addMethods(visitMethods)
+      .addTypeVariable(VISITOR_TYPE_VARIABLE)
+      .build()
+  }
+}
+
+class VisitorMethodSpec(private val implementations: List<ClassName>) {
+
+  fun createVisitorMethod(): MethodSpec {
+    val visitorConsumer = MethodSpec.methodBuilder(VISITOR_METHOD_NAME)
+      .returns(VISITOR_TYPE_VARIABLE)
+      .addModifiers(Modifier.PUBLIC, Modifier.DEFAULT)
+      .addTypeVariable(VISITOR_TYPE_VARIABLE)
+      .addParameter(ParameterSpec.builder(ParameterizedTypeName.get(
+        ClassName.get("", VISITOR_CLASSNAME),
+        VISITOR_TYPE_VARIABLE
+      ), "visitor").build())
+
+    implementations.forEachIndexed { index, className ->
+      when (index) {
+        0 -> visitorConsumer
+          .beginControlFlow(
+            "if (this instanceof \$T)",
+            ClassName.get("", className.simpleName())
+          )
+          .addStatement(
+            "return visitor.visit((\$T) this)",
+            ClassName.get("", className.simpleName())
+          )
+        else -> visitorConsumer
+          .nextControlFlow(
+            "else if (this instanceof \$T)",
+            ClassName.get("", className.simpleName())
+          )
+          .addStatement(
+            "return visitor.visit((\$T) this)",
+            ClassName.get("", className.simpleName())
+          )
+      }
+    }
+
+    return visitorConsumer
+      .endControlFlow()
+      .addStatement("return visitor.visitDefault(this)")
+      .build()
+  }
+}
+
+object VisitorSpec {
+
+  val VISITOR_TYPE_VARIABLE = TypeVariableName.get("T")!!
+  const val VISITOR_METHOD_NAME = "visit"
+  const val DEFAULT_VISITOR_METHOD_NAME = "visitDefault"
+  const val VISITOR_CLASSNAME = "Visitor"
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/CodeGenerationContext.kt
@@ -13,5 +13,6 @@ data class CodeGenerationContext(
     val useSemanticNaming: Boolean,
     val generateModelBuilder: Boolean,
     val useJavaBeansSemanticNaming: Boolean,
-    val suppressRawTypesWarning: Boolean
+    val suppressRawTypesWarning: Boolean,
+    val generateVisitorForPolymorphicDatatypes: Boolean
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.compiler.ir
 
 import com.apollographql.apollo.compiler.*
+import com.apollographql.apollo.compiler.VisitorSpec.VISITOR_CLASSNAME
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec
@@ -37,6 +38,7 @@ data class Fragment(
         .addTypeConditionField()
         .build()
         .flatten(excludeTypeNames = listOf(
+            VISITOR_CLASSNAME,
             Util.RESPONSE_FIELD_MAPPER_TYPE_NAME,
             (SchemaTypeSpecBuilder.FRAGMENTS_FIELD.type as ClassName).simpleName(),
             ClassNames.BUILDER.simpleName()

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -62,6 +62,23 @@ public interface HeroDetails extends GraphqlFragment {
 
   ResponseFieldMarshaller marshaller();
 
+  default <T> T visit(Visitor<T> visitor) {
+    if (this instanceof AsDroid) {
+      return visitor.visit((AsDroid) this);
+    } else if (this instanceof AsCharacter) {
+      return visitor.visit((AsCharacter) this);
+    }
+    return visitor.visitDefault(this);
+  }
+
+  interface Visitor<T> {
+    T visitDefault(@NotNull HeroDetails heroDetails);
+
+    T visit(@NotNull AsDroid asDroid);
+
+    T visit(@NotNull AsCharacter asCharacter);
+  }
+
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -71,14 +71,6 @@ public interface HeroDetails extends GraphqlFragment {
     return visitor.visitDefault(this);
   }
 
-  interface Visitor<T> {
-    T visitDefault(@NotNull HeroDetails heroDetails);
-
-    T visit(@NotNull AsDroid asDroid);
-
-    T visit(@NotNull AsCharacter asCharacter);
-  }
-
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 
@@ -97,6 +89,14 @@ public interface HeroDetails extends GraphqlFragment {
       }
       return asCharacterFieldMapper.map(reader);
     }
+  }
+
+  interface Visitor<T> {
+    T visitDefault(@NotNull HeroDetails heroDetails);
+
+    T visit(@NotNull AsDroid asDroid);
+
+    T visit(@NotNull AsCharacter asCharacter);
   }
 
   interface FriendsConnection {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -186,14 +186,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Hero hero);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -212,6 +204,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -177,6 +177,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
+
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -197,6 +197,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsDroid) {
+        return visitor.visit((AsDroid) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
+
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -208,16 +208,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Hero hero);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsDroid asDroid);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -247,6 +237,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
@@ -65,23 +65,6 @@ public interface HeroDetails extends GraphqlFragment {
 
   ResponseFieldMarshaller marshaller();
 
-  default <T> T visit(Visitor<T> visitor) {
-    if (this instanceof AsDroid) {
-      return visitor.visit((AsDroid) this);
-    } else if (this instanceof AsCharacter) {
-      return visitor.visit((AsCharacter) this);
-    }
-    return visitor.visitDefault(this);
-  }
-
-  interface Visitor<T> {
-    T visitDefault(@NotNull HeroDetails heroDetails);
-
-    T visit(@NotNull AsDroid asDroid);
-
-    T visit(@NotNull AsCharacter asCharacter);
-  }
-
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
@@ -65,6 +65,23 @@ public interface HeroDetails extends GraphqlFragment {
 
   ResponseFieldMarshaller marshaller();
 
+  default <T> T visit(Visitor<T> visitor) {
+    if (this instanceof AsDroid) {
+      return visitor.visit((AsDroid) this);
+    } else if (this instanceof AsCharacter) {
+      return visitor.visit((AsCharacter) this);
+    }
+    return visitor.visitDefault(this);
+  }
+
+  interface Visitor<T> {
+    T visitDefault(@NotNull HeroDetails heroDetails);
+
+    T visit(@NotNull AsDroid asDroid);
+
+    T visit(@NotNull AsCharacter asCharacter);
+  }
+
   final class Mapper implements ResponseFieldMapper<HeroDetails> {
     final AsDroid.Mapper asDroidFieldMapper = new AsDroid.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -259,6 +259,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsDroid) {
+        return visitor.visit((AsDroid) this);
+      } else if (this instanceof AsCharacter2) {
+        return visitor.visit((AsCharacter2) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter2 asCharacter2);
+    }
+
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -427,6 +448,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @NotNull String name();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman1) {
+        return visitor.visit((AsHuman1) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend friend);
+
+      T visit(@NotNull AsHuman1 asHuman1);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
 
     final class Mapper implements ResponseFieldMapper<Friend> {
       final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
@@ -784,6 +822,23 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @NotNull String name();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman2) {
+        return visitor.visit((AsHuman2) this);
+      } else if (this instanceof AsCharacter1) {
+        return visitor.visit((AsCharacter1) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend1 friend1);
+
+      T visit(@NotNull AsHuman2 asHuman2);
+
+      T visit(@NotNull AsCharacter1 asCharacter1);
+    }
 
     final class Mapper implements ResponseFieldMapper<Friend1> {
       final AsHuman2.Mapper asHuman2FieldMapper = new AsHuman2.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -270,16 +270,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Hero hero);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsDroid asDroid);
-
-      T visit(@NotNull AsCharacter2 asCharacter2);
-    }
-
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -309,6 +299,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacter2FieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter2 asCharacter2);
     }
   }
 
@@ -458,14 +458,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Friend friend);
-
-      T visit(@NotNull AsHuman1 asHuman1);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<Friend> {
       final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
 
@@ -484,6 +476,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend friend);
+
+      T visit(@NotNull AsHuman1 asHuman1);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 
@@ -832,14 +832,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Friend1 friend1);
-
-      T visit(@NotNull AsHuman2 asHuman2);
-
-      T visit(@NotNull AsCharacter1 asCharacter1);
-    }
-
     final class Mapper implements ResponseFieldMapper<Friend1> {
       final AsHuman2.Mapper asHuman2FieldMapper = new AsHuman2.Mapper();
 
@@ -858,6 +850,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacter1FieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend1 friend1);
+
+      T visit(@NotNull AsHuman2 asHuman2);
+
+      T visit(@NotNull AsCharacter1 asCharacter1);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
@@ -49,6 +49,23 @@ public interface TestSetting extends GraphqlFragment {
 
   ResponseFieldMarshaller marshaller();
 
+  default <T> T visit(Visitor<T> visitor) {
+    if (this instanceof AsSelectSetting) {
+      return visitor.visit((AsSelectSetting) this);
+    } else if (this instanceof AsSetting) {
+      return visitor.visit((AsSetting) this);
+    }
+    return visitor.visitDefault(this);
+  }
+
+  interface Visitor<T> {
+    T visitDefault(@NotNull TestSetting testSetting);
+
+    T visit(@NotNull AsSelectSetting asSelectSetting);
+
+    T visit(@NotNull AsSetting asSetting);
+  }
+
   final class Mapper implements ResponseFieldMapper<TestSetting> {
     final AsSelectSetting.Mapper asSelectSettingFieldMapper = new AsSelectSetting.Mapper();
 
@@ -73,6 +90,23 @@ public interface TestSetting extends GraphqlFragment {
     @NotNull String __typename();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsStringListSettingValue) {
+        return visitor.visit((AsStringListSettingValue) this);
+      } else if (this instanceof AsSettingValue) {
+        return visitor.visit((AsSettingValue) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value value);
+
+      T visit(@NotNull AsStringListSettingValue asStringListSettingValue);
+
+      T visit(@NotNull AsSettingValue asSettingValue);
+    }
 
     final class Mapper implements ResponseFieldMapper<Value> {
       final AsStringListSettingValue.Mapper asStringListSettingValueFieldMapper = new AsStringListSettingValue.Mapper();
@@ -399,6 +433,23 @@ public interface TestSetting extends GraphqlFragment {
     @NotNull String __typename();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsStringListSettingValue1) {
+        return visitor.visit((AsStringListSettingValue1) this);
+      } else if (this instanceof AsSettingValue1) {
+        return visitor.visit((AsSettingValue1) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value1 value1);
+
+      T visit(@NotNull AsStringListSettingValue1 asStringListSettingValue1);
+
+      T visit(@NotNull AsSettingValue1 asSettingValue1);
+    }
 
     final class Mapper implements ResponseFieldMapper<Value1> {
       final AsStringListSettingValue1.Mapper asStringListSettingValue1FieldMapper = new AsStringListSettingValue1.Mapper();
@@ -807,6 +858,23 @@ public interface TestSetting extends GraphqlFragment {
     @NotNull String __typename();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsStringListSettingValue2) {
+        return visitor.visit((AsStringListSettingValue2) this);
+      } else if (this instanceof AsSettingValue2) {
+        return visitor.visit((AsSettingValue2) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value2 value2);
+
+      T visit(@NotNull AsStringListSettingValue2 asStringListSettingValue2);
+
+      T visit(@NotNull AsSettingValue2 asSettingValue2);
+    }
 
     final class Mapper implements ResponseFieldMapper<Value2> {
       final AsStringListSettingValue2.Mapper asStringListSettingValue2FieldMapper = new AsStringListSettingValue2.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/fragment/TestSetting.java
@@ -58,14 +58,6 @@ public interface TestSetting extends GraphqlFragment {
     return visitor.visitDefault(this);
   }
 
-  interface Visitor<T> {
-    T visitDefault(@NotNull TestSetting testSetting);
-
-    T visit(@NotNull AsSelectSetting asSelectSetting);
-
-    T visit(@NotNull AsSetting asSetting);
-  }
-
   final class Mapper implements ResponseFieldMapper<TestSetting> {
     final AsSelectSetting.Mapper asSelectSettingFieldMapper = new AsSelectSetting.Mapper();
 
@@ -86,6 +78,14 @@ public interface TestSetting extends GraphqlFragment {
     }
   }
 
+  interface Visitor<T> {
+    T visitDefault(@NotNull TestSetting testSetting);
+
+    T visit(@NotNull AsSelectSetting asSelectSetting);
+
+    T visit(@NotNull AsSetting asSetting);
+  }
+
   interface Value {
     @NotNull String __typename();
 
@@ -98,14 +98,6 @@ public interface TestSetting extends GraphqlFragment {
         return visitor.visit((AsSettingValue) this);
       }
       return visitor.visitDefault(this);
-    }
-
-    interface Visitor<T> {
-      T visitDefault(@NotNull Value value);
-
-      T visit(@NotNull AsStringListSettingValue asStringListSettingValue);
-
-      T visit(@NotNull AsSettingValue asSettingValue);
     }
 
     final class Mapper implements ResponseFieldMapper<Value> {
@@ -126,6 +118,14 @@ public interface TestSetting extends GraphqlFragment {
         }
         return asSettingValueFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value value);
+
+      T visit(@NotNull AsStringListSettingValue asStringListSettingValue);
+
+      T visit(@NotNull AsSettingValue asSettingValue);
     }
   }
 
@@ -443,14 +443,6 @@ public interface TestSetting extends GraphqlFragment {
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Value1 value1);
-
-      T visit(@NotNull AsStringListSettingValue1 asStringListSettingValue1);
-
-      T visit(@NotNull AsSettingValue1 asSettingValue1);
-    }
-
     final class Mapper implements ResponseFieldMapper<Value1> {
       final AsStringListSettingValue1.Mapper asStringListSettingValue1FieldMapper = new AsStringListSettingValue1.Mapper();
 
@@ -469,6 +461,14 @@ public interface TestSetting extends GraphqlFragment {
         }
         return asSettingValue1FieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value1 value1);
+
+      T visit(@NotNull AsStringListSettingValue1 asStringListSettingValue1);
+
+      T visit(@NotNull AsSettingValue1 asSettingValue1);
     }
   }
 
@@ -868,14 +868,6 @@ public interface TestSetting extends GraphqlFragment {
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Value2 value2);
-
-      T visit(@NotNull AsStringListSettingValue2 asStringListSettingValue2);
-
-      T visit(@NotNull AsSettingValue2 asSettingValue2);
-    }
-
     final class Mapper implements ResponseFieldMapper<Value2> {
       final AsStringListSettingValue2.Mapper asStringListSettingValue2FieldMapper = new AsStringListSettingValue2.Mapper();
 
@@ -894,6 +886,14 @@ public interface TestSetting extends GraphqlFragment {
         }
         return asSettingValue2FieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Value2 value2);
+
+      T visit(@NotNull AsStringListSettingValue2 asStringListSettingValue2);
+
+      T visit(@NotNull AsSettingValue2 asSettingValue2);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -197,16 +197,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Hero hero);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsDroid asDroid);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -236,6 +226,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -186,6 +186,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsDroid) {
+        return visitor.visit((AsDroid) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Hero hero);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
+
     final class Mapper implements ResponseFieldMapper<Hero> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -222,6 +222,31 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsDroid1) {
+        return visitor.visit((AsDroid1) this);
+      } else if (this instanceof AsStarship) {
+        return visitor.visit((AsStarship) this);
+      } else if (this instanceof AsSearchResult) {
+        return visitor.visit((AsSearchResult) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Search search);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid1 asDroid1);
+
+      T visit(@NotNull AsStarship asStarship);
+
+      T visit(@NotNull AsSearchResult asSearchResult);
+    }
+
     final class Mapper implements ResponseFieldMapper<Search> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -418,6 +443,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @NotNull String name();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman1) {
+        return visitor.visit((AsHuman1) this);
+      } else if (this instanceof AsDroid) {
+        return visitor.visit((AsDroid) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend friend);
+
+      T visit(@NotNull AsHuman1 asHuman1);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
 
     final class Mapper implements ResponseFieldMapper<Friend> {
       final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
@@ -1187,6 +1233,27 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     @NotNull String name();
 
     ResponseFieldMarshaller marshaller();
+
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman2) {
+        return visitor.visit((AsHuman2) this);
+      } else if (this instanceof AsDroid2) {
+        return visitor.visit((AsDroid2) this);
+      } else if (this instanceof AsCharacter1) {
+        return visitor.visit((AsCharacter1) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend3 friend3);
+
+      T visit(@NotNull AsHuman2 asHuman2);
+
+      T visit(@NotNull AsDroid2 asDroid2);
+
+      T visit(@NotNull AsCharacter1 asCharacter1);
+    }
 
     final class Mapper implements ResponseFieldMapper<Friend3> {
       final AsHuman2.Mapper asHuman2FieldMapper = new AsHuman2.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -235,18 +235,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Search search);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsDroid1 asDroid1);
-
-      T visit(@NotNull AsStarship asStarship);
-
-      T visit(@NotNull AsSearchResult asSearchResult);
-    }
-
     final class Mapper implements ResponseFieldMapper<Search> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -287,6 +275,18 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asSearchResultFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Search search);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsDroid1 asDroid1);
+
+      T visit(@NotNull AsStarship asStarship);
+
+      T visit(@NotNull AsSearchResult asSearchResult);
     }
   }
 
@@ -455,16 +455,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Friend friend);
-
-      T visit(@NotNull AsHuman1 asHuman1);
-
-      T visit(@NotNull AsDroid asDroid);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<Friend> {
       final AsHuman1.Mapper asHuman1FieldMapper = new AsHuman1.Mapper();
 
@@ -494,6 +484,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend friend);
+
+      T visit(@NotNull AsHuman1 asHuman1);
+
+      T visit(@NotNull AsDroid asDroid);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 
@@ -1245,16 +1245,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull Friend3 friend3);
-
-      T visit(@NotNull AsHuman2 asHuman2);
-
-      T visit(@NotNull AsDroid2 asDroid2);
-
-      T visit(@NotNull AsCharacter1 asCharacter1);
-    }
-
     final class Mapper implements ResponseFieldMapper<Friend3> {
       final AsHuman2.Mapper asHuman2FieldMapper = new AsHuman2.Mapper();
 
@@ -1284,6 +1274,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         }
         return asCharacter1FieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull Friend3 friend3);
+
+      T visit(@NotNull AsHuman2 asHuman2);
+
+      T visit(@NotNull AsDroid2 asDroid2);
+
+      T visit(@NotNull AsCharacter1 asCharacter1);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -228,14 +228,6 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
       return visitor.visitDefault(this);
     }
 
-    interface Visitor<T> {
-      T visitDefault(@NotNull HeroDetailQuery1 heroDetailQuery1);
-
-      T visit(@NotNull AsHuman asHuman);
-
-      T visit(@NotNull AsCharacter asCharacter);
-    }
-
     final class Mapper implements ResponseFieldMapper<HeroDetailQuery1> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 
@@ -254,6 +246,14 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
         }
         return asCharacterFieldMapper.map(reader);
       }
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull HeroDetailQuery1 heroDetailQuery1);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsCharacter asCharacter);
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -219,6 +219,23 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
     ResponseFieldMarshaller marshaller();
 
+    default <T> T visit(Visitor<T> visitor) {
+      if (this instanceof AsHuman) {
+        return visitor.visit((AsHuman) this);
+      } else if (this instanceof AsCharacter) {
+        return visitor.visit((AsCharacter) this);
+      }
+      return visitor.visitDefault(this);
+    }
+
+    interface Visitor<T> {
+      T visitDefault(@NotNull HeroDetailQuery1 heroDetailQuery1);
+
+      T visit(@NotNull AsHuman asHuman);
+
+      T visit(@NotNull AsCharacter asCharacter);
+    }
+
     final class Mapper implements ResponseFieldMapper<HeroDetailQuery1> {
       final AsHuman.Mapper asHumanFieldMapper = new AsHuman.Mapper();
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -130,6 +130,10 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
               it.name == "custom_scalar_type_warnings" -> true
               else -> false
             }
+            val generateVisitorForPolymorphicDatatypes = when {
+              it.name == "java_beans_semantic_naming" -> false
+              else -> true
+            }
             val args = GraphQLCompiler.Arguments(
                 irFile = File(it, "TestOperation.json"),
                 outputDir = GraphQLCompiler.OUTPUT_DIRECTORY.plus("sources").fold(File("build"), ::File),
@@ -139,7 +143,8 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
                 generateModelBuilder = generateModelBuilder,
                 useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
                 suppressRawTypesWarning = suppressRawTypesWarning,
-                outputPackageName = null
+                outputPackageName = null,
+                generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes
             )
             arrayOf(it.name, args)
           }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -20,7 +20,8 @@ class JavaTypeResolverTest {
       useSemanticNaming = false,
       generateModelBuilder = false,
       useJavaBeansSemanticNaming = false,
-      suppressRawTypesWarning = false
+      suppressRawTypesWarning = false,
+      generateVisitorForPolymorphicDatatypes = false
   )
   private val defaultResolver = JavaTypeResolver(defaultContext, packageName)
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/VisitorSpecTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/VisitorSpecTest.kt
@@ -1,0 +1,55 @@
+package com.apollographql.apollo.compiler
+
+import com.squareup.javapoet.ClassName
+import org.junit.Assert
+import org.junit.Test
+
+class VisitorSpecTest {
+
+  private val schemaType = ClassName.get("", "Hero")
+  private val implementations = listOf(
+    ClassName.get("", "AsHuman"),
+    ClassName.get("", "AsDroid"),
+    ClassName.get("", "AsCharacter")
+  )
+
+  @Test
+  fun createVisitorInterface() {
+    val expected = """
+      public interface Visitor<T> {
+        T visitDefault(@org.jetbrains.annotations.NotNull Hero hero);
+      
+        T visit(@org.jetbrains.annotations.NotNull AsHuman asHuman);
+      
+        T visit(@org.jetbrains.annotations.NotNull AsDroid asDroid);
+      
+        T visit(@org.jetbrains.annotations.NotNull AsCharacter asCharacter);
+      }
+      
+    """.trimIndent()
+    val actual = VisitorInterfaceSpec(schemaType, implementations).createVisitorInterface().toString()
+
+    Assert.assertEquals(expected, actual)
+  }
+
+  @Test
+  fun createVisitorMethod() {
+    val expected = """
+      public default <T> T visit(Visitor<T> visitor) {
+        if (this instanceof AsHuman) {
+          return visitor.visit((AsHuman) this);
+        } else if (this instanceof AsDroid) {
+          return visitor.visit((AsDroid) this);
+        } else if (this instanceof AsCharacter) {
+          return visitor.visit((AsCharacter) this);
+        }
+        return visitor.visitDefault(this);
+      }
+
+    """.trimIndent()
+    val actual = VisitorMethodSpec(implementations).createVisitorMethod().toString()
+
+    Assert.assertEquals(expected, actual)
+  }
+
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -22,6 +22,7 @@ class ApolloClassGenerationTask extends SourceTask {
   @Input final Property<Boolean> useJavaBeansSemanticNaming = project.objects.property(Boolean.class)
   @Input final Property<Boolean> suppressRawTypesWarning = project.objects.property(Boolean.class)
   @Input final Property<Boolean> generateKotlinModels = project.objects.property(Boolean.class)
+  @Input final Property<Boolean> generateVisitorForPolymorphicDatatypes = project.objects.property(Boolean.class)
   @Optional @Input final Property<String> outputPackageName = project.objects.property(String.class)
   @OutputDirectory final DirectoryProperty outputDir = project.layout.directoryProperty()
 
@@ -54,7 +55,7 @@ class ApolloClassGenerationTask extends SourceTask {
             inputFile, outputDir.get().asFile, customTypeMapping.get(),
             nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
             generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
-            suppressRawTypesWarning.get(), generateKotlinModels.get()
+            suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()
         )
         new GraphQLCompiler().write(args)
       }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
@@ -13,6 +13,7 @@ class ApolloExtension {
   final Property<Boolean> useJavaBeansSemanticNaming
   final Property<Boolean> suppressRawTypesWarning
   final Property<Boolean> generateKotlinModels
+  final Property<Boolean> generateVisitorForPolymorphicDatatypes
   final Property<String> schemaFilePath
   final Property<String> outputPackageName
   final Property<Map> customTypeMapping
@@ -35,6 +36,9 @@ class ApolloExtension {
 
     generateKotlinModels = project.objects.property(Boolean.class)
     generateKotlinModels.set(false)
+
+    generateVisitorForPolymorphicDatatypes = project.objects.property(Boolean.class)
+    generateVisitorForPolymorphicDatatypes.set(false)
 
     schemaFilePath = project.objects.property(String.class)
     schemaFilePath.set("")
@@ -68,6 +72,10 @@ class ApolloExtension {
 
   void setGenerateKotlinModels(Boolean generateKotlinModels) {
     this.generateKotlinModels.set(generateKotlinModels)
+  }
+
+  void setGenerateVisitorForPolymorphicDatatypes(Boolean generateVisitorForPolymorphicDatatypes) {
+    this.generateKotlinModels.set(generateVisitorForPolymorphicDatatypes)
   }
 
   void setSchemaFilePath(String schemaFilePath) {

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -192,6 +192,7 @@ class ApolloPlugin implements Plugin<Project> {
       outputPackageName = project.apollo.outputPackageName
       suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
       generateKotlinModels = project.apollo.generateKotlinModels
+      generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
     }
   }
 

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/basic.gradle
@@ -37,6 +37,11 @@ android {
       }
     }
   }
+  
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/flavored.gradle
@@ -49,6 +49,11 @@ android {
       }
     }
   }
+  
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {

--- a/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
+++ b/apollo-gradle-plugin/src/test/testProject/android/buildScriptFixtures/libraryProject.gradle
@@ -36,6 +36,11 @@ android {
       }
     }
   }
+  
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -37,6 +37,11 @@ android {
   packagingOptions {
     exclude 'META-INF/rxjava.properties'
   }
+  
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 dependencies {


### PR DESCRIPTION
[Related issue for context](https://github.com/apollographql/apollo-android/issues/1413)

Add visitors for easier and compile-time safe consumption of polymorphic data types in the schema.