### PR TITLE
Allow a noverify option for apollo codegen

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -220,7 +220,15 @@ class ApolloPlugin implements Plugin<Project> {
         System.properties['apollographql.useGlobalApolloCodegen'].toBoolean()
   }
 
+  private static boolean noVerifyApolloCodegenEnabled() {
+    return (System.properties['apollographql.useGlobalApolloCodegen.noVerify'] != null) &&
+        System.properties['apollographql.useGlobalApolloCodegen.noVerify'].toBoolean()
+  }
+
   private static boolean verifySystemApolloCodegenVersion() {
+    if (noVerifyApolloCodegenEnabled()) {
+      return
+    }
     println("Verifying system 'apollo-codegen' version (executing command 'apollo-codegen --version') ...")
     try {
       StringBuilder output = new StringBuilder()


### PR DESCRIPTION
This command gets run on every plugin configuration unnecessarily, and I think it's reasonable to add a noverify option for "I know what I'm doing" cases. Can add an info log statement if desired.

This adds a `apollographql.useGlobalApolloCodegen.noVerify` option to skip this