### PR TITLE
Fix: Speed up build configuration time

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -26,7 +26,7 @@ class ApolloPlugin implements Plugin<Project> {
 
   private Project project
   private final FileResolver fileResolver
-  private boolean useGlobalApolloCodegen
+  private boolean useGlobalApolloCodegen = System.properties['apollographql.useGlobalApolloCodegen']?.toBoolean()
 
   @Inject
   ApolloPlugin(FileResolver fileResolver) {
@@ -48,9 +48,7 @@ class ApolloPlugin implements Plugin<Project> {
   }
 
   private void applyApolloPlugin() {
-    if (isUseGlobalApolloCodegenEnabled() && verifySystemApolloCodegenVersion()) {
-      useGlobalApolloCodegen = true
-    } else {
+    if (!useGlobalApolloCodegen) {
       setupNode()
     }
 
@@ -213,34 +211,5 @@ class ApolloPlugin implements Plugin<Project> {
   private DomainObjectCollection<BaseVariant> getVariants() {
     return project.android.hasProperty(
         'libraryVariants') ? project.android.libraryVariants : project.android.applicationVariants
-  }
-
-  private static boolean isUseGlobalApolloCodegenEnabled() {
-    return (System.properties['apollographql.useGlobalApolloCodegen'] != null) &&
-        System.properties['apollographql.useGlobalApolloCodegen'].toBoolean()
-  }
-
-  private static boolean verifySystemApolloCodegenVersion() {
-    println("Verifying system 'apollo-codegen' version (executing command 'apollo-codegen --version') ...")
-    try {
-      StringBuilder output = new StringBuilder()
-      Process checkGlobalApolloCodegen = "apollo-codegen --version".execute()
-      checkGlobalApolloCodegen.consumeProcessOutput(output, null)
-      checkGlobalApolloCodegen.waitForOrKill(5000)
-
-      if (output.toString().trim() == GraphQLCompiler.APOLLOCODEGEN_VERSION) {
-        println("Found required 'apollo-codegen@" + GraphQLCompiler.APOLLOCODEGEN_VERSION + "' version.")
-        println("Skip apollo-codegen installation.")
-        return true
-      } else {
-        println("Required 'apollo-codegen@" + GraphQLCompiler.APOLLOCODEGEN_VERSION + "' version not found.")
-        println("Installing apollo-codegen ... ")
-        return false
-      }
-    } catch (Exception e) {
-      println("Failed to verify system 'apollo-codegen' version: " + e)
-      println("Installing apollo-codegen ... ")
-      return false
-    }
   }
 }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloSystemCodegenGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloSystemCodegenGenerationTask.groovy
@@ -2,6 +2,7 @@ package com.apollographql.apollo.gradle
 
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.AbstractExecTask
 import org.gradle.api.tasks.Input
@@ -20,7 +21,7 @@ class ApolloSystemCodegenGenerationTask extends AbstractExecTask<ApolloSystemCod
   ApolloSystemCodegenGenerationTask() {
     super(ApolloSystemCodegenGenerationTask.class)
     doFirst {
-      verifySystemApolloCodegenVersion()
+      verifySystemApolloCodegenVersion(logger)
     }
   }
 
@@ -38,8 +39,8 @@ class ApolloSystemCodegenGenerationTask extends AbstractExecTask<ApolloSystemCod
     }
   }
 
-  private static verifySystemApolloCodegenVersion() {
-    println("Verifying system 'apollo-codegen' version (executing command 'apollo-codegen --version') ...")
+  private static verifySystemApolloCodegenVersion(Logger logger) {
+    logger.info("Verifying system 'apollo-codegen' version (executing command 'apollo-codegen --version') ...")
     try {
       StringBuilder output = new StringBuilder()
       Process checkGlobalApolloCodegen = "apollo-codegen --version".execute()
@@ -48,8 +49,8 @@ class ApolloSystemCodegenGenerationTask extends AbstractExecTask<ApolloSystemCod
 
       def version = output.toString().trim()
       if (version == APOLLOCODEGEN_VERSION) {
-        println("Found required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version.")
-        println("Skip apollo-codegen installation.")
+        logger.info("Found required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version.")
+        logger.info("Skip apollo-codegen installation.")
       } else {
         throw new GradleException("Required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version but found: $version. Consider disabling `apollographql.useGlobalApolloCodegen` property.")
       }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloSystemCodegenGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloSystemCodegenGenerationTask.groovy
@@ -20,13 +20,11 @@ class ApolloSystemCodegenGenerationTask extends AbstractExecTask<ApolloSystemCod
 
   ApolloSystemCodegenGenerationTask() {
     super(ApolloSystemCodegenGenerationTask.class)
-    doFirst {
-      verifySystemApolloCodegenVersion(logger)
-    }
   }
 
   @Override
   void exec() {
+    verifySystemApolloCodegenVersion(logger)
     setCommandLine("apollo-codegen")
 
     List<CodegenGenerationTaskCommandArgsBuilder.CommandArgs> args = new CodegenGenerationTaskCommandArgsBuilder(
@@ -52,10 +50,10 @@ class ApolloSystemCodegenGenerationTask extends AbstractExecTask<ApolloSystemCod
         logger.info("Found required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version.")
         logger.info("Skip apollo-codegen installation.")
       } else {
-        throw new GradleException("Required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version but found: $version. Consider disabling `apollographql.useGlobalApolloCodegen` property.")
+        throw new GradleException("Required 'apollo-codegen@$APOLLOCODEGEN_VERSION' version but found: $version. Consider disabling `apollographql.useGlobalApolloCodegen` in gradle.properties file.")
       }
     } catch (Exception exception) {
-      throw new GradleException("Failed to verify system 'apollo-codegen' version. Consider disabling `apollographql.useGlobalApolloCodegen` property.", exception)
+      throw new GradleException("Failed to verify system 'apollo-codegen' version. Consider disabling `apollographql.useGlobalApolloCodegen` in gradle.properties file.", exception)
     }
   }
 }


### PR DESCRIPTION
### Problem

When `useGlobalApolloCodegen` is used, installation is verified in every Gradle run causing slower builds. More info #1203 
This PR speeds up build configuration time by lazily verifying apollo-codegen installation.

### Considerations

Move Apollo global verification to the beginning of the task to speed up configuration process.

This I/O operation (version check) currently runs in configuration time and take up to 5sec. This runs in every Gradle execution (even when unrelated to Apollo)

This commit fixes #1203 and moves verification to a later stage.

This means that we cannot easily fall-back to local installation that easily. That's why an exception is thrown with an appropriate message. User should disable using this feature if they don't have global installation.

### Screenshot

![Screen Shot 2019-07-24 at 00 41 40](https://user-images.githubusercontent.com/763339/61752499-2946d980-adac-11e9-8e3d-560b1ed289c7.png)
