### PR TITLE
Make androidPlugin dependency optional

### DIFF
--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   fixtureClasspath dep.androidPlugin
 }
 
+// Inspired by: https://github.com/square/sqldelight/blob/83145b28cbdd949e98e87819299638074bd21147/sqldelight-gradle-plugin/build.gradle#L18
 // Append any extra dependencies to the test fixtures via a custom configuration classpath. This
 // allows us to apply additional plugins in a fixture while still leveraging dependency resolution
 // and de-duplication semantics.

--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   implementation dep.gradleNodePlugin
   implementation dep.moshi
 
+  testImplementation dep.androidPlugin
   testImplementation dep.junit
   testImplementation(dep.spock) {
     exclude module: 'groovy-all'

--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -7,11 +7,11 @@ sourceSets.main.groovy.srcDirs = ["src/main/java", "src/main/groovy"]
 
 dependencies {
   compileOnly gradleApi()
+  compileOnly dep.androidPlugin
 
   implementation localGroovy()
   implementation project(':apollo-compiler')
   implementation dep.gradleNodePlugin
-  implementation dep.androidPlugin
   implementation dep.moshi
 
   testImplementation dep.junit


### PR DESCRIPTION
The plugin works fine and quite well actually with kotlin or java only projects without Android. So having android plugin as dependency should not be mandatory. Non-android projects need to download the Android plugin and its all transitive dependencies which is quite big.

Having `compileOnly` should make this possible.