### PR TITLE
Relax GraphQL keywords

### DIFF
--- a/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphQL.g4
+++ b/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphQL.g4
@@ -36,7 +36,7 @@ definition
    ;
 
 operationDefinition
-   : selectionSet | operationType NAME variableDefinitions? directives? selectionSet
+   : operationType NAME variableDefinitions? directives? selectionSet
    ;
 
 selectionSet
@@ -44,7 +44,7 @@ selectionSet
    ;
 
 operationType
-   : 'query' | 'mutation' | 'subscription'
+   : NAME
    ;
 
 selection
@@ -80,7 +80,11 @@ inlineFragment
    ;
 
 fragmentDefinition
-   : 'fragment' fragmentName 'on' typeCondition directives? selectionSet
+   : fragmentKeyword fragmentName 'on' typeCondition directives? selectionSet
+   ;
+
+fragmentKeyword
+   : NAME
    ;
 
 fragmentName


### PR DESCRIPTION
Make `query`, `mutation`, `subscription` and `fragment` as soft keywords rather than hard.