### PR TITLE
Fix various Kotlin warnings in the apollo-compiler

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/BuilderTypeSpecBuilder.kt
@@ -190,12 +190,13 @@ class BuilderTypeSpecBuilder(
         .returns(targetObjectClassName)
         .addCode(validationCodeBuilder.build())
         .addStatement("return new \$T\$L", targetObjectClassName,
-            fields.map { it.first }.joinToString(prefix = "(", separator = ", ", postfix = ")"))
+            fields.joinToString(prefix = "(", separator = ", ", postfix = ")") { it.first }
+        )
         .build()
   }
 
   companion object {
-    val TO_BUILDER_METHOD_NAME = "toBuilder"
+    const val TO_BUILDER_METHOD_NAME = "toBuilder"
 
     private fun mutatorParam(fieldType: TypeName): ParameterSpec {
       val fieldBuilderType = if (fieldType.isList()) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
@@ -39,7 +39,7 @@ class CustomEnumTypeSpecBuilder(
               .addModifiers(Modifier.PUBLIC)
               .apply {
                 if (context.suppressRawTypesWarning) {
-                  this.addAnnotation(com.apollographql.apollo.compiler.Annotations.SUPPRESS_RAW_VALUE_WARNING)
+                  addAnnotation(Annotations.SUPPRESS_RAW_VALUE_WARNING)
                 }
               }
               .addAnnotation(Override::class.java)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
@@ -8,7 +8,7 @@ import com.squareup.javapoet.*
 import javax.lang.model.element.Modifier
 
 /**
- * Responsible for [Fragments.Mapper] class generation
+ * Responsible for Fragments.Mapper class generation
  *
  * Example of generated class:
  *

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
@@ -26,7 +26,7 @@ fun String.singularize(): String {
 
   if (exclude.contains(this.toLowerCase())) return this
 
-  val irregular = irregular().firstOrNull() { this.toLowerCase() == it.component2() }
+  val irregular = irregular().firstOrNull { this.toLowerCase() == it.component2() }
   if (irregular != null) return irregular.component1()
 
   if (singularizationRules().find { match(it.component1(), this) } == null) return this

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputFieldSpec.kt
@@ -114,16 +114,20 @@ class InputFieldSpec(
     fun writeScalar(): CodeBlock {
       val writeMethod = SCALAR_LIST_ITEM_WRITE_METHODS[itemType] ?: "writeString"
       return if (itemType.isEnum(context)) {
-        CodeBlock.of("\$L.\$L(\$L != null ? \$L.rawValue() : null);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam,
-            itemParam)
+        CodeBlock.of(
+            "\$L.\$L(\$L != null ? \$L.rawValue() : null);\n",
+            LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam, itemParam
+        )
       } else {
         CodeBlock.of("\$L.\$L(\$L);\n", LIST_ITEM_WRITER_PARAM.name, writeMethod, itemParam)
       }
     }
 
     fun writeObject(): CodeBlock {
-      return CodeBlock.of("\$L.writeObject(\$L != null ? \$L.\$L : null);\n", LIST_ITEM_WRITER_PARAM.name, itemParam,
-          itemParam, marshaller);
+      return CodeBlock.of(
+          "\$L.writeObject(\$L != null ? \$L.\$L : null);\n",
+          LIST_ITEM_WRITER_PARAM.name, itemParam, itemParam, marshaller
+      )
     }
 
     return when {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -20,7 +20,7 @@ class ResponseFieldSpec(
     val context: CodeGenerationContext
 ) {
   fun factoryCode(): CodeBlock {
-    val factoryMethod = FACTORY_METHODS[responseFieldType]!!
+    val factoryMethod = FACTORY_METHODS[responseFieldType] ?: error("Unrecognized responseFieldType: $responseFieldType")
     return when (responseFieldType) {
       ResponseField.Type.CUSTOM -> customTypeFactoryCode(irField, factoryMethod)
       ResponseField.Type.INLINE_FRAGMENT, ResponseField.Type.FRAGMENT ->
@@ -171,15 +171,15 @@ class ResponseFieldSpec(
     }
 
     fun readList(): CodeBlock {
-      val rawFieldType = rawFieldType.listParamType()
-      val readItemCode = readListItemStatement(rawFieldType)
+      val listItemType = rawFieldType.listParamType()
+      val readItemCode = readListItemStatement(listItemType)
       val listItemReaderTypeSpec = TypeSpec.anonymousClassBuilder("")
-          .superclass(responseFieldListItemReaderType(rawFieldType))
+          .superclass(responseFieldListItemReaderType(listItemType))
           .addMethod(MethodSpec
               .methodBuilder("read")
               .addModifiers(Modifier.PUBLIC)
               .addAnnotation(Override::class.java)
-              .returns(rawFieldType)
+              .returns(listItemType)
               .addParameter(RESPONSE_LIST_ITEM_READER_PARAM)
               .addCode(readItemCode)
               .build())

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -445,7 +445,7 @@ class SchemaTypeSpecBuilder(
           fieldSpec = fieldSpec,
           normalizedFieldSpec = normalizedFieldSpec,
           responseFieldType = ResponseField.Type.INLINE_FRAGMENT,
-          typeConditions = if (inlineFragment.possibleTypes != null && !inlineFragment.possibleTypes.isEmpty())
+          typeConditions = if (inlineFragment.possibleTypes != null && inlineFragment.possibleTypes.isNotEmpty())
             inlineFragment.possibleTypes
           else
             listOf(inlineFragment.typeCondition),

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
@@ -20,7 +20,7 @@ internal fun CodeGenerationIR.ast(
         typesPackageName = typesPackageName
     )
   }
-  val irFragments = fragments.associate { it.fragmentName to it }
+  val irFragments = fragments.associateBy { it.fragmentName }
   val fragments = fragments.map {
     it.ast(
         Context(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -78,15 +78,17 @@ data class Field(
         .map { (name, value, type) ->
           when (value) {
             is Number -> {
-              val scalarType = ScalarType.forName(type.removeSuffix("!"))
-              when (scalarType) {
+              when (ScalarType.forName(type.removeSuffix("!"))) {
                 is ScalarType.INT -> CodeBlock.of(".put(\$S, \$L)\n", name, value.toInt())
                 is ScalarType.FLOAT -> CodeBlock.of(".put(\$S, \$Lf)\n", name, value.toDouble())
                 else -> CodeBlock.of(".put(\$S, \$L)\n", name, value)
               }
             }
             is Boolean -> CodeBlock.of(".put(\$S, \$L)\n", name, value)
-            is Map<*, *> -> CodeBlock.of(".put(\$S, \$L)\n", name, jsonMapToCodeBlock(value as Map<String, Any?>))
+            is Map<*, *> -> {
+              @Suppress("UNCHECKED_CAST")
+              CodeBlock.of(".put(\$S, \$L)\n", name, jsonMapToCodeBlock(value as Map<String, Any?>))
+            }
             else -> CodeBlock.of(".put(\$S, \$S)\n", name, value)
           }
         }
@@ -111,6 +113,7 @@ data class Field(
     return map
         .map { (key, value) ->
           if (value is Map<*, *>) {
+            @Suppress("UNCHECKED_CAST")
             CodeBlock.of(".put(\$S, \$L)\n", key, jsonMapToCodeBlock(value as Map<String, Any?>))
           } else {
             CodeBlock.of(".put(\$S, \$S)\n", key, value)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -68,10 +68,10 @@ data class Fragment(
           .build())
 
   private fun possibleTypesInitCode(): CodeBlock {
-    val builder = CodeBlock.builder().add("\$T.unmodifiableList(\$T.asList(", Collections::class.java,
+    val initialBuilder = CodeBlock.builder().add("\$T.unmodifiableList(\$T.asList(", Collections::class.java,
         Arrays::class.java)
     return possibleTypes.foldIndexed(
-        builder,
+        initialBuilder,
         { i, builder, type ->
           if (i > 0) {
             builder.add(",")
@@ -82,7 +82,7 @@ data class Fragment(
   }
 
   companion object {
-    val FRAGMENT_DEFINITION_FIELD_NAME: String = "FRAGMENT_DEFINITION"
-    val POSSIBLE_TYPES_VAR: String = "POSSIBLE_TYPES"
+    const val FRAGMENT_DEFINITION_FIELD_NAME: String = "FRAGMENT_DEFINITION"
+    const val POSSIBLE_TYPES_VAR: String = "POSSIBLE_TYPES"
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/ScalarType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/ScalarType.kt
@@ -9,10 +9,10 @@ sealed class ScalarType(val name: String) {
 
   companion object {
     fun forName(name: String): ScalarType? = when (name) {
-      ScalarType.STRING.name -> ScalarType.STRING
-      ScalarType.INT.name -> ScalarType.INT
-      ScalarType.BOOLEAN.name -> ScalarType.BOOLEAN
-      ScalarType.FLOAT.name -> ScalarType.FLOAT
+      STRING.name -> STRING
+      INT.name -> INT
+      BOOLEAN.name -> BOOLEAN
+      FLOAT.name -> FLOAT
       else -> null
     }
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -14,14 +14,10 @@ data class TypeDeclaration(
     val values: List<TypeDeclarationValue>?,
     val fields: List<TypeDeclarationField>?
 ) : CodeGenerator {
-  override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec {
-    if (kind == KIND_ENUM) {
-      return enumTypeToTypeSpec()
-    } else if (kind == KIND_INPUT_OBJECT_TYPE) {
-      return inputObjectToTypeSpec(context)
-    } else {
-      throw UnsupportedOperationException("unsupported $kind type declaration")
-    }
+  override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec = when (kind) {
+    KIND_ENUM -> enumTypeToTypeSpec()
+    KIND_INPUT_OBJECT_TYPE -> inputObjectToTypeSpec(context)
+    else -> throw UnsupportedOperationException("unsupported $kind type declaration")
   }
 
   private fun enumTypeToTypeSpec(): TypeSpec {


### PR DESCRIPTION
Fix various Kotlin warnings in the apollo-compiler. They're all minor warnings. Details will be explained with inline comments.