### PR TITLE
Fix ClassNotFoundException problem after #1470

### DIFF
--- a/apollo-gradle-plugin/build.gradle
+++ b/apollo-gradle-plugin/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
   implementation localGroovy()
   implementation project(':apollo-compiler')
+  implementation dep.guavaJre
   implementation dep.gradleNodePlugin
   implementation dep.moshi
 

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -1,29 +1,20 @@
 package com.apollographql.apollo.gradle
 
-import com.android.build.gradle.api.BaseVariant
-import com.apollographql.apollo.compiler.GraphQLCompiler
-import com.google.common.base.Joiner
-import com.google.common.collect.ImmutableList
+import com.apollographql.apollo.gradle.android.AndroidTaskConfiguratorFactory
+import com.apollographql.apollo.gradle.jvm.JvmTaskConfiguratorFactory
 import com.moowork.gradle.node.NodeExtension
 import com.moowork.gradle.node.NodePlugin
-import org.gradle.api.DomainObjectCollection
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.internal.file.FileResolver
-import org.gradle.api.tasks.SourceSet
-import org.gradle.api.tasks.compile.AbstractCompile
-import org.gradle.api.tasks.compile.JavaCompile
 
 import javax.inject.Inject
 
 class ApolloPlugin implements Plugin<Project> {
   private static final String NODE_VERSION = "6.7.0"
   public static final String TASK_GROUP = "apollo"
-  public static final String APOLLO_CODEGEN_GENERATE_TASK_NAME = "generate%sApolloIR"
 
   private Project project
   private final FileResolver fileResolver
@@ -73,94 +64,9 @@ class ApolloPlugin implements Plugin<Project> {
     apolloClassGenTask.group = TASK_GROUP
 
     if (isAndroidProject()) {
-      getVariants().all { BaseVariant variant ->
-        addVariantTasks(variant, apolloIRGenTask, apolloClassGenTask, variant.sourceSets)
-      }
-      project.android.testVariants.each { BaseVariant tv ->
-        addVariantTasks(tv, apolloIRGenTask, apolloClassGenTask, tv.sourceSets)
-      }
+      AndroidTaskConfiguratorFactory.create(project).configureTasks(apolloIRGenTask, apolloClassGenTask)
     } else {
-      getSourceSets().all { SourceSet sourceSet ->
-        addSourceSetTasks(sourceSet, apolloIRGenTask, apolloClassGenTask)
-      }
-    }
-  }
-
-  private void addVariantTasks(BaseVariant variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection sourceSets) {
-    if (useExperimentalCodegen) {
-      ApolloExperimentalCodegenTask codegenTask = createExperimentalCodegenTask(variant.name, variant.sourceSets)
-      variant.registerJavaGeneratingTask(codegenTask, codegenTask.outputDir.asFile.get())
-      apolloClassGenTask.dependsOn(codegenTask)
-    } else {
-      AbstractTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
-      ApolloClassGenerationTask variantClassTask = createApolloClassGenTask(variant.name)
-      variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir.asFile.get())
-      apolloIRGenTask.dependsOn(variantIRTask)
-      apolloClassGenTask.dependsOn(variantClassTask)
-    }
-  }
-
-  private void addSourceSetTasks(SourceSet sourceSet, Task apolloIRGenTask, Task apolloClassGenTask) {
-    String taskName = "main".equals(sourceSet.name) ? "" : sourceSet.name
-
-    DirectoryProperty outputDir;
-    if (useExperimentalCodegen) {
-      ApolloExperimentalCodegenTask codegenTask = createExperimentalCodegenTask(sourceSet.name, [sourceSet])
-      apolloClassGenTask.dependsOn(codegenTask)
-      outputDir = codegenTask.outputDir
-    } else {
-      AbstractTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
-      ApolloClassGenerationTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name)
-      apolloIRGenTask.dependsOn(sourceSetIRTask)
-      apolloClassGenTask.dependsOn(sourceSetClassTask)
-      outputDir = sourceSetClassTask.outputDir
-    }
-
-    // we use afterEvaluate here as we need to know the value of generateKotlinModels from addSourceSetTasks
-    // TODO we should avoid afterEvaluate usage
-    project.afterEvaluate {
-      if (project.apollo.generateKotlinModels.get() != true) {
-        JavaCompile compileTask = (JavaCompile) project.tasks.findByName("compile${taskName.capitalize()}Java")
-        compileTask.source += project.fileTree(outputDir)
-        compileTask.dependsOn(apolloClassGenTask)
-      }
-    }
-
-    sourceSet.java.srcDir(outputDir)
-
-    AbstractCompile compileKotlinTask = (AbstractCompile) project.tasks.findByName(
-        "compile${taskName.capitalize()}Kotlin")
-    if (compileKotlinTask != null) {
-      // kotlinc uses the generated java classes as input too so we need the generated classes
-      compileKotlinTask.dependsOn(apolloClassGenTask)
-      // this is somewhat redundant with sourceSet.java.srcDir above but I believe by the time we come here the java plugin
-      // has been configured already so we need to manually tell kotlinc where to find the generated classes
-      compileKotlinTask.source(outputDir)
-    }
-  }
-
-  private ApolloExperimentalCodegenTask createExperimentalCodegenTask(String sourceSetOrVariantName, Collection sourceSets) {
-    File outputFolder = new File(project.buildDir, Joiner.on(File.separator).join(GraphQLCompiler.OUTPUT_DIRECTORY + sourceSetOrVariantName))
-    String taskName = String.format(ApolloExperimentalCodegenTask.NAME, sourceSetOrVariantName.capitalize())
-    return project.tasks.create(taskName, ApolloExperimentalCodegenTask) {
-      source(sourceSets.collect { it.graphql })
-      excludeFiles = project.apollo.sourceSet.exclude
-      group = TASK_GROUP
-      description = "Generate Android classes for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
-      schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
-          project.apollo.sourceSet.schemaFile
-      outputPackageName = project.apollo.outputPackageName
-      variant = sourceSetOrVariantName
-      sourceSetNames = sourceSets.collect { it.name }
-      outputDir.set(outputFolder)
-      customTypeMapping = project.apollo.customTypeMapping
-      nullableValueType = project.apollo.nullableValueType
-      useSemanticNaming = project.apollo.useSemanticNaming
-      generateModelBuilder = project.apollo.generateModelBuilder
-      useJavaBeansSemanticNaming = project.apollo.useJavaBeansSemanticNaming
-      suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
-      generateKotlinModels = project.apollo.generateKotlinModels
-      generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
+      JvmTaskConfiguratorFactory.create(project).configureTasks(apolloIRGenTask, apolloClassGenTask)
     }
   }
 
@@ -169,70 +75,6 @@ class ApolloPlugin implements Plugin<Project> {
     NodeExtension nodeConfig = project.extensions.findByName("node") as NodeExtension
     nodeConfig.download = true
     nodeConfig.version = NODE_VERSION
-  }
-
-  private AbstractTask createApolloIRGenTask(String sourceSetOrVariantName, Collection sourceSets) {
-    ImmutableList.Builder<String> sourceSetNamesList = ImmutableList.builder()
-    sourceSets.each { sourceSet ->
-      sourceSetNamesList.add(sourceSet.name)
-    }
-
-    File outputFolder = new File(project.buildDir, Joiner.on(File.separator)
-        .join(GraphQLCompiler.IR_OUTPUT_DIRECTORY + sourceSetOrVariantName))
-
-    String taskName = String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, sourceSetOrVariantName.capitalize())
-    if (useGlobalApolloCodegen) {
-      return project.tasks.create(taskName, ApolloSystemCodegenGenerationTask) {
-        sourceSets.each { sourceSet ->
-          sourceSet.graphql.exclude(project.apollo.sourceSet.exclude.get())
-          inputs.files(sourceSet.graphql).skipWhenEmpty()
-        }
-        group = TASK_GROUP
-        description = "Generate an IR file using apollo-codegen for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
-        schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
-            project.apollo.sourceSet.schemaFile
-        outputPackageName = project.apollo.outputPackageName
-        variant = sourceSetOrVariantName
-        sourceSetNames = sourceSetNamesList.build()
-        outputDir.set(outputFolder)
-      }
-    } else {
-      return project.tasks.create(taskName, ApolloLocalCodegenGenerationTask) {
-        sourceSets.each { sourceSet ->
-          sourceSet.graphql.exclude(project.apollo.sourceSet.exclude.get())
-          inputs.files(sourceSet.graphql).skipWhenEmpty()
-        }
-        group = TASK_GROUP
-        description = "Generate an IR file using apollo-codegen for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
-        dependsOn(ApolloCodegenInstallTask.NAME)
-        schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
-            project.apollo.sourceSet.schemaFile
-        outputPackageName = project.apollo.outputPackageName
-        variant = sourceSetOrVariantName
-        sourceSetNames = sourceSetNamesList.build()
-        outputDir.set(outputFolder)
-      }
-    }
-  }
-
-  private ApolloClassGenerationTask createApolloClassGenTask(String name) {
-    String taskName = String.format(ApolloClassGenerationTask.NAME, name.capitalize())
-    return project.tasks.create(taskName, ApolloClassGenerationTask) {
-      group = TASK_GROUP
-      description = "Generate Android classes for ${name.capitalize()} GraphQL queries"
-      dependsOn(getProject().getTasks().findByName(String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, name.capitalize())))
-      source = project.tasks.findByName(String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, name.capitalize())).outputDir
-      include "**${File.separatorChar}*API.json"
-      customTypeMapping = project.apollo.customTypeMapping
-      nullableValueType = project.apollo.nullableValueType
-      useSemanticNaming = project.apollo.useSemanticNaming
-      generateModelBuilder = project.apollo.generateModelBuilder
-      useJavaBeansSemanticNaming = project.apollo.useJavaBeansSemanticNaming
-      outputPackageName = project.apollo.outputPackageName
-      suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
-      generateKotlinModels = project.apollo.generateKotlinModels
-      generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
-    }
   }
 
   private void createSourceSetExtensions() {
@@ -251,10 +93,5 @@ class ApolloPlugin implements Plugin<Project> {
 
   private Object getSourceSets() {
     return (isAndroidProject() ? project.android.sourceSets : project.sourceSets)
-  }
-
-  private DomainObjectCollection<BaseVariant> getVariants() {
-    return project.android.hasProperty(
-        'libraryVariants') ? project.android.libraryVariants : project.android.applicationVariants
   }
 }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -1,0 +1,107 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.GraphQLCompiler
+import com.google.common.base.Joiner
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.internal.AbstractTask
+
+abstract class TaskConfigurator {
+    public static final String APOLLO_CODEGEN_GENERATE_TASK_NAME = "generate%sApolloIR"
+
+    final boolean useGlobalApolloCodegen = System.properties['apollographql.useGlobalApolloCodegen']?.toBoolean()
+    final boolean useExperimentalCodegen = System.properties['apollographql.useExperimentalCodegen']?.toBoolean()
+    protected final Project project
+
+    TaskConfigurator(Project project) {
+        this.project = project
+    }
+
+    abstract void configureTasks(Task apolloIRGenTask, Task apolloClassGenTask)
+
+    protected final ApolloExperimentalCodegenTask createExperimentalCodegenTask(String sourceSetOrVariantName, Collection sourceSets) {
+        File outputFolder = new File(project.buildDir, Joiner.on(File.separator).join(GraphQLCompiler.OUTPUT_DIRECTORY + sourceSetOrVariantName))
+        String taskName = String.format(ApolloExperimentalCodegenTask.NAME, sourceSetOrVariantName.capitalize())
+        return project.tasks.create(taskName, ApolloExperimentalCodegenTask) {
+            source(sourceSets.collect { it.graphql })
+            excludeFiles = project.apollo.sourceSet.exclude
+            group = ApolloPlugin.TASK_GROUP
+            description = "Generate Android classes for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
+            schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
+                    project.apollo.sourceSet.schemaFile
+            outputPackageName = project.apollo.outputPackageName
+            variant = sourceSetOrVariantName
+            sourceSetNames = sourceSets.collect { it.name }
+            outputDir.set(outputFolder)
+            customTypeMapping = project.apollo.customTypeMapping
+            nullableValueType = project.apollo.nullableValueType
+            useSemanticNaming = project.apollo.useSemanticNaming
+            generateModelBuilder = project.apollo.generateModelBuilder
+            useJavaBeansSemanticNaming = project.apollo.useJavaBeansSemanticNaming
+            suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
+            generateKotlinModels = project.apollo.generateKotlinModels
+            generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
+        }
+    }
+
+    protected final AbstractTask createApolloIRGenTask(String sourceSetOrVariantName, Collection sourceSets) {
+        def sourceSetNamesList = sourceSets.collect { it.name }
+        File outputFolder = new File(project.buildDir, Joiner.on(File.separator)
+                .join(GraphQLCompiler.IR_OUTPUT_DIRECTORY + sourceSetOrVariantName))
+
+        String taskName = String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, sourceSetOrVariantName.capitalize())
+        if (useGlobalApolloCodegen) {
+            return project.tasks.create(taskName, ApolloSystemCodegenGenerationTask) {
+                sourceSets.each { sourceSet ->
+                    sourceSet.graphql.exclude(project.apollo.sourceSet.exclude.get())
+                    inputs.files(sourceSet.graphql).skipWhenEmpty()
+                }
+                group = ApolloPlugin.TASK_GROUP
+                description = "Generate an IR file using apollo-codegen for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
+                schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
+                        project.apollo.sourceSet.schemaFile
+                outputPackageName = project.apollo.outputPackageName
+                variant = sourceSetOrVariantName
+                sourceSetNames = sourceSetNamesList
+                outputDir.set(outputFolder)
+            }
+        } else {
+            return project.tasks.create(taskName, ApolloLocalCodegenGenerationTask) {
+                sourceSets.each { sourceSet ->
+                    sourceSet.graphql.exclude(project.apollo.sourceSet.exclude.get())
+                    inputs.files(sourceSet.graphql).skipWhenEmpty()
+                }
+                group = ApolloPlugin.TASK_GROUP
+                description = "Generate an IR file using apollo-codegen for ${sourceSetOrVariantName.capitalize()} GraphQL queries"
+                dependsOn(ApolloCodegenInstallTask.NAME)
+                schemaFilePath = (project.apollo.sourceSet.schemaFile.get().length() == 0) ? project.apollo.schemaFilePath :
+                        project.apollo.sourceSet.schemaFile
+                outputPackageName = project.apollo.outputPackageName
+                variant = sourceSetOrVariantName
+                sourceSetNames = sourceSetNamesList
+                outputDir.set(outputFolder)
+            }
+        }
+    }
+
+    protected final ApolloClassGenerationTask createApolloClassGenTask(String name) {
+        String taskName = String.format(ApolloClassGenerationTask.NAME, name.capitalize())
+        return project.tasks.create(taskName, ApolloClassGenerationTask) {
+            group = ApolloPlugin.TASK_GROUP
+            description = "Generate Android classes for ${name.capitalize()} GraphQL queries"
+            dependsOn(getProject().getTasks().findByName(String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, name.capitalize())))
+            source = project.tasks.findByName(String.format(APOLLO_CODEGEN_GENERATE_TASK_NAME, name.capitalize())).outputDir
+            include "**${File.separatorChar}*API.json"
+            customTypeMapping = project.apollo.customTypeMapping
+            nullableValueType = project.apollo.nullableValueType
+            useSemanticNaming = project.apollo.useSemanticNaming
+            generateModelBuilder = project.apollo.generateModelBuilder
+            useJavaBeansSemanticNaming = project.apollo.useJavaBeansSemanticNaming
+            outputPackageName = project.apollo.outputPackageName
+            suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
+            generateKotlinModels = project.apollo.generateKotlinModels
+            generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
+        }
+    }
+
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/android/AndroidTaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/android/AndroidTaskConfigurator.groovy
@@ -1,0 +1,45 @@
+package com.apollographql.apollo.gradle.android
+
+import com.android.build.gradle.api.BaseVariant
+import com.apollographql.apollo.gradle.ApolloClassGenerationTask
+import com.apollographql.apollo.gradle.ApolloExperimentalCodegenTask
+import com.apollographql.apollo.gradle.TaskConfigurator
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.internal.AbstractTask
+
+class AndroidTaskConfigurator extends TaskConfigurator {
+
+    AndroidTaskConfigurator(Project project) {
+        super(project)
+    }
+
+    @Override
+    void configureTasks(Task apolloIRGenTask, Task apolloClassGenTask) {
+        getVariants().all { BaseVariant variant ->
+            addVariantTasks(variant, apolloIRGenTask, apolloClassGenTask, variant.sourceSets)
+        }
+        project.android.testVariants.each { BaseVariant tv ->
+            addVariantTasks(tv, apolloIRGenTask, apolloClassGenTask, tv.sourceSets)
+        }
+    }
+
+    private void addVariantTasks(BaseVariant variant, Task apolloIRGenTask, Task apolloClassGenTask, Collection sourceSets) {
+        if (useExperimentalCodegen) {
+            ApolloExperimentalCodegenTask codegenTask = createExperimentalCodegenTask(variant.name, variant.sourceSets)
+            variant.registerJavaGeneratingTask(codegenTask, codegenTask.outputDir.asFile.get())
+            apolloClassGenTask.dependsOn(codegenTask)
+        } else {
+            AbstractTask variantIRTask = createApolloIRGenTask(variant.name, sourceSets)
+            ApolloClassGenerationTask variantClassTask = createApolloClassGenTask(variant.name)
+            variant.registerJavaGeneratingTask(variantClassTask, variantClassTask.outputDir.asFile.get())
+            apolloIRGenTask.dependsOn(variantIRTask)
+            apolloClassGenTask.dependsOn(variantClassTask)
+        }
+    }
+
+    private DomainObjectCollection<BaseVariant> getVariants() {
+        return project.android.hasProperty('libraryVariants') ? project.android.libraryVariants : project.android.applicationVariants
+    }
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/android/AndroidTaskConfiguratorFactory.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/android/AndroidTaskConfiguratorFactory.groovy
@@ -1,0 +1,10 @@
+package com.apollographql.apollo.gradle.android
+
+import org.gradle.api.Project
+
+class AndroidTaskConfiguratorFactory {
+
+    static AndroidTaskConfigurator create(Project project) {
+        return new AndroidTaskConfigurator(project)
+    }
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/jvm/JvmTaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/jvm/JvmTaskConfigurator.groovy
@@ -1,0 +1,64 @@
+package com.apollographql.apollo.gradle.jvm
+
+import com.apollographql.apollo.gradle.ApolloClassGenerationTask
+import com.apollographql.apollo.gradle.ApolloExperimentalCodegenTask
+import com.apollographql.apollo.gradle.TaskConfigurator
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.internal.AbstractTask
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.compile.JavaCompile
+
+class JvmTaskConfigurator  extends TaskConfigurator{
+    JvmTaskConfigurator(Project project) {
+        super(project)
+    }
+
+    @Override
+    void configureTasks(Task apolloIRGenTask, Task apolloClassGenTask) {
+        project.sourceSets.all { SourceSet sourceSet ->
+            addSourceSetTasks(sourceSet, apolloIRGenTask, apolloClassGenTask)
+        }
+    }
+
+    private void addSourceSetTasks(SourceSet sourceSet, Task apolloIRGenTask, Task apolloClassGenTask) {
+        String taskName = "main".equals(sourceSet.name) ? "" : sourceSet.name
+
+        DirectoryProperty outputDir;
+        if (useExperimentalCodegen) {
+            ApolloExperimentalCodegenTask codegenTask = createExperimentalCodegenTask(sourceSet.name, [sourceSet])
+            apolloClassGenTask.dependsOn(codegenTask)
+            outputDir = codegenTask.outputDir
+        } else {
+            AbstractTask sourceSetIRTask = createApolloIRGenTask(sourceSet.name, [sourceSet])
+            ApolloClassGenerationTask sourceSetClassTask = createApolloClassGenTask(sourceSet.name)
+            apolloIRGenTask.dependsOn(sourceSetIRTask)
+            apolloClassGenTask.dependsOn(sourceSetClassTask)
+            outputDir = sourceSetClassTask.outputDir
+        }
+
+        // we use afterEvaluate here as we need to know the value of generateKotlinModels from addSourceSetTasks
+        // TODO we should avoid afterEvaluate usage
+        project.afterEvaluate {
+            if (project.apollo.generateKotlinModels.get() != true) {
+                JavaCompile compileTask = (JavaCompile) project.tasks.findByName("compile${taskName.capitalize()}Java")
+                compileTask.source += project.fileTree(outputDir)
+                compileTask.dependsOn(apolloClassGenTask)
+            }
+        }
+
+        sourceSet.java.srcDir(outputDir)
+
+        def compileKotlinTask = project.tasks.findByName("compile${taskName.capitalize()}Kotlin") as SourceTask
+        if (compileKotlinTask != null) {
+            // kotlinc uses the generated java classes as input too so we need the generated classes
+            compileKotlinTask.dependsOn(apolloClassGenTask)
+            // this is somewhat redundant with sourceSet.java.srcDir above but I believe by the time we come here the java plugin
+            // has been configured already so we need to manually tell kotlinc where to find the generated classes
+            compileKotlinTask.source(outputDir)
+        }
+    }
+
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/jvm/JvmTaskConfiguratorFactory.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/jvm/JvmTaskConfiguratorFactory.groovy
@@ -1,0 +1,10 @@
+package com.apollographql.apollo.gradle.jvm
+
+import org.gradle.api.Project
+
+class JvmTaskConfiguratorFactory {
+
+    static JvmTaskConfigurator create(Project project) {
+        return new JvmTaskConfigurator(project)
+    }
+}

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -15,8 +15,8 @@ class ApolloAndroidPluginSpec extends Specification {
     ApolloPluginTestHelper.applyApolloPlugin(project)
     project.evaluate()
 
-    def debugTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug"))
-    def releaseTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release"))
+    def debugTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug"))
+    def releaseTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release"))
 
     then:
     debugTask.group.equals(ApolloPlugin.TASK_GROUP)
@@ -38,8 +38,8 @@ class ApolloAndroidPluginSpec extends Specification {
 
     then:
     flavors.each { flavor ->
-      def debugTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "${flavor}Debug"))
-      def releaseTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "${flavor}Release"))
+      def debugTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "${flavor}Debug"))
+      def releaseTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "${flavor}Release"))
 
       assert (debugTask.group) == ApolloPlugin.TASK_GROUP
       assert (debugTask.description) == "Generate an IR file using apollo-codegen for " + flavor + "Debug GraphQL queries"

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloIRGenTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloIRGenTaskSpec.groovy
@@ -1,8 +1,8 @@
 package com.apollographql.apollo.gradle.unit
 
 import com.apollographql.apollo.gradle.ApolloCodegenInstallTask
-import com.apollographql.apollo.gradle.ApolloPlugin
 import com.apollographql.apollo.gradle.ApolloPluginTestHelper
+import com.apollographql.apollo.gradle.TaskConfigurator
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -16,8 +16,8 @@ class ApolloIRGenTaskSpec extends Specification {
     ApolloPluginTestHelper.applyApolloPlugin(project)
     project.evaluate()
 
-    def debugTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug"))
-    def releaseTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release"))
+    def debugTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug"))
+    def releaseTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release"))
 
     then:
     debugTask.dependsOn.contains(ApolloCodegenInstallTask.NAME)
@@ -33,10 +33,10 @@ class ApolloIRGenTaskSpec extends Specification {
     ApolloPluginTestHelper.applyApolloPlugin(project)
     project.evaluate()
 
-    def generateApolloIR = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, ""))
+    def generateApolloIR = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, ""))
 
     then:
-    generateApolloIR.dependsOn.contains(project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug")))
-    generateApolloIR.dependsOn.contains(project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release")))
+    generateApolloIR.dependsOn.contains(project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Debug")))
+    generateApolloIR.dependsOn.contains(project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Release")))
   }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloJavaPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloJavaPluginSpec.groovy
@@ -15,7 +15,7 @@ class ApolloJavaPluginSpec extends Specification {
     ApolloPluginTestHelper.applyApolloPlugin(project)
     project.evaluate()
 
-    def mainTask = project.tasks.getByName(String.format(ApolloPlugin.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Main"))
+    def mainTask = project.tasks.getByName(String.format(TaskConfigurator.APOLLO_CODEGEN_GENERATE_TASK_NAME, "Main"))
 
     then:
     mainTask.group.equals(ApolloPlugin.TASK_GROUP)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,6 +36,7 @@ ext.dep = [
     recyclerView            : "com.android.support:recyclerview-v7:$versions.supportLibVersion",
     compiletesting          : 'com.google.testing.compile:compile-testing:0.15',
     cache                   : "com.nytimes.android:cache:$versions.cacheVersion",
+    guavaJre                : 'com.google.guava:guava:28.0-jre',
     javaPoet                : 'com.squareup:javapoet:1.9.0',
     kotlinpoet              : 'com.squareup:kotlinpoet:1.3.0',
     moshi                   : "com.squareup.moshi:moshi:$versions.moshi",


### PR DESCRIPTION
## Problem

After #1470 was merged, non-Android pure Kotlin projects would not download/pull Android plugin anymore. This causes `ClassNotFoundException` on `BaseVariant` class from Android. 

## Solution

Split task creation for Android and Jvm only projects. `TaskConfigurator` is introduced to capture the common functionality. Yes, used inheritance so far 🤦‍♂ Groovy does not make it easy.

Android and Jvm subclasses encapsulates fully the task configuration for 2 different platforms.

**Note:** I verified that this works with @martinbonnin 's project: https://github.com/martinbonnin/testAndroidCompileOnly But it would be good if somebody else also does it.