### PR TITLE
Enable new code gen by default

### DIFF
--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloPlugin.groovy
@@ -19,7 +19,7 @@ class ApolloPlugin implements Plugin<Project> {
   private Project project
   private final FileResolver fileResolver
   private boolean useGlobalApolloCodegen = System.properties['apollographql.useGlobalApolloCodegen']?.toBoolean()
-  private boolean useExperimentalCodegen = System.properties['apollographql.useExperimentalCodegen']?.toBoolean()
+  private boolean useExperimentalCodegen = (System.properties['apollographql.useExperimentalCodegen'] ?: "true").toBoolean()
 
   @Inject
   ApolloPlugin(FileResolver fileResolver) {

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -10,7 +10,7 @@ abstract class TaskConfigurator {
     public static final String APOLLO_CODEGEN_GENERATE_TASK_NAME = "generate%sApolloIR"
 
     final boolean useGlobalApolloCodegen = System.properties['apollographql.useGlobalApolloCodegen']?.toBoolean()
-    final boolean useExperimentalCodegen = System.properties['apollographql.useExperimentalCodegen']?.toBoolean()
+    final boolean useExperimentalCodegen = (System.properties['apollographql.useExperimentalCodegen'] ?: "true").toBoolean()
     protected final Project project
 
     TaskConfigurator(Project project) {

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -20,6 +20,7 @@ class BasicAndroidSpec extends Specification {
 
   def setupSpec() {
     testProjectDir = setupBasicAndroidProject()
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
   }
 
   def "builds successfully and generates expected outputs"() {
@@ -419,6 +420,7 @@ class BasicAndroidSpec extends Specification {
 
   def cleanupSpec() {
     FileUtils.deleteDirectory(testProjectDir)
+    System.clearProperty("apollographql.useExperimentalCodegen")
   }
 
   private static File setupBasicAndroidProject() {

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/FlavoredMultiSchemaSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/FlavoredMultiSchemaSpec.groovy
@@ -15,6 +15,7 @@ class FlavoredMultiSchemaSpec extends Specification {
 
   def setupSpec() {
     testProjectDir = setupFlavoredAndroidProject()
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
   }
 
   def "generates expected outputs for the demo debug variant"() {
@@ -101,6 +102,7 @@ class FlavoredMultiSchemaSpec extends Specification {
 
   def cleanupSpec() {
     FileUtils.deleteDirectory(testProjectDir)
+    System.clearProperty("apollographql.useExperimentalCodegen")
   }
 
   private void assertDemoDebugGenerationSucces() {

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloAndroidPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloAndroidPluginSpec.groovy
@@ -6,6 +6,15 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApolloAndroidPluginSpec extends Specification {
+
+  def setupSpec() {
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
+  }
+
+  def cleanupSpec() {
+    System.clearProperty("apollographql.useExperimentalCodegen")
+  }
+
   def "creates an IRGen task under the apollo group for a default project"() {
     setup:
     def project = ProjectBuilder.builder().build()

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloCodeGenInstallTaskSpec.groovy
@@ -7,6 +7,14 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApolloCodeGenInstallTaskSpec extends Specification {
+  def setupSpec() {
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
+  }
+
+  def cleanupSpec() {
+    System.clearProperty("apollographql.useExperimentalCodegen")
+  }
+
   def "creates a task under the apollo group"() {
     setup:
     def project = ProjectBuilder.builder().build()

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloIRGenTaskSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloIRGenTaskSpec.groovy
@@ -7,6 +7,15 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApolloIRGenTaskSpec extends Specification {
+
+  def setupSpec() {
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
+  }
+
+  def cleanupSpec() {
+    System.clearProperty("apollographql.useExperimentalCodegen")
+  }
+
   def "creates tasks for default project variants that depend on apolloCodegenInstall task"() {
     setup:
     def project = ProjectBuilder.builder().build()

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloJavaPluginSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/unit/ApolloJavaPluginSpec.groovy
@@ -6,6 +6,14 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
 class ApolloJavaPluginSpec extends Specification {
+  def setupSpec() {
+    System.setProperty("apollographql.useExperimentalCodegen", "false")
+  }
+
+  def cleanupSpec() {
+    System.clearProperty("apollographql.useExperimentalCodegen")
+  }
+
   def "creates an IRGen task under the apollo group"() {
     setup:
     def project = ProjectBuilder.builder().build()


### PR DESCRIPTION
If `apollographql.useExperimentalCodegen` system flag is not set explicitly use new code generator by default.