### PR TITLE
Escape Android SDK path in test projects' local.properties

### DIFF
--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
@@ -58,7 +58,7 @@ class ApolloPluginTestHelper {
 
   private static def setupAndroidProject(Project project) {
     def localProperties = new File("${project.projectDir.absolutePath}", "local.properties")
-    localProperties.write("sdk.dir=${androidHome()}")
+    localProperties.write("sdk.dir=${escapeFilePathCharacters(androidHome())}")
 
     def manifest = new File("${project.projectDir.absolutePath}/src/main", "AndroidManifest.xml")
     manifest.getParentFile().mkdirs()
@@ -113,10 +113,17 @@ class ApolloPluginTestHelper {
 
   static def prepareLocalProperties(File destDir) {
     def localProperties = new File(destDir, "local.properties")
-    localProperties.write("sdk.dir=${androidHome()}")
+    localProperties.write("sdk.dir=${escapeFilePathCharacters(androidHome())}")
   }
 
-  static def replaceTextInFile(source, Closure replaceText){
+  static def replaceTextInFile(source, Closure replaceText) {
     source.write(replaceText(source.text))
+  }
+
+  static def escapeFilePathCharacters(CharSequence input) {
+    return input.replace([
+            "\\": "\\\\",
+            ":" : "\\:"
+    ])
   }
 }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/ApolloPluginTestHelper.groovy
@@ -116,7 +116,7 @@ class ApolloPluginTestHelper {
     localProperties.write("sdk.dir=${escapeFilePathCharacters(androidHome())}")
   }
 
-  static def replaceTextInFile(source, Closure replaceText) {
+  static def replaceTextInFile(source, Closure replaceText){
     source.write(replaceText(source.text))
   }
 


### PR DESCRIPTION
Currently, most of `apollo-gradle-plugin`'s tests fail on Windows because of a malformed Android SDK path:
>```
>A problem occurred configuring root project 'basic'.
>> The SDK directory 'C:\Users\steve\Documents\Projects\apollo-android-master\apollo-gradle->plugin\build\integrationTests\basic\C:UserssteveAppDataLocalAndroidSdk' does not exist.
>```

In an actual Gradle project generated on Windows, local.properties' paths contain two backslashes, i.e.
>```
>sdk.dir=C\:\\Users\\steve\\AppData\\Local\\Android\\Sdk
>```

This changes the tests to escape `:` and `\` in the Android SDK path before writing local.properties.