### PR TITLE
Trying to make integration tests pass

### DIFF
--- a/.buildscript/integration_tests_composite.sh
+++ b/.buildscript/integration_tests_composite.sh
@@ -20,7 +20,7 @@ cp gradle/composite/apollo-integration-settings.gradle apollo-integration/settin
 cp gradle/composite/root-settings.gradle settings.gradle
 
 echo "Running integration tests..."
-integrationTestOutput=$(./gradlew -p apollo-integration clean build -s)
+integrationTestOutput=$(./gradlew -p apollo-integration clean build -s 2>&1)
 echo "${integrationTestOutput}"
 
 if [[ $integrationTestOutput == *"FAILED"* ]]; then

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/httpcache/AllFilms.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/httpcache/AllFilms.graphql
@@ -1,5 +1,5 @@
 query AllFilms {
-  allFilms(first:100) {
+  allFilms(first: 100) {
     totalCount
     films {
       title

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/AllFilms.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/interceptor/AllFilms.graphql
@@ -1,5 +1,5 @@
-query AllFilms($after:String, $first:Int, $before:String, $last:Int) {
-  allFilms(after:$after, first:$first, before:$before, last:$last) {
+query AllFilms($after: String, $first: Int, $before: String, $last: Int) {
+  allFilms(after: $after, first: $first, before: $before, last: $last) {
     totalCount
     films {
       title

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/CharacterDetails.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/CharacterDetails.graphql
@@ -1,5 +1,5 @@
-query CharacterDetails($id:ID!) {
-  character(id:$id) {
+query CharacterDetails($id: ID!) {
+  character(id: $id) {
     ... on Human {
       name
       birthDate

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/CharacterNameById.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/CharacterNameById.graphql
@@ -1,5 +1,5 @@
-query CharacterNameById($id:ID!) {
-  character(id:$id) {
+query CharacterNameById($id: ID!) {
+  character(id: $id) {
     ... on Human {
       name
     }

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/upload/NestedUpload.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/upload/NestedUpload.graphql
@@ -1,3 +1,3 @@
-mutation NestedUpload($topFile:Upload, $topFileList:[Upload], $nested: NestedObject) {
+mutation NestedUpload($topFile: Upload, $topFileList: [Upload], $nested: NestedObject) {
     nestedUpload(topFile: $topFile, topFileList: $topFileList, nested: $nested)
 }

--- a/gradle/composite/apollo-integration-build.gradle
+++ b/gradle/composite/apollo-integration-build.gradle
@@ -48,7 +48,6 @@ dependencies {
   compileOnly dep.jetbrainsAnnotations
 
   implementation dep.apolloRuntime
-  implementation dep.apolloRxSupport
   implementation dep.apolloRx2Support
   implementation dep.apolloHttpCache
   implementation dep.appcompat

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,5 @@
 def versions = [
-    apolloVersion                : '1.1.0',
+    apolloVersion                : '1.1.1-SNAPSHOT',
     antlr4                       : '4.5.3',
     cacheVersion                 : '2.0.2',
     okHttpVersion                : '3.12.2',


### PR DESCRIPTION
This makes it sure that Travis fails if the integration tests fail.

Also removes rxJava1 support that made the integration test fail.

It still fails with 

```
Caused by: com.squareup.moshi.JsonDataException: Required property 'data' missing at $
	at com.apollographql.apollo.compiler.parser.IntrospectionQueryJsonAdapter.fromJson(IntrospectionQueryJsonAdapter.kt:35)
	at com.apollographql.apollo.compiler.parser.IntrospectionQueryJsonAdapter.fromJson(IntrospectionQueryJsonAdapter.kt:12)
	at com.squareup.moshi.JsonAdapter$2.fromJson(JsonAdapter.java:137)
	at com.squareup.moshi.JsonAdapter.fromJson(JsonAdapter.java:36)
	at com.apollographql.apollo.compiler.parser.Schema$Companion.parse(Schema.kt:136)
	... 100 more

```
