### PR TITLE
Fix issue generated package name doesn't respect graphql subfolders

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
@@ -49,6 +49,6 @@ class CustomEnumTypeSpecBuilder(
           .build()
 
   companion object {
-    fun className(context: CodeGenerationContext): ClassName = ClassName.get(context.packageNameProvider.typesPackageName(), "CustomType")
+    fun className(context: CodeGenerationContext): ClassName = ClassName.get(context.packageNameProvider.typesPackageName, "CustomType")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
@@ -106,7 +106,7 @@ class FragmentsResponseMapperBuilder(
       fragments
           .map { it.type.unwrapOptionalType(withoutAnnotations = true) as ClassName }
           .map {
-            val mapperClassName = ClassName.get(context.packageNameProvider.fragmentsPackageName(), it.simpleName(),
+            val mapperClassName = ClassName.get(context.packageNameProvider.fragmentsPackageName, it.simpleName(),
                 Util.RESPONSE_FIELD_MAPPER_TYPE_NAME)
             FieldSpec.builder(mapperClassName, it.mapperFieldName(), Modifier.FINAL)
                 .initializer(CodeBlock.of("new \$T()", mapperClassName))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -13,8 +13,8 @@ class GraphQLCompiler {
   fun write(args: Arguments) {
     val ir = args.ir ?: irAdapter.fromJson(args.irFile!!.readText())!!
     val packageNameProvider = PackageNameProvider(
-        customPackageName = args.outputPackageName,
-        schemaFilePath = args.schemaFilePath
+        schemaFilePath = args.schemaFilePath,
+        rootPackageName = args.outputPackageName
     )
     val customTypeMap = args.customTypeMap.supportedTypeMap(ir.typesUsed)
     val context = CodeGenerationContext(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
@@ -138,7 +138,7 @@ class InputTypeSpecBuilder(
   }
 
   private fun TypeDeclarationField.javaTypeName(context: CodeGenerationContext): TypeName {
-    return JavaTypeResolver(context, context.packageNameProvider.typesPackageName())
+    return JavaTypeResolver(context, context.packageNameProvider.typesPackageName)
         .resolve(typeName = type, nullableValueType = NullableValueType.INPUT_TYPE)
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -148,7 +148,7 @@ class OperationTypeSpecBuilder(
           .map { variable ->
             variable.name.decapitalize() to JavaTypeResolver(
                 context.copy(nullableValueType = NullableValueType.INPUT_TYPE),
-                context.packageNameProvider.typesPackageName()
+                context.packageNameProvider.typesPackageName
             ).resolve(variable.type)
           }
           .map { (name, type) ->
@@ -205,7 +205,7 @@ class OperationTypeSpecBuilder(
         .map {
           it.first to JavaTypeResolver(
               context.copy(nullableValueType = NullableValueType.INPUT_TYPE),
-              context.packageNameProvider.typesPackageName()
+              context.packageNameProvider.typesPackageName
           ).resolve(it.second)
         }
         .let {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -2,9 +2,9 @@ package com.apollographql.apollo.compiler
 
 class PackageNameProvider(
     private val schemaFilePath: String,
-    customPackageName: String? = null
+    rootPackageName: String? = null
 ) {
-  val packageName: String = customPackageName?.takeIf { it.isNotEmpty() } ?: schemaFilePath.formatPackageName()
+  val packageName: String = rootPackageName?.takeIf { it.isNotEmpty() } ?: schemaFilePath.formatPackageName()
   val fragmentsPackageName: String = "$packageName.fragment"
   val typesPackageName: String = "$packageName.type"
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -1,7 +1,20 @@
 package com.apollographql.apollo.compiler
 
 class PackageNameProvider(
+    /**
+     * Location of the schema file.
+     *
+     * Used to format target package name if custom root package name is not provided
+     * or to format relative position for GraphQL operations.
+     */
     private val schemaFilePath: String,
+    /**
+     * Root package name for all classes:
+     *
+     * - fragments will use `rootPackageName.fragment`
+     * - types will use `rootPackageName.type`
+     * - operations, will use `rootPackageName.{relativePosition to schema location}`
+     */
     rootPackageName: String? = null
 ) {
   val packageName: String = rootPackageName?.takeIf { it.isNotEmpty() } ?: schemaFilePath.formatPackageName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -18,15 +18,15 @@ class PackageNameProvider(
     rootPackageName: String? = null
 ) {
   val packageName: String = rootPackageName?.takeIf { it.isNotEmpty() } ?: schemaFilePath.formatPackageName()
-  val fragmentsPackageName: String = "$packageName.fragment"
-  val typesPackageName: String = "$packageName.type"
+  val fragmentsPackageName: String = "$packageName.fragment".removePrefix(".")
+  val typesPackageName: String = "$packageName.type".removePrefix(".")
 
   fun operationPackageName(operationFilePath: String): String {
     val relativePackageName = operationFilePath.formatPackageName()
-        .replace(schemaFilePath.formatPackageName(), "")
-        .replace("..", ".")
+        .removePrefix(schemaFilePath.formatPackageName())
+        .removePrefix(".")
         .removePrefix(packageName)
         .removePrefix(".")
-    return "$packageName.$relativePackageName".removeSuffix(".")
+    return "$packageName.$relativePackageName".removePrefix(".").removeSuffix(".")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -1,37 +1,19 @@
 package com.apollographql.apollo.compiler
 
-import java.io.File
-
 class PackageNameProvider(
-    /**
-     * the root package name for all classes:
-     *
-     * fragments will use rootPackageName.fragment
-     * types will use rootPackageName.type
-     * operations, will use rootPackageName.{relativePosition to rootDir}
-     */
-    private val rootPackageName: String?,
-    private val rootDir: File?,
-    /**
-     * the package name for fragments and types will be written there
-     */
-    val irPackageName: String,
-    /**
-     * the package name for fragments, types, queries and mutations
-     * This will flatten all the classes in the same package name. If you have operations in subfolders,
-     * use rootPackageName instead
-     */
-    private val outputPackageName: String?
+    private val schemaFilePath: String,
+    customPackageName: String? = null
 ) {
-  fun fragmentsPackageName(): String {
-    return if (irPackageName.isNotEmpty()) "$irPackageName.fragment" else "fragment"
-  }
+  val packageName: String = customPackageName?.takeIf { it.isNotEmpty() } ?: schemaFilePath.formatPackageName()
+  val fragmentsPackageName: String = "$packageName.fragment"
+  val typesPackageName: String = "$packageName.type"
 
-  fun typesPackageName(): String {
-    return if (irPackageName.isNotEmpty()) "$irPackageName.type" else "type"
-  }
-
-  fun operationPackageName(filePath: String): String {
-   return outputPackageName ?: filePath.formatPackageName()
+  fun operationPackageName(operationFilePath: String): String {
+    val relativePackageName = operationFilePath.formatPackageName()
+        .replace(schemaFilePath.formatPackageName(), "")
+        .replace("..", ".")
+        .removePrefix(packageName)
+        .removePrefix(".")
+    return "$packageName.$relativePackageName".removeSuffix(".")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -178,7 +178,7 @@ class SchemaTypeSpecBuilder(
       return fragmentSpreads.map { fragmentName ->
         val optional = isOptional(fragmentName)
         FieldSpec.builder(
-            JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName())
+            JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName)
                 .resolve(typeName = fragmentName.capitalize(), isOptional = optional), fragmentName.decapitalize())
             .addModifiers(Modifier.FINAL)
             .build()
@@ -194,7 +194,7 @@ class SchemaTypeSpecBuilder(
           fragmentName.decapitalize()
         }
         MethodSpec.methodBuilder(methodName)
-            .returns(JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName())
+            .returns(JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName)
                 .resolve(typeName = fragmentName.capitalize(), isOptional = optional))
             .addModifiers(Modifier.PUBLIC)
             .addStatement("return this.\$L", fragmentName.decapitalize())

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
@@ -147,7 +147,7 @@ class VariablesTypeSpecBuilder(
   }
 
   private fun Variable.javaTypeName(context: CodeGenerationContext): TypeName {
-    return JavaTypeResolver(context.copy(nullableValueType = NullableValueType.INPUT_TYPE), context.packageNameProvider.typesPackageName())
+    return JavaTypeResolver(context.copy(nullableValueType = NullableValueType.INPUT_TYPE), context.packageNameProvider.typesPackageName)
         .resolve(type)
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
@@ -19,15 +19,12 @@ class GraphQLKompiler(
     val customTypeMap = customTypeMap.supportedCustomTypes(ir.typesUsed)
     val schema = ir.ast(
         customTypeMap = customTypeMap,
-        typesPackageName = packageNameProvider.typesPackageName(),
-        fragmentsPackage = packageNameProvider.fragmentsPackageName(),
+        typesPackageName = packageNameProvider.typesPackageName,
+        fragmentsPackage = packageNameProvider.fragmentsPackageName,
         useSemanticNaming = useSemanticNaming
     )
 
-    val irPackageName = packageNameProvider.irPackageName
-    if (irPackageName.isNotEmpty()) {
-      File(outputDir, irPackageName.replace('.', File.separatorChar)).deleteRecursively()
-    }
+    File(outputDir, packageNameProvider.packageName.replace('.', File.separatorChar)).deleteRecursively()
 
     val schemaCodegen = SchemaCodegen(
         packageNameProvider = packageNameProvider

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
@@ -12,19 +12,19 @@ internal class SchemaCodegen(
   private var fileSpecs: List<FileSpec> = emptyList()
 
   override fun visit(customTypes: CustomTypes) {
-    fileSpecs = fileSpecs + customTypes.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + customTypes.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(enumType: EnumType) {
-    fileSpecs = fileSpecs + enumType.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + enumType.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(inputType: InputType) {
-    fileSpecs = fileSpecs + inputType.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + inputType.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(fragmentType: FragmentType) {
-    fileSpecs = fileSpecs + fragmentType.typeSpec().fileSpec(packageNameProvider.fragmentsPackageName())
+    fileSpecs = fileSpecs + fragmentType.typeSpec().fileSpec(packageNameProvider.fragmentsPackageName)
   }
 
   override fun visit(operationType: OperationType) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -126,7 +126,7 @@ data class Field(
   }
 
   private fun toTypeName(responseType: String, context: CodeGenerationContext): TypeName {
-    val packageName = if (isNonScalar()) "" else context.packageNameProvider.typesPackageName()
+    val packageName = if (isNonScalar()) "" else context.packageNameProvider.typesPackageName
     return JavaTypeResolver(context, packageName, isDeprecated ?: false).resolve(responseType, isOptional())
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
@@ -619,7 +619,7 @@ class GraphQLDocumentParser(val schema: Schema) {
   }
 
   private fun List<Operation>.checkMultipleOperationDefinitions() {
-    groupBy { it.filePath.formatPackageName(dropLast = true) + it.operationName }
+    groupBy { it.filePath.formatPackageName() + it.operationName }
         .values
         .find { it.size > 1 }
         ?.last()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -62,8 +62,8 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
   private fun generateKotlinExpectedClasses(args: GraphQLCompiler.Arguments) {
     val ir = args.ir ?: GraphQLCompiler.parseIrFile(args.irFile!!)
     val packageNameProvider = PackageNameProvider(
-        customPackageName = args.outputPackageName,
-        schemaFilePath = args.schemaFilePath
+        schemaFilePath = args.schemaFilePath,
+        rootPackageName = args.outputPackageName
     )
     GraphQLKompiler(
         ir = ir,

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -60,13 +60,10 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
   }
 
   private fun generateKotlinExpectedClasses(args: GraphQLCompiler.Arguments) {
-    val irPackageName = args.outputPackageName ?: args.irFile!!.absolutePath.formatPackageName()
     val ir = args.ir ?: GraphQLCompiler.parseIrFile(args.irFile!!)
     val packageNameProvider = PackageNameProvider(
-        rootPackageName = null,
-        rootDir = null,
-        irPackageName = irPackageName,
-        outputPackageName = args.outputPackageName
+        customPackageName = args.outputPackageName,
+        schemaFilePath = args.schemaFilePath
     )
     GraphQLKompiler(
         ir = ir,
@@ -150,9 +147,9 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
               else -> true
             }
 
+            val schemaJson = folder.listFiles().find { it.isFile && it.name == "schema.json" } ?: File("src/test/graphql/schema.json")
             val ir = if (folder.name != "nested_inline_fragment" && folder.name != "reserved_words" && folder.name != "scalar_types" &&
                 folder.name != "union_inline_fragments") {
-              val schemaJson = folder.listFiles().find { it.isFile && it.name == "schema.json" } ?: File("src/test/graphql/schema.json")
               val schema = Schema(schemaJson)
               val graphQLFile = File(folder, "TestOperation.graphql")
               GraphQLDocumentParser(schema).parse(listOf(graphQLFile))
@@ -162,6 +159,7 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
             val args = GraphQLCompiler.Arguments(
                 irFile = irFile,
                 ir = ir,
+                schemaFilePath = schemaJson.absolutePath,
                 outputDir = GraphQLCompiler.OUTPUT_DIRECTORY.plus("sources").fold(File("build"), ::File),
                 customTypeMap = customTypeMap,
                 nullableValueType = nullableValueType,

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -10,10 +10,8 @@ import java.util.*
 
 class JavaTypeResolverTest {
   private val packageNameProvider = PackageNameProvider(
-      rootPackageName = null,
-      rootDir = null,
-      outputPackageName = null,
-      irPackageName = ""
+      customPackageName = null,
+      schemaFilePath = ""
   )
   private val defaultContext = CodeGenerationContext(
       reservedTypeNames = emptyList(),

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -10,8 +10,8 @@ import java.util.*
 
 class JavaTypeResolverTest {
   private val packageNameProvider = PackageNameProvider(
-      customPackageName = null,
-      schemaFilePath = ""
+      schemaFilePath = "",
+      rootPackageName = null
   )
   private val defaultContext = CodeGenerationContext(
       reservedTypeNames = emptyList(),

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -11,7 +11,7 @@ import java.util.*
 class JavaTypeResolverTest {
   private val packageNameProvider = PackageNameProvider(
       schemaFilePath = "",
-      rootPackageName = null
+      rootPackageName = packageName
   )
   private val defaultContext = CodeGenerationContext(
       reservedTypeNames = emptyList(),

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
@@ -6,10 +6,10 @@ import org.junit.Test
 class PackageNameProviderTest {
 
   @Test
-  fun `when custom package not set format package name from schema location`() {
+  fun `when root package not set format package name from schema location`() {
     val packageNameProvider = PackageNameProvider(
         schemaFilePath = "src/main/graphql/com/sample/api/schema.json",
-        customPackageName = null
+        rootPackageName = null
     )
 
     assertThat(packageNameProvider.packageName).isEqualTo("com.sample.api")
@@ -24,10 +24,10 @@ class PackageNameProviderTest {
   }
 
   @Test
-  fun `when custom package name set format package name from it`() {
+  fun `when root package name set format package name from it`() {
     val packageNameProvider = PackageNameProvider(
         schemaFilePath = "src/main/graphql/com/sample/api/schema.json",
-        customPackageName = "com.mysample.graphql"
+        rootPackageName = "com.mysample.graphql"
     )
 
     assertThat(packageNameProvider.packageName).isEqualTo("com.mysample.graphql")
@@ -45,7 +45,7 @@ class PackageNameProviderTest {
   fun `when schema located at the root format package name`() {
     val packageNameProvider = PackageNameProvider(
         schemaFilePath = "src/main/graphql/schema.json",
-        customPackageName = "com.mysample.graphql"
+        rootPackageName = "com.mysample.graphql"
     )
 
     assertThat(packageNameProvider.packageName).isEqualTo("com.mysample.graphql")

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
@@ -16,7 +16,7 @@ class PackageNameProviderTest {
     assertThat(packageNameProvider.fragmentsPackageName).isEqualTo("com.sample.api.fragment")
     assertThat(packageNameProvider.typesPackageName).isEqualTo("com.sample.api.type")
 
-     assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/query.graphql")).isEqualTo("com.sample.api")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/query.graphql")).isEqualTo("com.sample.api")
     assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/query.graphql"))
         .isEqualTo("com.sample.api.features")
     assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/feature/query.graphql"))
@@ -42,7 +42,28 @@ class PackageNameProviderTest {
   }
 
   @Test
-  fun `when schema located at the root format package name`() {
+  fun `when schema located at the root and root package name not set, format package name`() {
+    val packageNameProvider = PackageNameProvider(
+        schemaFilePath = "src/main/graphql/schema.json",
+        rootPackageName = null
+    )
+
+    assertThat(packageNameProvider.packageName).isEqualTo("")
+    assertThat(packageNameProvider.fragmentsPackageName).isEqualTo("fragment")
+    assertThat(packageNameProvider.typesPackageName).isEqualTo("type")
+
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/sample/api/query.graphql"))
+        .isEqualTo("sample.api")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/query.graphql"))
+        .isEqualTo("com.mysample.graphql")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/features/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/features/feature/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features.feature")
+  }
+
+  @Test
+  fun `when schema located at the root and root package name set, format package name`() {
     val packageNameProvider = PackageNameProvider(
         schemaFilePath = "src/main/graphql/schema.json",
         rootPackageName = "com.mysample.graphql"

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/PackageNameProviderTest.kt
@@ -1,0 +1,64 @@
+package com.apollographql.apollo.compiler
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PackageNameProviderTest {
+
+  @Test
+  fun `when custom package not set format package name from schema location`() {
+    val packageNameProvider = PackageNameProvider(
+        schemaFilePath = "src/main/graphql/com/sample/api/schema.json",
+        customPackageName = null
+    )
+
+    assertThat(packageNameProvider.packageName).isEqualTo("com.sample.api")
+    assertThat(packageNameProvider.fragmentsPackageName).isEqualTo("com.sample.api.fragment")
+    assertThat(packageNameProvider.typesPackageName).isEqualTo("com.sample.api.type")
+
+     assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/query.graphql")).isEqualTo("com.sample.api")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/query.graphql"))
+        .isEqualTo("com.sample.api.features")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/feature/query.graphql"))
+        .isEqualTo("com.sample.api.features.feature")
+  }
+
+  @Test
+  fun `when custom package name set format package name from it`() {
+    val packageNameProvider = PackageNameProvider(
+        schemaFilePath = "src/main/graphql/com/sample/api/schema.json",
+        customPackageName = "com.mysample.graphql"
+    )
+
+    assertThat(packageNameProvider.packageName).isEqualTo("com.mysample.graphql")
+    assertThat(packageNameProvider.fragmentsPackageName).isEqualTo("com.mysample.graphql.fragment")
+    assertThat(packageNameProvider.typesPackageName).isEqualTo("com.mysample.graphql.type")
+
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/query.graphql")).isEqualTo("com.mysample.graphql")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/sample/api/features/feature/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features.feature")
+  }
+
+  @Test
+  fun `when schema located at the root format package name`() {
+    val packageNameProvider = PackageNameProvider(
+        schemaFilePath = "src/main/graphql/schema.json",
+        customPackageName = "com.mysample.graphql"
+    )
+
+    assertThat(packageNameProvider.packageName).isEqualTo("com.mysample.graphql")
+    assertThat(packageNameProvider.fragmentsPackageName).isEqualTo("com.mysample.graphql.fragment")
+    assertThat(packageNameProvider.typesPackageName).isEqualTo("com.mysample.graphql.type")
+
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/sample/api/query.graphql"))
+        .isEqualTo("com.mysample.graphql.sample.api")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/query.graphql"))
+        .isEqualTo("com.mysample.graphql")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/features/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features")
+    assertThat(packageNameProvider.operationPackageName("src/main/graphql/com/mysample/graphql/features/feature/query.graphql"))
+        .isEqualTo("com.mysample.graphql.features.feature")
+  }
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -53,7 +53,7 @@ class ApolloClassGenerationTask extends SourceTask {
           outputPackageName = null
         }
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
-            inputFile, null, outputDir.get().asFile, customTypeMapping.get(),
+            inputFile, null, inputFile.absolutePath, outputDir.get().asFile, customTypeMapping.get(),
             nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
             generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
             suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
@@ -1,7 +1,6 @@
 package com.apollographql.apollo.gradle
 
 import com.apollographql.apollo.compiler.GraphQLCompiler
-import com.apollographql.apollo.compiler.InflectorKt
 import com.apollographql.apollo.compiler.NullableValueType
 import com.apollographql.apollo.compiler.ir.CodeGenerationIR
 import com.apollographql.apollo.compiler.parser.GraphQLDocumentParser
@@ -49,14 +48,10 @@ class ApolloExperimentalCodegenTask extends SourceTask {
     for (CodegenGenerationTaskCommandArgsBuilder.ApolloCodegenIRArgs codegenArg : codegenArgs) {
       Schema schema = Schema.parse(codegenArg.schemaFile)
       CodeGenerationIR codeGenerationIR = new GraphQLDocumentParser(schema).parse(codegenArg.queryFilePaths.toList().collect { new File(it) })
-      String outputPackageName = outputPackageName.get()
-      if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
-        outputPackageName = InflectorKt.formatPackageName(codegenArg.irOutputFolder.absolutePath, false)
-      }
       GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
-          null, codeGenerationIR, outputDir.get().asFile, customTypeMapping.get(),
+          null, codeGenerationIR, codegenArg.schemaFile.absolutePath, outputDir.get().asFile, customTypeMapping.get(),
           nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
-          generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
+          generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName.get(),
           suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()
       )
       new GraphQLCompiler().write(args)

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -395,7 +395,7 @@ class BasicAndroidSpec extends Specification {
         "build/generated/source/apollo/generatedIR/debug/src/main/graphql/com/myexample/DebugAPI.json").isFile()
     assert new File(testProjectDir,
         "build/generated/source/apollo/generatedIR/release/src/main/graphql/com/myexample/ReleaseAPI.json").isFile()
-    assert new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/DroidDetails.java").isFile()
+    assert new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/com/example/DroidDetails.java").isFile()
   }
 
   def "remove graphql files, builds successfully and generates expected outputs"() {
@@ -413,9 +413,9 @@ class BasicAndroidSpec extends Specification {
     then:
     result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
     // Java classes generated successfully
-    assert new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/DroidDetails.java").isFile()
-    assert !new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/Films.java").exists()
-    assert !new File(testProjectDir, "build/generated/source/apollo/classes/fragment/SpeciesInformation.java").exists()
+    assert new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/com/example/DroidDetails.java").isFile()
+    assert !new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/com/example/Films.java").exists()
+    assert !new File(testProjectDir, "build/generated/source/apollo/classes/com/myexample/fragment/SpeciesInformation.java").exists()
   }
 
   def cleanupSpec() {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/1522
Closes https://github.com/apollographql/apollo-android/issues/1367

Check the tests to get the idea of rules applied when formatting target package names:
https://github.com/apollographql/apollo-android/pull/1539/files#diff-dab7ed2442415d0be3727ce680c61c19

CC: @martinbonnin 