### PR TITLE
Fix 1522 package name regression

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -12,7 +12,7 @@ import java.io.File
 class GraphQLCompiler {
   fun write(args: Arguments) {
     val ir = args.ir ?: irAdapter.fromJson(args.irFile!!.readText())!!
-    val irPackageName = args.outputPackageName ?: args.irFile!!.absolutePath.formatPackageName()
+    val irPackageName = args.irPackageName
     val packageNameProvider = PackageNameProvider(
         rootPackageName = null,
         rootDir = null,
@@ -48,13 +48,12 @@ class GraphQLCompiler {
     } else {
       ir.writeJavaFiles(
           context = context,
-          outputDir = args.outputDir,
-          outputPackageName = args.outputPackageName
+          outputDir = args.outputDir
       )
     }
   }
 
-  private fun CodeGenerationIR.writeJavaFiles(context: CodeGenerationContext, outputDir: File, outputPackageName: String?) {
+  private fun CodeGenerationIR.writeJavaFiles(context: CodeGenerationContext, outputDir: File) {
     fragments.forEach {
       val typeSpec = it.toTypeSpec(context.copy())
       JavaFile
@@ -129,10 +128,10 @@ class GraphQLCompiler {
       val useSemanticNaming: Boolean,
       val generateModelBuilder: Boolean,
       val useJavaBeansSemanticNaming: Boolean,
+      val irPackageName: String,
       val outputPackageName: String?,
       val suppressRawTypesWarning: Boolean,
       val generateKotlinModels: Boolean = false,
       val generateVisitorForPolymorphicDatatypes: Boolean = false
   )
-
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -32,10 +32,6 @@ class PackageNameProvider(
   }
 
   fun operationPackageName(filePath: String): String {
-    return if (outputPackageName.isNullOrEmpty()) {
-      filePath.formatPackageName()
-    } else {
-      outputPackageName
-    }
+   return outputPackageName ?: filePath.formatPackageName()
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/PackageNameProvider.kt
@@ -32,6 +32,10 @@ class PackageNameProvider(
   }
 
   fun operationPackageName(filePath: String): String {
-   return outputPackageName ?: filePath.formatPackageName()
+    return if (outputPackageName.isNullOrEmpty()) {
+      filePath.formatPackageName()
+    } else {
+      outputPackageName
+    }
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -159,6 +159,8 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
             } else null
 
             val irFile = File(folder, "TestOperation.json")
+            val outputPackageName = "com.example.${folder.name}"
+
             val args = GraphQLCompiler.Arguments(
                 irFile = irFile,
                 ir = ir,
@@ -169,7 +171,8 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments) {
                 generateModelBuilder = generateModelBuilder,
                 useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
                 suppressRawTypesWarning = suppressRawTypesWarning,
-                outputPackageName = "com.example.${folder.name}",
+                irPackageName = outputPackageName,
+                outputPackageName = outputPackageName,
                 generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes
             )
             arrayOf(folder.name, args)

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -52,10 +52,12 @@ class ApolloClassGenerationTask extends SourceTask {
         if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
           outputPackageName = null
         }
+        String irPackageName = outputPackageName ?: inputFile.absolutePath.formatPackageName()
+
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
             inputFile, null, outputDir.get().asFile, customTypeMapping.get(),
             nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
-            generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
+            generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), irPackageName, outputPackageName,
             suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()
         )
         new GraphQLCompiler().write(args)

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloClassGenerationTask.groovy
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.gradle
 
 import com.apollographql.apollo.compiler.GraphQLCompiler
+import com.apollographql.apollo.compiler.InflectorKt
 import com.apollographql.apollo.compiler.NullableValueType
 import com.google.common.base.Joiner
 import org.gradle.api.Action
@@ -52,7 +53,7 @@ class ApolloClassGenerationTask extends SourceTask {
         if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
           outputPackageName = null
         }
-        String irPackageName = outputPackageName ?: inputFile.absolutePath.formatPackageName()
+        String irPackageName = outputPackageName ?: InflectorKt.formatPackageName(inputFile.absolutePath, true)
 
         GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
             inputFile, null, outputDir.get().asFile, customTypeMapping.get(),

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
@@ -50,13 +50,12 @@ class ApolloExperimentalCodegenTask extends SourceTask {
       Schema schema = Schema.parse(codegenArg.schemaFile)
       CodeGenerationIR codeGenerationIR = new GraphQLDocumentParser(schema).parse(codegenArg.queryFilePaths.toList().collect { new File(it) })
       String outputPackageName = outputPackageName.get()
-      if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
-        outputPackageName = InflectorKt.formatPackageName(codegenArg.irOutputFolder.absolutePath, false)
-      }
+      String irPackageName =  InflectorKt.formatPackageName(codegenArg.irOutputFolder.absolutePath, false)
+
       GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(
           null, codeGenerationIR, outputDir.get().asFile, customTypeMapping.get(),
           nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
-          generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), outputPackageName,
+          generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), irPackageName, outputPackageName,
           suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()
       )
       new GraphQLCompiler().write(args)

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExperimentalCodegenTask.groovy
@@ -50,6 +50,9 @@ class ApolloExperimentalCodegenTask extends SourceTask {
       Schema schema = Schema.parse(codegenArg.schemaFile)
       CodeGenerationIR codeGenerationIR = new GraphQLDocumentParser(schema).parse(codegenArg.queryFilePaths.toList().collect { new File(it) })
       String outputPackageName = outputPackageName.get()
+      if (outputPackageName != null && outputPackageName.trim().isEmpty()) {
+        outputPackageName = null
+      }
       String irPackageName =  InflectorKt.formatPackageName(codegenArg.irOutputFolder.absolutePath, false)
 
       GraphQLCompiler.Arguments args = new GraphQLCompiler.Arguments(


### PR DESCRIPTION
This PR should fix https://github.com/apollographql/apollo-android/issues/1522 and make the ExperimentalApolloCodegenTask behave like the regular one. 

It doesn't fix https://github.com/apollographql/apollo-android/issues/1367 yet as over time the logic that governs schema location/package name has grown complex and it's hard to make it evolve without breaking the existing. I'd like to do that once we can simplify the plugin and rewrite it in kotlin (see https://github.com/apollographql/apollo-android/pull/1507)

