### PR TITLE
Add serverUrl setter

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -237,6 +237,15 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   }
 
   /**
+   * <p>Set the API server's base url.</p>
+   *
+   * @param serverUrl the url to set.
+   */
+  public void setServerUrl(HttpUrl serverUrl) {
+    this.serverUrl = serverUrl;   
+  }
+
+  /**
    * Returns the count of {@link ApolloCall} & {@link ApolloPrefetch} objects which are currently in progress.
    */
   public int activeCallsCount() {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -76,7 +76,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     return new Builder();
   }
 
-  private final HttpUrl serverUrl;
+  private HttpUrl serverUrl;
   private final Call.Factory httpCallFactory;
   private final HttpCache httpCache;
   private final ApolloStore apolloStore;


### PR DESCRIPTION
In certain situations you want to be able to change the server URL without creating a whole new client. For example a Spring Bean.