### PR TITLE
Plugin Kotlin rewrite take #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ android:
     - google-gdk-license-.+
 
 script:
-  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2 -x apollo-integration:build -x apollo-integration:connectedCheck -x :apollo-android-support:connectedCheck
+  - ./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2 -x apollo-integration:build -x apollo-integration:connectedCheck -x :apollo-android-support:connectedCheck -x :apollo-gradle-plugin-incubating:test
+  # We are running these tests in different gradle instances to avoid a OOM error. See https://github.com/gradle/gradle/issues/8354
+  - ./gradlew :apollo-gradle-plugin-incubating:test --tests "com.apollographql.apollo.gradle.test.*"
+  - ./gradlew :apollo-gradle-plugin-incubating:test --tests "com.apollographql.apollo.gradle.dsltest.KotlinDSLTests"
   - .buildscript/integration_tests_composite.sh
 
 before_script:
@@ -34,7 +37,7 @@ env:
   global:
     - secure: "j6yjcBdSkrQ1FdIIJB9Xv5mZF2HHGDuYsRrAUTA3a22klaYdkgIj2bsmcyDsWutkKqJcsZiV9/MJ/2GhLNoExELk5eWL2a1mq0Fn4CzjVN9JKRYoQbIvbAhvsTFPg+UdMePXSEpG4PgF8HrKzq4HUBuHdNc8P3izaHyqokj/84+YLXFWZ7SBMWS6F5CAAoixfCLQDMCeg4l47qhQBt570ENWz9qME4cRfLBSsYjx/YvCLSva13/vFSrQ2J72VlguYHu7FstYOewd7//Hk5azxhT0KmLzO39MN37o6kpQGz7zNstw56xIJaTNMQ2ClrZhvI3yDpyDP2c/MgPeOeEP6lDdfq08BL1fWjO7njWHKvmieRN7+NsN50o9yNd40fxdgySEKK9B54PVBaUFnYB0GfAVbsGCUNT6zIO42MuN/Slv9471Cr9ZtpBicXYv8kAaKsi0p/dyPDB3X72VQTFnVKna4cZowumxAavJ+ISlewjNs/k+nbB/9J4f0Ax0A60hO51yf41ikjkELdbAAQMeZJHCyuJoGDXz6NKwb+HaVgje1F0jndeKPKG2rTB88mBGAkkS9nSaV5+IeHQnzJRjqjf5ObYkAfsvp8oN1Uz1RHSRHVtkx56gWB24ZZ5gv+SKVZAsCX36JJCzYtIMG150D+2UnA5GrlngJUJvzNRlGnI="
     - secure: "WQLS5VDqdCT0f6MzS0mOS5ug+zJPuDcuiZNL5K21DO9UO3dV36eYgo1dLUVPk6ZB2kBMdr2myiHOafsVC1uJSJ3f2O0oXaOQwIHEtwYN2kCjNossPAhhFS3NFQg/F05Fvx2pxR9hggZe3GDWZOMB4r9Eg2EYF/Jozx3LGt7UwWwT2tl8nVGa009yXlVbDP9XuyqqDM+A2Mosj8ih8xPIUMfyzBlcQDOg8BzIBeyZoaCJfeA4kXOGiWYkC27ZMrlOaqPDmAiSiVSihn3lc4kD0p+RINgl05kjzBQ2P3bb2x4QvQMaQqJ8WCRgAGGlRyyIKcnOvfBjSyC15OwdUMYMJMYam8H9L4FaMFMDMWOUjgKvGU7+uNuu5RyjgSeTHlBa4T2F9Dh585QQxCyIKws5XSX06HTrfIb9AoFhKTYEJCBqiyDIMWPZPT9OFRiOaM5PurJUc287rk+8zgZHn9Tq0yr7eAQ+ILuwM/ugPs3jPshiRSStHNkATV0yhvO6LSwGi3LD2gOsqlTtuh9sXFFw2sYtKJVOjH4pdSa0m9LPDiK5WgrqNa46EkJL9Yrm4hU6wW5za8eVPdjW4/4V3w7PuSt3Munulnxpg+SsXqTMabmokX+A0+FkehSrz9LnS4HGsc1nXkXAbERXbRqAJjxbiGhmCRhEKHEcf0JgkmQ4/AA="
-    - GRADLE_OPTS="-Xmx2048m"
+    - GRADLE_OPTS="-Xmx4096m"
     # - ADB_INSTALL_TIMEOUT=8 # minutes (2 minutes by default)
 
 notifications:

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/CustomEnumTypeSpecBuilder.kt
@@ -49,6 +49,6 @@ class CustomEnumTypeSpecBuilder(
           .build()
 
   companion object {
-    fun className(context: CodeGenerationContext): ClassName = ClassName.get(context.packageNameProvider.typesPackageName(), "CustomType")
+    fun className(context: CodeGenerationContext): ClassName = ClassName.get(context.packageNameProvider.typesPackageName, "CustomType")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/FragmentsResponseMapperBuilder.kt
@@ -106,7 +106,7 @@ class FragmentsResponseMapperBuilder(
       fragments
           .map { it.type.unwrapOptionalType(withoutAnnotations = true) as ClassName }
           .map {
-            val mapperClassName = ClassName.get(context.packageNameProvider.fragmentsPackageName(), it.simpleName(),
+            val mapperClassName = ClassName.get(context.packageNameProvider.fragmentsPackageName, it.simpleName(),
                 Util.RESPONSE_FIELD_MAPPER_TYPE_NAME)
             FieldSpec.builder(mapperClassName, it.mapperFieldName(), Modifier.FINAL)
                 .initializer(CodeBlock.of("new \$T()", mapperClassName))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
@@ -9,18 +9,6 @@ import java.util.regex.Pattern
  * The singularization methods were heavily based off rogueweb <link> https://code.google.com/archive/p/rogueweb/source</link>
  */
 
-fun String.formatPackageName(dropLast: Boolean = true): String {
-  val parts = split(File.separatorChar)
-  (parts.size - 1 downTo 2)
-      .filter { parts[it - 2] == "src" && parts[it] == "graphql" }
-      .forEach {
-        return parts.subList(it + 1, parts.size).let { parts ->
-          if (dropLast) parts.dropLast(1) else parts
-        }.joinToString(".")
-      }
-  throw IllegalArgumentException("Files must be organized like src/main/graphql/...")
-}
-
 fun String.singularize(): String {
   if (uncountable.contains(this.toLowerCase())) return this
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
@@ -138,7 +138,7 @@ class InputTypeSpecBuilder(
   }
 
   private fun TypeDeclarationField.javaTypeName(context: CodeGenerationContext): TypeName {
-    return JavaTypeResolver(context, context.packageNameProvider.typesPackageName())
+    return JavaTypeResolver(context, context.packageNameProvider.typesPackageName)
         .resolve(typeName = type, nullableValueType = NullableValueType.INPUT_TYPE)
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -148,7 +148,7 @@ class OperationTypeSpecBuilder(
           .map { variable ->
             variable.name.decapitalize() to JavaTypeResolver(
                 context.copy(nullableValueType = NullableValueType.INPUT_TYPE),
-                context.packageNameProvider.typesPackageName()
+                context.packageNameProvider.typesPackageName
             ).resolve(variable.type)
           }
           .map { (name, type) ->
@@ -205,7 +205,7 @@ class OperationTypeSpecBuilder(
         .map {
           it.first to JavaTypeResolver(
               context.copy(nullableValueType = NullableValueType.INPUT_TYPE),
-              context.packageNameProvider.typesPackageName()
+              context.packageNameProvider.typesPackageName
           ).resolve(it.second)
         }
         .let {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -178,7 +178,7 @@ class SchemaTypeSpecBuilder(
       return fragmentSpreads.map { fragmentName ->
         val optional = isOptional(fragmentName)
         FieldSpec.builder(
-            JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName())
+            JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName)
                 .resolve(typeName = fragmentName.capitalize(), isOptional = optional), fragmentName.decapitalize())
             .addModifiers(Modifier.FINAL)
             .build()
@@ -194,7 +194,7 @@ class SchemaTypeSpecBuilder(
           fragmentName.decapitalize()
         }
         MethodSpec.methodBuilder(methodName)
-            .returns(JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName())
+            .returns(JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName)
                 .resolve(typeName = fragmentName.capitalize(), isOptional = optional))
             .addModifiers(Modifier.PUBLIC)
             .addStatement("return this.\$L", fragmentName.decapitalize())

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/VariablesTypeSpecBuilder.kt
@@ -147,7 +147,7 @@ class VariablesTypeSpecBuilder(
   }
 
   private fun Variable.javaTypeName(context: CodeGenerationContext): TypeName {
-    return JavaTypeResolver(context.copy(nullableValueType = NullableValueType.INPUT_TYPE), context.packageNameProvider.typesPackageName())
+    return JavaTypeResolver(context.copy(nullableValueType = NullableValueType.INPUT_TYPE), context.packageNameProvider.typesPackageName)
         .resolve(type)
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
@@ -19,12 +19,12 @@ class GraphQLKompiler(
     val customTypeMap = customTypeMap.supportedCustomTypes(ir.typesUsed)
     val schema = ir.ast(
         customTypeMap = customTypeMap,
-        typesPackageName = packageNameProvider.typesPackageName(),
-        fragmentsPackage = packageNameProvider.fragmentsPackageName(),
+        typesPackageName = packageNameProvider.typesPackageName,
+        fragmentsPackage = packageNameProvider.fragmentsPackageName,
         useSemanticNaming = useSemanticNaming
     )
 
-    val irPackageName = packageNameProvider.irPackageName
+    val irPackageName = packageNameProvider.schemaPackageName
     if (irPackageName.isNotEmpty()) {
       File(outputDir, irPackageName.replace('.', File.separatorChar)).deleteRecursively()
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
@@ -12,19 +12,19 @@ internal class SchemaCodegen(
   private var fileSpecs: List<FileSpec> = emptyList()
 
   override fun visit(customTypes: CustomTypes) {
-    fileSpecs = fileSpecs + customTypes.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + customTypes.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(enumType: EnumType) {
-    fileSpecs = fileSpecs + enumType.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + enumType.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(inputType: InputType) {
-    fileSpecs = fileSpecs + inputType.typeSpec().fileSpec(packageNameProvider.typesPackageName())
+    fileSpecs = fileSpecs + inputType.typeSpec().fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(fragmentType: FragmentType) {
-    fileSpecs = fileSpecs + fragmentType.typeSpec().fileSpec(packageNameProvider.fragmentsPackageName())
+    fileSpecs = fileSpecs + fragmentType.typeSpec().fileSpec(packageNameProvider.fragmentsPackageName)
   }
 
   override fun visit(operationType: OperationType) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -126,7 +126,7 @@ data class Field(
   }
 
   private fun toTypeName(responseType: String, context: CodeGenerationContext): TypeName {
-    val packageName = if (isNonScalar()) "" else context.packageNameProvider.typesPackageName()
+    val packageName = if (isNonScalar()) "" else context.packageNameProvider.typesPackageName
     return JavaTypeResolver(context, packageName, isDeprecated ?: false).resolve(responseType, isOptional())
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.compiler.parser
 
-import com.apollographql.apollo.compiler.formatPackageName
+import com.apollographql.apollo.compiler.PackageNameProvider
 import com.apollographql.apollo.compiler.ir.*
 import com.apollographql.apollo.compiler.parser.GraphQLDocumentSourceBuilder.graphQLDocumentSource
 import com.apollographql.apollo.compiler.parser.antlr.GraphQLLexer
@@ -10,7 +10,7 @@ import org.antlr.v4.runtime.atn.PredictionMode
 import java.io.File
 import java.io.IOException
 
-class GraphQLDocumentParser(val schema: Schema) {
+class GraphQLDocumentParser(val schema: Schema, private val packageNameProvider: PackageNameProvider) {
   fun parse(graphQLFiles: List<File>): CodeGenerationIR {
     val (operations, fragments, usedTypes) = graphQLFiles.fold(DocumentParseResult()) { acc, graphQLFile ->
       val result = graphQLFile.parse()
@@ -656,7 +656,7 @@ class GraphQLDocumentParser(val schema: Schema) {
   }
 
   private fun List<Operation>.checkMultipleOperationDefinitions() {
-    groupBy { it.filePath.formatPackageName(dropLast = true) + it.operationName }
+    groupBy { packageNameProvider.operationPackageName(it.filePath) + it.operationName }
         .values
         .find { it.size > 1 }
         ?.last()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -17,21 +17,21 @@ import java.util.*
 import javax.tools.JavaFileObject
 
 @RunWith(Parameterized::class)
-class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments, val graphQLFile: File) {
+class CodeGenTest(val folder: File) {
   private val javaExpectedFileMatcher = FileSystems.getDefault().getPathMatcher("glob:**.java")
   private val kotlinExpectedFileMatcher = FileSystems.getDefault().getPathMatcher("glob:**.kt")
   private val sourceFileObjects: MutableList<JavaFileObject> = ArrayList()
 
   @Test
   fun generateExpectedClasses() {
-    generateJavaExpectedClasses(args)
-    generateKotlinExpectedClasses(args)
+    generateJavaExpectedClasses(arguments(folder = folder, generateKotlinModels = false))
+    generateKotlinExpectedClasses(arguments(folder = folder, generateKotlinModels = true))
   }
 
   private fun generateJavaExpectedClasses(args: GraphQLCompiler.Arguments) {
     GraphQLCompiler().write(args)
 
-    Files.walkFileTree(graphQLFile.parentFile.toPath(), object : SimpleFileVisitor<Path>() {
+    Files.walkFileTree(folder.toPath(), object : SimpleFileVisitor<Path>() {
       override fun visitFile(expectedFile: Path, attrs: BasicFileAttributes): FileVisitResult {
         if (javaExpectedFileMatcher.matches(expectedFile)) {
           val expected = expectedFile.toFile()
@@ -44,7 +44,7 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments, val 
           }
 
           assertThat(actual.readText()).isEqualTo(expected.readText())
-          sourceFileObjects.add(JavaFileObjects.forSourceLines("com.example.$pkgName.$actualClassName",
+          sourceFileObjects.add(JavaFileObjects.forSourceLines("com.example.${folder.name}.$actualClassName",
               actual.readLines()))
         }
         return FileVisitResult.CONTINUE
@@ -54,20 +54,9 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments, val 
   }
 
   private fun generateKotlinExpectedClasses(args: GraphQLCompiler.Arguments) {
-    val packageNameProvider = PackageNameProvider(
-        rootPackageName = null,
-        rootDir = null,
-        irPackageName = args.irPackageName,
-        outputPackageName = args.outputPackageName
-    )
-    GraphQLKompiler(
-        ir = args.ir,
-        customTypeMap = args.customTypeMap,
-        useSemanticNaming = args.useSemanticNaming,
-        packageNameProvider = packageNameProvider
-    ).write(args.outputDir)
+    GraphQLCompiler().write(args)
 
-    Files.walkFileTree(graphQLFile.parentFile.toPath(), object : SimpleFileVisitor<Path>() {
+    Files.walkFileTree(folder.toPath(), object : SimpleFileVisitor<Path>() {
       override fun visitFile(expectedFile: Path, attrs: BasicFileAttributes): FileVisitResult {
         if (kotlinExpectedFileMatcher.matches(expectedFile)) {
           val expected = expectedFile.toFile()
@@ -93,80 +82,87 @@ class CodeGenTest(val pkgName: String, val args: GraphQLCompiler.Arguments, val 
   private fun findActual(className: String, extension: String, args: GraphQLCompiler.Arguments): File {
     val possiblePaths = arrayOf("$className.$extension", "type/$className.$extension", "fragment/$className.$extension")
     possiblePaths
-        .map { args.outputDir.toPath().resolve("com/example/$pkgName/$it").toFile() }
+        .map { args.outputDir.toPath().resolve("com/example/${folder.name}/$it").toFile() }
         .filter { it.isFile }
         .forEach { return it }
     throw AssertionError("Couldn't find actual file: $className")
   }
 
   companion object {
+    fun arguments(folder: File, generateKotlinModels: Boolean): GraphQLCompiler.Arguments {
+      val customTypeMap = if (folder.name in listOf("custom_scalar_type", "input_object_type",
+              "mutation_create_review")) {
+        mapOf("Date" to "java.util.Date", "URL" to "java.lang.String", "ID" to "java.lang.Integer")
+      } else {
+        emptyMap()
+      }
+      val nullableValueType = when {
+        folder.name == "hero_details_guava" -> NullableValueType.GUAVA_OPTIONAL
+        folder.name == "hero_details_java_optional" -> NullableValueType.JAVA_OPTIONAL
+        folder.name == "fragments_with_type_condition_nullable" -> NullableValueType.ANNOTATED
+        folder.name == "hero_details_nullable" -> NullableValueType.ANNOTATED
+        folder.name == "union_fragment" -> NullableValueType.ANNOTATED
+        else -> NullableValueType.APOLLO_OPTIONAL
+      }
+      val useSemanticNaming = when {
+        folder.name == "hero_details_semantic_naming" -> true
+        folder.name == "mutation_create_review_semantic_naming" -> true
+        else -> false
+      }
+      val generateModelBuilder = when {
+        folder.name == "fragment_with_inline_fragment" -> true
+        else -> false
+      }
+      val useJavaBeansSemanticNaming = when {
+        folder.name == "java_beans_semantic_naming" -> true
+        else -> false
+      }
+      val suppressRawTypesWarning = when {
+        folder.name == "custom_scalar_type_warnings" -> true
+        else -> false
+      }
+      val generateVisitorForPolymorphicDatatypes = when {
+        folder.name == "java_beans_semantic_naming" -> false
+        else -> true
+      }
+
+      val schemaJson = folder.listFiles().find { it.isFile && it.name == "schema.json" }
+          ?: File("src/test/graphql/schema.json")
+      val schema = Schema(schemaJson)
+      val graphQLFile = File(folder, "TestOperation.graphql")
+
+      val outputPackageName = "com.example.${folder.name}"
+
+      val packageNameProvider = PackageNameProvider(
+          rootPackageName = "",
+          schemaPackageName = "",
+          outputPackageName = outputPackageName
+      )
+      val ir = GraphQLDocumentParser(schema, packageNameProvider).parse(listOf(graphQLFile))
+      val args = GraphQLCompiler.Arguments(
+          ir = ir,
+          outputDir = GraphQLCompiler.OUTPUT_DIRECTORY.plus("sources").fold(File("build"), ::File),
+          customTypeMap = customTypeMap,
+          generateKotlinModels = generateKotlinModels,
+          nullableValueType = nullableValueType,
+          useSemanticNaming = useSemanticNaming,
+          generateModelBuilder = generateModelBuilder,
+          useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
+          suppressRawTypesWarning = suppressRawTypesWarning,
+          generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes,
+          packageNameProvider = packageNameProvider
+      )
+      return args
+    }
+
     @JvmStatic
     @Parameterized.Parameters(name = "{0}")
-    fun data(): Collection<Array<Any>> {
+    fun data(): Collection<File> {
       return File("src/test/graphql/com/example/")
-          .listFiles()
+          .listFiles()!!
           .filter { it.isDirectory }
           // TODO figure out what to do with these cases
           .filter { it.name != "nested_inline_fragment" && it.name != "reserved_words" && it.name != "scalar_types" }
-          .map { folder ->
-            val customTypeMap = if (folder.name in listOf("custom_scalar_type", "input_object_type",
-                    "mutation_create_review")) {
-              mapOf("Date" to "java.util.Date", "URL" to "java.lang.String", "ID" to "java.lang.Integer")
-            } else {
-              emptyMap()
-            }
-            val nullableValueType = when {
-              folder.name == "hero_details_guava" -> NullableValueType.GUAVA_OPTIONAL
-              folder.name == "hero_details_java_optional" -> NullableValueType.JAVA_OPTIONAL
-              folder.name == "fragments_with_type_condition_nullable" -> NullableValueType.ANNOTATED
-              folder.name == "hero_details_nullable" -> NullableValueType.ANNOTATED
-              folder.name == "union_fragment" -> NullableValueType.ANNOTATED
-              else -> NullableValueType.APOLLO_OPTIONAL
-            }
-            val useSemanticNaming = when {
-              folder.name == "hero_details_semantic_naming" -> true
-              folder.name == "mutation_create_review_semantic_naming" -> true
-              else -> false
-            }
-            val generateModelBuilder = when {
-              folder.name == "fragment_with_inline_fragment" -> true
-              else -> false
-            }
-            val useJavaBeansSemanticNaming = when {
-              folder.name == "java_beans_semantic_naming" -> true
-              else -> false
-            }
-            val suppressRawTypesWarning = when {
-              folder.name == "custom_scalar_type_warnings" -> true
-              else -> false
-            }
-            val generateVisitorForPolymorphicDatatypes = when {
-              folder.name == "java_beans_semantic_naming" -> false
-              else -> true
-            }
-
-            val schemaJson = folder.listFiles().find { it.isFile && it.name == "schema.json" } ?: File("src/test/graphql/schema.json")
-            val schema = Schema(schemaJson)
-            val graphQLFile = File(folder, "TestOperation.graphql")
-            val ir = GraphQLDocumentParser(schema).parse(listOf(graphQLFile))
-
-            val outputPackageName = "com.example.${folder.name}"
-
-            val args = GraphQLCompiler.Arguments(
-                ir = ir,
-                outputDir = GraphQLCompiler.OUTPUT_DIRECTORY.plus("sources").fold(File("build"), ::File),
-                customTypeMap = customTypeMap,
-                nullableValueType = nullableValueType,
-                useSemanticNaming = useSemanticNaming,
-                generateModelBuilder = generateModelBuilder,
-                useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
-                suppressRawTypesWarning = suppressRawTypesWarning,
-                irPackageName = outputPackageName,
-                outputPackageName = outputPackageName,
-                generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes
-            )
-            arrayOf(folder.name, args, graphQLFile)
-          }
     }
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/JavaTypeResolverTest.kt
@@ -10,10 +10,9 @@ import java.util.*
 
 class JavaTypeResolverTest {
   private val packageNameProvider = PackageNameProvider(
-      rootPackageName = null,
-      rootDir = null,
+      rootPackageName = "",
       outputPackageName = null,
-      irPackageName = ""
+      schemaPackageName = ""
   )
   private val defaultContext = CodeGenerationContext(
       reservedTypeNames = emptyList(),

--- a/apollo-gradle-plugin-incubating/build.gradle.kts
+++ b/apollo-gradle-plugin-incubating/build.gradle.kts
@@ -1,0 +1,38 @@
+plugins {
+  id("java")
+  id("org.jetbrains.kotlin.jvm")
+  id("java-gradle-plugin")
+}
+
+// groovy strings with double quotes are GString.
+// groovy strings with single quotes are java.lang.String
+// In all cases, gradle APIs take Any so just feed them whatever is returned
+fun dep(key: String) = (extra["dep"] as Map<*, *>)[key]!!
+
+fun Any.dot(key: String): Any {
+  return (this as Map<String, *>)[key]!!
+}
+
+dependencies {
+  compileOnly(gradleApi())
+  compileOnly(dep("kotlin").dot("plugin"))
+  compileOnly(dep("android").dot("plugin"))
+
+  implementation(project(":apollo-compiler"))
+  implementation(dep("kotlin").dot("stdLib"))
+  implementation(dep("okHttp").dot("okHttp"))
+  implementation(dep("moshi").dot("moshi"))
+  
+  testImplementation(dep("junit"))
+  testImplementation(dep("okHttp").dot("mockWebServer"))
+}
+
+tasks.named<Task>("test") {
+  dependsOn(":apollo-api:installLocally")
+  dependsOn(":apollo-compiler:installLocally")
+  dependsOn("installLocally")
+}
+
+apply(rootProject.file("gradle/gradle-mvn-push.gradle"))
+apply(rootProject.file("gradle/bintray.gradle"))
+

--- a/apollo-gradle-plugin-incubating/gradle.properties
+++ b/apollo-gradle-plugin-incubating/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=apollo-gradle-plugin-incubating
+POM_NAME=Apollo Gradle Plugin
+POM_DESCRIPTION=Gradle plugin for generating java/kotlin classes for graphql files
+POM_PACKAGING=jar

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -1,0 +1,61 @@
+package com.apollographql.apollo.gradle
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.api.BaseVariant
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import org.gradle.api.Action
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+
+object AndroidTaskConfigurator {
+  fun configure(apolloExtension: ApolloExtension,
+                androidExtension: Any,
+                project: Project,
+                registerVariantTask: (Project, ApolloVariant, block: (TaskProvider<ApolloCodegenTask>) -> Unit) -> Unit
+                ) {
+    when {
+      androidExtension is LibraryExtension -> {
+        androidExtension.libraryVariants.all(Action { variant ->
+          registerAndroid(project,  apolloExtension, androidExtension, variant, registerVariantTask)
+        })
+        // TODO: add test variants ?
+      }
+      androidExtension is AppExtension -> {
+        androidExtension.applicationVariants.all(Action { variant ->
+          registerAndroid(project,  apolloExtension, androidExtension, variant, registerVariantTask)
+        })
+        // TODO: add test variants ?
+      }
+      else -> {
+        // InstantAppExtension or something else we don't support yet
+        throw IllegalArgumentException("${androidExtension.javaClass.name} is not supported at the moment")
+      }
+    }
+  }
+
+  private fun registerAndroid(project: Project,
+                              apolloExtension: ApolloExtension,
+                              androidExtension: BaseExtension,
+                              variant: BaseVariant,
+                              registerVariantTask: (Project, ApolloVariant, block: (TaskProvider<ApolloCodegenTask>) -> Unit) -> Unit) {
+
+    val apolloVariant = ApolloVariant(
+        name = variant.name,
+        sourceSetNames = variant.sourceSets.map { it.name }.distinct()
+    )
+
+    registerVariantTask(project,  apolloVariant) { serviceVariantTask ->
+      if (apolloExtension.generateKotlinModels) {
+        androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(serviceVariantTask.get().outputDir)
+        project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(serviceVariantTask) }
+      } else {
+        // apparently, this does everything automagically
+        variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
+      }
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -16,17 +16,17 @@ object AndroidTaskConfigurator {
                 androidExtension: Any,
                 project: Project,
                 registerVariantTask: (Project, ApolloVariant, block: (TaskProvider<ApolloCodegenTask>) -> Unit) -> Unit
-                ) {
+  ) {
     when {
       androidExtension is LibraryExtension -> {
         androidExtension.libraryVariants.all(Action { variant ->
-          registerAndroid(project,  apolloExtension, androidExtension, variant, registerVariantTask)
+          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
         })
         // TODO: add test variants ?
       }
       androidExtension is AppExtension -> {
         androidExtension.applicationVariants.all(Action { variant ->
-          registerAndroid(project,  apolloExtension, androidExtension, variant, registerVariantTask)
+          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
         })
         // TODO: add test variants ?
       }
@@ -48,7 +48,7 @@ object AndroidTaskConfigurator {
         sourceSetNames = variant.sourceSets.map { it.name }.distinct()
     )
 
-    registerVariantTask(project,  apolloVariant) { serviceVariantTask ->
+    registerVariantTask(project, apolloVariant) { serviceVariantTask ->
       if (apolloExtension.generateKotlinModels) {
         androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(serviceVariantTask.get().outputDir)
         project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(serviceVariantTask) }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
@@ -58,7 +58,8 @@ open class ApolloCodegenTask : SourceTask() {
     return super.getSource()
   }
 
-  @Internal lateinit var graphqlFiles: List<File>
+  @Internal
+  lateinit var graphqlFiles: List<File>
 
   @TaskAction
   fun taskAction() {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
@@ -1,0 +1,102 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.GraphQLCompiler
+import com.apollographql.apollo.compiler.NullableValueType
+import com.apollographql.apollo.compiler.PackageNameProvider
+import com.apollographql.apollo.compiler.parser.GraphQLDocumentParser
+import com.apollographql.apollo.compiler.parser.Schema
+import org.gradle.api.file.FileTree
+import org.gradle.api.tasks.*
+import java.io.File
+
+@CacheableTask
+open class ApolloCodegenTask : SourceTask() {
+  @get:Input
+  var schemaFile: File? = null
+
+  @get:Input
+  lateinit var rootPackageName: String
+
+  @get:Input
+  lateinit var schemaPackageName: String
+
+  @get:OutputDirectory
+  lateinit var outputDir: File
+
+  @get:Input
+  lateinit var customTypeMapping: Map<String, String>
+
+  @get:Input
+  lateinit var nullableValueType: String
+
+  @get:Input
+  var useSemanticNaming: Boolean = false
+
+  @get:Input
+  var generateModelBuilder: Boolean = false
+
+  @get:Input
+  var useJavaBeansSemanticNaming: Boolean = false
+
+  @get:Input
+  var suppressRawTypesWarning: Boolean = false
+
+  @get:Input
+  var generateKotlinModels: Boolean = false
+
+  @get:Input
+  var generateVisitorForPolymorphicDatatypes: Boolean = false
+
+  @Optional
+  @get:Input
+  var transformedQueriesOutputDir: File? = null
+
+  @InputFiles
+  @SkipWhenEmpty
+  @PathSensitive(PathSensitivity.RELATIVE)
+  override fun getSource(): FileTree {
+    return super.getSource()
+  }
+
+  @Internal lateinit var graphqlFiles: List<File>
+
+  @TaskAction
+  fun taskAction() {
+    val nullableValueTypeEnum = NullableValueType.values().find { it.value == nullableValueType }
+
+    if (schemaFile == null || !schemaFile!!.exists()) {
+      return
+    }
+
+    if (graphqlFiles.isEmpty()) {
+      return
+    }
+
+    outputDir.delete()
+
+    val schema = Schema.invoke(schemaFile!!)
+
+    val packageNameProvider = PackageNameProvider(
+        schemaPackageName = schemaPackageName,
+        rootPackageName = rootPackageName,
+        outputPackageName = null
+    )
+
+    val codeGenerationIR = GraphQLDocumentParser(schema, packageNameProvider).parse(graphqlFiles)
+    val args = GraphQLCompiler.Arguments(
+        ir = codeGenerationIR,
+        outputDir = outputDir,
+        customTypeMap = customTypeMapping,
+        nullableValueType = nullableValueTypeEnum ?: NullableValueType.ANNOTATED,
+        useSemanticNaming = useSemanticNaming,
+        generateModelBuilder = generateModelBuilder,
+        useJavaBeansSemanticNaming = useJavaBeansSemanticNaming,
+        suppressRawTypesWarning = suppressRawTypesWarning,
+        generateKotlinModels = generateKotlinModels,
+        generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes,
+        packageNameProvider = packageNameProvider,
+        transformedQueriesOutputDir = transformedQueriesOutputDir
+    )
+    GraphQLCompiler().write(args)
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloDownloadSchemaTask.kt
@@ -1,0 +1,163 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.child
+import com.squareup.moshi.JsonWriter
+import okhttp3.*
+import okio.Okio
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import java.io.ByteArrayOutputStream
+
+open class ApolloDownloadSchemaTask : DefaultTask() {
+  @Input
+  var endpointUrl: String? = null
+
+  @Input
+  var schemaFilePath: String? = null
+
+  @Optional
+  @Input
+  var headers: Map<String, String>? = null
+
+  @Optional
+  @Input
+  var queryParameters: Map<String, String>? = null
+
+  @TaskAction
+  fun taskAction() {
+    if (schemaFilePath == null) {
+      throw IllegalArgumentException("you need to define service.schemaFilePath.")
+    }
+
+    val byteArrayOutputStream = ByteArrayOutputStream()
+    val writer = JsonWriter.of(Okio.buffer(Okio.sink(byteArrayOutputStream)))
+    writer.beginObject()
+    writer.name("query")
+    writer.value(introspectionQuery)
+    writer.endObject()
+    writer.flush()
+
+    val body = RequestBody.create(MediaType.parse("application/json"), byteArrayOutputStream.toByteArray())
+    val requestBuilder = Request.Builder()
+        .post(body)
+
+    headers?.entries?.forEach {
+      requestBuilder.addHeader(it.key, it.value)
+    }
+
+    val urlBuilder = HttpUrl.get(endpointUrl!!).newBuilder()
+    queryParameters?.entries?.forEach {
+      urlBuilder.addQueryParameter(it.key, it.value)
+    }
+
+    requestBuilder.url(urlBuilder.build())
+        .url(urlBuilder.build())
+        .build()
+
+    val response = OkHttpClient().newCall(requestBuilder.build()).execute()
+
+    if (!response.isSuccessful) {
+      throw Exception("cannot get schema: ${response.code()}:\n${response.body()?.string()}")
+    }
+
+    project.projectDir.child(schemaFilePath!!).writeText(response.body()!!.string())
+  }
+
+  companion object {
+    val introspectionQuery = """
+    query IntrospectionQuery {
+      __schema {
+        queryType { name }
+        mutationType { name }
+        subscriptionType { name }
+        types {
+          ...FullType
+        }
+        directives {
+          name
+          description
+          locations
+          args {
+            ...InputValue
+          }
+        }
+      }
+    }
+
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+
+    fragment InputValue on __InputValue {
+      name
+      description
+      type { ...TypeRef }
+      defaultValue
+    }
+
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }""".trimIndent()
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloExtension.kt
@@ -1,0 +1,125 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.NullableValueType
+import org.gradle.api.Action
+
+open class ApolloExtension {
+  @JvmField
+  var nullableValueType: String? = null
+  @JvmField
+  var useSemanticNaming = true
+  @JvmField
+  var generateModelBuilder = false
+  @JvmField
+  var useJavaBeansSemanticNaming = false
+  @JvmField
+  var suppressRawTypesWarning = false
+  @JvmField
+  var generateKotlinModels = false
+  @JvmField
+  var generateVisitorForPolymorphicDatatypes = false
+  @JvmField
+  var generateTransformedQueries = false
+
+  @JvmField
+  var customTypeMapping: Map<String, String> = emptyMap()
+
+  @JvmField
+  var services = mutableListOf<Service>()
+
+
+  /**
+   * Deprecated,use @{link service} instead
+   */
+  @JvmField
+  var schemaFilePath: String? = null
+
+  /**
+   * Deprecated, use @{link service} instead
+   */
+  @JvmField
+  var outputPackageName: String? = null
+
+  fun service(name: String, action: Action<Service>) {
+    val service = Service(name)
+    action.execute(service)
+    services.add(service)
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setNullableValueType(nullableValueType: String) {
+    this.nullableValueType = nullableValueType
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setUseSemanticNaming(useSemanticNaming: Boolean) {
+    this.useSemanticNaming = useSemanticNaming
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setGenerateModelBuilder(generateModelBuilder: Boolean) {
+    this.generateModelBuilder = generateModelBuilder
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setUseJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean) {
+    this.useJavaBeansSemanticNaming = useJavaBeansSemanticNaming
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setSuppressRawTypesWarning(suppressRawTypesWarning: Boolean) {
+    this.suppressRawTypesWarning = suppressRawTypesWarning
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setGenerateKotlinModels(generateKotlinModels: Boolean) {
+    this.generateKotlinModels = generateKotlinModels
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setGenerateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean) {
+    this.generateKotlinModels = generateVisitorForPolymorphicDatatypes
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setSchemaFilePath(schemaFilePath: String) {
+    this.schemaFilePath = schemaFilePath
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setOutputPackageName(outputPackageName: String) {
+    this.outputPackageName = outputPackageName
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setCustomTypeMapping(customTypeMapping: Map<String, String>) {
+    this.customTypeMapping = customTypeMapping
+  }
+
+  /**
+   * For backward compatibility
+   */
+  fun setGenerateTransformedQueries(generateTransformedQueries: Boolean) {
+    this.generateTransformedQueries = generateTransformedQueries
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
@@ -1,0 +1,210 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.NullableValueType
+import com.apollographql.apollo.compiler.child
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.TaskProvider
+
+open class ApolloPlugin : Plugin<Project> {
+  companion object {
+    const val TASK_GROUP = "apollo"
+  }
+
+  private lateinit var apolloExtension: ApolloExtension
+  private lateinit var apolloSourceSetExtension: ApolloSourceSetExtension
+  private lateinit var generateClassesTask: TaskProvider<Task>
+
+  override fun apply(project: Project) {
+    apolloExtension = project.extensions.create("apollo", ApolloExtension::class.java)
+
+    // for backward compatibility
+    apolloSourceSetExtension = (apolloExtension as ExtensionAware).extensions.create("sourceSet", ApolloSourceSetExtension::class.java)
+
+    generateClassesTask = project.tasks.register("generateApolloClasses") {
+      it.group = TASK_GROUP
+    }
+
+    // the extension block has not been evaluated yet, register a callback once the project has been evaluated
+    project.afterEvaluate {
+      afterEvaluate(it)
+    }
+  }
+
+  private fun useService(schemaFilePath: String?, outputPackageName: String? = null, exclude: String? = null): String {
+    var ret = """
+      |Please use a service instead:
+      |apollo {
+      |  service("github") {
+      """.trimMargin()
+
+    if (schemaFilePath != null) {
+      ret += "\n    schemaFilePath = \"$schemaFilePath\""
+    }
+    if (outputPackageName != null) {
+      ret += "\n    rootPackageName = \"$outputPackageName\""
+    }
+    if (exclude != null) {
+      ret += "\n    exclude = $exclude"
+    }
+    ret += """
+      |
+      |  }
+      |}
+    """.trimMargin()
+    return ret
+  }
+
+  private fun afterEvaluate(project: Project) {
+
+    val androidExtension = project.extensions.findByName("android")
+
+    if (apolloExtension.generateKotlinModels && apolloExtension.generateModelBuilder) {
+      throw IllegalArgumentException("""
+        Using `generateModelBuilder = true` does not make sense with `generateKotlinModels = true`. You can use .copy() as models are data classes.
+      """.trimIndent())
+    }
+
+    if (apolloExtension.generateKotlinModels && apolloExtension.useJavaBeansSemanticNaming) {
+      throw IllegalArgumentException("""
+        Using `useJavaBeansSemanticNaming = true` does not make sense with `generateKotlinModels = true`
+      """.trimIndent())
+    }
+
+    if (apolloExtension.generateKotlinModels && apolloExtension.nullableValueType != null) {
+      throw IllegalArgumentException("""
+        Using `nullableValueType = true` does not make sense with `generateKotlinModels = true`
+      """.trimIndent())
+    }
+
+    if (apolloExtension.schemaFilePath != null) {
+      throw IllegalArgumentException("""
+        apollo.schemaFilePath is not supported anymore as it doesn't work for multiple services.
+        
+      """.trimIndent() + useService(apolloExtension.schemaFilePath, apolloExtension.outputPackageName))
+    }
+
+    if (apolloExtension.outputPackageName != null) {
+      throw IllegalArgumentException("""
+        apollo.outputPackageName is not supported anymore as it doesn't work for multiple services and also flattens the packages.
+        
+      """.trimIndent() + useService(apolloExtension.schemaFilePath, apolloExtension.outputPackageName))
+    }
+
+    if (apolloSourceSetExtension.schemaFile != null || apolloSourceSetExtension.exclude != null) {
+      throw IllegalArgumentException("""
+        apollo.sourceSet is not supported anymore.
+        
+      """.trimIndent() + useService(apolloSourceSetExtension.schemaFile, null, "[${apolloSourceSetExtension.exclude?.joinToString(",")}]"))
+    }
+
+    if (androidExtension == null) {
+      val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
+      val sourceSets = javaPlugin.sourceSets
+
+      // TODO: should we add tasks for the test sourceSet ?
+      val name = "main"
+      val apolloVariant = ApolloVariant(
+          name = name,
+          sourceSetNames = listOf(name)
+      )
+
+      registerVariantTask(project, apolloVariant) {serviceVariantTask ->
+        val sourceDirectorySet =  if (!apolloExtension.generateKotlinModels) {
+          sourceSets.getByName(name).getJava()
+        } else {
+          sourceSets.getByName(name).kotlin!!
+        }
+        val compileTaskName =  if (!apolloExtension.generateKotlinModels) {
+          "compileJava"
+        } else {
+          "compileKotlin"
+        }
+        sourceDirectorySet.srcDir(serviceVariantTask.get().outputDir)
+        project.tasks.named(compileTaskName).configure { it.dependsOn(serviceVariantTask) }
+      }
+    } else {
+      AndroidTaskConfigurator.configure(apolloExtension, androidExtension, project, this::registerVariantTask)
+    }
+
+    apolloExtension.services.forEach {service ->
+      val introspection = service.introspection
+      if (introspection != null) {
+        project.tasks.register("download${service.name.capitalize()}ApolloSchema", ApolloDownloadSchemaTask::class.java) {task->
+          task.group = TASK_GROUP
+          task.schemaFilePath = service.schemaFilePath
+          task.endpointUrl = introspection.endpointUrl!!
+          task.queryParameters = introspection.queryParameters
+          task.headers = introspection.headers
+        }
+      }
+    }
+  }
+
+  private fun registerVariantTask(project: Project,
+                                  apolloVariant: ApolloVariant,
+                                  addOutputDirToSourceSetDir: (TaskProvider<ApolloCodegenTask>) -> Unit) {
+
+    val generateVariantClassesTask = project.tasks.register("generate${apolloVariant.name.capitalize()}ApolloClasses") {
+      it.group = TASK_GROUP
+    }
+
+    var serviceVariants = apolloExtension.services.map {
+      ServiceVariant.from(project, apolloVariant.sourceSetNames, it)
+    }
+    if (serviceVariants.isEmpty()) {
+      serviceVariants = ServiceVariant.default(project, apolloVariant.sourceSetNames)
+    }
+    serviceVariants.forEach { serviceVariant ->
+      val serviceVariantTask = registerCodegenTasks(project, apolloExtension, apolloVariant.name, serviceVariant)
+      generateVariantClassesTask.configure {
+        it.dependsOn(serviceVariantTask)
+      }
+
+      addOutputDirToSourceSetDir(serviceVariantTask)
+    }
+
+    generateClassesTask.configure {
+      it.dependsOn(generateVariantClassesTask)
+    }
+  }
+
+  fun registerCodegenTasks(project: Project, extension: ApolloExtension, variantName: String, serviceVariant: ServiceVariant): TaskProvider<ApolloCodegenTask> {
+    val taskName = "generate${variantName.capitalize()}${serviceVariant.name.capitalize()}ApolloClasses"
+
+    return project.tasks.register(taskName, ApolloCodegenTask::class.java) {
+      val outputFolder = project.buildDir.child("generated", "apollo", "classes", variantName, serviceVariant.name)
+
+      val transformedQueriesOutputDir = if (extension.generateTransformedQueries) {
+        project.buildDir.child("generated", "apollo", "transformedQueries", variantName, serviceVariant.name)
+      } else {
+        null
+      }
+
+      it.source(serviceVariant.files)
+      if (serviceVariant.schemaFile != null) {
+        it.source(serviceVariant.files)
+      }
+
+      it.graphqlFiles = serviceVariant.files
+      it.schemaFile = serviceVariant.schemaFile
+      it.schemaPackageName = serviceVariant.schemaPackageName
+      it.rootPackageName = serviceVariant.rootPackageName
+      it.group = TASK_GROUP
+      it.description = "Generate Android classes for ${variantName.capitalize()}${serviceVariant.name} GraphQL queries"
+      it.outputDir = outputFolder
+      it.nullableValueType = extension.nullableValueType ?: NullableValueType.ANNOTATED.value
+      it.useSemanticNaming = extension.useSemanticNaming
+      it.generateModelBuilder = extension.generateModelBuilder
+      it.useJavaBeansSemanticNaming = extension.useJavaBeansSemanticNaming
+      it.suppressRawTypesWarning = extension.suppressRawTypesWarning
+      it.generateKotlinModels = extension.generateKotlinModels
+      it.generateVisitorForPolymorphicDatatypes = extension.generateVisitorForPolymorphicDatatypes
+      it.customTypeMapping = extension.customTypeMapping
+      it.transformedQueriesOutputDir = transformedQueriesOutputDir
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
@@ -112,13 +112,13 @@ open class ApolloPlugin : Plugin<Project> {
           sourceSetNames = listOf(name)
       )
 
-      registerVariantTask(project, apolloVariant) {serviceVariantTask ->
-        val sourceDirectorySet =  if (!apolloExtension.generateKotlinModels) {
+      registerVariantTask(project, apolloVariant) { serviceVariantTask ->
+        val sourceDirectorySet = if (!apolloExtension.generateKotlinModels) {
           sourceSets.getByName(name).getJava()
         } else {
           sourceSets.getByName(name).kotlin!!
         }
-        val compileTaskName =  if (!apolloExtension.generateKotlinModels) {
+        val compileTaskName = if (!apolloExtension.generateKotlinModels) {
           "compileJava"
         } else {
           "compileKotlin"
@@ -130,10 +130,10 @@ open class ApolloPlugin : Plugin<Project> {
       AndroidTaskConfigurator.configure(apolloExtension, androidExtension, project, this::registerVariantTask)
     }
 
-    apolloExtension.services.forEach {service ->
+    apolloExtension.services.forEach { service ->
       val introspection = service.introspection
       if (introspection != null) {
-        project.tasks.register("download${service.name.capitalize()}ApolloSchema", ApolloDownloadSchemaTask::class.java) {task->
+        project.tasks.register("download${service.name.capitalize()}ApolloSchema", ApolloDownloadSchemaTask::class.java) { task ->
           task.group = TASK_GROUP
           task.schemaFilePath = service.schemaFilePath
           task.endpointUrl = introspection.endpointUrl!!

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPluginAndroid.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPluginAndroid.kt
@@ -1,0 +1,10 @@
+package com.apollographql.apollo.gradle
+
+import org.gradle.api.Project
+
+open class ApolloPluginAndroid : ApolloPlugin() {
+  override fun apply(project: Project) {
+    project.logger.error("The `com.apollographql.android` plugin works for non-android as well. You can use `com.apollographql.apollo` if you prefer.")
+    super.apply(project)
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloSourceSetExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloSourceSetExtension.kt
@@ -1,0 +1,25 @@
+package com.apollographql.apollo.gradle
+
+/**
+ * @Deprecated
+ *
+ * This class is only there for backward compatibility reasons with the old groovy plugin
+ */
+open class ApolloSourceSetExtension {
+  @JvmField
+  var schemaFile: String? = null
+  @JvmField
+  var exclude: List<String>? = null
+
+  fun setSchemaFile(schemaFile: String) {
+    this.schemaFile = schemaFile
+  }
+
+  fun setExclude(exclude: List<String> ) {
+    this.exclude = exclude
+  }
+
+  fun setExclude(exclude: String) {
+    this.exclude = listOf(exclude)
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloSourceSetExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloSourceSetExtension.kt
@@ -15,7 +15,7 @@ open class ApolloSourceSetExtension {
     this.schemaFile = schemaFile
   }
 
-  fun setExclude(exclude: List<String> ) {
+  fun setExclude(exclude: List<String>) {
     this.exclude = exclude
   }
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloVariant.kt
@@ -1,0 +1,28 @@
+package com.apollographql.apollo.gradle
+
+import org.gradle.api.file.SourceDirectorySet
+
+class ApolloVariant(
+    /**
+     * The full name of the variant
+     *
+     * For an example for the demoDebug variant: `demoDebug`
+     */
+    val name: String,
+
+    /**
+     * A list of root sourceSets names where to look for .graphql files. We're not using sourceDirectorySet as
+     * we don't want to look into generated files.
+     * They are sorted in the same order as Android variant.sourceSets so the last one overrides the ones before
+     *
+     * For an example for the demoDebug variant:
+     *
+     * main
+     * demo
+     * demoDebug
+     * etc...
+     *
+     */
+    val sourceSetNames: List<String>
+
+)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Introspection.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Introspection.kt
@@ -1,0 +1,7 @@
+package com.apollographql.apollo.gradle
+
+class Introspection {
+  var endpointUrl: String ? = null
+  var queryParameters: Map<String, String>? = null
+  var headers: Map<String, String>? = null
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Introspection.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Introspection.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.gradle
 
 class Introspection {
-  var endpointUrl: String ? = null
+  var endpointUrl: String? = null
   var queryParameters: Map<String, String>? = null
   var headers: Map<String, String>? = null
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/KotlinSourceSetExtensions.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/KotlinSourceSetExtensions.kt
@@ -1,0 +1,29 @@
+package com.apollographql.apollo.gradle
+
+import com.android.build.gradle.api.AndroidSourceSet
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.HasConvention
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.jetbrains.kotlin.gradle.plugin.KOTLIN_DSL_NAME
+import org.jetbrains.kotlin.gradle.plugin.KOTLIN_JS_DSL_NAME
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+
+internal val AndroidSourceSet.kotlin: SourceDirectorySet?
+  get() = kotlinSourceSet
+
+internal val SourceSet.kotlin: SourceDirectorySet?
+  get() = kotlinSourceSet
+
+// Copied from kotlin plugin
+private val Any.kotlinSourceSet: SourceDirectorySet?
+  get() {
+    val convention = (getConvention(KOTLIN_DSL_NAME) ?: getConvention(KOTLIN_JS_DSL_NAME)) ?: return null
+    val kotlinSourceSetIface =
+        convention.javaClass.interfaces.find { it.name == KotlinSourceSet::class.qualifiedName }
+    val getKotlin = kotlinSourceSetIface?.methods?.find { it.name == "getKotlin" } ?: return null
+    return getKotlin(convention) as? SourceDirectorySet
+  }
+
+private fun Any.getConvention(name: String): Any? =
+    (this as HasConvention).convention.plugins[name]

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/Service.kt
@@ -1,0 +1,59 @@
+package com.apollographql.apollo.gradle
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+
+class Service(val name: String) {
+  /**
+   * Place where the schema.json file is.
+   * This path is relative to the current project directory.
+   * schemaFilePath can point outside of src/{foo}/graphql but in that case, you'll want
+   * to define rootPackageName else fragments/types will be stored at the root of the namespace.
+   * By default, the plugin will look for a schema.json file in src/{foo}/graphql
+   */
+  var schemaFilePath: String? = null
+
+  /**
+   * Place where the graphql files are searched.
+   * This path is relative to the current sourceSet (e.g src/{foo}/graphql/{sourceFolderPath})
+   * By default, this is the directory where the schema.json is stored or "." if the schema is outside.
+   * You need to define this if you have two or more services whose schema is stored outside src/{foo}/graphql.
+   * If not, you can certainly omit it.
+   */
+  var sourceFolderPath: String? = null
+
+  var rootPackageName: String? = null
+
+  /**
+   * list of pattern of files to exclude
+   */
+  var exclude: List<String>? = null
+
+  var introspection: Introspection? = null
+
+  fun introspection(closure: Closure<Introspection>) {
+    val introspection = Introspection()
+    closure.delegate = introspection
+    closure.resolveStrategy = Closure.DELEGATE_FIRST
+    closure.call()
+
+    introspection(introspection)
+  }
+
+  fun introspection(action: Action<Introspection>) {
+    val introspection = Introspection()
+    action.execute(introspection)
+
+    introspection(introspection)
+  }
+
+  fun introspection(introspection: Introspection) {
+    if (introspection.endpointUrl == null) {
+      throw IllegalArgumentException("introspection must have a url")
+    }
+    if (this.introspection != null) {
+      throw IllegalArgumentException("there must be only one introspection block")
+    }
+    this.introspection = introspection
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
@@ -72,19 +72,19 @@ class ServiceVariant(
       val services = schemaFiles.entries
           .sortedBy { it.value.canonicalPath } // make sure the order is predicable for tests
           .map { entry ->
-        val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
-        val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
+            val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
+            val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
 
-        val name = (i++).toString()//entry.key.split(File.separator).map { it.capitalize() }.joinToString("")
+            val name = (i++).toString()//entry.key.split(File.separator).map { it.capitalize() }.joinToString("")
 
-        ServiceVariant(
-            name = name,
-            files = files,
-            schemaFile = entry.value,
-            schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
-            rootPackageName = ""
-        )
-      }
+            ServiceVariant(
+                name = name,
+                files = files,
+                schemaFile = entry.value,
+                schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
+                rootPackageName = ""
+            )
+          }
 
       return services
     }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
@@ -1,0 +1,133 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.*
+import org.gradle.api.Project
+import org.gradle.api.tasks.util.PatternSet
+import java.io.File
+
+class ServiceVariant(
+    val name: String,
+    val files: List<File>,
+    val schemaFile: File?,
+    val schemaPackageName: String,
+    val rootPackageName: String
+) {
+
+  companion object {
+    fun from(project: Project, sourceSetNames: List<String>, service: Service): ServiceVariant {
+      val schemaFilePath = service.schemaFilePath
+      if (schemaFilePath == null) {
+        throw IllegalArgumentException("Please define schemaFilePath for service '${service.name}'")
+      }
+
+      var schemaFile = project.projectDir.child(schemaFilePath)
+      if (!schemaFile.isFile) {
+        throw IllegalArgumentException("No schema found at:\n${schemaFile.absolutePath}")
+      }
+      val schemaKey = schemaFile.canonicalPath.relativePathToGraphql()
+      if (schemaKey != null) {
+        // schema is under src/{foo}/graphql, see if it is overriden by anoter variant
+        val schemaCandidates = findFilesInSourceSets(project, sourceSetNames, schemaKey) { true }
+        schemaFile = schemaCandidates.values.first()
+      }
+
+      val sourceFolderPath = if (service.sourceFolderPath != null) {
+        service.sourceFolderPath!!
+      } else {
+        // if schemaFilePath is outside src/{foo}/graphql, search the whole graphql folder
+        schemaFile.canonicalPath.relativePathToGraphql(dropLast = 1) ?: "."
+      }
+
+      val candidateFiles = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
+
+      val files = if (service.exclude != null) {
+        val patternSet = PatternSet()
+        patternSet.exclude(service.exclude!!)
+        project.files(candidateFiles).asFileTree.matching(patternSet).toList()
+      } else {
+        candidateFiles
+      }
+
+      val schemaPackageName = schemaFile.canonicalPath.formatPackageName(dropLast = 1) ?: ""
+
+      return ServiceVariant(
+          name = service.name,
+          files = files,
+          schemaFile = schemaFile,
+          schemaPackageName = schemaPackageName,
+          rootPackageName = service.rootPackageName ?: ""
+      )
+    }
+
+    fun default(project: Project, sourceSetNames: List<String>): List<ServiceVariant> {
+      val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
+        it.name == "schema.json"
+      }
+
+      if (schemaFiles.isEmpty()) {
+        return emptyList()
+      }
+
+      var i = 0
+      val services = schemaFiles.entries
+          .sortedBy { it.value.canonicalPath } // make sure the order is predicable for tests
+          .map { entry ->
+        val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
+        val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
+
+        val name = (i++).toString()//entry.key.split(File.separator).map { it.capitalize() }.joinToString("")
+
+        ServiceVariant(
+            name = name,
+            files = files,
+            schemaFile = entry.value,
+            schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
+            rootPackageName = ""
+        )
+      }
+
+      return services
+    }
+
+    fun isGraphQL(file: File): Boolean {
+      return file.name.endsWith(".graphql") || file.name.endsWith(".gql")
+    }
+
+    /**
+     * Finds the files in the given sourceSets taking into account their precedence according to the android plugin order
+     *
+     * Returns a map with the relative path to the path as key and the file as value
+     *
+     * Files coming last will have higher priorities that the first ones.
+     */
+    private fun findFilesInSourceSets(project: Project, sourceSetNames: List<String>, path: String, predicate: (File) -> Boolean): Map<String, File> {
+      val candidates = mutableMapOf<String, File>()
+      sourceSetNames.forEach { sourceSetName ->
+        val root = project.projectDir.child("src", sourceSetName, "graphql", path)
+        val files = root.findFiles(predicate)
+
+        files.forEach {
+          val key = if (root.isFile) {
+            // toRelativeString only works on directories.
+            ""
+          } else {
+            it.toRelativeString(root)
+          }
+
+          // overwrite the previous entry if it was there already
+          // this is ok as Android orders the sourceSetNames from lower to higher priority
+          candidates[key] = it
+        }
+      }
+      return candidates
+    }
+
+    private fun File.findFiles(predicate: (File) -> Boolean): List<File> {
+      return when {
+        isDirectory -> listFiles()?.flatMap { it.findFiles(predicate) } ?: emptyList()
+        isFile && predicate(this) -> listOf(this)
+        else -> emptyList()
+      }
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/resources/META-INF/gradle-plugins/com.apollographql.android.properties
+++ b/apollo-gradle-plugin-incubating/src/main/resources/META-INF/gradle-plugins/com.apollographql.android.properties
@@ -1,0 +1,1 @@
+implementation-class=com.apollographql.apollo.gradle.ApolloPluginAndroid

--- a/apollo-gradle-plugin-incubating/src/main/resources/META-INF/gradle-plugins/com.apollographql.apollo.properties
+++ b/apollo-gradle-plugin-incubating/src/main/resources/META-INF/gradle-plugins/com.apollographql.apollo.properties
@@ -1,0 +1,1 @@
+implementation-class=com.apollographql.apollo.gradle.ApolloPlugin

--- a/apollo-gradle-plugin-incubating/src/test/files/githunt/FeedQuery.graphql
+++ b/apollo-gradle-plugin-incubating/src/test/files/githunt/FeedQuery.graphql
@@ -1,0 +1,29 @@
+query FeedQuery($type: FeedType!, $limit: Int!) {
+  feed(type: $type, limit: $limit) {
+    comments {
+      ...FeedCommentFragment
+    }
+    repository {
+      ...RepositoryFragment
+    }
+    postedBy {
+      login
+    }
+  }
+}
+
+fragment RepositoryFragment on Repository {
+  name
+  full_name
+  owner {
+    login
+  }
+}
+
+fragment FeedCommentFragment on Comment {
+  id
+  postedBy {
+    login
+  }
+  content
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/githunt/schema.json
+++ b/apollo-gradle-plugin-incubating/src/test/files/githunt/schema.json
@@ -1,0 +1,1747 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "feed",
+              "description": "A feed of repository submissions",
+              "args": [
+                {
+                  "name": "type",
+                  "description": "The sort order for the feed",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "FeedType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "The number of items to skip, for pagination",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": "The number of items to fetch starting from the offset, for pagination",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "entry",
+              "description": "A single entry",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentUser",
+              "description": "Return the currently logged in user, or null if nobody is logged in",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FeedType",
+          "description": "A list of options for the sort order of the feed",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "HOT",
+              "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NEW",
+              "description": "Newest entries first",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOP",
+              "description": "Highest score entries first",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Entry",
+          "description": "Information about a GitHub repository submitted to GitHunt",
+          "fields": [
+            {
+              "name": "repository",
+              "description": "Information about the repository from GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Repository",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postedBy",
+              "description": "The GitHub user who submitted this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "A timestamp of when the entry was submitted",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": "The score of this repository, upvotes - downvotes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hotScore",
+              "description": "The hot score of this repository",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comments",
+              "description": "Comments posted about this repository",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Comment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commentCount",
+              "description": "The number of comments posted about this repository",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The SQL ID of this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vote",
+              "description": "XXX to be changed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vote",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Repository",
+          "description": "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "Just the name of the repository, e.g. GitHunt-API",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "full_name",
+              "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "The description of the repository",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "html_url",
+              "description": "The link to the repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stargazers_count",
+              "description": "The number of people who have starred this repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "open_issues_count",
+              "description": "The number of open issues on this repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "owner",
+              "description": "The owner of this repository on GitHub, e.g. apollostack",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "description": "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+          "fields": [
+            {
+              "name": "login",
+              "description": "The name of the user, e.g. apollostack",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "avatar_url",
+              "description": "The URL to a directly embeddable image for this user's avatar",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "html_url",
+              "description": "The URL of this user's GitHub page",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Comment",
+          "description": "A comment about an entry, submitted by a user",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The SQL ID of this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postedBy",
+              "description": "The GitHub user who posted the comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "A timestamp of when the comment was posted",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "content",
+              "description": "The text of the comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "repoName",
+              "description": "The repository which this comment is about",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Vote",
+          "description": "XXX to be removed",
+          "fields": [
+            {
+              "name": "vote_value",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": "",
+          "fields": [
+            {
+              "name": "submitRepository",
+              "description": "Submit a new repository, returns the new submission",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vote",
+              "description": "Vote on a repository submission, returns the submission that was voted on",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "type",
+                  "description": "The type of vote - UP, DOWN, or CANCEL",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "VoteType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submitComment",
+              "description": "Comment on a repository, returns the new comment",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "commentContent",
+                  "description": "The text content for the new comment",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "VoteType",
+          "description": "The type of vote to record, when submitting a vote",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "UP",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DOWN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CANCEL",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": "",
+          "fields": [
+            {
+              "name": "commentAdded",
+              "description": "Subscription fires on every comment added",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.kts.template
+++ b/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.kts.template
@@ -1,0 +1,65 @@
+import com.apollographql.apollo.gradle.ApolloExtension
+
+buildscript {
+  apply("../../../gradle/dependencies.gradle")
+
+  val classpathDep = {artifact: String ->
+    val c = artifact.split(".")
+
+    var ret = (extra["dep"] as Map<String, *>)[c[0]]!!
+
+    if (c.size > 1) {
+      ret = (ret as Map<String, *>)[c[1]]!!
+    }
+    ret
+  }
+
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url = uri("../../../build/localMaven")
+    }
+  }
+  dependencies {
+    // ADD BUILDSCRIPT DEPENDENCIES HERE
+  }
+}
+
+fun kotlinDep(artifact: String): Any {
+  val c = artifact.split(".")
+
+  var ret = (extra["dep"] as Map<String, *>)[c[0]]!!
+
+  if (c.size > 1) {
+    ret = (ret as Map<String, *>)[c[1]]!!
+  }
+  return ret
+}
+
+// ADD PLUGINS HERE
+// apply plugin: 'com.android.library'
+// apply plugin: 'com.apollographql.apollo'
+
+repositories {
+  google() // for aapt2
+  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
+  jcenter() // for org.jetbrains.trove4j, depended on by lint
+  maven {
+    url = uri("../../../build/localMaven")
+  }
+}
+
+dependencies {
+  // ADD DEPENDENCIES HERE
+  add("implementation", kotlinDep("jetbrainsAnnotations"))
+  add("implementation", kotlinDep("apollo.api"))
+}
+
+// ADD ANDROID CONFIGURATION HERE
+// android {
+//   compileSdkVersion androidConfig.compileSdkVersion
+// }
+
+// ADD APOLLO CONFIGURATION HERE
+

--- a/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.template
+++ b/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.template
@@ -1,0 +1,42 @@
+buildscript {
+  apply from: "../../../gradle/dependencies.gradle"
+
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url = uri("../../../build/localMaven")
+    }
+  }
+  dependencies {
+    // ADD BUILDSCRIPT DEPENDENCIES HERE
+    // classpath(dep.androidPlugin)
+    // classpath(dep.apolloPluginIncubating)
+  }
+}
+
+// ADD PLUGINS HERE
+// apply plugin: 'com.android.library'
+// apply plugin: 'com.apollographql.apollo'
+
+repositories {
+  google() // for aapt2
+  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
+  jcenter() // for org.jetbrains.trove4j, depended on by lint
+  maven {
+    url = uri("../../../build/localMaven")
+  }
+}
+
+dependencies {
+  // ADD DEPENDENCIES HERE
+  implementation dep.jetbrainsAnnotations
+  implementation dep.apollo.api
+}
+
+// ADD ANDROID CONFIGURATION HERE
+// android {
+//   compileSdkVersion androidConfig.compileSdkVersion
+// }
+
+// ADD APOLLO CONFIGURATION HERE

--- a/apollo-gradle-plugin-incubating/src/test/files/gradle/settings.gradle
+++ b/apollo-gradle-plugin-incubating/src/test/files/gradle/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name="testProject"

--- a/apollo-gradle-plugin-incubating/src/test/files/java/com/example/Main.java
+++ b/apollo-gradle-plugin-incubating/src/test/files/java/com/example/Main.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.example.DroidDetailsQuery;
+
+class Main {
+    DroidDetailsQuery aMethodThatReferencesAGeneratedQuery() {
+        return new DroidDetailsQuery();
+    }
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/kotlin/com/example/Main.kt
+++ b/apollo-gradle-plugin-incubating/src/test/files/kotlin/com/example/Main.kt
@@ -1,0 +1,9 @@
+package com.example
+
+import com.example.DroidDetailsQuery
+
+class Main {
+  fun aMethodThatReferencesAGeneratedQuery(): DroidDetailsQuery {
+    return DroidDetailsQuery()
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/manifest/AndroidManifest.xml
+++ b/apollo-gradle-plugin-incubating/src/test/files/manifest/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.apollographql">
+
+</manifest>

--- a/apollo-gradle-plugin-incubating/src/test/files/starwars/AllFilms.graphql
+++ b/apollo-gradle-plugin-incubating/src/test/files/starwars/AllFilms.graphql
@@ -1,0 +1,9 @@
+query Films {
+  allFilms {
+    films {
+      id
+      title
+      releaseDate
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/starwars/DroidDetails.graphql
+++ b/apollo-gradle-plugin-incubating/src/test/files/starwars/DroidDetails.graphql
@@ -1,0 +1,7 @@
+query DroidDetails {
+  species(id: "c3BlY2llczoy") {
+    id
+    name
+    classification
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/starwars/DroidDetailsSpeciesInfo.graphql
+++ b/apollo-gradle-plugin-incubating/src/test/files/starwars/DroidDetailsSpeciesInfo.graphql
@@ -1,0 +1,12 @@
+query DroidDetailsSpeciesInfo {
+  species(id: "c3BlY2llczoy") {
+    id
+    name
+    ...SpeciesInformation
+
+  }
+}
+
+fragment SpeciesInformation on Species {
+  classification
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/starwars/schema.json
+++ b/apollo-gradle-plugin-incubating/src/test/files/starwars/schema.json
@@ -1,0 +1,5843 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Root"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Root",
+          "description": null,
+          "fields": [
+            {
+              "name": "allFilms",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "film",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "filmID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allPeople",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PeopleConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "person",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "personID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allPlanets",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PlanetsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planet",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "planetID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allSpecies",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SpeciesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "species",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "speciesID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Species",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allStarships",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "StarshipsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starship",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "starshipID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Starship",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "allVehicles",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "VehiclesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicle",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "vehicleID",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Vehicle",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": "Fetches an object given its ID",
+              "args": [
+                {
+                  "name": "id",
+                  "description": "The ID of an object",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Node",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "DateTime",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PageInfo",
+          "description": "Information about pagination in a connection.",
+          "fields": [
+            {
+              "name": "hasNextPage",
+              "description": "When paginating forwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hasPreviousPage",
+              "description": "When paginating backwards, are there more items?",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startCursor",
+              "description": "When paginating backwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "endCursor",
+              "description": "When paginating forwards, the cursor to continue.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Film",
+          "description": "A single film.",
+          "fields": [
+            {
+              "name": "title",
+              "description": "The title of this film.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "episodeID",
+              "description": "The episode number of this film.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "openingCrawl",
+              "description": "The opening paragraphs at the beginning of this film.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "director",
+              "description": "The name of the director of this film.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "producers",
+              "description": "The name(s) of the producer(s) of this film.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "releaseDate",
+              "description": "The ISO 8601 date format of film release at original creator country.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "speciesConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmSpeciesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starshipConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmStarshipsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicleConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmVehiclesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "characterConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmCharactersConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planetConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FilmPlanetsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "Node",
+          "description": "An object with an ID",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id of the object.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Planet",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Species",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Starship",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Vehicle",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Person",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Film",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Planet",
+          "description": "A large mass, planet or planetoid in the Star Wars Universe, at the time of\n0 ABY.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of this planet.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "diameter",
+              "description": "The diameter of this planet in kilometers.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rotationPeriod",
+              "description": "The number of standard hours it takes for this planet to complete a single\nrotation on its axis.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orbitalPeriod",
+              "description": "The number of standard days it takes for this planet to complete a single orbit\nof its local star.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gravity",
+              "description": "A number denoting the gravity of this planet, where \"1\" is normal or 1 standard\nG. \"2\" is twice or 2 standard Gs. \"0.5\" is half or 0.5 standard Gs.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "population",
+              "description": "The average population of sentient beings inhabiting this planet.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "climates",
+              "description": "The climates of this planet.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "terrains",
+              "description": "The terrains of this planet.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surfaceWater",
+              "description": "The percentage of the planet surface that is naturally occuring water or bodies\nof water.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "residentConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PlanetResidentsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filmConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PlanetFilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetResidentsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PlanetResidentsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "residents",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetResidentsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Person",
+          "description": "An individual person or character within the Star Wars universe.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of this person.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "birthYear",
+              "description": "The birth year of the person, using the in-universe standard of BBY or ABY -\nBefore the Battle of Yavin or After the Battle of Yavin. The Battle of Yavin is\na battle that occurs at the end of Star Wars episode IV: A New Hope.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eyeColor",
+              "description": "The eye color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have an eye.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "gender",
+              "description": "The gender of this person. Either \"Male\", \"Female\" or \"unknown\",\n\"n/a\" if the person does not have a gender.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hairColor",
+              "description": "The hair color of this person. Will be \"unknown\" if not known or \"n/a\" if the\nperson does not have hair.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "height",
+              "description": "The height of the person in centimeters.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mass",
+              "description": "The mass of the person in kilograms.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "skinColor",
+              "description": "The skin color of this person.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homeworld",
+              "description": "A planet that this person was born on or inhabits.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filmConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PersonFilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "species",
+              "description": "The species that this person belongs to, or null if unknown.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Species",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starshipConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PersonStarshipsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicleConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PersonVehiclesConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonFilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PersonFilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonFilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Species",
+          "description": "A type of person or character within the Star Wars Universe.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of this species.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "classification",
+              "description": "The classification of this species, such as \"mammal\" or \"reptile\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "designation",
+              "description": "The designation of this species, such as \"sentient\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "averageHeight",
+              "description": "The average height of this species in centimeters.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "averageLifespan",
+              "description": "The average lifespan of this species in years.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "eyeColors",
+              "description": "Common eye colors for this species, null if this species does not typically\nhave eyes.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hairColors",
+              "description": "Common hair colors for this species, null if this species does not typically\nhave hair.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "skinColors",
+              "description": "Common skin colors for this species, null if this species does not typically\nhave skin.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "language",
+              "description": "The language commonly spoken by this species.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "homeworld",
+              "description": "A planet that this species originates from.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "personConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SpeciesPeopleConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filmConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SpeciesFilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesPeopleConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SpeciesPeopleEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "people",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesPeopleEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesFilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SpeciesFilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesFilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonStarshipsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PersonStarshipsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starships",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Starship",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonStarshipsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Starship",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Starship",
+          "description": "A single transport craft that has hyperdrive capability.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of this starship. The common name, such as \"Death Star\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "model",
+              "description": "The model or official name of this starship. Such as \"T-65 X-wing\" or \"DS-1\nOrbital Battle Station\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starshipClass",
+              "description": "The class of this starship, such as \"Starfighter\" or \"Deep Space Mobile\nBattlestation\"",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manufacturers",
+              "description": "The manufacturers of this starship.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "costInCredits",
+              "description": "The cost of this starship new, in galactic credits.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "length",
+              "description": "The length of this starship in meters.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "crew",
+              "description": "The number of personnel needed to run or pilot this starship.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "passengers",
+              "description": "The number of non-essential people this starship can transport.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxAtmospheringSpeed",
+              "description": "The maximum speed of this starship in atmosphere. null if this starship is\nincapable of atmosphering flight.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hyperdriveRating",
+              "description": "The class of this starships hyperdrive.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MGLT",
+              "description": "The Maximum number of Megalights this starship can travel in a standard hour.\nA \"Megalight\" is a standard unit of distance and has never been defined before\nwithin the Star Wars universe. This figure is only really useful for measuring\nthe difference in speed of starships. We can assume it is similar to AU, the\ndistance between our Sun (Sol) and Earth.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cargoCapacity",
+              "description": "The maximum number of kilograms that this starship can transport.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "consumables",
+              "description": "The maximum length of time that this starship can provide consumables for its\nentire crew without having to resupply.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pilotConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "StarshipPilotsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filmConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "StarshipFilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipPilotsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "StarshipPilotsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pilots",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipPilotsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipFilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "StarshipFilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipFilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonVehiclesConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PersonVehiclesEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicles",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vehicle",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PersonVehiclesEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Vehicle",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Vehicle",
+          "description": "A single transport craft that does not have hyperdrive capability",
+          "fields": [
+            {
+              "name": "name",
+              "description": "The name of this vehicle. The common name, such as \"Sand Crawler\" or \"Speeder\nbike\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "model",
+              "description": "The model or official name of this vehicle. Such as \"All-Terrain Attack\nTransport\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicleClass",
+              "description": "The class of this vehicle, such as \"Wheeled\" or \"Repulsorcraft\".",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manufacturers",
+              "description": "The manufacturers of this vehicle.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "costInCredits",
+              "description": "The cost of this vehicle new, in Galactic Credits.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "length",
+              "description": "The length of this vehicle in meters.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "crew",
+              "description": "The number of personnel needed to run or pilot this vehicle.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "passengers",
+              "description": "The number of non-essential people this vehicle can transport.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxAtmospheringSpeed",
+              "description": "The maximum speed of this vehicle in atmosphere.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cargoCapacity",
+              "description": "The maximum number of kilograms that this vehicle can transport.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "consumables",
+              "description": "The maximum length of time that this vehicle can provide consumables for its\nentire crew without having to resupply.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pilotConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "VehiclePilotsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filmConnection",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "before",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "last",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "VehicleFilmsConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created",
+              "description": "The ISO 8601 date format of the time that this resource was created.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edited",
+              "description": "The ISO 8601 date format of the time that this resource was edited.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The ID of an object",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Node",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehiclePilotsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VehiclePilotsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pilots",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehiclePilotsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehicleFilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VehicleFilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehicleFilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetFilmsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PlanetFilmsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "films",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Film",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetFilmsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Film",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmSpeciesConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmSpeciesEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "species",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Species",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmSpeciesEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Species",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmStarshipsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmStarshipsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starships",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Starship",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmStarshipsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Starship",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmVehiclesConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmVehiclesEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicles",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vehicle",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmVehiclesEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Vehicle",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmCharactersConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmCharactersEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "characters",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmCharactersEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmPlanetsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FilmPlanetsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planets",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Planet",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FilmPlanetsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PeopleConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PeopleEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "people",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Person",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PeopleEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Person",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PlanetsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planets",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Planet",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PlanetsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Planet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SpeciesEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "species",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Species",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SpeciesEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Species",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipsConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "StarshipsEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "starships",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Starship",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StarshipsEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Starship",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehiclesConnection",
+          "description": "A connection to a list of items.",
+          "fields": [
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "edges",
+              "description": "Information to aid in pagination.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VehiclesEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": "A count of the total number of objects in this connection, ignoring pagination.\nThis allows a client to fetch the first five objects by passing \"5\" as the\nargument to \"first\", then fetch the total count so it could display \"5 of 83\",\nfor example.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicles",
+              "description": "A list of all of the objects returned in the connection. This is a convenience\nfield provided for quickly exploring the API; rather than querying for\n\"{ edges { node } }\" when no edge data is needed, this field can be be used\ninstead. Note that when clients like Relay need to fetch the \"cursor\" field on\nthe edge to enable efficient pagination, this shortcut cannot be used, and the\nfull \"{ edges { node } }\" version should be used instead.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vehicle",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehiclesEdge",
+          "description": "An edge in a connection.",
+          "fields": [
+            {
+              "name": "node",
+              "description": "The item at the end of the edge",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Vehicle",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cursor",
+              "description": "A cursor for use in pagination",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
@@ -1,0 +1,84 @@
+package com.apollographql.apollo.gradle.dsltest
+
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KotlinDSLTests {
+  @Test
+  fun `project configures correctly and generates something`() {
+    val apolloConfiguration = """
+      (extensions.getByName("apollo") as ApolloExtension).apply {
+        setNullableValueType("annotated")
+        setUseJavaBeansSemanticNaming(false)
+        setGenerateModelBuilder(false)
+        setUseSemanticNaming(false)
+        setUseJavaBeansSemanticNaming(false)
+        setSuppressRawTypesWarning(false)
+        setGenerateVisitorForPolymorphicDatatypes(false)
+        //setSchemaFilePath("")
+        //setOutputPackageName("")
+        setCustomTypeMapping(mapOf("DateTime" to "java.util.Date"))
+        setGenerateKotlinModels(false)
+        setGenerateTransformedQueries(false)
+        
+        service("starwars") {
+          sourceFolderPath = "com/example"
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+          rootPackageName = "com.starwars"
+          exclude = listOf("*.gql")
+        }
+      }
+    """.trimIndent()
+
+    TestUtils.withProject(
+        usesKotlinDsl = true,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
+        apolloConfiguration = apolloConfiguration
+    ) { dir ->
+      val result = TestUtils.executeTask("generateApolloClasses", dir)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+      Assert.assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/DroidDetails.java").isFile)
+    }
+  }
+
+  @Test
+  fun `property syntax is also working`() {
+    val apolloConfiguration = """
+      (extensions.getByName("apollo") as ApolloExtension).apply {
+        nullableValueType = "annotated"
+        useJavaBeansSemanticNaming = false
+        generateModelBuilder = false
+        useSemanticNaming = false
+        useJavaBeansSemanticNaming = false
+        suppressRawTypesWarning = false
+        generateVisitorForPolymorphicDatatypes = false
+        //schemaFilePath = ""
+        //outputPackageName = ""
+        customTypeMapping = mapOf("DateTime" to "java.util.Date")
+        generateKotlinModels = false
+        generateTransformedQueries = false
+        
+        service("starwars") {
+          sourceFolderPath = "com/example"
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+          rootPackageName = "com.starwars"
+          exclude = listOf("*.gql")
+        }
+      }
+    """.trimIndent()
+
+    TestUtils.withProject(
+        usesKotlinDsl = true,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
+        apolloConfiguration = apolloConfiguration
+    ) { dir ->
+      val result = TestUtils.executeTask("generateApolloClasses", dir)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+      Assert.assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/DroidDetails.java").isFile)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -17,7 +17,7 @@ class AndroidTests {
   fun `android library is compiling fine`() {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) { dir ->
       val result = TestUtils.executeTask("build", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
@@ -36,7 +36,7 @@ class AndroidTests {
   fun `android library debug does not compile release`() {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) { dir ->
       val result = TestUtils.executeTask("generateDebugApolloClasses", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
@@ -51,7 +51,7 @@ class AndroidTests {
   fun `android library debug query overrides main`() {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) { dir ->
 
       val debugFile = File(dir, "src/debug/graphql/com/example/DroidDetails.graphql")
       File(dir, "src/main/graphql/com/example/DroidDetails.graphql").copyTo(debugFile)
@@ -72,7 +72,7 @@ class AndroidTests {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
         isFlavored = true,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) { dir ->
 
       TestUtils.executeTask("build", dir)
 
@@ -88,7 +88,7 @@ class AndroidTests {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
         isFlavored = true,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) { dir ->
 
       val freeDebugDir = File(dir, "src/freeDebug/graphql/com/example/")
       freeDebugDir.mkdirs()
@@ -113,7 +113,7 @@ class AndroidTests {
   fun `android application is compiling fine`() {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
-        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin)) { dir ->
       val result = TestUtils.executeTask("build", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
@@ -132,7 +132,7 @@ class AndroidTests {
   fun `applying com-apollographql-android shows a warning`() {
     withProject(apolloConfiguration = "",
         usesKotlinDsl = false,
-        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPluginAndroid)) {dir ->
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPluginAndroid)) { dir ->
 
       val result = TestUtils.executeTask("generateDebugApolloClasses", dir)
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -1,0 +1,143 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import com.apollographql.apollo.gradle.util.replaceInText
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.File
+
+class AndroidTests {
+
+  @Test
+  fun `android library is compiling fine`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+      val result = TestUtils.executeTask("build", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
+
+      // Java classes generated successfully
+      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `android library debug does not compile release`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+      val result = TestUtils.executeTask("generateDebugApolloClasses", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
+
+      // Java classes generated successfully
+      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
+      assertFalse(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").exists())
+    }
+  }
+
+  @Test
+  fun `android library debug query overrides main`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+
+      val debugFile = File(dir, "src/debug/graphql/com/example/DroidDetails.graphql")
+      File(dir, "src/main/graphql/com/example/DroidDetails.graphql").copyTo(debugFile)
+      debugFile.replaceInText("c3BlY2llczoy", "speciesIdForDebug")
+
+      val result = TestUtils.executeTask("generateDebugApolloClasses", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
+
+      // Java classes generated successfully
+      assertThat(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").readText(), containsString("speciesIdForDebug"))
+    }
+  }
+
+
+  @Test
+  fun `product flavors compile correctly`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        isFlavored = true,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+
+      TestUtils.executeTask("build", dir)
+
+      assertTrue(dir.generatedChild("freeDebug/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("freeRelease/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidDebug/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidRelease/0/com/example/DroidDetailsQuery.java").isFile)
+    }
+  }
+
+  @Test
+  fun `flavor with invalid schema fails while others compile correctly`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        isFlavored = true,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin)) {dir ->
+
+      val freeDebugDir = File(dir, "src/freeDebug/graphql/com/example/")
+      freeDebugDir.mkdirs()
+      File(freeDebugDir, "schema.json").writeText("This is an invalid schema")
+
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateFreeDebugApolloClasses", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("Failed to parse GraphQL schema introspection query"))
+      }
+
+      assertNotNull(exception)
+
+      val result = TestUtils.executeTask("generatePaidDebugApolloClasses", dir)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generatePaidDebugApolloClasses")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `android application is compiling fine`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin)) {dir ->
+      val result = TestUtils.executeTask("build", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
+
+      // Java classes generated successfully
+      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/0/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `applying com-apollographql-android shows a warning`() {
+    withProject(apolloConfiguration = "",
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPluginAndroid)) {dir ->
+
+      val result = TestUtils.executeTask("generateDebugApolloClasses", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
+      assertThat(result.output, containsString("You can use `com.apollographql.apollo` if you prefer."))
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
@@ -1,0 +1,41 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class CacheTests {
+
+  @Test
+  fun `generate apollo classes task is cached`() {
+    TestUtils.withSimpleProject { dir ->
+
+      val buildCacheDir = dir.child("buildCache")
+
+      File(dir, "settings.gradle").appendText("""
+        
+        buildCache {
+            local {
+                directory '${buildCacheDir.absolutePath}'
+            }
+        }
+      """.trimIndent())
+
+      System.out.println("build the project")
+      var result = TestUtils.executeTask("generateMain0ApolloClasses", dir, "--build-cache")
+
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMain0ApolloClasses")!!.outcome)
+
+      System.out.println("delete build folder")
+      dir.child("build").deleteRecursively()
+
+      System.out.println("build from cache")
+      result = TestUtils.executeTask("generateMain0ApolloClasses", dir, "--build-cache")
+
+      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMain0ApolloClasses")!!.outcome)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -47,11 +47,11 @@ class ConfigurationTests {
 
   @Test
   fun `useSemanticNaming defaults to true`() {
-      withSimpleProject("""
+    withSimpleProject("""
     """.trimIndent()) { dir ->
-        TestUtils.executeTask("generateApolloClasses", dir)
-        TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
-      }
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+    }
   }
 
   @Test

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -1,0 +1,267 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert.*
+import org.junit.Test
+import java.io.File
+
+class ConfigurationTests {
+  @Test
+  fun `customTypeMapping is working`() {
+    withSimpleProject("""
+      apollo {
+        customTypeMapping = ["DateTime": "java.util.Date"]
+        suppressRawTypesWarning = "true"
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Date.class;")
+    }
+  }
+
+  @Test
+  fun `nullableValueType is working`() {
+    for (pair in listOf(
+        "annotated" to "@Nullable String name()",
+        "apolloOptional" to "import com.apollographql.apollo.api.internal.Optional;",
+        "guavaOptional" to "import com.google.common.base.Optional;",
+        "javaOptional" to "import java.util.Optional;",
+        "inputType" to "Input<String> name()"
+    )) {
+      withSimpleProject("""
+      apollo {
+        nullableValueType = "${pair.first}"
+      }
+    """.trimIndent()) { dir ->
+        TestUtils.executeTask("generateApolloClasses", dir)
+        TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", pair.second)
+      }
+    }
+  }
+
+  @Test
+  fun `useSemanticNaming defaults to true`() {
+      withSimpleProject("""
+    """.trimIndent()) { dir ->
+        TestUtils.executeTask("generateApolloClasses", dir)
+        TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+      }
+  }
+
+  @Test
+  fun `useSemanticNaming can be turned off correctly`() {
+    withSimpleProject("""
+      apollo {
+        useSemanticNaming = false
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetails.java", "class DroidDetails ")
+    }
+  }
+
+  @Test
+  fun `generateModelBuilders defaults to false`() {
+    withSimpleProject("""
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileDoesNotContain(dir, "main/0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+    }
+  }
+
+  @Test
+  fun `generateModelBuilders generates builders correctly`() {
+    withSimpleProject("""
+      apollo {
+        generateModelBuilder = true
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+    }
+  }
+
+  @Test
+  fun `useJavaBeansSemanticNaming defaults to false`() {
+    withSimpleProject("""
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "String name()")
+    }
+  }
+
+  @Test
+  fun `useJavaBeansSemanticNaming generates java beans methods correctly`() {
+    withSimpleProject("""
+      apollo {
+        useJavaBeansSemanticNaming = true
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloClasses", dir)
+      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "String getName()")
+    }
+  }
+
+  @Test
+  fun `schemaFilePath fails`() {
+    withSimpleProject("""
+      apollo {
+        schemaFilePath = "schema.json"
+      }
+    """.trimIndent()) { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateApolloClasses", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("is not supported anymore"))
+      }
+      assertNotNull(exception)
+    }
+  }
+
+  @Test
+  fun `outputPackageName fails`() {
+    withSimpleProject("""
+      apollo {
+        outputPackageName = "com.starwars"
+      }
+    """.trimIndent()) { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateApolloClasses", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("is not supported anymore"))
+      }
+      assertNotNull(exception)
+    }
+  }
+
+  @Test
+  fun `sourceSet fails gracefully`() {
+    withSimpleProject("""
+      apollo {
+        sourceSet {
+          schemaFile = "schema.json"
+          exclude = "**/*.gql"
+        }
+      }
+    """.trimIndent()) { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateApolloClasses", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("is not supported anymore"))
+      }
+      assertNotNull(exception)
+    }
+  }
+
+  @Test
+  fun `sourceSet with multiple exclude fails gracefully`() {
+    withSimpleProject("""
+      apollo {
+        sourceSet {
+          schemaFile = "schema.json"
+          exclude = ["**/Query1.graphql", "**/Query2.graphql"]
+        }
+      }
+    """.trimIndent()) { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateApolloClasses", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("is not supported anymore"))
+      }
+      assertNotNull(exception)
+    }
+  }
+
+  @Test
+  fun `schemaFilePath can be changed`() {
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaFilePath = "starwars.json"
+          sourceFolderPath = "starwars"
+        }
+      }
+    """.trimIndent()) { dir ->
+      File(dir, "src/main/graphql/com/example").copyRecursively(File(dir, "src/main/graphql/starwars"))
+      File(dir, "src/main/graphql/com").deleteRecursively()
+      File(dir, "src/main/graphql/starwars/schema.json").copyTo(File(dir, "starwars.json"))
+      File(dir, "src/main/graphql/starwars/schema.json").delete()
+
+      TestUtils.executeTask("generateApolloClasses", dir)
+      assertTrue(dir.generatedChild("main/starwars/starwars/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `rootPackageName can be changed`() {
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaFilePath = "starwars.json"
+          sourceFolderPath = "starwars"
+          rootPackageName = "com.starwars"
+        }
+      }
+    """.trimIndent()) { dir ->
+      File(dir, "src/main/graphql/com/example").copyRecursively(File(dir, "src/main/graphql/starwars"))
+      File(dir, "src/main/graphql/com").deleteRecursively()
+      File(dir, "src/main/graphql/starwars/schema.json").copyTo(File(dir, "starwars.json"))
+      File(dir, "src/main/graphql/starwars/schema.json").delete()
+
+      TestUtils.executeTask("generateApolloClasses", dir)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/starwars/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `exclude is working properly`() {
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+          exclude = ["**/*.gql"]
+        }
+      }
+    """.trimIndent()) { dir ->
+      File(dir, "src/main/graphql/com/example/error.gql").writeText("this is not valid graphql")
+      File(dir, "src/main/graphql/com/example/error/").mkdir()
+      File(dir, "src/main/graphql/com/example/error/error.gql").writeText("this is not valid graphql")
+      val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `generateTransformedQueries generates queries with __typename`() {
+    withSimpleProject("""
+      apollo {
+        generateTransformedQueries = true
+      }
+    """.trimIndent()) { dir ->
+      val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+      val transformedQuery = dir.child("build", "generated", "apollo", "transformedQueries", "main", "0", "com", "example", "DroidDetails.graphql")
+      assertThat(transformedQuery.readText(), containsString("__typename"))
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
@@ -1,0 +1,73 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+class DownloadSchemaTests {
+  val mockServer = MockWebServer()
+
+  val apolloConfiguration = """
+      apollo {
+        service("mock") {
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+          introspection {
+            endpointUrl = "${mockServer.url("/").url()}"
+          }
+        }
+      }
+    """.trimIndent()
+
+  @Test
+  fun `schema is downloaded correctly`() {
+
+    withSimpleProject(apolloConfiguration = apolloConfiguration) {dir ->
+      val content = "schema should be here"
+      val mockResponse = MockResponse().setBody(content)
+      mockServer.enqueue(mockResponse)
+
+      TestUtils.executeTask("downloadMockApolloSchema", dir)
+
+      assertEquals(content, dir.child("src", "main", "graphql", "com", "example", "schema.json").readText())
+    }
+  }
+
+
+  @Test
+  fun `download schema is never cached`() {
+
+    withSimpleProject(apolloConfiguration = apolloConfiguration) { dir ->
+      val buildCacheDir = dir.child("buildCache")
+
+      File(dir, "settings.gradle").appendText("""
+        
+        buildCache {
+            local {
+                directory '${buildCacheDir.absolutePath}'
+            }
+        }
+      """.trimIndent())
+
+      val schemaFile = dir.child("src", "main", "graphql", "com", "example", "schema.json")
+
+      val content1 = "schema1"
+      mockServer.enqueue(MockResponse().setBody(content1))
+
+      TestUtils.executeTask("downloadMockApolloSchema", dir, "--build-cache")
+      assertEquals(content1, schemaFile.readText())
+
+      val content2 = "schema2"
+      mockServer.enqueue(MockResponse().setBody(content2))
+
+      TestUtils.executeTask("downloadMockApolloSchema", dir, "--build-cache")
+      assertEquals(content2, schemaFile.readText())
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
@@ -28,7 +28,7 @@ class DownloadSchemaTests {
   @Test
   fun `schema is downloaded correctly`() {
 
-    withSimpleProject(apolloConfiguration = apolloConfiguration) {dir ->
+    withSimpleProject(apolloConfiguration = apolloConfiguration) { dir ->
       val content = "schema should be here"
       val mockResponse = MockResponse().setBody(content)
       mockServer.enqueue(mockResponse)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -1,0 +1,33 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class KotlinCodegenTests {
+  @Test
+  fun `generates and compiles kotlin`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = true
+      }
+    """.trimIndent()
+    withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)) {dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
+
+      TestUtils.executeTask("build", dir)
+      Assert.assertTrue(File(dir,"build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/0/com/example/type/CustomType.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.kt").isFile)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -18,13 +18,13 @@ class KotlinCodegenTests {
     """.trimIndent()
     withProject(usesKotlinDsl = false,
         apolloConfiguration = apolloConfiguration,
-        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)) {dir ->
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)) { dir ->
 
       val source = TestUtils.fixturesDirectory()
       source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
 
       TestUtils.executeTask("build", dir)
-      Assert.assertTrue(File(dir,"build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.kt").isFile)
       Assert.assertTrue(dir.generatedChild("main/0/com/example/type/CustomType.kt").isFile)
       Assert.assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.kt").isFile)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
@@ -12,7 +12,7 @@ class MultipleServicesTests {
   fun withMultipleServicesProject(apolloConfiguration: String, block: (File) -> Unit) {
     withProject(usesKotlinDsl = false,
         plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
-        apolloConfiguration = apolloConfiguration) {dir ->
+        apolloConfiguration = apolloConfiguration) { dir ->
       val source = TestUtils.fixturesDirectory()
       val target = dir.child("src", "main", "graphql", "githunt")
       File(source, "githunt").copyRecursively(target = target, overwrite = true)
@@ -23,7 +23,7 @@ class MultipleServicesTests {
 
   @Test
   fun `default services are found`() {
-    withMultipleServicesProject("") {dir ->
+    withMultipleServicesProject("") { dir ->
       TestUtils.executeTask("build", dir)
 
       assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
@@ -46,7 +46,7 @@ class MultipleServicesTests {
         }
       }
     """.trimIndent()
-    withMultipleServicesProject(apolloConfiguration) {dir ->
+    withMultipleServicesProject(apolloConfiguration) { dir ->
       TestUtils.executeTask("build", dir)
 
       assertTrue(dir.generatedChild("main/starwars/com/example/DroidDetailsQuery.java").isFile)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
@@ -1,0 +1,59 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class MultipleServicesTests {
+  fun withMultipleServicesProject(apolloConfiguration: String, block: (File) -> Unit) {
+    withProject(usesKotlinDsl = false,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
+        apolloConfiguration = apolloConfiguration) {dir ->
+      val source = TestUtils.fixturesDirectory()
+      val target = dir.child("src", "main", "graphql", "githunt")
+      File(source, "githunt").copyRecursively(target = target, overwrite = true)
+
+      block(dir)
+    }
+  }
+
+  @Test
+  fun `default services are found`() {
+    withMultipleServicesProject("") {dir ->
+      TestUtils.executeTask("build", dir)
+
+      assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/1/githunt/FeedQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/1/githunt/fragment/RepositoryFragment.java").isFile)
+    }
+  }
+
+  @Test
+  fun `can specify services explicitely`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+        }
+        service("githunt") {
+          schemaFilePath = "src/main/graphql/githunt/schema.json"
+        }
+      }
+    """.trimIndent()
+    withMultipleServicesProject(apolloConfiguration) {dir ->
+      TestUtils.executeTask("build", dir)
+
+      assertTrue(dir.generatedChild("main/starwars/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/githunt/githunt/FeedQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/githunt/githunt/fragment/RepositoryFragment.java").isFile)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/NonAndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/NonAndroidTests.kt
@@ -1,0 +1,23 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
+import com.apollographql.apollo.gradle.util.replaceInText
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class NonAndroidTests {
+  @Test
+  fun `applying the apollo plugin does not pull the android plugin in the classpath`() {
+    withSimpleProject {dir ->
+      // Remove the google() repo where the android plugin resides
+      File(dir, "build.gradle").replaceInText("google()", "")
+
+      val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/NonAndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/NonAndroidTests.kt
@@ -11,7 +11,7 @@ import java.io.File
 class NonAndroidTests {
   @Test
   fun `applying the apollo plugin does not pull the android plugin in the classpath`() {
-    withSimpleProject {dir ->
+    withSimpleProject { dir ->
       // Remove the google() repo where the android plugin resides
       File(dir, "build.gradle").replaceInText("google()", "")
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -1,0 +1,102 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class SourceDirectorySetTests {
+  @Test
+  fun `android-kotlin builds an apk`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = true
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.kotlinAndroidPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
+
+      TestUtils.executeTask("assembleDebug", dir)
+
+      Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/Main.class").isFile)
+      Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.kt").isFile)
+    }
+  }
+
+  @Test
+  fun `non-android-kotlin builds a jar`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = true
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
+
+      TestUtils.executeTask("build", dir)
+
+      Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/Main.class").isFile)
+      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
+    }
+  }
+
+  @Test
+  fun `android-java builds an apk`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("java").copyRecursively(dir.child("src", "main", "java"))
+
+      TestUtils.executeTask("assembleDebug", dir)
+
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/Main.class").isFile)
+      Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
+    }
+  }
+
+  @Test
+  fun `non-android-java builds a jar`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("java").copyRecursively(dir.child("src", "main", "java"))
+
+      TestUtils.executeTask("build", dir)
+
+      Assert.assertTrue(File(dir, "build/classes/java/main/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/java/main/com/example/Main.class").isFile)
+      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
@@ -1,0 +1,71 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class UpToDateTests {
+  @Test
+  fun test() {
+    withSimpleProject { dir ->
+      `builds successfully and generates expected outputs`(dir)
+      `nothing changed, task up to date`(dir)
+      `adding a custom type to the build script re-generates the CustomType class`(dir)
+    }
+  }
+
+  private fun `builds successfully and generates expected outputs`(dir: File) {
+    val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+
+    // Java classes generated successfully
+    assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
+
+    // verify that the custom type generated was Object.class because no customType mapping was specified
+    TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Object.class;")
+
+    // Optional is not added to the generated classes
+    assert(!TestUtils.fileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "Optional"))
+    TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "import org.jetbrains.annotations.Nullable;")
+  }
+
+  fun `nothing changed, task up to date`(dir: File) {
+    val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+    assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateApolloClasses")!!.outcome)
+
+    // Java classes generated successfully
+    assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
+  }
+
+  fun `adding a custom type to the build script re-generates the CustomType class`(dir: File) {
+    val apolloBlock = """
+      apollo {
+        customTypeMapping = ["DateTime": "java.util.Date"]
+      }
+    """.trimIndent()
+
+    File(dir, "build.gradle").appendText(apolloBlock)
+
+    val result = TestUtils.executeTask("generateApolloClasses", dir)
+
+    // modifying the customTypeMapping should cause the task to be out of date
+    // and the task should run again
+    assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
+
+    TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Date.class;")
+
+    val text = File(dir, "build.gradle").readText()
+    File(dir, "build.gradle").writeText(text.replace(apolloBlock, ""))
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/AndroidTestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/AndroidTestUtils.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.apollographql.apollo.gradle.util
+
+import java.io.File
+import java.util.Properties
+
+fun String.withInvariantPathSeparators() = replace("\\", "/")
+
+internal fun androidHome(): String {
+  val env = System.getenv("ANDROID_HOME")
+  if (env != null) {
+    return env.withInvariantPathSeparators()
+  }
+  val localProp = File(File(System.getProperty("user.dir")).parentFile, "local.properties")
+  if (localProp.exists()) {
+    val prop = Properties()
+    localProp.inputStream().use {
+      prop.load(it)
+    }
+    val sdkHome = prop.getProperty("sdk.dir")
+    if (sdkHome != null) {
+      return sdkHome.withInvariantPathSeparators()
+    }
+  }
+  throw IllegalStateException(
+      "Missing 'ANDROID_HOME' environment variable or local.properties with 'sdk.dir'")
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -1,0 +1,170 @@
+package com.apollographql.apollo.gradle.util
+
+import com.apollographql.apollo.compiler.child
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.junit.Assert.assertThat
+import java.io.File
+
+object TestUtils {
+  class Plugin(val artifact: String?, val id: String)
+
+  val javaPlugin = Plugin(id = "java", artifact = null)
+  val androidApplicationPlugin = Plugin(id = "com.android.application", artifact = "android.plugin")
+  val androidLibraryPlugin = Plugin(id = "com.android.library", artifact = "android.plugin")
+  val kotlinJvmPlugin = Plugin(id = "org.jetbrains.kotlin.jvm", artifact = "kotlin.plugin")
+  val kotlinAndroidPlugin = Plugin(id = "org.jetbrains.kotlin.android", artifact = "kotlin.plugin")
+  val apolloPlugin = Plugin(id = "com.apollographql.apollo", artifact = "apollo.pluginIncubating")
+  val apolloPluginAndroid = Plugin(id = "com.apollographql.android", artifact = "apollo.pluginIncubating")
+
+  fun withProject(usesKotlinDsl: Boolean,
+                  plugins: List<Plugin>,
+                  apolloConfiguration: String,
+                  isFlavored: Boolean = false,
+                  block: (File) -> Unit) {
+    val source = fixturesDirectory()
+    val dest = File(System.getProperty("user.dir")).child("build", "testProject")
+
+    dest.deleteRecursively()
+
+    source.child("starwars").copyRecursively(target = dest.child("src", "main", "graphql", "com", "example"))
+    source.child("gradle", "settings.gradle").copyTo(target = dest.child("settings.gradle"))
+
+    val isAndroid = plugins.firstOrNull { it.id.startsWith("com.android") } != null
+    val hasKotlin = plugins.firstOrNull { it.id.startsWith("org.jetbrains.kotlin") } != null
+
+    if (usesKotlinDsl) {
+      val applyLines = plugins.map { "apply(plugin = \"${it.id}\")" }.joinToString("\n")
+      val classPathLines = plugins.filter { it.artifact != null }
+          .map { "classpath(classpathDep(\"${it.artifact!!}\"))" }
+          .joinToString("\n")
+
+      var buildscript = File(source, "gradle/build.gradle.kts.template")
+          .readText()
+          .replace("// ADD BUILDSCRIPT DEPENDENCIES HERE", classPathLines)
+          .replace("// ADD PLUGINS HERE", applyLines)
+          .replace("// ADD APOLLO CONFIGURATION HERE", apolloConfiguration)
+
+      if (isAndroid) {
+        val androidConfiguration = """
+        android {
+          setCompileSdkVersion((extra["androidConfig"] as Map<String,*>).get("compileSdkVersion") as Int)
+        }
+      """.trimIndent()
+        if (isFlavored) {
+          throw IllegalArgumentException("flavored build using build.gradle.kts are not supported")
+        }
+        buildscript = buildscript.replace("// ADD ANDROID CONFIGURATION HERE", androidConfiguration)
+      }
+
+      if (hasKotlin) {
+        buildscript = buildscript.replace(
+            "// ADD DEPENDENCIES HERE",
+            "add(\"implementation\", kotlinDep(\"kotlin.stdlib\"))")
+      }
+
+      File(dest, "build.gradle.kts").writeText(buildscript)
+    } else {
+      val applyLines = plugins.map { "apply plugin: \"${it.id}\"" }.joinToString("\n")
+      val classPathLines = plugins.filter { it.artifact != null }.map { "classpath(dep.${it.artifact})" }.joinToString("\n")
+
+      var buildscript = File(source, "gradle/build.gradle.template")
+          .readText()
+          .replace("// ADD BUILDSCRIPT DEPENDENCIES HERE", classPathLines)
+          .replace("// ADD PLUGINS HERE", applyLines)
+          .replace("// ADD APOLLO CONFIGURATION HERE", apolloConfiguration)
+
+      if (isAndroid) {
+        var androidConfiguration = """
+        |android {
+        |  compileSdkVersion androidConfig.compileSdkVersion
+        |
+      """.trimMargin()
+
+        if (isFlavored) {
+          androidConfiguration += """
+          |  flavorDimensions "price"
+          |  productFlavors {
+          |    free {
+          |      dimension 'price'
+          |    }
+          |
+          |    paid {
+          |      dimension 'price'
+          |    }
+          |  }
+          |
+          """.trimMargin()
+        }
+
+        androidConfiguration += """
+        |}
+      """.trimMargin()
+
+        buildscript = buildscript.replace("// ADD ANDROID CONFIGURATION HERE", androidConfiguration)
+      }
+
+      if (hasKotlin) {
+        buildscript = buildscript.replace("// ADD DEPENDENCIES HERE", "implementation dep.kotlin.stdLib")
+      }
+
+      File(dest, "build.gradle").writeText(buildscript)
+    }
+
+    if (isAndroid) {
+      source.child("manifest", "AndroidManifest.xml").copyTo(dest.child("src", "main", "AndroidManifest.xml"))
+      File(dest, "local.properties").writeText("sdk.dir=${androidHome()}\n")
+    }
+
+    block(dest)
+
+    dest.deleteRecursively()
+  }
+
+  /**
+   * creates a simple java non-android non-kotlin-gradle project
+   */
+  fun withSimpleProject(apolloConfiguration: String = "", block: (File) -> Unit) = withProject(
+      usesKotlinDsl = false,
+      plugins = listOf(javaPlugin, apolloPlugin),
+      apolloConfiguration = apolloConfiguration
+  ) { dir ->
+    fixturesDirectory().child("java").copyRecursively(dir.child("src", "main", "java"))
+    block(dir)
+  }
+
+  fun executeTask(task: String, projectDir: File, vararg args: String): BuildResult {
+    return GradleRunner.create()
+        .forwardStdOutput(System.out.writer())
+        .forwardStdError(System.err.writer())
+        .withProjectDir(projectDir)
+        .withArguments(task, "--stacktrace", *args)
+        .build()
+  }
+
+  fun assertFileContains(projectDir: File, path: String, content: String) {
+    val text = projectDir.generatedChild(path).readText()
+    assertThat(text, containsString(content))
+  }
+
+  fun assertFileDoesNotContain(projectDir: File, path: String, content: String) {
+    val text = projectDir.generatedChild(path).readText()
+    assertThat(text, not(containsString(content)))
+  }
+
+  fun fileContains(projectDir: File, path: String, content: String): Boolean {
+    return projectDir.generatedChild(path).readText()
+        .contains(content)
+  }
+
+  fun fixturesDirectory() = File(System.getProperty("user.dir")).child("src", "test", "files")
+}
+
+fun File.generatedChild(path: String) = child("build", "generated", "apollo", "classes", path)
+
+fun File.replaceInText(oldValue: String, newValue: String) {
+  val text = readText()
+  writeText(text.replace(oldValue, newValue))
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,6 +28,10 @@ echo ${YELLOW}Deploying Gradle Plugin ...${CLEAR}
 ./gradlew clean :apollo-gradle-plugin:bintrayUpload
 echo ${YELLOW}Deploying Gradle Plugin - ${GREEN}Done!${CLEAR}
 
+echo ${YELLOW}Deploying Gradle Plugin Incubating...${CLEAR}
+./gradlew clean :apollo-gradle-plugin-incubating:bintrayUpload
+echo ${YELLOW}Deploying Gradle Plugin Incubating - ${GREEN}Done!${CLEAR}
+
 echo ${YELLOW}Deploying Http Cache ...${CLEAR}
 ./gradlew clean :apollo-http-cache:bintrayUpload
 echo ${YELLOW}Deploying Http Cache - ${GREEN}Done!${CLEAR}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,11 +39,12 @@ ext.dep = [
         runtime: "org.antlr:antlr4-runtime:$versions.antlr4",
     ],
     apollo                : [
-        plugin   : "com.apollographql.apollo:apollo-gradle-plugin:$versions.apollo",
-        runtime  : "com.apollographql.apollo:apollo-runtime:$versions.apollo",
-        rx2      : "com.apollographql.apollo:apollo-rx2-support:$versions.apollo",
-        httpCache: "com.apollographql.apollo:apollo-http-cache:$versions.apollo",
-        api      : "com.apollographql.apollo:apollo-api:$versions.apollo",
+        plugin          : "com.apollographql.apollo:apollo-gradle-plugin:$versions.apollo",
+        pluginIncubating: "com.apollographql.apollo:apollo-gradle-plugin-incubating:$versions.apollo",
+        runtime         : "com.apollographql.apollo:apollo-runtime:$versions.apollo",
+        rx2             : "com.apollographql.apollo:apollo-rx2-support:$versions.apollo",
+        httpCache       : "com.apollographql.apollo:apollo-http-cache:$versions.apollo",
+        api             : "com.apollographql.apollo:apollo-api:$versions.apollo",
     ],
     bintrayGradlePlugin   : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintray",
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
@@ -89,4 +90,3 @@ ext.androidConfig = [
     minSdkVersion    : 15,
     targetSdkVersion : 28
 ]
-

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -100,6 +100,16 @@ afterEvaluate { project ->
     }
   }
 
+  tasks.create("installLocally", Upload) {
+    configuration = configurations.archives
+
+    repositories {
+      mavenDeployer {
+        repository(url: "file://${rootProject.buildDir}/localMaven")
+      }
+    }
+  }
+  
   signing {
     required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = 'apollo-android'
 
 include 'apollo-compiler'
 include 'apollo-gradle-plugin'
+include 'apollo-gradle-plugin-incubating'
 include 'apollo-runtime'
 include 'apollo-api'
 include 'apollo-android-support'

--- a/upload_archives.sh
+++ b/upload_archives.sh
@@ -4,6 +4,7 @@
 ./gradlew clean :apollo-coroutines-support:bintrayUpload
 ./gradlew clean :apollo-espresso-support:bintrayUpload
 ./gradlew clean :apollo-gradle-plugin:bintrayUpload
+./gradlew clean :apollo-gradle-plugin-incubating:bintrayUpload
 ./gradlew clean :apollo-http-cache:bintrayUpload
 ./gradlew clean :apollo-runtime:bintrayUpload
 ./gradlew clean :apollo-rx2-support:bintrayUpload


### PR DESCRIPTION
Update on the incubating plugin. It's mainly compatible with the existing plugin now except for `schemaFilePath` and `outputPackageName` which is not supported anymore since it flattens the package hierarchy.

Anyone using these options will get an exception:

    apollo.outputPackageName is not supported anymore.
  
    Please use a service instead:
  
    apollo {
      service("starwars") {
        schemaFilePath = "${schemaFilePath}"
        rootPackageNamge = "${outputPackageName}"
        exclude = "${exclude}"
      }
    }

The configuration block now uses `services` similar to retrofit services. A service has a schema and related graphql files. If the user specifies the service endpoint, the `downloadApolloSchema` task will update the schema directly into `schemaFilePath`:

```groovy
apollo {
  generateKotlinModels = true
  customTypeMapping = ["DateTime": "java.util.Date"]
  ...

  service("starwars") {

    /**
     * Place where the schema.json file is.
     * This path is relative to the current project directory.
     * schemaFilePath can point outside of src/{foo}/graphql but in that case, you'll want
     * to define rootPackageName else fragments/types will be stored at the root of the namespace.
     * By default, the plugin will look for a schema.json file in src/{foo}/graphql
     */
    schemaFilePath = "src/main/graphql/com/starwars/schema.json"

    /**
     * Place where the graphql files are searched.
     * This path is relative to the current sourceSet (e.g src/{foo}/graphql/)
     * By default, this is the directory where the schema.json is stored or "." if the schema is outside.
     * You need to define this if you have two or more services whose schema is stored outside src/{foo}/graphql.
     * If not, you can certainly omit it.
     */
    sourceFolderPath = "."

    /**
     * list of pattern of files to exclude as in PatternFilterable
     */
    exclude = []

    /**
     * the HTTP enpoint of your graphql service. Used by the `downloadApolloSchema` task
     */
    endpointUrl = "https://api.example.com/graphql"

    /**
     * Extra query parameters needed by your service
     */
    queryParameters = []

    /**
     * Extra headers needed by your service
     */
    headers = []
  }

  service("githunt") {
    schemaFilePath = "src/main/graphql/com/githunt/schema.json"
  }
}
```

It's using two plugin id that point to the same implementation so you can either use:
* `com.apollographql.android`
* `com.apollographql.apollo`

It's working on my projects and in tests but we might need more data points so all feedback welcome ! 
