### PR TITLE
Coroutines: Swallow exception when calling channel.offer on a closed channel

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -135,7 +135,13 @@ fun <T> ApolloSubscriptionCall<T>.toChannel(capacity: Int = Channel.UNLIMITED): 
         }
 
         override fun onResponse(response: Response<T>) {
-            channel.offer(response)
+            try {
+                channel.offer(response)
+            } catch (ex: Exception) {
+                // Swallow exception if the channel is closed.
+                // Due to concurrency, this can be called between channel.close and cancel().
+                // For the same reason, we cannot use channel.isClosedForSend.
+            }
         }
 
         override fun onFailure(e: ApolloException) {

--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -14,7 +14,13 @@ import kotlin.coroutines.resumeWithException
 private class ChannelCallback<T>(val channel: Channel<Response<T>>) : ApolloCall.Callback<T>() {
 
     override fun onResponse(response: Response<T>) {
-        channel.offer(response)
+        try {
+            channel.offer(response)
+        } catch (ex: Exception) {
+            // Swallow exception if the channel is closed.
+            // Due to concurrency, this can be called between channel.close and cancel().
+            // For the same reason, we cannot use channel.isClosedForSend.
+        }
     }
 
     override fun onFailure(e: ApolloException) {

--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -18,8 +18,6 @@ private class ChannelCallback<T>(val channel: Channel<Response<T>>) : ApolloCall
             channel.offer(response)
         } catch (ex: Exception) {
             // Swallow exception if the channel is closed.
-            // Due to concurrency, this can be called between channel.close and cancel().
-            // For the same reason, we cannot use channel.isClosedForSend.
         }
     }
 


### PR DESCRIPTION
Fixes #1585 