### PR TITLE
close #1008 Allow shared custom types

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -3,6 +3,7 @@ package com.apollographql.apollo.response;
 import com.apollographql.apollo.api.FileUpload;
 import com.apollographql.apollo.api.ScalarType;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -12,16 +13,20 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ScalarTypeAdapters {
   private static final Map<Class, CustomTypeAdapter> DEFAULT_ADAPTERS = defaultAdapters();
-  private final Map<ScalarType, CustomTypeAdapter> customAdapters;
+  private final Map<String, CustomTypeAdapter> customAdapters;
 
   public ScalarTypeAdapters(@NotNull Map<ScalarType, CustomTypeAdapter> customAdapters) {
-    this.customAdapters = checkNotNull(customAdapters, "customAdapters == null");
+    Map<ScalarType, CustomTypeAdapter> nonNullcustomAdapters = checkNotNull(customAdapters, "customAdapters == null");
+    this.customAdapters = new HashMap<>();
+    for (Map.Entry<ScalarType, CustomTypeAdapter> entry:nonNullcustomAdapters.entrySet()) {
+      this.customAdapters.put(entry.getKey().typeName(), entry.getValue());
+    }
   }
 
   @SuppressWarnings("unchecked") @NotNull public <T> CustomTypeAdapter<T> adapterFor(@NotNull ScalarType scalarType) {
     checkNotNull(scalarType, "scalarType == null");
 
-    CustomTypeAdapter<T> customTypeAdapter = customAdapters.get(scalarType);
+    CustomTypeAdapter<T> customTypeAdapter = customAdapters.get(scalarType.typeName());
     if (customTypeAdapter == null) {
       customTypeAdapter = DEFAULT_ADAPTERS.get(scalarType.javaType());
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/json/InputFieldJsonWriterTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/json/InputFieldJsonWriterTest.java
@@ -204,7 +204,7 @@ public class InputFieldJsonWriterTest {
     }
 
     @Override public String typeName() {
-      throw new UnsupportedOperationException();
+      return clazz.getSimpleName();
     }
 
     @Override public Class javaType() {


### PR DESCRIPTION
The suggested approach for the issue ([LINK HERE](https://github.com/apollographql/apollo-android/issues/1008)) was to somehow the gradle plugin would track in-between modules compilation but that has two issues IMHO:
- it's really complex to execute,
- it doesn't cope with a module from an AAR

The suggested approach here uses from the facts that:
- ScalarType already has a typeName() parameter of String; and
- The typename is unique within a GraphQl Server

From this approach it is just a matter of mapping from a String (instead of the class) to the desired type.  
The gradle plugin will re-generate CustomType with their own separate package name for each module,
but those will be ProGuarded and the type defined on the ApolloClient.builder() will be used and most importantly,shared between different modules.