### PR TITLE
Add option for outputting transformed queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Apollo-Android is designed primarily with Android in mind but you can use it in 
   - [Java Beans Semantic Naming for Accessors](#java-beans-semantic-naming-for-accessors)
   - [Explicit Schema location](#explicit-schema-location)
   - [Kotlin model generation (experimental)](#kotlin-model-generation-experimental)
+  - [Transformed queries](#transformed-queries)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update --> 
@@ -668,6 +669,17 @@ By default Apollo Gradle plugin generates Java models but you can configure it t
 ```groovy
 apollo {
   generateKotlinModels = true
+}
+```
+
+### Transformed queries
+When Apollo-Android executes your queries, the actual queries sent to the server differs slightly from what was given; specifically, type hints are added to variable-type fields, and fragments are bundled. These differences don't affect typical use. If you want access to these transformed queries, Apollo Gradle plugin can save them to a build directory for you. This can be useful if you need to upload a query's exact content to a server that doesn't support automatic persisted queries.
+
+#### Usage
+
+```groovy
+apollo {
+  generateTransformedQueries = true
 }
 ```
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -52,6 +52,9 @@ class GraphQLCompiler {
     }
 
     args.transformedQueriesOutputDir?.let { transformedQueriesOutputDir ->
+      if (transformedQueriesOutputDir.exists()) {
+        transformedQueriesOutputDir.deleteRecursively()
+      }
       val transformedQueryOutput = TransformedQueryOutput(
           packageNameProvider
       )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -118,6 +118,8 @@ class GraphQLCompiler {
         "It should not be modified by hand.\n"
     @JvmField
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo", "classes")
+    @JvmField
+    val TRANSFORMED_QUERIES_OUTPUT_DIRECTORY = listOf("generated", "apollo", "transformedQueries")
     const val APOLLOCODEGEN_VERSION = "0.19.1"
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -50,6 +50,13 @@ class GraphQLCompiler {
           outputDir = args.outputDir
       )
     }
+
+    args.transformedQueriesOutputDir?.let { transformedQueriesOutputDir ->
+      val transformedQueryOutput = TransformedQueryOutput(
+          packageNameProvider
+      )
+      transformedQueryOutput.apply { visit(ir.operations) }.writeTo(transformedQueriesOutputDir)
+    }
   }
 
   private fun CodeGenerationIR.writeJavaFiles(context: CodeGenerationContext, outputDir: File) {
@@ -123,6 +130,7 @@ class GraphQLCompiler {
       val outputPackageName: String?,
       val suppressRawTypesWarning: Boolean,
       val generateKotlinModels: Boolean = false,
-      val generateVisitorForPolymorphicDatatypes: Boolean = false
+      val generateVisitorForPolymorphicDatatypes: Boolean = false,
+      val transformedQueriesOutputDir: File? = null
   )
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
@@ -1,0 +1,36 @@
+package com.apollographql.apollo.compiler
+
+import com.apollographql.apollo.compiler.ir.Operation
+import java.io.File
+
+internal class TransformedQueryOutput(
+    private val packageNameProvider: PackageNameProvider
+) {
+  private var transformedQueries: List<TransformedQuery> = emptyList()
+
+  fun visit(operations: List<Operation>) {
+    transformedQueries = transformedQueries + operations.map { operation ->
+      val targetPackage = packageNameProvider.operationPackageName(operation.filePath)
+      TransformedQuery(
+          queryName = operation.operationName,
+          queryDocument = operation.sourceWithFragments!!,
+          packageName = targetPackage
+      )
+    }
+  }
+
+  fun writeTo(outputDir: File) {
+    transformedQueries.forEach { transformedQuery ->
+      outputDir.resolve(transformedQuery.packageName.replace('.', File.separatorChar)).run {
+        mkdirs()
+        resolve("${transformedQuery.queryName}.graphql")
+      }.writeText(transformedQuery.queryDocument)
+    }
+  }
+
+  private class TransformedQuery(
+      val queryName: String,
+      val queryDocument: String,
+      val packageName: String
+  )
+}

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloCodegenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloCodegenTask.groovy
@@ -29,6 +29,7 @@ class ApolloCodegenTask extends SourceTask {
   @Input Property<Boolean> suppressRawTypesWarning = project.objects.property(Boolean.class)
   @Input Property<Boolean> generateKotlinModels = project.objects.property(Boolean.class)
   @Input Property<Boolean> generateVisitorForPolymorphicDatatypes = project.objects.property(Boolean.class)
+  @Optional @OutputDirectory DirectoryProperty transformedQueriesOutputDir = project.objects.directoryProperty()
   @Input ListProperty<String> excludeFiles = project.objects.listProperty(String.class)
 
   @TaskAction
@@ -59,7 +60,8 @@ class ApolloCodegenTask extends SourceTask {
           codeGenerationIR, outputDir.get().asFile, customTypeMapping.get(),
           nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED, useSemanticNaming.get(),
           generateModelBuilder.get(), useJavaBeansSemanticNaming.get(), irPackageName, outputPackageName,
-          suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get()
+          suppressRawTypesWarning.get(), generateKotlinModels.get(), generateVisitorForPolymorphicDatatypes.get(),
+          transformedQueriesOutputDir.getOrNull()?.asFile
       )
       new GraphQLCompiler().write(args)
     }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
@@ -17,6 +17,7 @@ class ApolloExtension {
   final Property<Boolean> generateVisitorForPolymorphicDatatypes
   final Property<String> schemaFilePath
   final Property<String> outputPackageName
+  final Property<String> transformedQueriesOutputDir
   final MapProperty<String, String> customTypeMapping
 
   ApolloExtension(Project project) {
@@ -46,6 +47,9 @@ class ApolloExtension {
 
     outputPackageName = project.objects.property(String.class)
     outputPackageName.set("")
+
+    transformedQueriesOutputDir = project.objects.property(String.class)
+    transformedQueriesOutputDir.set("")
 
     customTypeMapping = project.objects.mapProperty(String.class, String.class)
     customTypeMapping.set(new LinkedHashMap())
@@ -85,6 +89,10 @@ class ApolloExtension {
 
   void setOutputPackageName(String outputPackageName) {
     this.outputPackageName.set(outputPackageName)
+  }
+
+  void setTransformedQueriesOutputDir(String transformedQueriesOutputDir) {
+    this.transformedQueriesOutputDir.set(transformedQueriesOutputDir)
   }
 
   void setCustomTypeMapping(Map customTypeMapping) {

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
@@ -17,7 +17,7 @@ class ApolloExtension {
   final Property<Boolean> generateVisitorForPolymorphicDatatypes
   final Property<String> schemaFilePath
   final Property<String> outputPackageName
-  final Property<String> transformedQueriesOutputDir
+  final Property<Boolean> generateTransformedQueries
   final MapProperty<String, String> customTypeMapping
 
   ApolloExtension(Project project) {
@@ -48,8 +48,8 @@ class ApolloExtension {
     outputPackageName = project.objects.property(String.class)
     outputPackageName.set("")
 
-    transformedQueriesOutputDir = project.objects.property(String.class)
-    transformedQueriesOutputDir.set("")
+    generateTransformedQueries = project.objects.property(Boolean.class)
+    generateTransformedQueries.set(false)
 
     customTypeMapping = project.objects.mapProperty(String.class, String.class)
     customTypeMapping.set(new LinkedHashMap())
@@ -91,8 +91,8 @@ class ApolloExtension {
     this.outputPackageName.set(outputPackageName)
   }
 
-  void setTransformedQueriesOutputDir(String transformedQueriesOutputDir) {
-    this.transformedQueriesOutputDir.set(transformedQueriesOutputDir)
+  void setGenerateTransformedQueries(Boolean generateTransformedQueries) {
+    this.generateTransformedQueries.set(generateTransformedQueries)
   }
 
   void setCustomTypeMapping(Map customTypeMapping) {

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -17,6 +17,13 @@ abstract class TaskConfigurator {
   protected final ApolloCodegenTask createCodegenTask(String sourceSetOrVariantName, Collection sourceSets) {
     File outputFolder = new File(project.buildDir, Joiner.on(File.separator).join(GraphQLCompiler.OUTPUT_DIRECTORY + sourceSetOrVariantName))
     String taskName = String.format(ApolloCodegenTask.NAME, sourceSetOrVariantName.capitalize())
+    File transformedQueriesOutputFolder = null
+    if (project.apollo.transformedQueriesOutputDir.getOrNull()) {
+      transformedQueriesOutputFolder = new File(
+          project.apollo.transformedQueriesOutputDir.get(),
+          sourceSetOrVariantName
+      )
+    }
     return project.tasks.create(taskName, ApolloCodegenTask) {
       source(sourceSets.collect { it.graphql })
       excludeFiles = project.apollo.sourceSet.exclude
@@ -36,6 +43,7 @@ abstract class TaskConfigurator {
       suppressRawTypesWarning = project.apollo.suppressRawTypesWarning
       generateKotlinModels = project.apollo.generateKotlinModels
       generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
+      transformedQueriesOutputDir.set(transformedQueriesOutputFolder)
     }
   }
 }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -18,11 +18,9 @@ abstract class TaskConfigurator {
     File outputFolder = new File(project.buildDir, Joiner.on(File.separator).join(GraphQLCompiler.OUTPUT_DIRECTORY + sourceSetOrVariantName))
     String taskName = String.format(ApolloCodegenTask.NAME, sourceSetOrVariantName.capitalize())
     File transformedQueriesOutputFolder = null
-    if (project.apollo.transformedQueriesOutputDir.getOrNull()) {
-      transformedQueriesOutputFolder = new File(
-          project.apollo.transformedQueriesOutputDir.get(),
-          sourceSetOrVariantName
-      )
+    if (project.apollo.generateTransformedQueries.get()) {
+      transformedQueriesOutputFolder = new File(project.buildDir, Joiner.on(File.separator)
+          .join(GraphQLCompiler.TRANSFORMED_QUERIES_OUTPUT_DIRECTORY + sourceSetOrVariantName)) // TODO service?
     }
     return project.tasks.create(taskName, ApolloCodegenTask) {
       source(sourceSets.collect { it.graphql })

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -325,6 +325,30 @@ class BasicAndroidSpec extends Specification {
     assert !new File(testProjectDir, "build/generated/source/apollo/classes/release/fragment/SpeciesInformation.java").exists()
   }
 
+  def "set transformed queries output dir generates queries with __typename"() {
+    setup: "a testProject with a previous build and a modified build script"
+    replaceTextInFile(new File("$testProjectDir/build.gradle")) {
+      it.replace("apollo {",
+          "apollo {\n " +
+              "transformedQueriesOutputDir = \"\$buildDir/transformedQueries/\"\n"
+      )
+    }
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err))
+//        .forwardStdOutput(new OutputStreamWriter(System.out))
+        .build()
+
+    then:
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetailsSpeciesInfo.graphql").isFile()
+    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetailsSpeciesInfo.graphql").getText(
+        'UTF-8').contains("__typename")
+  }
+
   def cleanupSpec() {
     FileUtils.deleteDirectory(testProjectDir)
   }

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -86,6 +86,30 @@ class BasicAndroidSpec extends Specification {
     result.task(":generateApolloClasses").outcome == TaskOutcome.UP_TO_DATE
   }
 
+  def "set transformed queries output dir generates queries with __typename"() {
+    setup: "a testProject with a previous build and a modified build script"
+    replaceTextInFile(new File("$testProjectDir/build.gradle")) {
+      it.replace("apollo {",
+          "apollo {\n " +
+              "transformedQueriesOutputDir = \"\$buildDir/transformedQueries/\"\n"
+      )
+    }
+
+    when:
+    def result = GradleRunner.create().withProjectDir(testProjectDir)
+        .withPluginClasspath()
+        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
+        .forwardStdError(new OutputStreamWriter(System.err))
+//        .forwardStdOutput(new OutputStreamWriter(System.out))
+        .build()
+
+    then:
+    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
+    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetails.graphql").isFile()
+    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetails.graphql").getText(
+        'UTF-8').contains("__typename")
+  }
+
   def "exclude graphql files, builds successfully and generates expected outputs"() {
     setup: "a testProject with a excluded files"
     replaceTextInFile(new File("$testProjectDir/build.gradle")) {
@@ -323,30 +347,6 @@ class BasicAndroidSpec extends Specification {
     assert new File(testProjectDir, "build/generated/source/apollo/classes/release/com/myexample/DroidDetails.java").isFile()
     assert !new File(testProjectDir, "build/generated/source/apollo/classes/release/com/myexample/Films.java").exists()
     assert !new File(testProjectDir, "build/generated/source/apollo/classes/release/fragment/SpeciesInformation.java").exists()
-  }
-
-  def "set transformed queries output dir generates queries with __typename"() {
-    setup: "a testProject with a previous build and a modified build script"
-    replaceTextInFile(new File("$testProjectDir/build.gradle")) {
-      it.replace("apollo {",
-          "apollo {\n " +
-              "transformedQueriesOutputDir = \"\$buildDir/transformedQueries/\"\n"
-      )
-    }
-
-    when:
-    def result = GradleRunner.create().withProjectDir(testProjectDir)
-        .withPluginClasspath()
-        .withArguments("generateApolloClasses", "-Dapollographql.skipRuntimeDep=true")
-        .forwardStdError(new OutputStreamWriter(System.err))
-//        .forwardStdOutput(new OutputStreamWriter(System.out))
-        .build()
-
-    then:
-    result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
-    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetailsSpeciesInfo.graphql").isFile()
-    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetailsSpeciesInfo.graphql").getText(
-        'UTF-8').contains("__typename")
   }
 
   def cleanupSpec() {

--- a/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
+++ b/apollo-gradle-plugin/src/test/groovy/com/apollographql/apollo/gradle/integration/BasicAndroidSpec.groovy
@@ -91,7 +91,7 @@ class BasicAndroidSpec extends Specification {
     replaceTextInFile(new File("$testProjectDir/build.gradle")) {
       it.replace("apollo {",
           "apollo {\n " +
-              "transformedQueriesOutputDir = \"\$buildDir/transformedQueries/\"\n"
+              "generateTransformedQueries = true\n"
       )
     }
 
@@ -105,8 +105,8 @@ class BasicAndroidSpec extends Specification {
 
     then:
     result.task(":generateApolloClasses").outcome == TaskOutcome.SUCCESS
-    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetails.graphql").isFile()
-    assert new File(testProjectDir, "build/transformedQueries/release/com/example/DroidDetails.graphql").getText(
+    assert new File(testProjectDir, "build/generated/apollo/transformedQueries/release/com/example/DroidDetails.graphql").isFile()
+    assert new File(testProjectDir, "build/generated/apollo/transformedQueries/release/com/example/DroidDetails.graphql").getText(
         'UTF-8').contains("__typename")
   }
 


### PR DESCRIPTION
Currently, if I want access to the "transformed" queries that have `__typename` and bundled fragments, I need to get it from the generated query classes' bodies. This adds an option to output them to a specified directory.
For my use case, this will allow manual creation of persisted operations that require the real body of the queries being made.
Fixes #1597.