### PR TITLE
Upgrade internal Apollo-Android dependency to 1.2.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     androidPlugin         : '3.4.2',
-    apollo                : '1.1.2-SNAPSHOT',
+    apollo                : '1.1.3-SNAPSHOT',
     antlr4                : '4.5.3',
     bintray               : '1.8.0',
     cache                 : '2.0.2',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     androidPlugin         : '3.4.2',
-    apollo                : '1.1.3-SNAPSHOT',
+    apollo                : '1.2.0-SNAPSHOT',
     antlr4                : '4.5.3',
     bintray               : '1.8.0',
     cache                 : '2.0.2',


### PR DESCRIPTION
I'm trying to set up the Gradle plugin as a [source dependency](https://blog.gradle.org/introducing-source-dependencies), but since this project itself uses an included build to substitute the dependencies, Gradle's actually checking out _two_ versions of Apollo-Android in my build. While investigating that I found that this internal dependency was still set to the last snapshot version. This upgrades it.