### PR TITLE
Make SourceLocation a data class

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/SourceLocation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/SourceLocation.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo.compiler.ir
 
-class SourceLocation(val line: Int, val position: Int) {
+data class SourceLocation(val line: Int, val position: Int) {
   companion object {
     val UNKNOWN = SourceLocation(-1, -1)
   }


### PR DESCRIPTION
On _one_ of my machines, I get this error parsing my query:
>com.apollographql.apollo.compiler.parser.GraphQLDocumentParseException: 
>Failed to parse GraphQL file /blah/TestOperation.graphql (14:10)
>Fields `myField` conflict because they have different inline fragment. Use different aliases on the fields.

I'm very confused as to why this is only happening on one machine and not the other. However, I found that the equality check is failing on `inlineFragments[0].fields[1].inlineFragments[0].sourceLocation`. The two `SourceLocation`s have the same line and position, but are different instances. Having a proper equality check fixes the issue.

My only guess is to why it's happening is that the inner nested inline fragment is being parsed separately and that creates a new SourceLocation instance. But again, even if that's true, no idea why I can't repro on my other machine.