### PR TITLE
Incubating plugin improvements

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -49,12 +49,11 @@ object AndroidTaskConfigurator {
     )
 
     registerVariantTask(project, apolloVariant) { serviceVariantTask ->
+      variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
       if (apolloExtension.generateKotlinModels) {
+        // For java, this is done by registerJavaGeneratingTask
         androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(serviceVariantTask.get().outputDir)
         project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(serviceVariantTask) }
-      } else {
-        // apparently, this does everything automagically
-        variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
       }
     }
   }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -51,7 +51,7 @@ object AndroidTaskConfigurator {
     registerVariantTask(project, apolloVariant) { serviceVariantTask ->
       variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
       if (apolloExtension.generateKotlinModels) {
-        // For java, this is done by registerJavaGeneratingTask
+        // For java models, this is done by registerJavaGeneratingTask
         androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(serviceVariantTask.get().outputDir)
         project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(serviceVariantTask) }
       }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -45,7 +45,8 @@ object AndroidTaskConfigurator {
 
     val apolloVariant = ApolloVariant(
         name = variant.name,
-        sourceSetNames = variant.sourceSets.map { it.name }.distinct()
+        sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
+        androidVariant = variant
     )
 
     registerVariantTask(project, apolloVariant) { serviceVariantTask ->

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -49,11 +49,12 @@ object AndroidTaskConfigurator {
     )
 
     registerVariantTask(project, apolloVariant) { serviceVariantTask ->
-      variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
       if (apolloExtension.generateKotlinModels) {
-        // For java models, this is done by registerJavaGeneratingTask
+        variant.addJavaSourceFoldersToModel(serviceVariantTask.get().outputDir)
         androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(serviceVariantTask.get().outputDir)
         project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(serviceVariantTask) }
+      } else {
+        variant.registerJavaGeneratingTask(serviceVariantTask.get(), serviceVariantTask.get().outputDir)
       }
     }
   }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloCodegenTask.kt
@@ -12,9 +12,6 @@ import java.io.File
 @CacheableTask
 open class ApolloCodegenTask : SourceTask() {
   @get:Input
-  var schemaFile: File? = null
-
-  @get:Input
   lateinit var rootPackageName: String
 
   @get:Input
@@ -57,6 +54,9 @@ open class ApolloCodegenTask : SourceTask() {
   override fun getSource(): FileTree {
     return super.getSource()
   }
+
+  @Internal
+  var schemaFile: File? = null
 
   @Internal
   lateinit var graphqlFiles: List<File>

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloExtension.kt
@@ -2,8 +2,10 @@ package com.apollographql.apollo.gradle
 
 import com.apollographql.apollo.compiler.NullableValueType
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
 
-open class ApolloExtension {
+open class ApolloExtension(project: Project) {
   @JvmField
   var nullableValueType: String? = null
   @JvmField
@@ -27,6 +29,7 @@ open class ApolloExtension {
   @JvmField
   var services = mutableListOf<Service>()
 
+  val compilationUnits = project.container(CompilationUnit::class.java)
 
   /**
    * Deprecated,use @{link service} instead

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
@@ -188,7 +188,7 @@ open class ApolloPlugin : Plugin<Project> {
 
       it.source(compilationUnit.files)
       if (compilationUnit.schemaFile != null) {
-        it.source(compilationUnit.files)
+        it.source(compilationUnit.schemaFile)
       }
 
       it.graphqlFiles = compilationUnit.files

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloVariant.kt
@@ -1,7 +1,5 @@
 package com.apollographql.apollo.gradle
 
-import org.gradle.api.file.SourceDirectorySet
-
 class ApolloVariant(
     /**
      * The full name of the variant
@@ -23,6 +21,12 @@ class ApolloVariant(
      * etc...
      *
      */
-    val sourceSetNames: List<String>
+    val sourceSetNames: List<String>,
 
+    /**
+     * The androidVariant if any. This can be used to link other tasks/plugins in your build logic.
+     * This is Any so that it does not pull a dependency on the gradle plugin but can be safely cast
+     * to BaseVariant.
+     */
+    val androidVariant: Any?
 )

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
@@ -16,8 +16,8 @@ class CompilationUnit(
         project: Project
 ) {
     val name = "${variantName}${serviceName}"
-    val outputDir = project.buildDir.child("generated", "apollo", "classes", variantName, serviceName)
-    val transformedQueriesDir = project.buildDir.child("generated", "apollo", "transformedQueries", variantName, serviceName)
+    val outputDir = project.buildDir.child("generated", "source", "apollo", "classes", variantName, serviceName)
+    val transformedQueriesDir = project.buildDir.child("generated", "transformedQueries", "apollo", variantName, serviceName)
 
     companion object {
         fun from(project: Project, apolloVariant: ApolloVariant, service: Service): CompilationUnit {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
@@ -6,143 +6,143 @@ import org.gradle.api.tasks.util.PatternSet
 import java.io.File
 
 class CompilationUnit(
-        val serviceName: String,
-        val variantName: String,
-        val files: List<File>,
-        val schemaFile: File?,
-        val schemaPackageName: String,
-        val rootPackageName: String,
-        val androidVariant: Any?,
-        project: Project
+    val serviceName: String,
+    val variantName: String,
+    val files: List<File>,
+    val schemaFile: File?,
+    val schemaPackageName: String,
+    val rootPackageName: String,
+    val androidVariant: Any?,
+    project: Project
 ) {
-    val name = "${variantName}${serviceName}"
-    val outputDir = project.buildDir.child("generated", "source", "apollo", "classes", variantName, serviceName)
-    val transformedQueriesDir = project.buildDir.child("generated", "transformedQueries", "apollo", variantName, serviceName)
+  val name = "${variantName}${serviceName}"
+  val outputDir = project.buildDir.child("generated", "source", "apollo", "classes", variantName, serviceName)
+  val transformedQueriesDir = project.buildDir.child("generated", "transformedQueries", "apollo", variantName, serviceName)
 
-    companion object {
-        fun from(project: Project, apolloVariant: ApolloVariant, service: Service): CompilationUnit {
-            val sourceSetNames = apolloVariant.sourceSetNames
+  companion object {
+    fun from(project: Project, apolloVariant: ApolloVariant, service: Service): CompilationUnit {
+      val sourceSetNames = apolloVariant.sourceSetNames
 
-            val schemaFilePath = service.schemaFilePath
-            if (schemaFilePath == null) {
-                throw IllegalArgumentException("Please define schemaFilePath for service '${service.name}'")
-            }
+      val schemaFilePath = service.schemaFilePath
+      if (schemaFilePath == null) {
+        throw IllegalArgumentException("Please define schemaFilePath for service '${service.name}'")
+      }
 
-            var schemaFile = project.projectDir.child(schemaFilePath)
-            if (!schemaFile.isFile) {
-                throw IllegalArgumentException("No schema found at:\n${schemaFile.absolutePath}")
-            }
-            val schemaKey = schemaFile.canonicalPath.relativePathToGraphql()
-            if (schemaKey != null) {
-                // schema is under src/{foo}/graphql, see if it is overriden by anoter variant
-                val schemaCandidates = findFilesInSourceSets(project, sourceSetNames, schemaKey) { true }
-                schemaFile = schemaCandidates.values.first()
-            }
+      var schemaFile = project.projectDir.child(schemaFilePath)
+      if (!schemaFile.isFile) {
+        throw IllegalArgumentException("No schema found at:\n${schemaFile.absolutePath}")
+      }
+      val schemaKey = schemaFile.canonicalPath.relativePathToGraphql()
+      if (schemaKey != null) {
+        // schema is under src/{foo}/graphql, see if it is overriden by anoter variant
+        val schemaCandidates = findFilesInSourceSets(project, sourceSetNames, schemaKey) { true }
+        schemaFile = schemaCandidates.values.first()
+      }
 
-            val sourceFolderPath = if (service.sourceFolderPath != null) {
-                service.sourceFolderPath!!
-            } else {
-                // if schemaFilePath is outside src/{foo}/graphql, search the whole graphql folder
-                schemaFile.canonicalPath.relativePathToGraphql(dropLast = 1) ?: "."
-            }
+      val sourceFolderPath = if (service.sourceFolderPath != null) {
+        service.sourceFolderPath!!
+      } else {
+        // if schemaFilePath is outside src/{foo}/graphql, search the whole graphql folder
+        schemaFile.canonicalPath.relativePathToGraphql(dropLast = 1) ?: "."
+      }
 
-            val candidateFiles = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
+      val candidateFiles = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
 
-            val files = if (service.exclude != null) {
-                val patternSet = PatternSet()
-                patternSet.exclude(service.exclude!!)
-                project.files(candidateFiles).asFileTree.matching(patternSet).toList()
-            } else {
-                candidateFiles
-            }
+      val files = if (service.exclude != null) {
+        val patternSet = PatternSet()
+        patternSet.exclude(service.exclude!!)
+        project.files(candidateFiles).asFileTree.matching(patternSet).toList()
+      } else {
+        candidateFiles
+      }
 
-            val schemaPackageName = schemaFile.canonicalPath.formatPackageName(dropLast = 1) ?: ""
+      val schemaPackageName = schemaFile.canonicalPath.formatPackageName(dropLast = 1) ?: ""
 
-            return CompilationUnit(
-                    serviceName = service.name,
-                    variantName = apolloVariant.name,
-                    files = files,
-                    schemaFile = schemaFile,
-                    schemaPackageName = schemaPackageName,
-                    rootPackageName = service.rootPackageName ?: "",
-                    androidVariant = apolloVariant.androidVariant,
-                    project = project
-            )
-        }
-
-        fun default(project: Project, apolloVariant: ApolloVariant): List<CompilationUnit> {
-            val sourceSetNames = apolloVariant.sourceSetNames
-            val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
-                it.name == "schema.json"
-            }
-
-            if (schemaFiles.isEmpty()) {
-                return emptyList()
-            }
-
-            var i = 0
-            val services = schemaFiles.entries
-                    .sortedBy { it.value.canonicalPath } // make sure the order is predicable for tests
-                    .map { entry ->
-                        val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
-                        val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
-
-                        val name = "service${i++}"
-
-                        CompilationUnit(
-                                serviceName = name,
-                                variantName = apolloVariant.name,
-                                files = files,
-                                schemaFile = entry.value,
-                                schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
-                                rootPackageName = "",
-                                androidVariant = apolloVariant.androidVariant,
-                                project = project
-                        )
-                    }
-
-            return services
-        }
-
-        fun isGraphQL(file: File): Boolean {
-            return file.name.endsWith(".graphql") || file.name.endsWith(".gql")
-        }
-
-        /**
-         * Finds the files in the given sourceSets taking into account their precedence according to the android plugin order
-         *
-         * Returns a map with the relative path to the path as key and the file as value
-         *
-         * Files coming last will have higher priorities that the first ones.
-         */
-        private fun findFilesInSourceSets(project: Project, sourceSetNames: List<String>, path: String, predicate: (File) -> Boolean): Map<String, File> {
-            val candidates = mutableMapOf<String, File>()
-            sourceSetNames.forEach { sourceSetName ->
-                val root = project.projectDir.child("src", sourceSetName, "graphql", path)
-                val files = root.findFiles(predicate)
-
-                files.forEach {
-                    val key = if (root.isFile) {
-                        // toRelativeString only works on directories.
-                        ""
-                    } else {
-                        it.toRelativeString(root)
-                    }
-
-                    // overwrite the previous entry if it was there already
-                    // this is ok as Android orders the sourceSetNames from lower to higher priority
-                    candidates[key] = it
-                }
-            }
-            return candidates
-        }
-
-        private fun File.findFiles(predicate: (File) -> Boolean): List<File> {
-            return when {
-                isDirectory -> listFiles()?.flatMap { it.findFiles(predicate) } ?: emptyList()
-                isFile && predicate(this) -> listOf(this)
-                else -> emptyList()
-            }
-        }
+      return CompilationUnit(
+          serviceName = service.name,
+          variantName = apolloVariant.name,
+          files = files,
+          schemaFile = schemaFile,
+          schemaPackageName = schemaPackageName,
+          rootPackageName = service.rootPackageName ?: "",
+          androidVariant = apolloVariant.androidVariant,
+          project = project
+      )
     }
+
+    fun default(project: Project, apolloVariant: ApolloVariant): List<CompilationUnit> {
+      val sourceSetNames = apolloVariant.sourceSetNames
+      val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
+        it.name == "schema.json"
+      }
+
+      if (schemaFiles.isEmpty()) {
+        return emptyList()
+      }
+
+      var i = 0
+      val services = schemaFiles.entries
+          .sortedBy { it.value.canonicalPath } // make sure the order is predicable for tests
+          .map { entry ->
+            val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
+            val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
+
+            val name = "service${i++}"
+
+            CompilationUnit(
+                serviceName = name,
+                variantName = apolloVariant.name,
+                files = files,
+                schemaFile = entry.value,
+                schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
+                rootPackageName = "",
+                androidVariant = apolloVariant.androidVariant,
+                project = project
+            )
+          }
+
+      return services
+    }
+
+    fun isGraphQL(file: File): Boolean {
+      return file.name.endsWith(".graphql") || file.name.endsWith(".gql")
+    }
+
+    /**
+     * Finds the files in the given sourceSets taking into account their precedence according to the android plugin order
+     *
+     * Returns a map with the relative path to the path as key and the file as value
+     *
+     * Files coming last will have higher priorities that the first ones.
+     */
+    private fun findFilesInSourceSets(project: Project, sourceSetNames: List<String>, path: String, predicate: (File) -> Boolean): Map<String, File> {
+      val candidates = mutableMapOf<String, File>()
+      sourceSetNames.forEach { sourceSetName ->
+        val root = project.projectDir.child("src", sourceSetName, "graphql", path)
+        val files = root.findFiles(predicate)
+
+        files.forEach {
+          val key = if (root.isFile) {
+            // toRelativeString only works on directories.
+            ""
+          } else {
+            it.toRelativeString(root)
+          }
+
+          // overwrite the previous entry if it was there already
+          // this is ok as Android orders the sourceSetNames from lower to higher priority
+          candidates[key] = it
+        }
+      }
+      return candidates
+    }
+
+    private fun File.findFiles(predicate: (File) -> Boolean): List<File> {
+      return when {
+        isDirectory -> listFiles()?.flatMap { it.findFiles(predicate) } ?: emptyList()
+        isFile && predicate(this) -> listOf(this)
+        else -> emptyList()
+      }
+    }
+  }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ServiceVariant.kt
@@ -75,7 +75,7 @@ class ServiceVariant(
             val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
             val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
 
-            val name = (i++).toString()//entry.key.split(File.separator).map { it.capitalize() }.joinToString("")
+            val name = "service${i++}"
 
             ServiceVariant(
                 name = name,

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -23,12 +23,12 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/0/com/example/fragment/SpeciesInformation.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 
@@ -42,8 +42,8 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
-      assertFalse(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").exists())
+      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertFalse(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").exists())
     }
   }
 
@@ -62,7 +62,7 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloClasses")!!.outcome)
 
       // Java classes generated successfully
-      assertThat(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").readText(), containsString("speciesIdForDebug"))
+      assertThat(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").readText(), containsString("speciesIdForDebug"))
     }
   }
 
@@ -76,10 +76,10 @@ class AndroidTests {
 
       TestUtils.executeTask("build", dir)
 
-      assertTrue(dir.generatedChild("freeDebug/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("freeRelease/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("paidDebug/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("paidRelease/0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("freeDebug/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("freeRelease/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidDebug/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidRelease/service0/com/example/DroidDetailsQuery.java").isFile)
     }
   }
 
@@ -119,12 +119,12 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/0/com/example/fragment/SpeciesInformation.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service0/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
@@ -25,17 +25,17 @@ class CacheTests {
       """.trimIndent())
 
       System.out.println("build the project")
-      var result = TestUtils.executeTask("generateMain0ApolloClasses", dir, "--build-cache")
+      var result = TestUtils.executeTask("generateMainService0ApolloClasses", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMain0ApolloClasses")!!.outcome)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainService0ApolloClasses")!!.outcome)
 
       System.out.println("delete build folder")
       dir.child("build").deleteRecursively()
 
       System.out.println("build from cache")
-      result = TestUtils.executeTask("generateMain0ApolloClasses", dir, "--build-cache")
+      result = TestUtils.executeTask("generateMainService0ApolloClasses", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMain0ApolloClasses")!!.outcome)
+      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMainService0ApolloClasses")!!.outcome)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -260,7 +260,7 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("generateApolloClasses", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
-      val transformedQuery = dir.child("build", "generated", "apollo", "transformedQueries", "main", "service0", "com", "example", "DroidDetails.graphql")
+      val transformedQuery = dir.child("build", "generated", "transformedQueries", "apollo", "main", "service0", "com", "example", "DroidDetails.graphql")
       assertThat(transformedQuery.readText(), containsString("__typename"))
     }
   }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -21,7 +21,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Date.class;")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Date.class;")
     }
   }
 
@@ -40,7 +40,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
         TestUtils.executeTask("generateApolloClasses", dir)
-        TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", pair.second)
+        TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", pair.second)
       }
     }
   }
@@ -50,7 +50,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
     }
   }
 
@@ -62,7 +62,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetails.java", "class DroidDetails ")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetails.java", "class DroidDetails ")
     }
   }
 
@@ -71,7 +71,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileDoesNotContain(dir, "main/0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+      TestUtils.assertFileDoesNotContain(dir, "main/service0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
     }
   }
 
@@ -83,7 +83,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
     }
   }
 
@@ -92,7 +92,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "String name()")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "String name()")
     }
   }
 
@@ -104,7 +104,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloClasses", dir)
-      TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "String getName()")
+      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "String getName()")
     }
   }
 
@@ -260,7 +260,7 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("generateApolloClasses", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
-      val transformedQuery = dir.child("build", "generated", "apollo", "transformedQueries", "main", "0", "com", "example", "DroidDetails.graphql")
+      val transformedQuery = dir.child("build", "generated", "apollo", "transformedQueries", "main", "service0", "com", "example", "DroidDetails.graphql")
       assertThat(transformedQuery.readText(), containsString("__typename"))
     }
   }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -25,9 +25,9 @@ class KotlinCodegenTests {
 
       TestUtils.executeTask("build", dir)
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.kt").isFile)
-      Assert.assertTrue(dir.generatedChild("main/0/com/example/type/CustomType.kt").isFile)
-      Assert.assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service0/com/example/type/CustomType.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.kt").isFile)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
@@ -26,11 +26,11 @@ class MultipleServicesTests {
     withMultipleServicesProject("") { dir ->
       TestUtils.executeTask("build", dir)
 
-      assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
-      assertTrue(dir.generatedChild("main/1/githunt/FeedQuery.java").isFile)
-      assertTrue(dir.generatedChild("main/1/githunt/fragment/RepositoryFragment.java").isFile)
+      assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/service0/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/service1/githunt/FeedQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/service1/githunt/fragment/RepositoryFragment.java").isFile)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -27,7 +27,7 @@ class SourceDirectorySetTests {
       Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
-      Assert.assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.kt").isFile)
     }
   }
 
@@ -49,7 +49,7 @@ class SourceDirectorySetTests {
 
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/Main.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.kt").isFile)
       Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }
@@ -73,7 +73,7 @@ class SourceDirectorySetTests {
       Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
-      Assert.assertTrue(dir.generatedChild("debug/0/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
     }
   }
 
@@ -95,7 +95,7 @@ class SourceDirectorySetTests {
 
       Assert.assertTrue(File(dir, "build/classes/java/main/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/classes/java/main/com/example/Main.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
       Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
@@ -25,16 +25,16 @@ class UpToDateTests {
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
 
     // verify that the custom type generated was Object.class because no customType mapping was specified
-    TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Object.class;")
+    TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Object.class;")
 
     // Optional is not added to the generated classes
-    assert(!TestUtils.fileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "Optional"))
-    TestUtils.assertFileContains(dir, "main/0/com/example/DroidDetailsQuery.java", "import org.jetbrains.annotations.Nullable;")
+    assert(!TestUtils.fileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "Optional"))
+    TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "import org.jetbrains.annotations.Nullable;")
   }
 
   fun `nothing changed, task up to date`(dir: File) {
@@ -43,9 +43,9 @@ class UpToDateTests {
     assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateApolloClasses")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("main/0/com/example/DroidDetailsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/0/com/example/FilmsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/0/com/example/fragment/SpeciesInformation.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
   }
 
   fun `adding a custom type to the build script re-generates the CustomType class`(dir: File) {
@@ -63,7 +63,7 @@ class UpToDateTests {
     // and the task should run again
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloClasses")!!.outcome)
 
-    TestUtils.assertFileContains(dir, "main/0/com/example/type/CustomType.java", "return Date.class;")
+    TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Date.class;")
 
     val text = File(dir, "build.gradle").readText()
     File(dir, "build.gradle").writeText(text.replace(apolloBlock, ""))

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -162,7 +162,7 @@ object TestUtils {
   fun fixturesDirectory() = File(System.getProperty("user.dir")).child("src", "test", "files")
 }
 
-fun File.generatedChild(path: String) = child("build", "generated", "apollo", "classes", path)
+fun File.generatedChild(path: String) = child("build", "generated", "source", "apollo", "classes", path)
 
 fun File.replaceInText(oldValue: String, newValue: String) {
   val text = readText()


### PR DESCRIPTION
A few fixes/improvements:
* Use `service0, service1, ...` instead of plain `0, 1` as service names as it gives more hints about what the name is about.
* Make the autocomplete work in the IDE for kotlin models
* Expose CompilationUnit for other plugins/build logic to intercept outputs/transformedQueries
* Fix modifying schema.json did not rebuild the sources
* Put sources under `generated/source/` (same as kapt, BuildConfig)