### PR TITLE
Rework transformed query output to include separate fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,7 @@ apollo {
 ```
 
 ### Transformed queries
-When Apollo-Android executes your queries, the actual queries sent to the server differs slightly from what was given; specifically, type hints are added to variable-type fields, and fragments are bundled. These differences don't affect typical use. If you want access to these transformed queries, Apollo Gradle plugin can save them to a build directory for you. This can be useful if you need to upload a query's exact content to a server that doesn't support automatic persisted queries.
+When Apollo-Android executes your queries, the actual queries sent to the server differs slightly from what was given; specifically, type hints are added to variable-type fields. These differences don't affect typical use. If you want access to these transformed queries, Apollo Gradle plugin can save them to a build directory for you. This can be useful if you need to upload a query's exact content to a server that doesn't support automatic persisted queries.
 
 #### Usage
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -51,7 +51,7 @@ class GraphQLCompiler {
       val transformedQueryOutput = TransformedQueryOutput(
           args.packageNameProvider
       )
-      transformedQueryOutput.apply { visit(ir.operations) }.writeTo(transformedQueriesOutputDir)
+      transformedQueryOutput.apply { visit(ir) }.writeTo(transformedQueriesOutputDir)
     }
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -48,9 +48,7 @@ class GraphQLCompiler {
       if (transformedQueriesOutputDir.exists()) {
         transformedQueriesOutputDir.deleteRecursively()
       }
-      val transformedQueryOutput = TransformedQueryOutput(
-          args.packageNameProvider
-      )
+      val transformedQueryOutput = TransformedQueryOutput()
       transformedQueryOutput.apply { visit(ir) }.writeTo(transformedQueriesOutputDir)
     }
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
@@ -13,7 +13,7 @@ internal class TransformedQueryOutput(
       val targetPackage = packageNameProvider.operationPackageName(operation.filePath)
       TransformedQuery(
           queryName = operation.operationName,
-          queryDocument = operation.sourceWithFragments!!,
+          queryDocument = operation.source,
           packageName = targetPackage
       )
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/TransformedQueryOutput.kt
@@ -16,7 +16,7 @@ internal class TransformedQueryOutput {
     transformedDocuments = transformedDocuments + ir.fragments.map { fragment ->
       TransformedDocument(
           document = fragment.source,
-          filePath = fragment.filePath!!.relativePathToGraphql()!!
+          filePath = fragment.filePath.relativePathToGraphql()!!
       )
     }
   }
@@ -28,13 +28,9 @@ internal class TransformedQueryOutput {
         val outputFile = outputDir.resolve(filePath).also {
           it.parentFile.mkdirs()
         }
-        transformedDocuments.forEachIndexed { i, transformedDocument ->
-          if (i == 0) {
-            outputFile.writeText(transformedDocument.document)
-          } else {
-            outputFile.appendText("\n\n" + transformedDocument.document)
-          }
-        }
+        transformedDocuments
+          .joinToString(separator = "\n\n") { it.document }
+          .also { outputFile.writeText(it) }
       }
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -17,7 +17,7 @@ data class Fragment(
     val fields: List<Field>,
     val fragmentSpreads: List<String>,
     val inlineFragments: List<InlineFragment>,
-    val filePath: String?,
+    val filePath: String,
     val sourceLocation: SourceLocation
 ) : CodeGenerator {
 


### PR DESCRIPTION
I made a mistake thinking `sourceWithFragments` was the `__typename`-ified version of the document, while `source` wasn't.
`source` actually _does_ have the `__typename`s added.
Including the fragments in the transformed queries actually opens up potential problems for the workflow I described in #1597 (and likely the workflow in #1607), because APIs that required persisted operations but don't support APQ generally still follow the `queries/`+`mutations/`+`fragments/` pattern, and expect fragments to still be separated as they are in the developer-facing source.
This changes TransformedQueryOutput to save the transformed operations and transformed fragments separately, as they exist in the source. Fragments that are defined in operations (e.g. `query MyQuery { ...MyFragment } fragment MyFragment { }` are appended to the operation's file, resulting in no changes other than the addition of `__typename`s.
Also, no longer using `packageNameProvider` to get the destinations for these files, since those are more intended for Java/Kotlin source.