### PR TITLE
Mark incubating plugin's test files as inputs

### DIFF
--- a/apollo-gradle-plugin-incubating/build.gradle.kts
+++ b/apollo-gradle-plugin-incubating/build.gradle.kts
@@ -27,10 +27,12 @@ dependencies {
   testImplementation(dep("okHttp").dot("mockWebServer"))
 }
 
-tasks.named<Task>("test") {
+tasks.withType<Test> {
   dependsOn(":apollo-api:installLocally")
   dependsOn(":apollo-compiler:installLocally")
   dependsOn("installLocally")
+
+  inputs.dir("src/test/files")
 }
 
 apply(rootProject.file("gradle/gradle-mvn-push.gradle"))


### PR DESCRIPTION
Fixes `apollo-gradle-plugin-incubating:test` being `UP-TO-DATE` even after changing the test queries