### PR TITLE
Use mapIndexed when creating default compilation units

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/CompilationUnit.kt
@@ -80,14 +80,13 @@ class CompilationUnit(
         return emptyList()
       }
 
-      var i = 0
       val services = schemaFiles.entries
           .sortedBy { it.value.canonicalPath } // make sure the order is predicable for tests
-          .map { entry ->
+          .mapIndexed { i, entry ->
             val sourceFolderPath = entry.value.canonicalPath.relativePathToGraphql(dropLast = 1)!!
             val files = findFilesInSourceSets(project, sourceSetNames, sourceFolderPath, ::isGraphQL).values.toList()
 
-            val name = "service${i++}"
+            val name = "service$i"
 
             CompilationUnit(
                 serviceName = name,


### PR DESCRIPTION
Minor, but more idiomatic