### PR TITLE
Compile samples in CI

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - ./gradlew :apollo-gradle-plugin-incubating:test --tests "com.apollographql.apollo.gradle.test.*"
   - ./gradlew :apollo-gradle-plugin-incubating:test --tests "com.apollographql.apollo.gradle.dsltest.KotlinDSLTests"
   - .buildscript/integration_tests_composite.sh
+  - ./gradlew -p samples build
 
 before_script:
   - android list target

--- a/samples/build.gradle
+++ b/samples/build.gradle
@@ -17,5 +17,6 @@ subprojects {
   repositories {
     google()
     mavenCentral()
+    jcenter() // needed for trove4j (transitive dependency of lintVitalRelease)
   }
 }


### PR DESCRIPTION
Add the samples to Travis CI. Since they are now a composite build, they were not compiled from the root project automatically.

@tasomaniac I guess the gradle wrapper under `samples/gradlew` is needed to open the `samples` directory in IDEA ? Is there any chance we could merge it with the gradle wraper at the root of `apollo-android` ? Not only would that save some space but it would also ensure the gradle version stay in sync (right now we have gradle 5.6 in root vs 5.5.1 in samples). 