### PR TITLE
Add gitattributes file for compiler tests' expected outputs

### DIFF
--- a/apollo-compiler/src/test/graphql/.gitattributes
+++ b/apollo-compiler/src/test/graphql/.gitattributes
@@ -1,0 +1,3 @@
+# apollo generates code without carriage return. Make sure git does not add them when checking out the test fixtures
+/*.kt eof=lf
+/*.java eof=lf


### PR DESCRIPTION
Currently, `apollo-compiler`'s tests fail on Windows because `checkTestFixture` directly compares file contents, but Windows writes newlines differently from Unix.

![image](https://user-images.githubusercontent.com/1078569/67232273-de158480-f3f5-11e9-976e-56f738e7fed7.png)

~This fixes that by stripping carriage return (`\r`) characters from the compared strings.~
Now using gitattributes