### PR TITLE
Introduce CompilerParams

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -13,7 +13,7 @@ object AndroidTaskConfigurator {
   fun configure(apolloExtension: ApolloExtension,
                 androidExtension: Any,
                 project: Project,
-                registerVariantTask: (Project, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>) -> Unit) -> Unit
+                registerVariantTask: (Project, ApolloExtension, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) -> Unit
   ) {
     when {
       androidExtension is LibraryExtension -> {
@@ -39,7 +39,7 @@ object AndroidTaskConfigurator {
                               apolloExtension: ApolloExtension,
                               androidExtension: BaseExtension,
                               variant: BaseVariant,
-                              registerVariantTask: (Project, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>) -> Unit) -> Unit) {
+                              registerVariantTask: (Project, ApolloExtension, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) -> Unit) {
 
     val apolloVariant = ApolloVariant(
         name = variant.name,
@@ -47,8 +47,8 @@ object AndroidTaskConfigurator {
         androidVariant = variant
     )
 
-    registerVariantTask(project, apolloVariant) { generateSourcesTaskProvider ->
-      if (apolloExtension.generateKotlinModels) {
+    registerVariantTask(project, apolloExtension, apolloVariant) { generateSourcesTaskProvider, generateKotlinModels ->
+      if (generateKotlinModels) {
         variant.addJavaSourceFoldersToModel(generateSourcesTaskProvider.get().outputDir.get().asFile)
         androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(generateSourcesTaskProvider.get().outputDir)
         project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(generateSourcesTaskProvider) }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -10,6 +10,32 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 
 object AndroidTaskConfigurator {
+  fun getVariants(project: Project, androidExtension: Any) {
+    when {
+      androidExtension is LibraryExtension -> {
+        androidExtension.libraryVariants.all(Action { variant ->
+          val apolloVariant = ApolloVariant(
+              name = variant.name,
+              sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
+              androidVariant = variant
+          )
+          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
+        })
+        // TODO: add test variants ?
+      }
+      androidExtension is AppExtension -> {
+        androidExtension.applicationVariants.all(Action { variant ->
+          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
+        })
+        // TODO: add test variants ?
+      }
+      else -> {
+        // InstantAppExtension or something else we don't support yet
+        throw IllegalArgumentException("${androidExtension.javaClass.name} is not supported at the moment")
+      }
+    }
+  }
+
   fun configure(apolloExtension: ApolloExtension,
                 androidExtension: Any,
                 project: Project,

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/AndroidTaskConfigurator.kt
@@ -6,81 +6,60 @@ import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.api.BaseVariant
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskProvider
 
 object AndroidTaskConfigurator {
-  fun getVariants(project: Project, androidExtension: Any) {
+  fun getVariants(project: Project, androidExtension: Any): NamedDomainObjectContainer<ApolloVariant> {
+    val container = project.container(ApolloVariant::class.java)
+
     when {
       androidExtension is LibraryExtension -> {
-        androidExtension.libraryVariants.all(Action { variant ->
-          val apolloVariant = ApolloVariant(
+        // TODO: add test variants ?
+        androidExtension.libraryVariants.all { variant ->
+          container.add(ApolloVariant(
               name = variant.name,
               sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
               androidVariant = variant
-          )
-          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
-        })
-        // TODO: add test variants ?
+          ))
+        }
       }
       androidExtension is AppExtension -> {
-        androidExtension.applicationVariants.all(Action { variant ->
-          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
-        })
         // TODO: add test variants ?
+        androidExtension.applicationVariants.all { variant ->
+          container.add(ApolloVariant(
+              name = variant.name,
+              sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
+              androidVariant = variant
+          ))
+        }
       }
       else -> {
         // InstantAppExtension or something else we don't support yet
         throw IllegalArgumentException("${androidExtension.javaClass.name} is not supported at the moment")
       }
     }
+    return container
   }
 
-  fun configure(apolloExtension: ApolloExtension,
-                androidExtension: Any,
-                project: Project,
-                registerVariantTask: (Project, ApolloExtension, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) -> Unit
+  fun registerGeneratedDirectory(
+      project: Project,
+      androidExtension: Any,
+      compilationUnit: DefaultCompilationUnit,
+      codegenProvider: TaskProvider<ApolloGenerateSourcesTask>
   ) {
-    when {
-      androidExtension is LibraryExtension -> {
-        androidExtension.libraryVariants.all(Action { variant ->
-          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
-        })
-        // TODO: add test variants ?
-      }
-      androidExtension is AppExtension -> {
-        androidExtension.applicationVariants.all(Action { variant ->
-          registerAndroid(project, apolloExtension, androidExtension, variant, registerVariantTask)
-        })
-        // TODO: add test variants ?
-      }
-      else -> {
-        // InstantAppExtension or something else we don't support yet
-        throw IllegalArgumentException("${androidExtension.javaClass.name} is not supported at the moment")
-      }
-    }
-  }
 
-  private fun registerAndroid(project: Project,
-                              apolloExtension: ApolloExtension,
-                              androidExtension: BaseExtension,
-                              variant: BaseVariant,
-                              registerVariantTask: (Project, ApolloExtension, ApolloVariant, block: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) -> Unit) {
-
-    val apolloVariant = ApolloVariant(
-        name = variant.name,
-        sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
-        androidVariant = variant
-    )
-
-    registerVariantTask(project, apolloExtension, apolloVariant) { generateSourcesTaskProvider, generateKotlinModels ->
-      if (generateKotlinModels) {
-        variant.addJavaSourceFoldersToModel(generateSourcesTaskProvider.get().outputDir.get().asFile)
-        androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(generateSourcesTaskProvider.get().outputDir)
-        project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(generateSourcesTaskProvider) }
-      } else {
-        variant.registerJavaGeneratingTask(generateSourcesTaskProvider.get(), generateSourcesTaskProvider.get().outputDir.get().asFile)
-      }
+    val variant = compilationUnit.androidVariant as BaseVariant
+    if (compilationUnit.compilerParams.generateKotlinModels) {
+      variant.addJavaSourceFoldersToModel(codegenProvider.get().outputDir.get().asFile)
+      androidExtension as BaseExtension
+      // TODO: make this lazy
+      androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(codegenProvider.get().outputDir)
+      project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(codegenProvider) }
+    } else {
+      // TODO: make this lazy
+      variant.registerJavaGeneratingTask(codegenProvider.get(), codegenProvider.get().outputDir.get().asFile)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ApolloPlugin.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle
 import com.apollographql.apollo.compiler.NullableValueType
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.ApolloSourceSetExtension
+import com.apollographql.apollo.gradle.api.Service
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -36,8 +37,148 @@ open class ApolloPlugin : Plugin<Project> {
     """.trimMargin()
       return ret
     }
-  }
 
+    private fun deprecationChecks(apolloSourceSetExtension: ApolloSourceSetExtension) {
+      if (apolloSourceSetExtension.schemaFile != null || apolloSourceSetExtension.exclude != null) {
+        throw IllegalArgumentException("""
+        apollo.sourceSet is not supported anymore.
+        
+      """.trimIndent() + useService(apolloSourceSetExtension.schemaFile, null, "[${apolloSourceSetExtension.exclude?.joinToString(",")}]"))
+      }
+    }
+
+    private fun registerCodegenTasks(project: Project, apolloExtension: ApolloExtension) {
+      val androidExtension = project.extensions.findByName("android")
+
+      val apolloVariants = if (androidExtension == null) {
+        JvmTaskConfigurator.getVariants(project)
+
+        registerVariantTask(project, apolloExtension, apolloVariant) { generateSourcesTaskProvider, generateKotlinModels ->
+          val sourceDirectorySet = if (!generateKotlinModels) {
+            sourceSets.getByName(name).getJava()
+          } else {
+            sourceSets.getByName(name).kotlin!!
+          }
+          val compileTaskName = if (!generateKotlinModels) {
+            "compileJava"
+          } else {
+            "compileKotlin"
+          }
+          sourceDirectorySet.srcDir(generateSourcesTaskProvider.get().outputDir)
+          project.tasks.named(compileTaskName).configure { it.dependsOn(generateSourcesTaskProvider) }
+        }
+      } else {
+        AndroidTaskConfigurator.getVariants(project, androidExtension)
+        AndroidTaskConfigurator.configure(apolloExtension, androidExtension, project, this::registerVariantTask)
+      }
+    }
+
+    private fun registerVariantTask(project: Project,
+                                    apolloExtension: ApolloExtension,
+                                    apolloVariant: ApolloVariant,
+                                    addOutputDirToSourceSetDir: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) {
+
+      val generateVariantClassesTask = project.tasks.register("generate${apolloVariant.name.capitalize()}ApolloSources") {
+        it.group = TASK_GROUP
+      }
+
+      // for backward compatibility
+      val oldName = "generate${apolloVariant.name.capitalize()}ApolloClasses"
+      project.tasks.register(oldName) {
+        it.group = TASK_GROUP
+        it.doLast {
+          throw IllegalArgumentException("$oldName is deprecated. Please use generateApolloSources instead.")
+        }
+      }
+
+      var compilationUnits = apolloExtension.services.map {
+        DefaultCompilationUnit.from(project, apolloExtension, apolloVariant, it)
+      }
+      if (compilationUnits.isEmpty()) {
+        compilationUnits = DefaultCompilationUnit.default(project, apolloExtension, apolloVariant)
+      }
+      compilationUnits.forEach { compilationUnit ->
+        val generateSourcesTaskProvider = registerGenerateSourcesTask(project, compilationUnit)
+        generateVariantClassesTask.configure {
+          it.dependsOn(generateSourcesTaskProvider)
+        }
+
+        addOutputDirToSourceSetDir(generateSourcesTaskProvider, compilationUnit.compilerParams.generateKotlinModels)
+
+        apolloExtension.compilationUnits.add(compilationUnit)
+      }
+
+      generateSourcesTaskProvider.configure {
+        it.dependsOn(generateVariantClassesTask)
+      }
+    }
+
+    fun registerGenerateSourcesTask(project: Project, compilationUnit: DefaultCompilationUnit): TaskProvider<ApolloGenerateSourcesTask> {
+      val variantName = compilationUnit.variantName
+      val taskName = "generate${variantName.capitalize()}${compilationUnit.serviceName.capitalize()}ApolloSources"
+
+      val taskProvider = project.tasks.register(taskName, ApolloGenerateSourcesTask::class.java) {
+        it.source(compilationUnit.files)
+        if (compilationUnit.schemaFile != null) {
+          it.source(compilationUnit.schemaFile)
+        }
+
+        it.graphqlFiles = compilationUnit.files
+        it.schemaFile = compilationUnit.schemaFile
+        it.schemaPackageName = compilationUnit.schemaPackageName
+        it.rootPackageName = compilationUnit.rootPackageName
+        it.group = TASK_GROUP
+        it.description = "Generate Android classes for ${variantName.capitalize()}${compilationUnit.serviceName} GraphQL queries"
+        it.nullableValueType = compilationUnit.compilerParams.nullableValueType
+        it.useSemanticNaming = compilationUnit.compilerParams.useSemanticNaming
+        it.generateModelBuilder = compilationUnit.compilerParams.generateModelBuilder
+        it.useJavaBeansSemanticNaming = compilationUnit.compilerParams.useJavaBeansSemanticNaming
+        it.suppressRawTypesWarning = compilationUnit.compilerParams.suppressRawTypesWarning
+        it.generateKotlinModels = compilationUnit.compilerParams.generateKotlinModels
+        it.generateVisitorForPolymorphicDatatypes = compilationUnit.compilerParams.generateVisitorForPolymorphicDatatypes
+        it.customTypeMapping = compilationUnit.compilerParams.customTypeMapping
+        it.outputDir.apply {
+          set(compilationUnit.outputDirectory)
+          disallowChanges()
+        }
+        it.transformedQueriesOutputDir.apply {
+          if (compilationUnit.compilerParams.generateTransformedQueries) {
+            set(compilationUnit.transformedQueriesDirectory)
+          }
+          disallowChanges()
+        }
+      }
+
+      compilationUnit.outputDir = taskProvider.flatMap { it.outputDir }
+      compilationUnit.transformedQueriesDir = taskProvider.flatMap { it.transformedQueriesOutputDir }
+
+      return taskProvider
+    }
+
+    private fun registerDownloadSchemaTasks(project: Project, apolloExtension: ApolloExtension) {
+      apolloExtension.services.forEach { service ->
+        val introspection = service.introspection
+        if (introspection != null) {
+          project.tasks.register("download${service.name.capitalize()}ApolloSchema", ApolloDownloadSchemaTask::class.java) { task ->
+            task.group = TASK_GROUP
+            task.schemaFilePath = service.schemaFilePath
+            task.endpointUrl = introspection.endpointUrl!!
+            task.queryParameters = introspection.queryParameters
+            task.headers = introspection.headers
+          }
+        }
+      }
+    }
+
+    private fun afterEvaluate(project: Project, apolloExtension: ApolloExtension, apolloSourceSetExtension: ApolloSourceSetExtension) {
+
+      deprecationChecks(apolloSourceSetExtension)
+
+      registerCodegenTasks(project, apolloExtension)
+
+      registerDownloadSchemaTasks(project, apolloExtension)
+    }
+  }
 
   override fun apply(project: Project) {
     val apolloExtension = project.extensions.create("apollo", ApolloExtension::class.java, project)
@@ -61,142 +202,5 @@ open class ApolloPlugin : Plugin<Project> {
     project.afterEvaluate {
       afterEvaluate(it, apolloExtension, apolloSourceSetExtension)
     }
-  }
-
-  private fun afterEvaluate(project: Project, apolloExtension: ApolloExtension, apolloSourceSetExtension: ApolloSourceSetExtension) {
-
-    if (apolloSourceSetExtension.schemaFile != null || apolloSourceSetExtension.exclude != null) {
-      throw IllegalArgumentException("""
-        apollo.sourceSet is not supported anymore.
-        
-      """.trimIndent() + ApolloPlugin.useService(apolloSourceSetExtension.schemaFile, null, "[${apolloSourceSetExtension.exclude?.joinToString(",")}]"))
-    }
-
-    val androidExtension = project.extensions.findByName("android")
-
-    if (androidExtension == null) {
-      val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
-      val sourceSets = javaPlugin.sourceSets
-
-      // TODO: should we add tasks for the test sourceSet ?
-      val name = "main"
-      val apolloVariant = ApolloVariant(
-          name = name,
-          sourceSetNames = listOf(name),
-          androidVariant = null
-      )
-
-      registerVariantTask(project, apolloExtension, apolloVariant) { generateSourcesTaskProvider, generateKotlinModels ->
-        val sourceDirectorySet = if (!generateKotlinModels) {
-          sourceSets.getByName(name).getJava()
-        } else {
-          sourceSets.getByName(name).kotlin!!
-        }
-        val compileTaskName = if (!generateKotlinModels) {
-          "compileJava"
-        } else {
-          "compileKotlin"
-        }
-        sourceDirectorySet.srcDir(generateSourcesTaskProvider.get().outputDir)
-        project.tasks.named(compileTaskName).configure { it.dependsOn(generateSourcesTaskProvider) }
-      }
-    } else {
-      AndroidTaskConfigurator.configure(apolloExtension, androidExtension, project, this::registerVariantTask)
-    }
-
-    apolloExtension.services.forEach { service ->
-      val introspection = service.introspection
-      if (introspection != null) {
-        project.tasks.register("download${service.name.capitalize()}ApolloSchema", ApolloDownloadSchemaTask::class.java) { task ->
-          task.group = TASK_GROUP
-          task.schemaFilePath = service.schemaFilePath
-          task.endpointUrl = introspection.endpointUrl!!
-          task.queryParameters = introspection.queryParameters
-          task.headers = introspection.headers
-        }
-      }
-    }
-  }
-
-  private fun registerVariantTask(project: Project,
-                                  apolloExtension: ApolloExtension,
-                                  apolloVariant: ApolloVariant,
-                                  addOutputDirToSourceSetDir: (TaskProvider<ApolloGenerateSourcesTask>, Boolean) -> Unit) {
-
-    val generateVariantClassesTask = project.tasks.register("generate${apolloVariant.name.capitalize()}ApolloSources") {
-      it.group = TASK_GROUP
-    }
-
-    // for backward compatibility
-    val oldName = "generate${apolloVariant.name.capitalize()}ApolloClasses"
-    project.tasks.register(oldName) {
-      it.group = TASK_GROUP
-      it.doLast {
-        throw IllegalArgumentException("$oldName is deprecated. Please use generateApolloSources instead.")
-      }
-    }
-
-    var compilationUnits = apolloExtension.services.map {
-      DefaultCompilationUnit.from(project, apolloExtension, apolloVariant, it)
-    }
-    if (compilationUnits.isEmpty()) {
-      compilationUnits = DefaultCompilationUnit.default(project, apolloExtension, apolloVariant)
-    }
-    compilationUnits.forEach { compilationUnit ->
-      val generateSourcesTaskProvider = registerGenerateSourcesTask(project, compilationUnit)
-      generateVariantClassesTask.configure {
-        it.dependsOn(generateSourcesTaskProvider)
-      }
-
-      addOutputDirToSourceSetDir(generateSourcesTaskProvider, compilationUnit.compilerParams.generateKotlinModels)
-
-      apolloExtension.compilationUnits.add(compilationUnit)
-    }
-
-    generateSourcesTaskProvider.configure {
-      it.dependsOn(generateVariantClassesTask)
-    }
-  }
-
-  fun registerGenerateSourcesTask(project: Project, compilationUnit: DefaultCompilationUnit): TaskProvider<ApolloGenerateSourcesTask> {
-    val variantName = compilationUnit.variantName
-    val taskName = "generate${variantName.capitalize()}${compilationUnit.serviceName.capitalize()}ApolloSources"
-
-    val taskProvider = project.tasks.register(taskName, ApolloGenerateSourcesTask::class.java) {
-      it.source(compilationUnit.files)
-      if (compilationUnit.schemaFile != null) {
-        it.source(compilationUnit.schemaFile)
-      }
-
-      it.graphqlFiles = compilationUnit.files
-      it.schemaFile = compilationUnit.schemaFile
-      it.schemaPackageName = compilationUnit.schemaPackageName
-      it.rootPackageName = compilationUnit.rootPackageName
-      it.group = TASK_GROUP
-      it.description = "Generate Android classes for ${variantName.capitalize()}${compilationUnit.serviceName} GraphQL queries"
-      it.nullableValueType = compilationUnit.compilerParams.nullableValueType
-      it.useSemanticNaming = compilationUnit.compilerParams.useSemanticNaming
-      it.generateModelBuilder = compilationUnit.compilerParams.generateModelBuilder
-      it.useJavaBeansSemanticNaming = compilationUnit.compilerParams.useJavaBeansSemanticNaming
-      it.suppressRawTypesWarning = compilationUnit.compilerParams.suppressRawTypesWarning
-      it.generateKotlinModels = compilationUnit.compilerParams.generateKotlinModels
-      it.generateVisitorForPolymorphicDatatypes = compilationUnit.compilerParams.generateVisitorForPolymorphicDatatypes
-      it.customTypeMapping = compilationUnit.compilerParams.customTypeMapping
-      it.outputDir.apply {
-        set(compilationUnit.outputDirectory)
-        disallowChanges()
-      }
-      it.transformedQueriesOutputDir.apply {
-        if (compilationUnit.compilerParams.generateTransformedQueries) {
-          set(compilationUnit.transformedQueriesDirectory)
-        }
-        disallowChanges()
-      }
-    }
-
-    compilationUnit.outputDir = taskProvider.flatMap { it.outputDir }
-    compilationUnit.transformedQueriesDir = taskProvider.flatMap { it.transformedQueriesOutputDir }
-
-    return taskProvider
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/DefaultCompilationUnit.kt
@@ -25,7 +25,6 @@ class DefaultCompilationUnit(
   internal val outputDirectory = project.buildDir.child("generated", "source", "apollo", variantName, serviceName)
   internal val transformedQueriesDirectory = project.buildDir.child("generated", "transformedQueries", "apollo", variantName, serviceName)
 
-
   override lateinit var outputDir: Provider<Directory>
   override lateinit var transformedQueriesDir: Provider<Directory>
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/DefaultCompilationUnit.kt
@@ -106,7 +106,7 @@ class DefaultCompilationUnit(
                 schemaPackageName = entry.value.canonicalPath.formatPackageName(dropLast = 1)!!,
                 rootPackageName = "",
                 androidVariant = apolloVariant.androidVariant,
-                compilerParams = ResolvedCompilerParams.from(apolloExtension, service),
+                compilerParams = ResolvedCompilerParams.from(apolloExtension, null),
                 project = project
             )
           }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/JvmTaskConfigurator.kt
@@ -1,0 +1,26 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.gradle.api.CompilationUnit
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginConvention
+
+object JvmTaskConfigurator {
+
+  fun getVariants(project: Project): NamedDomainObjectContainer<ApolloVariant> {
+    val container = project.container(ApolloVariant::class.java)
+    val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
+    val sourceSets = javaPlugin.sourceSets
+
+    // TODO: should we add tasks for the test sourceSet ?
+    val name = "main"
+    val apolloVariant = ApolloVariant(
+        name = name,
+        sourceSetNames = listOf(name),
+        androidVariant = null
+    )
+
+    container.add(apolloVariant)
+    return container
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/JvmTaskConfigurator.kt
@@ -1,16 +1,14 @@
 package com.apollographql.apollo.gradle
 
-import com.apollographql.apollo.gradle.api.CompilationUnit
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.TaskProvider
 
 object JvmTaskConfigurator {
 
   fun getVariants(project: Project): NamedDomainObjectContainer<ApolloVariant> {
     val container = project.container(ApolloVariant::class.java)
-    val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
-    val sourceSets = javaPlugin.sourceSets
 
     // TODO: should we add tasks for the test sourceSet ?
     val name = "main"
@@ -22,5 +20,25 @@ object JvmTaskConfigurator {
 
     container.add(apolloVariant)
     return container
+  }
+
+  fun registerGeneratedDirectory(project: Project, compilationUnit: DefaultCompilationUnit, codegenProvider: TaskProvider<ApolloGenerateSourcesTask>) {
+    val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
+    val sourceSets = javaPlugin.sourceSets
+    val name = compilationUnit.variantName
+
+    val sourceDirectorySet = if (!compilationUnit.compilerParams.generateKotlinModels) {
+      sourceSets.getByName(name).java
+    } else {
+      sourceSets.getByName(name).kotlin!!
+    }
+
+    val compileTaskName = if (!compilationUnit.compilerParams.generateKotlinModels) {
+      "compileJava"
+    } else {
+      "compileKotlin"
+    }
+    sourceDirectorySet.srcDir(codegenProvider.get().outputDir)
+    project.tasks.named(compileTaskName).configure { it.dependsOn(codegenProvider) }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ResolvedCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ResolvedCompilerParams.kt
@@ -1,0 +1,71 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.compiler.NullableValueType
+import com.apollographql.apollo.gradle.api.ApolloExtension
+import com.apollographql.apollo.gradle.api.CompilerParams
+
+class ResolvedCompilerParams(
+    val generateKotlinModels: Boolean,
+    val generateTransformedQueries: Boolean,
+    val customTypeMapping: Map<String, String>,
+    val suppressRawTypesWarning: Boolean,
+    val useSemanticNaming: Boolean,
+
+    val nullableValueType: String,
+    val generateModelBuilder: Boolean,
+    val useJavaBeansSemanticNaming: Boolean,
+    val generateVisitorForPolymorphicDatatypes: Boolean
+) {
+  companion object {
+    fun from(apolloExtension: ApolloExtension, serviceParams: CompilerParams): ResolvedCompilerParams {
+
+      val params = ResolvedCompilerParams(
+          generateKotlinModels = serviceParams.generateKotlinModels ?: apolloExtension.generateKotlinModels ?: false,
+          generateTransformedQueries = serviceParams.generateTransformedQueries ?: apolloExtension.generateTransformedQueries ?: false,
+          customTypeMapping = serviceParams.customTypeMapping ?: apolloExtension.customTypeMapping ?: emptyMap(),
+          suppressRawTypesWarning = serviceParams.suppressRawTypesWarning ?: apolloExtension.suppressRawTypesWarning ?: false,
+          useSemanticNaming = serviceParams.useSemanticNaming ?: apolloExtension.useSemanticNaming ?: true,
+
+          nullableValueType = serviceParams.nullableValueType ?: apolloExtension.nullableValueType ?: NullableValueType.ANNOTATED.value,
+          generateModelBuilder = serviceParams.generateModelBuilder ?: apolloExtension.generateModelBuilder ?: false,
+          useJavaBeansSemanticNaming = serviceParams.useJavaBeansSemanticNaming ?: apolloExtension.useJavaBeansSemanticNaming ?: false,
+          generateVisitorForPolymorphicDatatypes = serviceParams.generateVisitorForPolymorphicDatatypes
+              ?: apolloExtension.generateVisitorForPolymorphicDatatypes ?: false
+      )
+
+      if (params.generateKotlinModels && params.generateModelBuilder) {
+        throw IllegalArgumentException("""
+        Using `generateModelBuilder = true` does not make sense with `generateKotlinModels = true`. You can use .copy() as models are data classes.
+      """.trimIndent())
+      }
+
+      if (params.generateKotlinModels && params.useJavaBeansSemanticNaming) {
+        throw IllegalArgumentException("""
+        Using `useJavaBeansSemanticNaming = true` does not make sense with `generateKotlinModels = true`
+      """.trimIndent())
+      }
+
+      if (params.generateKotlinModels && serviceParams.nullableValueType ?: apolloExtension.nullableValueType != null) {
+        throw IllegalArgumentException("""
+        Using `nullableValueType` does not make sense with `generateKotlinModels = true`
+      """.trimIndent())
+      }
+
+      if (apolloExtension.schemaFilePath != null) {
+        throw IllegalArgumentException("""
+        apollo.schemaFilePath is not supported anymore as it doesn't work for multiple services.
+        
+      """.trimIndent() + ApolloPlugin.useService(apolloExtension.schemaFilePath, apolloExtension.outputPackageName))
+      }
+
+      if (apolloExtension.outputPackageName != null) {
+        throw IllegalArgumentException("""
+        apollo.outputPackageName is not supported anymore as it doesn't work for multiple services and also flattens the packages.
+        
+      """.trimIndent() + ApolloPlugin.useService(apolloExtension.schemaFilePath, apolloExtension.outputPackageName))
+      }
+
+      return params
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ResolvedCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/ResolvedCompilerParams.kt
@@ -17,19 +17,19 @@ class ResolvedCompilerParams(
     val generateVisitorForPolymorphicDatatypes: Boolean
 ) {
   companion object {
-    fun from(apolloExtension: ApolloExtension, serviceParams: CompilerParams): ResolvedCompilerParams {
+    fun from(apolloExtension: ApolloExtension, serviceParams: CompilerParams?): ResolvedCompilerParams {
 
       val params = ResolvedCompilerParams(
-          generateKotlinModels = serviceParams.generateKotlinModels ?: apolloExtension.generateKotlinModels ?: false,
-          generateTransformedQueries = serviceParams.generateTransformedQueries ?: apolloExtension.generateTransformedQueries ?: false,
-          customTypeMapping = serviceParams.customTypeMapping ?: apolloExtension.customTypeMapping ?: emptyMap(),
-          suppressRawTypesWarning = serviceParams.suppressRawTypesWarning ?: apolloExtension.suppressRawTypesWarning ?: false,
-          useSemanticNaming = serviceParams.useSemanticNaming ?: apolloExtension.useSemanticNaming ?: true,
+          generateKotlinModels = serviceParams?.generateKotlinModels ?: apolloExtension.generateKotlinModels ?: false,
+          generateTransformedQueries = serviceParams?.generateTransformedQueries ?: apolloExtension.generateTransformedQueries ?: false,
+          customTypeMapping = serviceParams?.customTypeMapping ?: apolloExtension.customTypeMapping ?: emptyMap(),
+          suppressRawTypesWarning = serviceParams?.suppressRawTypesWarning ?: apolloExtension.suppressRawTypesWarning ?: false,
+          useSemanticNaming = serviceParams?.useSemanticNaming ?: apolloExtension.useSemanticNaming ?: true,
 
-          nullableValueType = serviceParams.nullableValueType ?: apolloExtension.nullableValueType ?: NullableValueType.ANNOTATED.value,
-          generateModelBuilder = serviceParams.generateModelBuilder ?: apolloExtension.generateModelBuilder ?: false,
-          useJavaBeansSemanticNaming = serviceParams.useJavaBeansSemanticNaming ?: apolloExtension.useJavaBeansSemanticNaming ?: false,
-          generateVisitorForPolymorphicDatatypes = serviceParams.generateVisitorForPolymorphicDatatypes
+          nullableValueType = serviceParams?.nullableValueType ?: apolloExtension.nullableValueType ?: NullableValueType.ANNOTATED.value,
+          generateModelBuilder = serviceParams?.generateModelBuilder ?: apolloExtension.generateModelBuilder ?: false,
+          useJavaBeansSemanticNaming = serviceParams?.useJavaBeansSemanticNaming ?: apolloExtension.useJavaBeansSemanticNaming ?: false,
+          generateVisitorForPolymorphicDatatypes = serviceParams?.generateVisitorForPolymorphicDatatypes
               ?: apolloExtension.generateVisitorForPolymorphicDatatypes ?: false
       )
 
@@ -45,7 +45,7 @@ class ResolvedCompilerParams(
       """.trimIndent())
       }
 
-      if (params.generateKotlinModels && serviceParams.nullableValueType ?: apolloExtension.nullableValueType != null) {
+      if (params.generateKotlinModels && serviceParams?.nullableValueType ?: apolloExtension.nullableValueType != null) {
         throw IllegalArgumentException("""
         Using `nullableValueType` does not make sense with `generateKotlinModels = true`
       """.trimIndent())

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -3,31 +3,23 @@ package com.apollographql.apollo.gradle.api
 import org.gradle.api.Action
 import org.gradle.api.Project
 
-open class ApolloExtension(project: Project) {
-  @JvmField
-  var nullableValueType: String? = null
-  @JvmField
-  var useSemanticNaming = true
-  @JvmField
-  var generateModelBuilder = false
-  @JvmField
-  var useJavaBeansSemanticNaming = false
-  @JvmField
-  var suppressRawTypesWarning = false
-  @JvmField
-  var generateKotlinModels = false
-  @JvmField
-  var generateVisitorForPolymorphicDatatypes = false
-  @JvmField
-  var generateTransformedQueries = false
+open class ApolloExtension(project: Project): CompilerParams by DefaultCompilerParams() {
+  /**
+   * This is the input to the apollo plugin. Users will populate the services from their gradle files
+   */
+  val services = mutableListOf<Service>()
 
-  @JvmField
-  var customTypeMapping: Map<String, String> = emptyMap()
-
-  @JvmField
-  var services = mutableListOf<Service>()
-
+  /**
+   * compilationUnits is meant to be consumed by other gradle plugin.
+   * The apollo plugin will add the {@link CompilationUnit} as it creates them
+   */
   val compilationUnits = project.container(CompilationUnit::class.java)
+
+  fun service(name: String, action: Action<Service>) {
+    val service = Service(name)
+    action.execute(service)
+    services.add(service)
+  }
 
   /**
    * Deprecated,use @{link service} instead
@@ -41,61 +33,6 @@ open class ApolloExtension(project: Project) {
   @JvmField
   var outputPackageName: String? = null
 
-  fun service(name: String, action: Action<Service>) {
-    val service = Service(name)
-    action.execute(service)
-    services.add(service)
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setNullableValueType(nullableValueType: String) {
-    this.nullableValueType = nullableValueType
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setUseSemanticNaming(useSemanticNaming: Boolean) {
-    this.useSemanticNaming = useSemanticNaming
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setGenerateModelBuilder(generateModelBuilder: Boolean) {
-    this.generateModelBuilder = generateModelBuilder
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setUseJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean) {
-    this.useJavaBeansSemanticNaming = useJavaBeansSemanticNaming
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setSuppressRawTypesWarning(suppressRawTypesWarning: Boolean) {
-    this.suppressRawTypesWarning = suppressRawTypesWarning
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setGenerateKotlinModels(generateKotlinModels: Boolean) {
-    this.generateKotlinModels = generateKotlinModels
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setGenerateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean) {
-    this.generateKotlinModels = generateVisitorForPolymorphicDatatypes
-  }
-
   /**
    * For backward compatibility
    */
@@ -108,19 +45,5 @@ open class ApolloExtension(project: Project) {
    */
   fun setOutputPackageName(outputPackageName: String) {
     this.outputPackageName = outputPackageName
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setCustomTypeMapping(customTypeMapping: Map<String, String>) {
-    this.customTypeMapping = customTypeMapping
-  }
-
-  /**
-   * For backward compatibility
-   */
-  fun setGenerateTransformedQueries(generateTransformedQueries: Boolean) {
-    this.generateTransformedQueries = generateTransformedQueries
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -1,0 +1,14 @@
+package com.apollographql.apollo.gradle.api
+
+interface CompilerParams {
+  var generateKotlinModels: Boolean?
+  var generateTransformedQueries: Boolean?
+  var customTypeMapping: Map<String, String>?
+  var suppressRawTypesWarning: Boolean?
+  var useSemanticNaming: Boolean?
+
+  var nullableValueType: String?
+  var generateModelBuilder: Boolean?
+  var useJavaBeansSemanticNaming: Boolean?
+  var generateVisitorForPolymorphicDatatypes: Boolean?
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/DefaultCompilerParams.kt
@@ -1,0 +1,14 @@
+package com.apollographql.apollo.gradle.api
+
+class DefaultCompilerParams(
+    override var generateKotlinModels: Boolean? = null,
+    override var generateTransformedQueries: Boolean? = null,
+    override var customTypeMapping: Map<String, String>? = null,
+    override var suppressRawTypesWarning: Boolean? = null,
+    override var useSemanticNaming: Boolean? = null,
+
+    override var generateModelBuilder: Boolean? = null,
+    override var useJavaBeansSemanticNaming: Boolean? = null,
+    override var generateVisitorForPolymorphicDatatypes: Boolean? = null,
+    override var nullableValueType: String? = null
+) : CompilerParams

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.gradle.api.Introspection
 import groovy.lang.Closure
 import org.gradle.api.Action
 
-class Service(val name: String) {
+class Service(val name: String): CompilerParams by DefaultCompilerParams() {
   /**
    * Place where the schema.json file is.
    * This path is relative to the current project directory.

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
@@ -9,43 +9,6 @@ import org.junit.Test
 
 class KotlinDSLTests {
   @Test
-  fun `project configures correctly and generates something`() {
-    val apolloConfiguration = """
-      (extensions.getByName("apollo") as ApolloExtension).apply {
-        setNullableValueType("annotated")
-        setUseJavaBeansSemanticNaming(false)
-        setGenerateModelBuilder(false)
-        setUseSemanticNaming(false)
-        setUseJavaBeansSemanticNaming(false)
-        setSuppressRawTypesWarning(false)
-        setGenerateVisitorForPolymorphicDatatypes(false)
-        //setSchemaFilePath("")
-        //setOutputPackageName("")
-        setCustomTypeMapping(mapOf("DateTime" to "java.util.Date"))
-        setGenerateKotlinModels(false)
-        setGenerateTransformedQueries(false)
-        
-        service("starwars") {
-          sourceFolderPath = "com/example"
-          schemaFilePath = "src/main/graphql/com/example/schema.json"
-          rootPackageName = "com.starwars"
-          exclude = listOf("*.gql")
-        }
-      }
-    """.trimIndent()
-
-    TestUtils.withProject(
-        usesKotlinDsl = true,
-        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
-        apolloConfiguration = apolloConfiguration
-    ) { dir ->
-      val result = TestUtils.executeTask("generateApolloSources", dir)
-      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      Assert.assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/DroidDetails.java").isFile)
-    }
-  }
-
-  @Test
   fun `property syntax is also working`() {
     val apolloConfiguration = """
       (extensions.getByName("apollo") as ApolloExtension).apply {

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -187,7 +187,24 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `schemaFilePath can be changed`() {
+  fun `service compilerParams override extension compilerParams`() {
+    withSimpleProject("""
+      apollo {
+        useSemanticNaming = false
+        service("starwars") {
+          useSemanticNaming = true
+          schemaFilePath = "src/main/graphql/com/example/schema.json"
+        }
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+      TestUtils.assertFileContains(dir, "main/starwars/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+    }
+  }
+
+
+  @Test
+  fun `sourceFolderPath can be changed`() {
     withSimpleProject("""
       apollo {
         service("starwars") {


### PR DESCRIPTION
`CompilerParams` is an interface implemented by both `ApolloExtension` and `Service`. This allows to override the global params on a per-service basis:

```groovy
      apollo {
        useSemanticNaming = false
        service("starwars") {
          useSemanticNaming = true
          schemaFilePath = "src/main/graphql/com/example/schema.json"
        }
      }
```

The above will resolve `useSemanticNaming=true`. Also part of this PR:
* refactoring of `ApolloPlugin.kt` to put most of the code in static method and reorganize it a bit.
* removal of `@JvmField` on the compiler params. That means users of Kotlin DSL are forced to use property syntax now. So that there's only one obvious way to do it (tm) and also this removes some boilerplate setters.

This should be merged before https://github.com/apollographql/apollo-android/pull/1673. I'll merge the conflicts afterwards.
