### PR TITLE
Make okhttp and apollo api deps in http-cache

### DIFF
--- a/apollo-http-cache/build.gradle.kts
+++ b/apollo-http-cache/build.gradle.kts
@@ -1,4 +1,4 @@
-apply(plugin = "java")
+apply(plugin = "java-library")
 
 
 withConvention(JavaPluginConvention::class) {

--- a/apollo-http-cache/build.gradle.kts
+++ b/apollo-http-cache/build.gradle.kts
@@ -9,8 +9,8 @@ withConvention(JavaPluginConvention::class) {
 dependencies {
   add("compileOnly", groovy.util.Eval.x(project, "x.dep.jetbrainsAnnotations"))
 
-  add("implementation", groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
-  add("implementation", project(":apollo-api"))
+  add("api", groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+  add("api", project(":apollo-api"))
 
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.junit"))
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.truth"))


### PR DESCRIPTION
These are both part of the cache's public API, and gives warnings in the IDE when they're hidden from the classpath.

![image](https://user-images.githubusercontent.com/1361086/68089950-1f695380-fe3c-11e9-913b-a0d3174d8769.png)
