### PR TITLE
Hide the extension implementation from kotlin dsl accessors

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.ApolloSourceSetExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -212,7 +213,7 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   override fun apply(project: Project) {
-    val apolloExtension = project.extensions.create("apollo", DefaultApolloExtension::class.java, project)
+    val apolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project) as DefaultApolloExtension
     // for backward compatibility
     val apolloSourceSetExtension = (apolloExtension as ExtensionAware).extensions.create("sourceSet", ApolloSourceSetExtension::class.java, project.objects)
 

--- a/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.kts
+++ b/apollo-gradle-plugin-incubating/src/test/files/gradle/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.apollographql.apollo")
+}

--- a/apollo-gradle-plugin-incubating/src/test/files/gradle/settings.gradle.kts
+++ b/apollo-gradle-plugin-incubating/src/test/files/gradle/settings.gradle.kts
@@ -1,0 +1,25 @@
+rootProject.name="testProject"
+
+apply("../../../gradle/dependencies.gradle")
+
+pluginManagement {
+  repositories {
+    maven {
+      url = uri("../../../build/localMaven")
+    }
+    gradlePluginPortal()
+  }
+
+
+  resolutionStrategy {
+    eachPlugin {
+      if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+        useModule(groovy.util.Eval.x(extra, "x.dep.kotlin.plugin"))
+      }
+
+      if (requested.id.id == "com.apollographql.apollo") {
+        useModule(groovy.util.Eval.x(extra, "x.dep.apollo.pluginIncubating"))
+      }
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/KotlinDSLTests.kt
@@ -3,11 +3,47 @@ package com.apollographql.apollo.gradle.dsltest
 import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.generatedChild
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class KotlinDSLTests {
+  @Test
+  fun `generated accessors work as expected`() {
+    val apolloConfiguration = """
+      apollo {
+        nullableValueType("annotated")
+      }
+    """.trimIndent()
+
+    TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
+      TestUtils.executeGradle(dir)
+    }
+  }
+
+  @Test
+  fun `generated accessors do not expose DefaultApolloExtension`() {
+    val apolloConfiguration = """
+      apollo {
+        println("apollo has ${'$'}{services.size} services")
+      }
+    """.trimIndent()
+
+    TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeGradle(dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        Assert.assertThat(e.message, CoreMatchers.containsString("Unresolved reference: services"))
+      }
+      Assert.assertNotNull(exception)
+    }
+  }
+
+
   @Test
   fun `parameters do not throw`() {
     val apolloConfiguration = """

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -19,15 +19,23 @@ object TestUtils {
   val apolloPlugin = Plugin(id = "com.apollographql.apollo", artifact = "apollo.pluginIncubating")
   val apolloPluginAndroid = Plugin(id = "com.apollographql.android", artifact = "apollo.pluginIncubating")
 
+
+  fun withDirectory(block: (File) -> Unit) {
+    val dest = File(System.getProperty("user.dir")).child("build", "testProject")
+    dest.deleteRecursively()
+
+    block(dest)
+
+    dest.deleteRecursively()
+  }
+
   fun withProject(usesKotlinDsl: Boolean,
                   plugins: List<Plugin>,
                   apolloConfiguration: String,
                   isFlavored: Boolean = false,
-                  block: (File) -> Unit) {
+                  block: (File) -> Unit) = withDirectory {
     val source = fixturesDirectory()
-    val dest = File(System.getProperty("user.dir")).child("build", "testProject")
-
-    dest.deleteRecursively()
+    val dest = it
 
     source.child("starwars").copyRecursively(target = dest.child("src", "main", "graphql", "com", "example"))
     source.child("gradle", "settings.gradle").copyTo(target = dest.child("settings.gradle"))
@@ -119,8 +127,15 @@ object TestUtils {
     }
 
     block(dest)
+  }
 
-    dest.deleteRecursively()
+  fun withGeneratedAccessorsProject(apolloConfiguration: String,  block: (File) -> Unit) = withDirectory {dir->
+    fixturesDirectory().child("gradle", "settings.gradle.kts").copyTo(dir.child("settings.gradle.kts"))
+    fixturesDirectory().child("gradle", "build.gradle.kts").copyTo(dir.child("build.gradle.kts"))
+
+    dir.child("build.gradle.kts").appendText(apolloConfiguration)
+
+    block(dir)
   }
 
   /**


### PR DESCRIPTION
This makes sure the kotlin accessors do not expose `DefaultApolloExtension`