### PR TITLE
fix gradle-6 warning regarding PathSensitivity

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -61,7 +61,6 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   abstract val rootFolders: Property<Collection<String>>
 
   @get:OutputDirectory
-  @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val outputDir: DirectoryProperty
 
   @get:Optional


### PR DESCRIPTION
`PathSensitive` is only for inputs