### PR TITLE
Incubating Plugin: added tests for symlinks and make sure to never follow them

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/DefaultPackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/DefaultPackageNameProvider.kt
@@ -3,11 +3,11 @@ package com.apollographql.apollo.compiler
 import java.io.File
 
 class DefaultPackageNameProvider(rootFolders: Collection<String>, schemaFile: File, private val rootPackageName: String) : PackageNameProvider {
-  private val roots = rootFolders.map(::File).map { File(it.canonicalPath) }
+  private val roots = rootFolders.map(::File).map { File(it.absolutePath).normalize() }
   private val schemaPackageName = try {
     filePackageName(schemaFile.absolutePath)
   } catch (e: IllegalArgumentException) {
-    // Can happen if the schema is not in the roots
+    // Can happen if the schema is not under roots
     ""
   }
 
@@ -19,7 +19,7 @@ class DefaultPackageNameProvider(rootFolders: Collection<String>, schemaFile: Fi
   }
 
   fun filePackageName(filePath: String): String {
-    val file = File(File(filePath).canonicalPath)
+    val file = File(File(filePath).absolutePath).normalize()
     roots.forEach { sourceDir ->
       try {
         val relative = file.toRelativeString(sourceDir)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -211,7 +211,7 @@ class DefaultCompilationUnit(
       }
 
       return schemaFiles.entries
-          .sortedBy { it.value.canonicalPath } // make sure the order is predictable for tests and in general
+          .sortedBy { it.key } // make sure the order is predictable for tests and in general
           .mapIndexed { i, entry ->
             val name = "service$i"
             val sourceFolder = entry.key.substringBeforeLast("/")

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -10,6 +10,8 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
 class ConfigurationTests {
   @Test
@@ -289,6 +291,42 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("customTaskmainservice0", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainService0ApolloSources")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `symlinks are not followed for the schema`() {
+    withSimpleProject { dir ->
+      dir.child("src/main/graphql/com/example/schema.json").copyTo(dir.child("schema.json"))
+      dir.child("src/main/graphql/com/example/schema.json").delete()
+
+
+      Files.createSymbolicLink(dir.child(
+          "src/main/graphql/com/example/schema.json").toPath(),
+          dir.child("schema.json").toPath()
+      )
+
+      TestUtils.executeTask("generateApolloSources", dir)
+
+      assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `symlinks are not followed for sources`() {
+    withSimpleProject { dir ->
+      dir.child("src/main/graphql/com/example").copyRecursively(dir.child("tmp"))
+      dir.child("src/main/graphql/com/").deleteRecursively()
+
+
+      Files.createSymbolicLink(
+          dir.child("src/main/graphql/example").toPath(),
+          dir.child("tmp").toPath()
+      )
+
+      TestUtils.executeTask("generateApolloSources", dir)
+
+      assertTrue(dir.generatedChild("main/service0/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 }


### PR DESCRIPTION
`canonicalPath` follows symlinks which is problematic since we use the relative path to determine package names. Instead use normalized paths everywhere.