### PR TITLE
Add proper support for custom JSON object / list scalar types

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
@@ -92,8 +92,8 @@ public class InputFieldJsonWriter implements InputFieldWriter {
         writeBoolean(fieldName, ((CustomTypeValue.GraphQLBoolean) customTypeValue).value);
       } else if (customTypeValue instanceof CustomTypeValue.GraphQLNumber) {
         writeNumber(fieldName, ((CustomTypeValue.GraphQLNumber) customTypeValue).value);
-      } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject ||
-          customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
+      } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject
+          || customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
         jsonWriter.name(fieldName);
         writeToJson(value, jsonWriter);
       } else {
@@ -211,8 +211,8 @@ public class InputFieldJsonWriter implements InputFieldWriter {
           writeBoolean(((CustomTypeValue.GraphQLBoolean) customTypeValue).value);
         } else if (customTypeValue instanceof CustomTypeValue.GraphQLNumber) {
           writeNumber(((CustomTypeValue.GraphQLNumber) customTypeValue).value);
-        } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject ||
-            customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
+        } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject
+            || customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
           writeToJson(value, jsonWriter);
         } else {
           throw new IllegalArgumentException("Unsupported custom value type: " + customTypeValue);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/json/InputFieldJsonWriter.java
@@ -92,10 +92,10 @@ public class InputFieldJsonWriter implements InputFieldWriter {
         writeBoolean(fieldName, ((CustomTypeValue.GraphQLBoolean) customTypeValue).value);
       } else if (customTypeValue instanceof CustomTypeValue.GraphQLNumber) {
         writeNumber(fieldName, ((CustomTypeValue.GraphQLNumber) customTypeValue).value);
-      } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonString) {
-        writeString(fieldName, ((CustomTypeValue.GraphQLJsonString) customTypeValue).value);
-      } else if (customTypeValue instanceof CustomTypeValue.GraphQLJson) {
-        writeMap(fieldName, ((CustomTypeValue.GraphQLJson) customTypeValue).value);
+      } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject ||
+          customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
+        jsonWriter.name(fieldName);
+        writeToJson(value, jsonWriter);
       } else {
         throw new IllegalArgumentException("Unsupported custom value type: " + customTypeValue);
       }
@@ -211,10 +211,9 @@ public class InputFieldJsonWriter implements InputFieldWriter {
           writeBoolean(((CustomTypeValue.GraphQLBoolean) customTypeValue).value);
         } else if (customTypeValue instanceof CustomTypeValue.GraphQLNumber) {
           writeNumber(((CustomTypeValue.GraphQLNumber) customTypeValue).value);
-        } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonString) {
-          writeString(((CustomTypeValue.GraphQLJsonString) customTypeValue).value);
-        } else if (customTypeValue instanceof CustomTypeValue.GraphQLJson) {
-          writeMap(((CustomTypeValue.GraphQLJson) customTypeValue).value);
+        } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject ||
+            customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
+          writeToJson(value, jsonWriter);
         } else {
           throw new IllegalArgumentException("Unsupported custom value type: " + customTypeValue);
         }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeAdapter.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeAdapter.java
@@ -55,11 +55,11 @@ public interface CustomTypeAdapter<T> {
   T decode(@NotNull CustomTypeValue value);
 
   /**
-   * Serializes the custom scalar type to the corresponding string value. Usually used in serializing variables or input
+   * Serializes the custom scalar type to the corresponding {@link CustomTypeValue} value. Usually used in serializing variables or input
    * values.
    *
    * @param value the custom scalar type to serialize
-   * @return serialized string value
+   * @return serialized value
    */
   @NotNull CustomTypeValue encode(@NotNull T value);
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeValue.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/CustomTypeValue.java
@@ -1,7 +1,5 @@
 package com.apollographql.apollo.response;
 
-import com.apollographql.apollo.internal.json.Utils;
-
 import java.util.List;
 import java.util.Map;
 
@@ -15,13 +13,12 @@ import java.util.Map;
 public abstract class CustomTypeValue<T> {
   public final T value;
 
+  @SuppressWarnings("unchecked")
   public static CustomTypeValue fromRawValue(Object value) {
-    if (value instanceof Map || value instanceof List) {
-      try {
-        return new GraphQLJsonString(Utils.toJsonString(value));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
+    if (value instanceof Map) {
+      return new GraphQLJsonObject((Map<String, Object>) value);
+    } else if (value instanceof List) {
+      return new GraphQLJsonList((List<Object>) value);
     } else if (value instanceof Boolean) {
       return new GraphQLBoolean((Boolean) value);
     } else if (value instanceof Number) {
@@ -63,19 +60,19 @@ public abstract class CustomTypeValue<T> {
   }
 
   /**
-   * Represents a {@code JsonString} value
+   * Represents a JSON object value
    */
-  public static class GraphQLJsonString extends CustomTypeValue<String> {
-    public GraphQLJsonString(String value) {
+  public static class GraphQLJsonObject extends CustomTypeValue<Map<String, Object>> {
+    public GraphQLJsonObject(Map<String, Object> value) {
       super(value);
     }
   }
 
   /**
-   * Represents a JSON object value, will serialized as an regular json object
+   * Represents a JSON list value
    */
-  public static class GraphQLJson extends CustomTypeValue<Map<String, Object>> {
-    public GraphQLJson(Map<String, Object> value) {
+  public static class GraphQLJsonList extends CustomTypeValue<List<Object>> {
+    public GraphQLJsonList(List<Object> value) {
       super(value);
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.ScalarType;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
@@ -18,7 +19,7 @@ public final class ScalarTypeAdapters {
   public ScalarTypeAdapters(@NotNull Map<ScalarType, CustomTypeAdapter> customAdapters) {
     Map<ScalarType, CustomTypeAdapter> nonNullcustomAdapters = checkNotNull(customAdapters, "customAdapters == null");
     this.customAdapters = new HashMap<>();
-    for (Map.Entry<ScalarType, CustomTypeAdapter> entry:nonNullcustomAdapters.entrySet()) {
+    for (Map.Entry<ScalarType, CustomTypeAdapter> entry : nonNullcustomAdapters.entrySet()) {
       this.customAdapters.put(entry.getKey().typeName(), entry.getValue());
     }
   }
@@ -53,7 +54,7 @@ public final class ScalarTypeAdapters {
         } else if (value instanceof CustomTypeValue.GraphQLString) {
           return Boolean.parseBoolean(((CustomTypeValue.GraphQLString) value).value);
         } else {
-          throw new IllegalArgumentException("Can't map: " + value + " to Boolean");
+          throw new IllegalArgumentException("Can't decode: " + value + " into Boolean");
         }
       }
     });
@@ -64,7 +65,7 @@ public final class ScalarTypeAdapters {
         } else if (value instanceof CustomTypeValue.GraphQLString) {
           return Integer.parseInt(((CustomTypeValue.GraphQLString) value).value);
         } else {
-          throw new IllegalArgumentException("Can't map: " + value + " to Integer");
+          throw new IllegalArgumentException("Can't decode: " + value + " into Integer");
         }
       }
     });
@@ -75,7 +76,7 @@ public final class ScalarTypeAdapters {
         } else if (value instanceof CustomTypeValue.GraphQLString) {
           return Long.parseLong(((CustomTypeValue.GraphQLString) value).value);
         } else {
-          throw new IllegalArgumentException("Can't map: " + value + " to Long");
+          throw new IllegalArgumentException("Can't decode: " + value + " into Long");
         }
       }
     });
@@ -86,7 +87,7 @@ public final class ScalarTypeAdapters {
         } else if (value instanceof CustomTypeValue.GraphQLString) {
           return Float.parseFloat(((CustomTypeValue.GraphQLString) value).value);
         } else {
-          throw new IllegalArgumentException("Can't map: " + value + " to Float");
+          throw new IllegalArgumentException("Can't decode: " + value + " into Float");
         }
       }
     });
@@ -97,7 +98,7 @@ public final class ScalarTypeAdapters {
         } else if (value instanceof CustomTypeValue.GraphQLString) {
           return Double.parseDouble(((CustomTypeValue.GraphQLString) value).value);
         } else {
-          throw new IllegalArgumentException("Can't map: " + value + " to Double");
+          throw new IllegalArgumentException("Can't decode: " + value + " into Double");
         }
       }
     });
@@ -115,6 +116,24 @@ public final class ScalarTypeAdapters {
     adapters.put(Object.class, new DefaultCustomTypeAdapter<Object>() {
       @NotNull @Override public Object decode(@NotNull CustomTypeValue value) {
         return value.value;
+      }
+    });
+    adapters.put(Map.class, new DefaultCustomTypeAdapter<Map>() {
+      @NotNull @Override public Map decode(@NotNull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLJsonObject) {
+          return ((CustomTypeValue.GraphQLJsonObject) value).value;
+        } else {
+          throw new IllegalArgumentException("Can't decode: " + value + " into Map");
+        }
+      }
+    });
+    adapters.put(List.class, new DefaultCustomTypeAdapter<List>() {
+      @NotNull @Override public List decode(@NotNull CustomTypeValue value) {
+        if (value instanceof CustomTypeValue.GraphQLJsonList) {
+          return ((CustomTypeValue.GraphQLJsonList) value).value;
+        } else {
+          throw new IllegalArgumentException("Can't decode: " + value + " into List");
+        }
       }
     });
     return adapters;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/json/InputFieldJsonWriterTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/json/InputFieldJsonWriterTest.java
@@ -8,7 +8,6 @@ import com.apollographql.apollo.response.CustomTypeAdapter;
 import com.apollographql.apollo.response.CustomTypeValue;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
 
-import com.sun.javafx.collections.UnmodifiableObservableMap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,7 +16,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ResponseReaderTest.java
@@ -194,11 +194,21 @@ public class ResponseReaderTest {
     }
   }
 
-  @Test public void readCustomObjectMap() throws Exception {
-    ResponseField successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
-        false, OBJECT_CUSTOM_TYPE, NO_CONDITIONS);
+  @Test public void readCustomObjectMap() {
+    final ScalarType mapScalarType = new ScalarType() {
+      @Override public String typeName() {
+        return Map.class.getName();
+      }
 
-    Map<String, Object> objectMap = new HashMap<>();
+      @Override public Class javaType() {
+        return Map.class;
+      }
+    };
+
+    final ResponseField successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
+        false, mapScalarType, NO_CONDITIONS);
+
+    final Map<String, Object> objectMap = new HashMap<>();
     objectMap.put("string", "string");
     objectMap.put("boolean", true);
     objectMap.put("double", 1.99D);
@@ -214,50 +224,41 @@ public class ResponseReaderTest {
     objectMap.put("object", new HashMap<>(objectMap));
     objectMap.put("objectList", asList(new HashMap<>(objectMap), new HashMap<>(objectMap)));
 
-    Map<String, Object> recordSet = new HashMap<>();
+    final Map<String, Object> recordSet = new HashMap<>();
     recordSet.put("successFieldResponseName", objectMap);
     recordSet.put("successFieldName", objectMap);
 
-    RealResponseReader<Map<String, Object>> responseReader = responseReader(recordSet);
-    assertThat(responseReader.readCustomType((ResponseField.CustomTypeField) successField))
-        .isEqualTo("{\"string\":\"string\",\"double\":1.99,\"intList\":[8,9,10],\"doubleList\":[1.99,2.99]," +
-            "\"float\":2.99,\"longList\":[5,7],\"long\":3,\"int\":4,\"objectList\":[{\"string\":\"string\"," +
-            "\"double\":1.99,\"intList\":[8,9,10],\"doubleList\":[1.99,2.99],\"float\":2.99,\"longList\":[5,7]," +
-            "\"long\":3,\"int\":4,\"boolean\":true,\"stringList\":[\"string1\",\"string2\"]," +
-            "\"floatList\":[3.99,4.99,5.99],\"booleanList\":[\"true\",\"false\"],\"object\":{\"string\":\"string\"," +
-            "\"double\":1.99,\"intList\":[8,9,10],\"doubleList\":[1.99,2.99],\"float\":2.99,\"longList\":[5,7]," +
-            "\"long\":3,\"int\":4,\"boolean\":true,\"stringList\":[\"string1\",\"string2\"]," +
-            "\"floatList\":[3.99,4.99,5.99],\"booleanList\":[\"true\",\"false\"]}},{\"string\":\"string\"," +
-            "\"double\":1.99,\"intList\":[8,9,10],\"doubleList\":[1.99,2.99],\"float\":2.99,\"longList\":[5,7]," +
-            "\"long\":3,\"int\":4,\"boolean\":true,\"stringList\":[\"string1\",\"string2\"]," +
-            "\"floatList\":[3.99,4.99,5.99],\"booleanList\":[\"true\",\"false\"],\"object\":{\"string\":\"string\"," +
-            "\"double\":1.99,\"intList\":[8,9,10],\"doubleList\":[1.99,2.99],\"float\":2.99,\"longList\":[5,7]," +
-            "\"long\":3,\"int\":4,\"boolean\":true,\"stringList\":[\"string1\",\"string2\"]," +
-            "\"floatList\":[3.99,4.99,5.99],\"booleanList\":[\"true\",\"false\"]}}],\"boolean\":true," +
-            "\"stringList\":[\"string1\",\"string2\"],\"floatList\":[3.99,4.99,5.99]," +
-            "\"booleanList\":[\"true\",\"false\"],\"object\":{\"string\":\"string\",\"double\":1.99," +
-            "\"intList\":[8,9,10],\"doubleList\":[1.99,2.99],\"float\":2.99,\"longList\":[5,7],\"long\":3,\"int\":4," +
-            "\"boolean\":true,\"stringList\":[\"string1\",\"string2\"],\"floatList\":[3.99,4.99,5.99]," +
-            "\"booleanList\":[\"true\",\"false\"]}}");
+    final RealResponseReader<Map<String, Object>> responseReader = responseReader(recordSet);
+    assertThat((Map<?, ?>) responseReader.readCustomType((ResponseField.CustomTypeField) successField))
+        .containsExactlyEntriesIn(objectMap);
   }
 
-  @Test public void readCustomObjectList() throws Exception {
-    ResponseField successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
-        false, OBJECT_CUSTOM_TYPE, NO_CONDITIONS);
+  @Test public void readCustomObjectList() {
+    final ScalarType listScalarType = new ScalarType() {
+      @Override public String typeName() {
+        return List.class.getName();
+      }
 
-    Map<String, Object> objectMap = new HashMap<>();
+      @Override public Class javaType() {
+        return List.class;
+      }
+    };
+    final ResponseField successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
+        false, listScalarType, NO_CONDITIONS);
+
+    final Map<String, Object> objectMap = new HashMap<>();
     objectMap.put("string", "string");
     objectMap.put("boolean", true);
 
-    List<?> objectList = asList(objectMap, objectMap);
+    final List<?> objectList = asList(objectMap, objectMap);
 
-    Map<String, Object> recordSet = new HashMap<>();
+    final Map<String, Object> recordSet = new HashMap<>();
     recordSet.put("successFieldResponseName", objectList);
     recordSet.put("successFieldName", objectList);
 
-    RealResponseReader<Map<String, Object>> responseReader = responseReader(recordSet);
-    assertThat(responseReader.readCustomType((ResponseField.CustomTypeField) successField))
-        .isEqualTo("[{\"boolean\":true,\"string\":\"string\"},{\"boolean\":true,\"string\":\"string\"}]");
+    final RealResponseReader<Map<String, Object>> responseReader = responseReader(recordSet);
+    assertThat((List<?>) responseReader.readCustomType((ResponseField.CustomTypeField) successField))
+        .containsExactlyElementsIn(objectList);
   }
 
   @Test public void readCustomWithDecodedNullValue() throws Exception {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/response/ScalarTypeAdaptersTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/response/ScalarTypeAdaptersTest.java
@@ -2,11 +2,15 @@ package com.apollographql.apollo.response;
 
 import com.apollographql.apollo.api.FileUpload;
 import com.apollographql.apollo.api.ScalarType;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -104,11 +108,31 @@ public class ScalarTypeAdaptersTest {
     assertThat(adapter.encode(10.10d).value).isEqualTo(10.10d);
   }
 
-   @Test
+  @Test
   public void defaultObjectAdapter() {
     final CustomTypeAdapter<Object> adapter = defaultAdapter(Object.class);
     assertThat(adapter.decode(CustomTypeValue.fromRawValue(RuntimeException.class))).isEqualTo("class java.lang.RuntimeException");
     assertThat(adapter.encode(RuntimeException.class).value).isEqualTo("class java.lang.RuntimeException");
+  }
+
+  @Test
+  public void defaultMapAdapter() {
+    final Map<String, Object> value = new UnmodifiableMapBuilder<String, Object>()
+        .put("key1", "value1")
+        .put("key2", "value2")
+        .build();
+
+    final CustomTypeAdapter<Map> adapter = defaultAdapter(Map.class);
+    assertThat(adapter.decode(CustomTypeValue.fromRawValue(value))).isEqualTo(value);
+    assertThat(adapter.encode(value).value).isEqualTo(value);
+  }
+
+  @Test
+  public void defaultListAdapter() {
+    final List<String> value = Arrays.asList("item 1", "item 2");
+    final CustomTypeAdapter<List> adapter = defaultAdapter(List.class);
+    assertThat(adapter.decode(CustomTypeValue.fromRawValue(value))).isEqualTo(value);
+    assertThat(adapter.encode(value).value).isEqualTo(value);
   }
 
   private <T> CustomTypeAdapter<T> defaultAdapter(final Class<T> clazz) {


### PR DESCRIPTION
Add support for encoding / decoding custom GraphQL scalar type value represented by JSON object into Map.
Add support for encoding / decoding custom GraphQL scalar type value represented by JSON list into List.