### PR TITLE
Incubating Plugin: Do not allow queries or schema variant overrides

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -233,11 +233,11 @@ class DefaultCompilationUnit(
     }
 
     /**
-     * Finds the files in the given sourceSets taking into account their precedence according to the android plugin order
+     * Finds the files in the given sourceSets.
      *
      * Returns a map with the relative path to the path as key and the file as value
      *
-     * Files coming last will have higher priorities that the first ones.
+     * @throws [kotlin.IllegalArgumentException] if there are multiple files with the same relative path
      */
     private fun findFilesInSourceSets(project: Project, sourceSetNames: List<String>, path: String, predicate: (File) -> Boolean): Map<String, File> {
       val candidates = mutableMapOf<String, File>()
@@ -253,8 +253,9 @@ class DefaultCompilationUnit(
             it.toRelativeString(root)
           }
 
-          // overwrite the previous entry if it was there already
-          // this is ok as Android orders the sourceSetNames from lower to higher priority
+          if (candidates[key] != null) {
+            throw IllegalArgumentException("ApolloGraphQL: duplicate file found:\n${it.absolutePath}\n${candidates[key]?.absolutePath}")
+          }
           candidates[key] = it
         }
       }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -57,12 +57,15 @@ class AndroidTests {
       File(dir, "src/main/graphql/com/example/DroidDetails.graphql").copyTo(debugFile)
       debugFile.replaceInText("c3BlY2llczoy", "speciesIdForDebug")
 
-      val result = TestUtils.executeTask("generateDebugApolloSources", dir)
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateDebugApolloSources", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("duplicate file found"))
+      }
 
-      assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloSources")!!.outcome)
-
-      // Java classes generated successfully
-      assertThat(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").readText(), containsString("speciesIdForDebug"))
+      assertNotNull(exception)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -97,6 +97,12 @@ class AndroidTests {
       freeDebugDir.mkdirs()
       File(freeDebugDir, "schema.json").writeText("This is an invalid schema")
 
+      val paidDebugDir = File(dir, "src/paidDebug/graphql/com/example/")
+      paidDebugDir.mkdirs()
+      File(dir, "src/main/graphql/com/example/schema.json").copyTo(File(paidDebugDir, "schema.json"))
+
+      File(dir, "src/main/graphql/com/example/schema.json").delete()
+
       var exception: Exception? = null
       try {
         TestUtils.executeTask("generateFreeDebugApolloSources", dir)


### PR DESCRIPTION
Similar to what the Android Plugin does for java sources (https://developer.android.com/studio/build/build-variants#sourceset-build), we should not allow overrides over variants. The layout below will throw an exception:

```
// duplicate schema.json
src/freeDebug/graphql/com/example/schema.json
src/main/graphql/com/example/schema.json

// duplicate Query.graphql
src/freeDebug/graphql/com/example/Query.graphql
src/main/graphql/com/example/Query.graphql
```

This makes it explicit that files are mutually exclusive for a given variant.

ping @tasomaniac 