### PR TITLE
Incubating plugin: do not resolve properties in parent DSL scopes

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.gradle.api
 
 import com.apollographql.apollo.gradle.internal.DefaultService
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.provider.Property

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Action
 import org.gradle.api.DomainObjectCollection
 import org.gradle.api.provider.Property
 
+@ApolloGraphqlDslMarker
 interface ApolloExtension: CompilerParams {
 
   val compilationUnits: DomainObjectCollection<CompilationUnit>

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloGraphqlDslMarker.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloGraphqlDslMarker.kt
@@ -1,0 +1,4 @@
+package com.apollographql.apollo.gradle.api
+
+@DslMarker
+annotation class ApolloGraphqlDslMarker

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -1,11 +1,9 @@
 package com.apollographql.apollo.gradle.api
 
-import org.apache.tools.ant.types.resources.FileProvider
 import org.gradle.api.file.*
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
+@ApolloGraphqlDslMarker
 interface CompilationUnit {
   val name: String
   val serviceName: String

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Introspection.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Introspection.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle.api
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 
+@ApolloGraphqlDslMarker
 interface Introspection {
   val endpointUrl: Property<String>
   fun endpointUrl(endpointUrl: String)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -1,11 +1,10 @@
 package com.apollographql.apollo.gradle.api
 
-import com.apollographql.apollo.gradle.internal.DefaultIntrospection
-import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
+@ApolloGraphqlDslMarker
 interface Service: CompilerParams {
   fun introspection(configure: Action<in Introspection>)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle.internal
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
@@ -18,6 +19,15 @@ open class DefaultApolloExtension(val project: Project): CompilerParams by Defau
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
   override val compilationUnits = project.container(CompilationUnit::class.java)
+
+  fun service(name: String, closure: Closure<DefaultService>) {
+    val service = project.objects.newInstance(DefaultService::class.java, project.objects, name)
+    closure.delegate = service
+    // do not resolve properties in parent scopes
+    closure.resolveStrategy = Closure.DELEGATE_ONLY
+    closure.call()
+    services.add(service)
+  }
 
   override fun service(name: String, action: Action<DefaultService>) {
     val service = project.objects.newInstance(DefaultService::class.java, project.objects, name)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle.internal
 import com.apollographql.apollo.gradle.api.CompilerParams
 import com.apollographql.apollo.gradle.api.Introspection
 import com.apollographql.apollo.gradle.api.Service
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import javax.inject.Inject
@@ -29,6 +30,24 @@ open class DefaultService @Inject constructor(val objects: ObjectFactory, val na
   }
 
   var introspection: DefaultIntrospection? = null
+
+  fun introspection(configure: Closure<Introspection>) {
+    val introspection = objects.newInstance(DefaultIntrospection::class.java, objects)
+
+    if (this.introspection != null) {
+      throw IllegalArgumentException("there must be only one introspection block")
+    }
+
+    configure.delegate = introspection
+    configure.resolveStrategy = Closure.DELEGATE_ONLY
+    configure.call()
+
+    if (!introspection.endpointUrl.isPresent) {
+      throw IllegalArgumentException("introspection must have a url")
+    }
+
+    this.introspection = introspection
+  }
 
   override fun introspection(configure: Action<in Introspection>) {
     val introspection = objects.newInstance(DefaultIntrospection::class.java, objects)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -6,7 +6,9 @@ import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
 import com.apollographql.apollo.gradle.util.generatedChild
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
+import org.junit.Assert
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
@@ -307,6 +309,26 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("customTaskmainservice0", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainService0ApolloSources")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `DslMarker is working for groovy`() {
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaFilePath = "foo"
+        }
+      }
+    """.trimIndent()) { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("generateApolloSources", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("Could not set unknown property"))
+      }
+      assertNotNull(exception)
     }
   }
 }


### PR DESCRIPTION
This prevents these kinds of scenarios where the user would inadvertently call a method/property on a parent scope:

```kotlin

      configure<ApolloExtension> {
        service("starwars") {
          // this should trigger a compilation error
          schemaFilePath.set("foo")
        }
      }
```

I did this pull request as an exercise but I have mixed feelings about it. I'm not sure what other plugins/gradle do. If they allow this behavior, it's maybe better to favor consistency.