### PR TITLE
[Incubating Plugin] Provide a DSL to change compilationUnit settings

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -2,12 +2,10 @@ package com.apollographql.apollo.gradle.api
 
 import com.apollographql.apollo.gradle.internal.DefaultService
 import org.gradle.api.Action
-import org.gradle.api.DomainObjectCollection
 import org.gradle.api.provider.Property
 
 interface ApolloExtension: CompilerParams {
 
-  val compilationUnits: DomainObjectCollection<CompilationUnit>
   fun onCompilationUnits(action: Action<CompilationUnit>)
 
   fun service(name: String, action: Action<DefaultService>)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -8,6 +8,7 @@ import org.gradle.api.provider.Property
 interface ApolloExtension: CompilerParams {
 
   val compilationUnits: DomainObjectCollection<CompilationUnit>
+  fun onCompilationUnits(action: Action<CompilationUnit>)
 
   fun service(name: String, action: Action<DefaultService>)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -17,9 +17,7 @@ interface CompilationUnit {
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
 
-  fun compilerParams(closure: Closure<*>)
   fun compilerParams(action: Action<CompilerParams>)
-  fun sources(closure: Closure<*>)
   fun sources(action: Action<Sources>)
 
   class Sources(

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -5,6 +5,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
+import java.io.File
 
 interface CompilationUnit {
   val name: String
@@ -17,12 +18,24 @@ interface CompilationUnit {
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
 
-  fun configure(configure: Action<Params>)
-  fun setSources(rootFolder: Provider<Directory>)
+  fun compilerParams(action: Action<CompilerParams>)
+  fun sources(configure: Action<Sources>)
 
-  data class Params(
-      val graphqlFolder: DirectoryProperty,
+  class Sources(
       val schemaFile: RegularFileProperty,
-      val rootPackageName: Provider<String>
-  )
+      val graphqlDir: DirectoryProperty
+  ) {
+    fun schemaFile(schemaFile: File) {
+      this.schemaFile.set(schemaFile)
+    }
+
+    fun graphqlDir(graphqlDir: File) {
+      require(graphqlDir.isDirectory) { "graphqlDir must be a directory: ${graphqlDir.absolutePath}"}
+      this.graphqlDir.set(graphqlDir)
+    }
+
+    fun graphqlDir(graphqlDir: Provider<out Directory>) {
+      this.graphqlDir.set(graphqlDir)
+    }
+  }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -17,7 +17,7 @@ interface CompilationUnit {
   val transformedQueriesDir: Provider<Directory>
 
   fun compilerParams(action: Action<CompilerParams>)
-  fun sources(configure: Action<Sources>)
+  fun sources(action: Action<Sources>)
 
   class Sources(
       val schemaFile: RegularFileProperty,

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -19,6 +19,7 @@ interface CompilationUnit {
 
   fun compilerParams(closure: Closure<*>)
   fun compilerParams(action: Action<CompilerParams>)
+  fun sources(closure: Closure<*>)
   fun sources(action: Action<Sources>)
 
   class Sources(

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -12,9 +12,7 @@ interface CompilationUnit {
   val serviceName: String
   val variantName: String
   val androidVariant: Any?
-
-  var compilerParams: CompilerParams
-
+  val compilerParams: CompilerParams
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.gradle.api
 
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -16,6 +17,7 @@ interface CompilationUnit {
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
 
+  fun compilerParams(closure: Closure<*>)
   fun compilerParams(action: Action<CompilerParams>)
   fun sources(action: Action<Sources>)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -1,9 +1,9 @@
 package com.apollographql.apollo.gradle.api
 
-import org.apache.tools.ant.types.resources.FileProvider
-import org.gradle.api.file.*
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
+import org.gradle.api.Action
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 
 interface CompilationUnit {
@@ -17,6 +17,12 @@ interface CompilationUnit {
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
 
+  fun configure(configure: Action<Params>)
   fun setSources(rootFolder: Provider<Directory>)
-  fun setSources(rootFolders: FileCollection, graphqlFiles: FileCollection, schemaFile: Provider<RegularFile>, rootPackageName: Provider<String>)
+
+  data class Params(
+      val graphqlFolder: DirectoryProperty,
+      val schemaFile: RegularFileProperty,
+      val rootPackageName: Provider<String>
+  )
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.gradle.api
 
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 
 interface CompilerParams {
   val generateKotlinModels: Property<Boolean>
@@ -24,7 +25,7 @@ interface CompilerParams {
   fun useSemanticNaming(useSemanticNaming: Boolean)
   fun setUseSemanticNaming(useSemanticNaming: Boolean)
 
-  val nullableValueType:Property<String>
+  val nullableValueType: Property<String>
   fun nullableValueType(nullableValueType: String)
   fun setNullableValueType(nullableValueType: String)
 
@@ -39,4 +40,7 @@ interface CompilerParams {
   val generateVisitorForPolymorphicDatatypes: Property<Boolean>
   fun generateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean)
   fun setGenerateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean)
+
+  val rootPackageName: Provider<String>
+  fun rootPackageName(rootPackageName: String)
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -1,12 +1,10 @@
 package com.apollographql.apollo.gradle.api
 
-import com.apollographql.apollo.gradle.internal.DefaultIntrospection
-import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
-interface Service: CompilerParams {
+interface Service : CompilerParams {
   fun introspection(configure: Action<in Introspection>)
 
   val schemaPath: Property<String>
@@ -14,9 +12,6 @@ interface Service: CompilerParams {
 
   val sourceFolder: Property<String>
   fun sourceFolder(sourceFolderPath: String)
-
-  val rootPackageName: Property<String>
-  fun rootPackageName(rootPackageName: String)
 
   val exclude: ListProperty<String>
   fun exclude(exclude: List<String>)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -83,7 +83,7 @@ open class ApolloPlugin : Plugin<Project> {
         val variantProvider = registerVariantTask(project, apolloVariant.name)
 
         val compilationUnits = if (apolloExtension.services.isEmpty()) {
-          DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant)
+          listOf(DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant))
         } else {
           apolloExtension.services.map {
             DefaultCompilationUnit.fromService(project, apolloExtension, apolloVariant, it)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -83,7 +83,7 @@ open class ApolloPlugin : Plugin<Project> {
         val variantProvider = registerVariantTask(project, apolloVariant.name)
 
         val compilationUnits = if (apolloExtension.services.isEmpty()) {
-          listOf(DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant))
+          listOfNotNull(DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant))
         } else {
           apolloExtension.services.map {
             DefaultCompilationUnit.fromService(project, apolloExtension, apolloVariant, it)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.compiler.child
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.ApolloSourceSetExtension
 import org.gradle.api.Plugin
@@ -157,7 +156,6 @@ open class ApolloPlugin : Plugin<Project> {
         it.graphqlFiles.setFrom(sources.graphqlFiles)
         it.rootFolders.set(sources.rootFolders.map { it.absolutePath })
         it.schemaFile.set(sources.schemaFile)
-        it.rootPackageName.set(sources.rootPackageName)
 
         it.nullableValueType.set(compilationUnit.compilerParams.nullableValueType)
         it.useSemanticNaming.set(compilationUnit.compilerParams.useSemanticNaming)
@@ -167,6 +165,7 @@ open class ApolloPlugin : Plugin<Project> {
         it.generateKotlinModels.set(compilationUnit.compilerParams.generateKotlinModels)
         it.generateVisitorForPolymorphicDatatypes.set(compilationUnit.compilerParams.generateVisitorForPolymorphicDatatypes)
         it.customTypeMapping.set(compilationUnit.compilerParams.customTypeMapping)
+        it.rootPackageName.set(compilationUnit.compilerParams.rootPackageName)
         it.outputDir.apply {
           set(project.layout.buildDirectory.map {
             it.dir("generated/source/apollo/${compilationUnit.variantName}/${compilationUnit.serviceName}")

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.compiler.NullableValueType
 import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.model.ObjectFactory
 
@@ -15,6 +14,7 @@ fun CompilerParams.withFallback(other: CompilerParams, factory: ObjectFactory): 
   merge.generateModelBuilder.set(this.generateModelBuilder.orElse(other.generateModelBuilder))
   merge.useJavaBeansSemanticNaming.set(this.useJavaBeansSemanticNaming.orElse(other.useJavaBeansSemanticNaming))
   merge.generateVisitorForPolymorphicDatatypes.set(this.generateVisitorForPolymorphicDatatypes.orElse(other.generateVisitorForPolymorphicDatatypes))
+  merge.rootPackageName.set(this.rootPackageName.orElse(other.rootPackageName))
   return merge
 }
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -5,9 +5,8 @@ import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.provider.Property
 
-open class DefaultApolloExtension(val project: Project): CompilerParams by DefaultCompilerParams(project.objects), ApolloExtension {
+open class DefaultApolloExtension(val project: Project) : CompilerParams by DefaultCompilerParams(project.objects), ApolloExtension {
   /**
    * This is the input to the apollo plugin. Users will populate the services from their gradle files
    */
@@ -18,6 +17,10 @@ open class DefaultApolloExtension(val project: Project): CompilerParams by Defau
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
   override val compilationUnits = project.container(CompilationUnit::class.java)
+
+  override fun onCompilationUnits(action: Action<CompilationUnit>) {
+    compilationUnits.all(action)
+  }
 
   override fun service(name: String, action: Action<DefaultService>) {
     val service = project.objects.newInstance(DefaultService::class.java, project.objects, name)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -16,7 +16,7 @@ open class DefaultApolloExtension(val project: Project) : CompilerParams by Defa
    * compilationUnits is meant to be consumed by other gradle plugin.
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
-  override val compilationUnits = project.container(CompilationUnit::class.java)
+  internal val compilationUnits = project.container(CompilationUnit::class.java)
 
   override fun onCompilationUnits(action: Action<CompilationUnit>) {
     compilationUnits.all(action)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -79,13 +79,27 @@ class DefaultCompilationUnit(
     action.execute(compilerParams)
   }
 
+  override fun sources(closure: Closure<*>) {
+    val params = CompilationUnit.Sources(
+        project.objects.fileProperty(),
+        project.objects.directoryProperty()
+    )
+    closure.delegate = params
+    closure.resolveStrategy = Closure.DELEGATE_FIRST
+    closure.call()
+    customSources(params)
+  }
+
   override fun sources(action: Action<CompilationUnit.Sources>) {
     val params = CompilationUnit.Sources(
         project.objects.fileProperty(),
         project.objects.directoryProperty()
     )
     action.execute(params)
+    customSources(params)
+  }
 
+  private fun customSources(params: CompilationUnit.Sources) {
     require(params.graphqlDir.isPresent) { "rootFolder must be specified" }
 
     if (params.schemaFile.isPresent.not()) {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -206,7 +206,7 @@ class DefaultCompilationUnit(
           |Please use a service instead:
           |apollo {
           |  service("serviceName") {
-          |    schemaPath("com/example/schema.json")
+          |    sourceFolder = "serviceName"
           |  }
           |}
         """.trimMargin()

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle.internal
 import com.apollographql.apollo.compiler.child
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
@@ -68,6 +69,12 @@ class DefaultCompilationUnit(
     return sources!!
   }
 
+  override fun compilerParams(closure: Closure<*>) {
+    closure.delegate = compilerParams
+    closure.resolveStrategy = Closure.DELEGATE_FIRST
+    closure.call()
+  }
+
   override fun compilerParams(action: Action<CompilerParams>) {
     action.execute(compilerParams)
   }
@@ -92,9 +99,7 @@ class DefaultCompilationUnit(
 
     val graphqlFiles = project.objects.fileCollection()
     graphqlFiles.setFrom(params.graphqlDir.map { dir ->
-      dir.asFileTree.matching {
-        it.include("**.graphql", "**.gql")
-      }
+      dir.asFileTree.filter(::isGraphQL)
     })
 
     val rootFolders = project.objects.fileCollection()

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -203,7 +203,7 @@ open class DefaultCompilationUnit @Inject constructor(
 
       val schema = schemaFiles.values.firstOrNull() ?: return null
       return project.objects.newInstance(DefaultCompilationUnit::class.java,
-          "service0",
+          "service",
           apolloVariant.name,
           apolloExtension,
           SourcesLocator.FromFiles(schema),

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -199,16 +199,7 @@ open class DefaultCompilationUnit @Inject constructor(
       val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
         it.name == "schema.json"
       }
-      require(schemaFiles.size <= 1) {
-        val service = schemaFiles.keys.joinToString("\n") {
-          """
-            |  service("serviceName") {
-            |    sourceFolder = "${it.replace("/schema.json", "")}"
-            |  }
-          """.trimMargin()
-        }
-        "By default only one schema.json file is supported.\nPlease use multiple services instead:\napollo {\n$service\n}"
-      }
+      require(schemaFiles.size <= 1) { multipleSchemaError(schemaFiles.keys) }
 
       val schema = schemaFiles.values.firstOrNull() ?: return null
       return project.objects.newInstance(DefaultCompilationUnit::class.java,
@@ -263,6 +254,17 @@ open class DefaultCompilationUnit @Inject constructor(
         isFile && predicate(this) -> listOf(this)
         else -> emptyList()
       }
+    }
+
+    private fun multipleSchemaError(schemaPaths: Set<String>): String {
+      val service = schemaPaths.joinToString("\n") {
+        """|
+          |  service("serviceName") {
+          |    sourceFolder = "${it.replace("/schema.json", "")}"
+          |  }
+        """.trimMargin()
+      }
+      return "By default only one schema.json file is supported.\nPlease use multiple services instead:\napollo {\n$service\n}"
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -219,7 +219,7 @@ open class DefaultCompilationUnit @Inject constructor(
           apolloVariant.sourceSetNames,
           project
       ).apply {
-        apolloVariant.androidVariant
+        androidVariant = apolloVariant.androidVariant
       }
     }
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -17,9 +17,7 @@ class DefaultCompilationUnit(
     override val serviceName: String,
     override val variantName: String,
     override val androidVariant: Any?,
-
-    override var compilerParams: CompilerParams,
-
+    override val compilerParams: CompilerParams,
     private val sourcesLocator: SourcesLocator,
     private val sourceSetNames: List<String>,
     private val project: Project

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -190,27 +190,32 @@ class DefaultCompilationUnit(
       )
     }
 
-    fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): List<DefaultCompilationUnit> {
+    fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): DefaultCompilationUnit {
       val sourceSetNames = apolloVariant.sourceSetNames
       val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
         it.name == "schema.json"
       }
+      require(schemaFiles.size == 1) {
+        """|
+          |By default only one schema.json file is supported. If you have multiple schema.json,
+          |Please use a service instead:
+          |apollo {
+          |  service("serviceName") {
+          |    schemaPath("com/example/schema.json")
+          |  }
+          |}
+        """.trimMargin()
+      }
 
-      return schemaFiles.entries
-          .sortedBy { it.key } // make sure the order is predictable for tests and in general
-          .mapIndexed { i, (_, value) ->
-            val name = "service$i"
-
-            DefaultCompilationUnit(
-                project = project,
-                variantName = apolloVariant.name,
-                sourceSetNames = apolloVariant.sourceSetNames,
-                androidVariant = apolloVariant.androidVariant,
-                serviceName = name,
-                compilerParams = apolloExtension,
-                sourcesLocator = SourcesLocator.FromFiles(value)
-            )
-          }
+      return DefaultCompilationUnit(
+          project = project,
+          variantName = apolloVariant.name,
+          sourceSetNames = apolloVariant.sourceSetNames,
+          androidVariant = apolloVariant.androidVariant,
+          serviceName = "service0",
+          compilerParams = apolloExtension,
+          sourcesLocator = SourcesLocator.FromFiles(schemaFiles.values.first())
+      )
     }
 
     fun isGraphQL(file: File): Boolean {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilerParams
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 
 class DefaultCompilerParams(val factory: ObjectFactory) : CompilerParams {
@@ -49,6 +50,11 @@ class DefaultCompilerParams(val factory: ObjectFactory) : CompilerParams {
     this.generateVisitorForPolymorphicDatatypes.set(generateVisitorForPolymorphicDatatypes)
   }
 
+  override val rootPackageName = factory.property(String::class.java)
+  override fun rootPackageName(rootPackageName: String) {
+    this.rootPackageName.set(rootPackageName)
+  }
+  
   @Deprecated(message = "please use generateKotlinModels instead", replaceWith = ReplaceWith("generateKotlinModels"))
   override fun setGenerateKotlinModels(generateKotlinModels: Boolean) {
     System.err.println("setGenerateKotlinModels() is deprecated, please use generateKotlinModels() instead")

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -18,11 +18,6 @@ open class DefaultService @Inject constructor(val objects: ObjectFactory, val na
     this.sourceFolder.set(sourceFolder)
   }
 
-  override val rootPackageName = objects.property(String::class.java)
-  override fun rootPackageName(rootPackageName: String) {
-    this.rootPackageName.set(rootPackageName)
-  }
-
   override val exclude = objects.listProperty(String::class.java)
   override fun exclude(exclude: List<String>) {
     this.exclude.set(exclude)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/LazyTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/dsltest/LazyTests.kt
@@ -46,8 +46,10 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
 }
 
 configure<ApolloExtension> {
-  compilationUnits.all {
-    this.setSources(installTask.flatMap { it.outputDir })
+  onCompilationUnits {
+    sources {
+      graphqlDir(installTask.flatMap { it.outputDir })
+    }
   }
 }
 """.trimIndent()

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -23,12 +23,12 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/service0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/service0/com/example/fragment/SpeciesInformation.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 
@@ -42,8 +42,8 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateDebugApolloSources")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertFalse(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").exists())
+      assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
+      assertFalse(dir.generatedChild("release/service/com/example/DroidDetailsQuery.java").exists())
     }
   }
 
@@ -79,10 +79,10 @@ class AndroidTests {
 
       TestUtils.executeTask("build", dir)
 
-      assertTrue(dir.generatedChild("freeDebug/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("freeRelease/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("paidDebug/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("paidRelease/service0/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("freeDebug/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("freeRelease/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidDebug/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("paidRelease/service/com/example/DroidDetailsQuery.java").isFile)
     }
   }
 
@@ -128,12 +128,12 @@ class AndroidTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/service0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("debug/service0/com/example/fragment/SpeciesInformation.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/FilmsQuery.java").isFile)
-      assertTrue(dir.generatedChild("release/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("debug/service/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/FilmsQuery.java").isFile)
+      assertTrue(dir.generatedChild("release/service/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
@@ -25,17 +25,17 @@ class CacheTests {
       """.trimIndent())
 
       System.out.println("build the project")
-      var result = TestUtils.executeTask("generateMainService0ApolloSources", dir, "--build-cache")
+      var result = TestUtils.executeTask("generateMainServiceApolloSources", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainService0ApolloSources")!!.outcome)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
 
       System.out.println("delete build folder")
       dir.child("build").deleteRecursively()
 
       System.out.println("build from cache")
-      result = TestUtils.executeTask("generateMainService0ApolloSources", dir, "--build-cache")
+      result = TestUtils.executeTask("generateMainServiceApolloSources", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMainService0ApolloSources")!!.outcome)
+      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMainServiceApolloSources")!!.outcome)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -22,7 +22,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Date.class;")
+      TestUtils.assertFileContains(dir, "main/service/com/example/type/CustomType.java", "return Date.class;")
     }
   }
 
@@ -41,7 +41,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
         TestUtils.executeTask("generateApolloSources", dir)
-        TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", pair.second)
+        TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", pair.second)
       }
     }
   }
@@ -51,7 +51,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+      TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
     }
   }
 
@@ -63,7 +63,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetails.java", "class DroidDetails ")
+      TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetails.java", "class DroidDetails ")
     }
   }
 
@@ -72,7 +72,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileDoesNotContain(dir, "main/service0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+      TestUtils.assertFileDoesNotContain(dir, "main/service/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
     }
   }
 
@@ -84,7 +84,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
+      TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "Builder toBuilder()")
     }
   }
 
@@ -93,7 +93,7 @@ class ConfigurationTests {
     withSimpleProject("""
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "String name()")
+      TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "String name()")
     }
   }
 
@@ -105,7 +105,7 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "String getName()")
+      TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "String getName()")
     }
   }
 
@@ -117,9 +117,9 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/type/CustomType.java").isFile)
-      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 
@@ -346,7 +346,7 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("generateApolloSources", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      val transformedQuery = dir.child("build", "generated", "transformedQueries", "apollo", "main", "service0", "com", "example", "DroidDetails.graphql")
+      val transformedQuery = dir.child("build", "generated", "transformedQueries", "apollo", "main", "service", "com", "example", "DroidDetails.graphql")
       assertThat(transformedQuery.readText(), containsString("__typename"))
     }
   }
@@ -358,16 +358,16 @@ class ConfigurationTests {
         generateTransformedQueries = true
         
         onCompilationUnits { compilationUnit ->
-          tasks.register("customTask" + compilationUnit.name) {
+          tasks.register("customTask" + compilationUnit.name.capitalize()) {
             inputs.dir(compilationUnit.outputDir)
             inputs.dir(compilationUnit.transformedQueriesDir)
           }
         }
       }
     """.trimIndent()) { dir ->
-      val result = TestUtils.executeTask("customTaskmainservice0", dir)
+      val result = TestUtils.executeTask("customTaskMainservice", dir)
 
-      assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainService0ApolloSources")!!.outcome)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
     }
   }
 
@@ -385,7 +385,7 @@ class ConfigurationTests {
 
       TestUtils.executeTask("generateApolloSources", dir)
 
-      assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 
@@ -403,7 +403,7 @@ class ConfigurationTests {
 
       TestUtils.executeTask("generateApolloSources", dir)
 
-      assertTrue(dir.generatedChild("main/service0/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/service/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -303,9 +303,9 @@ class ConfigurationTests {
         }
         
         onCompilationUnits {
-          sources { source ->
-            source.schemaFile(file("src/main/graphql/com/example/schema.json"))
-            source.graphqlDir(file("src/main/graphql/"))
+          sources {
+            schemaFile(file("src/main/graphql/com/example/schema.json"))
+            graphqlDir(file("src/main/graphql/"))
           }
         }
       }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -110,6 +110,21 @@ class ConfigurationTests {
   }
 
   @Test
+  fun `rootPackageName works as expected`() {
+    withSimpleProject("""
+      apollo {
+        rootPackageName("com.starwars")
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+      dir.generatedChild("main/service0/com/starwars").list()?.forEach(::println)
+      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
   fun `schemaFilePath with absolute path fails`() {
     withSimpleProject("""
       apollo {
@@ -242,9 +257,10 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `rootPackageName works as expected`() {
+  fun `rootPackageName can be overridden in service`() {
     withSimpleProject("""
       apollo {
+        rootPackageName "com.something.else"
         service("service") {
           rootPackageName "com.starwars"
         }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -245,7 +245,7 @@ class ConfigurationTests {
     withSimpleProject("""
       apollo {
         service("service") {
-          rootPackageName = "com.starwars"
+          rootPackageName "com.starwars"
         }
       }
     """.trimIndent()) { dir ->

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -117,7 +117,6 @@ class ConfigurationTests {
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      dir.generatedChild("main/service0/com/starwars").list()?.forEach(::println)
       assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/DroidDetailsQuery.java").isFile)
       assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/type/CustomType.java").isFile)
       assertTrue(dir.generatedChild("main/service0/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
@@ -236,7 +235,6 @@ class ConfigurationTests {
     }
   }
 
-
   @Test
   fun `sourceFolder can be changed`() {
     withSimpleProject("""
@@ -270,6 +268,52 @@ class ConfigurationTests {
       assertTrue(dir.generatedChild("main/service/com/starwars/com/example/DroidDetailsQuery.java").isFile)
       assertTrue(dir.generatedChild("main/service/com/starwars/com/example/type/CustomType.java").isFile)
       assertTrue(dir.generatedChild("main/service/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `rootPackageName can be overridden in compilationUnits`() {
+    withSimpleProject("""
+      apollo {
+        rootPackageName "com.default"
+        service("starwars") {
+          rootPackageName "com.starwars"
+        }
+        onCompilationUnits {
+          compilerParams {
+            rootPackageName.set("com.overrides")
+          }
+        }
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+      assertTrue(dir.generatedChild("main/starwars/com/overrides/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/overrides/com/example/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/overrides/com/example/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+
+  @Test
+  fun `sources can be overridden in compilationUnits`() {
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaPath("com/some/other/schema.json")
+          sourceFolder("com/some/other")
+        }
+        
+        onCompilationUnits {
+          sources { source ->
+            source.schemaFile(file("src/main/graphql/com/example/schema.json"))
+            source.graphqlDir(file("src/main/graphql/"))
+          }
+        }
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+      assertTrue(dir.generatedChild("main/starwars/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/example/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -11,7 +11,6 @@ import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Path
 
 class ConfigurationTests {
   @Test
@@ -298,7 +297,7 @@ class ConfigurationTests {
       apollo {
         generateTransformedQueries = true
         
-        compilationUnits.all { compilationUnit ->
+        onCompilationUnits { compilationUnit ->
           tasks.register("customTask" + compilationUnit.name) {
             inputs.dir(compilationUnit.outputDir)
             inputs.dir(compilationUnit.transformedQueriesDir)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -25,9 +25,9 @@ class KotlinCodegenTests {
 
       TestUtils.executeTask("build", dir)
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.kt").isFile)
-      Assert.assertTrue(dir.generatedChild("main/service0/com/example/type/CustomType.kt").isFile)
-      Assert.assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/type/CustomType.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.kt").isFile)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
@@ -35,7 +35,7 @@ class MultipleServicesTests {
         TestUtils.executeTask("generateApolloSources", dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        assertThat(e.message, containsString("By default only one schema.json file is supported. If you have multiple schema.json,"))
+        assertThat(e.message, containsString("By default only one schema.json file is supported."))
       }
       assertNotNull(exception)
     }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -27,7 +27,7 @@ class SourceDirectorySetTests {
       Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
-      Assert.assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.kt").isFile)
     }
   }
 
@@ -49,7 +49,7 @@ class SourceDirectorySetTests {
 
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/Main.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.kt").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.kt").isFile)
       Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }
@@ -73,7 +73,7 @@ class SourceDirectorySetTests {
       Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
-      Assert.assertTrue(dir.generatedChild("debug/service0/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
     }
   }
 
@@ -95,7 +95,7 @@ class SourceDirectorySetTests {
 
       Assert.assertTrue(File(dir, "build/classes/java/main/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/classes/java/main/com/example/Main.class").isFile)
-      Assert.assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").isFile)
       Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
@@ -2,12 +2,10 @@ package com.apollographql.apollo.gradle.test
 
 import com.apollographql.apollo.compiler.child
 import com.apollographql.apollo.gradle.util.TestUtils
-import com.apollographql.apollo.gradle.util.TestUtils.fileContains
 import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
 import com.apollographql.apollo.gradle.util.generatedChild
 import com.apollographql.apollo.gradle.util.replaceInText
 import org.gradle.testkit.runner.TaskOutcome
-import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.*
@@ -30,16 +28,16 @@ class UpToDateTests {
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/service0/com/example/FilmsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.java").isFile)
 
     // verify that the custom type generated was Object.class because no customType mapping was specified
-    TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Object.class;")
+    TestUtils.assertFileContains(dir, "main/service/com/example/type/CustomType.java", "return Object.class;")
 
     // Optional is not added to the generated classes
-    assert(!TestUtils.fileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "Optional"))
-    TestUtils.assertFileContains(dir, "main/service0/com/example/DroidDetailsQuery.java", "import org.jetbrains.annotations.Nullable;")
+    assert(!TestUtils.fileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "Optional"))
+    TestUtils.assertFileContains(dir, "main/service/com/example/DroidDetailsQuery.java", "import org.jetbrains.annotations.Nullable;")
   }
 
   fun `nothing changed, task up to date`(dir: File) {
@@ -48,9 +46,9 @@ class UpToDateTests {
     assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateApolloSources")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/service0/com/example/FilmsQuery.java").isFile)
-    assertTrue(dir.generatedChild("main/service0/com/example/fragment/SpeciesInformation.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/FilmsQuery.java").isFile)
+    assertTrue(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.java").isFile)
   }
 
   fun `adding a custom type to the build script re-generates the CustomType class`(dir: File) {
@@ -68,7 +66,7 @@ class UpToDateTests {
     // and the task should run again
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
 
-    TestUtils.assertFileContains(dir, "main/service0/com/example/type/CustomType.java", "return Date.class;")
+    TestUtils.assertFileContains(dir, "main/service/com/example/type/CustomType.java", "return Date.class;")
 
     val text = File(dir, "build.gradle").readText()
     File(dir, "build.gradle").writeText(text.replace(apolloBlock, ""))
@@ -80,14 +78,14 @@ class UpToDateTests {
       var result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").readText(), containsString("classification"))
+      assertThat(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").readText(), containsString("classification"))
 
       dir.child("src", "main", "graphql", "com", "example", "DroidDetails.graphql").replaceInText("classification", "")
 
       result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("main/service0/com/example/DroidDetailsQuery.java").readText(), not(containsString("classification")))
+      assertThat(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").readText(), not(containsString("classification")))
     }
   }
 


### PR DESCRIPTION
- Introduce new `dsl` called `sources` to set the graphql sources.
- `rootPackageName` is moved to `CompilerParams`. 
- Introcuded `compilerParams {}` DSL to override any `compilerParams` specific value per `compilationUnit`
- Remove the long `setSources`, the new DSL is much more useful and provide the same functionality

It would look like:

```
apollo {
  onCompilationUnits {
    compilerParams {
      rootPackageName("com.example.api")
    }
    sources {
      graphqlDir(files('some/path'))
      schemaFile(file('schema.json'))
    }
  }
}
```

## Tests

`LazyTests` uses the `setSources` function and they're still green. I would like to write more tests to see the whole DSL functionality works. 