### PR TITLE
[Incubating Plugin] Support absolute paths

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -1,10 +1,13 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.compiler.*
+import com.apollographql.apollo.compiler.child
+import com.apollographql.apollo.compiler.toPackageName
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.Project
-import org.gradle.api.file.*
+import org.gradle.api.file.Directory
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -113,38 +116,55 @@ class DefaultCompilationUnit(
     )
   }
 
-  fun sourcesFromService(fromService: SourcesLocator.FromService) {
-    val sourceFolder = fromService.sourceFolder.orElse(".")
-    val rootFolders = project.objects.fileCollection().apply {
-      setFrom({
+  private fun sourcesFromService(fromService: SourcesLocator.FromService) {
+    val sourceFolder = fromService.sourceFolder.orElse(".").get()
+    val rootFolders = project.objects.fileCollection()
+    if (sourceFolder.startsWith(File.separator)) {
+      rootFolders.setFrom(File(sourceFolder))
+    } else {
+      rootFolders.setFrom({
         sourceSetNames.map {
-          project.projectDir.child("src", it, "graphql", sourceFolder.get())
+          project.projectDir.child("src", it, "graphql", sourceFolder)
         }
       })
     }
 
     val schemaFile = project.objects.fileProperty().value {
       if (fromService.schemaPath.isPresent) {
-        val map = findFilesInSourceSets(project, sourceSetNames, fromService.schemaPath.get(), { true })
-        if (map.isEmpty()) {
-          val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", fromService.schemaPath.get()).absolutePath }
-          throw IllegalArgumentException("cannot find a schema. Tried:\n${tried.joinToString("\n")}")
+        val schemaPath = fromService.schemaPath.get()
+        if (schemaPath.startsWith(File.separator)) {
+          File(schemaPath).also {
+            require(it.exists()) { "Provided schema with absolute path does not exist: ${it.absolutePath}" }
+          }
+        } else {
+          val map = findFilesInSourceSets(project, sourceSetNames, schemaPath, { true })
+          if (map.isEmpty()) {
+            val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", schemaPath).absolutePath }
+            throw IllegalArgumentException("cannot find a schema. Tried:\n${tried.joinToString("\n")}")
+          }
+          map.values.first()
         }
-        map.values.first()
       } else {
-        val map = findFilesInSourceSets(project, sourceSetNames, sourceFolder.get(), { it.name.endsWith(".json") })
-        if (map.isEmpty()) {
-          val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", sourceFolder.get()).absolutePath }
-          throw IllegalArgumentException("cannot find a schema. Please specify service.schemaPath. Tried:\n${tried.joinToString("\n")}")
+        if (sourceFolder.startsWith(File.separator)) {
+          File(sourceFolder).findFiles(::isJsonFile).first()
+        } else {
+          val map = findFilesInSourceSets(project, sourceSetNames, sourceFolder, ::isJsonFile)
+          if (map.isEmpty()) {
+            val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", sourceFolder).absolutePath }
+            throw IllegalArgumentException("cannot find a schema. Please specify service.schemaPath. Tried:\n${tried.joinToString("\n")}")
+          }
+          map.values.first()
         }
-        map.values.first()
       }
     }
 
     val graphqlFiles = project.objects.fileCollection().apply {
       setFrom({
-        val candidates = findFilesInSourceSets(project, sourceSetNames, sourceFolder.get(), ::isGraphQL).values
-
+        val candidates = if (sourceFolder.startsWith(File.separator)) {
+          File(sourceFolder).findFiles(::isGraphQL)
+        } else {
+          findFilesInSourceSets(project, sourceSetNames, sourceFolder, ::isGraphQL).values
+        }
         project.files(candidates).asFileTree.matching {
           it.exclude(fromService.exclude.get())
         }.files
@@ -231,6 +251,8 @@ class DefaultCompilationUnit(
     fun isGraphQL(file: File): Boolean {
       return file.name.endsWith(".graphql") || file.name.endsWith(".gql")
     }
+
+    fun isJsonFile(file: File) = file.name.endsWith(".json")
 
     /**
      * Finds the files in the given sourceSets.

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -11,7 +11,6 @@ import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
-import java.nio.file.Path
 
 class ConfigurationTests {
   @Test
@@ -222,7 +221,6 @@ class ConfigurationTests {
     }
   }
 
-
   @Test
   fun `sourceFolder can be changed`() {
     withSimpleProject("""
@@ -236,6 +234,42 @@ class ConfigurationTests {
       File(dir, "src/main/graphql/com").deleteRecursively()
 
       TestUtils.executeTask("generateApolloSources", dir)
+      assertTrue(dir.generatedChild("main/starwars/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/fragment/SpeciesInformation.java").isFile)
+    }
+  }
+  
+  @Test
+  fun `schemaPath can be absolute path`() {
+    val schema = File(System.getProperty("user.dir"), "src/main/graphql/com/example/schema.json")
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          schemaPath("${schema.absolutePath}")
+        }
+      }
+    """.trimIndent()) { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+      TestUtils.assertFileContains(dir, "main/starwars/com/example/DroidDetailsQuery.java", "class DroidDetailsQuery ")
+    }
+  }
+
+  @Test
+  fun `sourceFolder can be absolute path`() {
+    val folder = File(System.getProperty("user.dir"), "src/main/graphql/com/example")
+    withSimpleProject("""
+      apollo {
+        service("starwars") {
+          sourceFolder("${folder.absolutePath}")
+        }
+      }
+    """.trimIndent()) { dir ->
+      File(dir, "src/main/graphql/com").deleteRecursively()
+
+      TestUtils.executeTask("generateApolloSources", dir)
+      println(dir.absolutePath)
+      dir.list()?.forEach(::println)
       assertTrue(dir.generatedChild("main/starwars/DroidDetailsQuery.java").isFile)
       assertTrue(dir.generatedChild("main/starwars/type/CustomType.java").isFile)
       assertTrue(dir.generatedChild("main/starwars/fragment/SpeciesInformation.java").isFile)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -242,7 +242,7 @@ class ConfigurationTests {
   
   @Test
   fun `schemaPath can be absolute path`() {
-    val schema = File(System.getProperty("user.dir"), "src/main/graphql/com/example/schema.json")
+    val schema = File(System.getProperty("user.dir"), "src/test/files/starwars/schema.json")
     withSimpleProject("""
       apollo {
         service("starwars") {
@@ -257,7 +257,7 @@ class ConfigurationTests {
 
   @Test
   fun `sourceFolder can be absolute path`() {
-    val folder = File(System.getProperty("user.dir"), "src/main/graphql/com/example")
+    val folder = File(System.getProperty("user.dir"), "src/test/files/starwars")
     withSimpleProject("""
       apollo {
         service("starwars") {


### PR DESCRIPTION
Service properties `schemaPath` and `sourceFolder` can now be absolute.

When they are absolute, they will take precedence over traversing android variant source sets

Example of accessing the files in the same repo but in rooProject:

```
apollo {
  service("service") {
    sourceFolder(rootProject.file('shared/graphql'))
    schemaPath(rootProject.file('shared/graphql/schema.json'))
  }
}
```