### PR TITLE
Fix warnings in compiler

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/InputTypeSpecBuilder.kt
@@ -55,8 +55,8 @@ class InputTypeSpecBuilder(
           }
           .associate { it.name.decapitalize().escapeJavaReservedWord() to it.defaultValue }
       val javaDocs = fields
-          .filter { !it.description.isNullOrBlank() }
-          .associate { it.name.decapitalize().escapeJavaReservedWord() to it.description!! }
+          .filter { it.description.isNotBlank() }
+          .associate { it.name.decapitalize().escapeJavaReservedWord() to it.description }
       return addMethod(BuilderTypeSpecBuilder.builderFactoryMethod())
           .addType(
               BuilderTypeSpecBuilder(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -383,7 +383,7 @@ class ResponseFieldSpec(
 
   private fun conditionsCodeBlock(irField: Field): CodeBlock {
     val conditions = irField.conditions.let {
-      if (irField.isConditional) it ?: emptyList() else emptyList()
+      if (irField.isConditional) it else emptyList()
     }.filter { it.kind == Condition.Kind.BOOLEAN.rawValue }
 
     if (conditions.isEmpty()) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -445,7 +445,7 @@ class SchemaTypeSpecBuilder(
           fieldSpec = fieldSpec,
           normalizedFieldSpec = normalizedFieldSpec,
           responseFieldType = ResponseField.Type.INLINE_FRAGMENT,
-          typeConditions = if (inlineFragment.possibleTypes != null && inlineFragment.possibleTypes.isNotEmpty())
+          typeConditions = if (inlineFragment.possibleTypes.isNotEmpty())
             inlineFragment.possibleTypes
           else
             listOf(inlineFragment.typeCondition),

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
@@ -71,7 +71,7 @@ private fun Field.array(context: Context): ObjectType.Field {
       description = description,
       isOptional = !type.endsWith("!") || isConditional,
       isDeprecated = isDeprecated,
-      deprecationReason = deprecationReason ?: "",
+      deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },
       conditions = normalizedConditions
   )
@@ -91,10 +91,10 @@ private fun Field.`object`(context: Context): ObjectType.Field {
       responseName = responseName,
       schemaName = fieldName,
       type = FieldType.Object(typeRef),
-      description = description ?: "",
+      description = description,
       isOptional = !type.endsWith("!") || isConditional || inlineFragments.isNotEmpty(),
-      isDeprecated = isDeprecated ?: false,
-      deprecationReason = deprecationReason ?: "",
+      isDeprecated = isDeprecated,
+      deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },
       conditions = normalizedConditions
   )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo.compiler.ast.FieldType
 import com.apollographql.apollo.compiler.ast.InputType
 import com.apollographql.apollo.compiler.ast.ObjectType
 import com.apollographql.apollo.compiler.ast.TypeRef
-import com.apollographql.apollo.compiler.ir.ScalarType
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 
@@ -206,23 +205,23 @@ internal object KotlinCodeGen {
         CodeBlock.builder()
             .beginControlFlow("%L.readConditional(%L) { conditionalType, reader ->", reader, field)
             .add(
-                fields.map { field ->
-                  if (field.isOptional) {
+                fields.map { fragmentField ->
+                  if (fragmentField.isOptional) {
                     CodeBlock.of("val %L = if (%T.POSSIBLE_TYPES.contains(conditionalType)) %T(reader) else null",
-                        field.name, field.type.asTypeName(), field.type.asTypeName())
+                        fragmentField.name, fragmentField.type.asTypeName(), fragmentField.type.asTypeName())
                   } else {
-                    CodeBlock.of("val %L = %T(reader)", field.name, field.type.asTypeName())
+                    CodeBlock.of("val %L = %T(reader)", fragmentField.name, fragmentField.type.asTypeName())
                   }
                 }.joinToCode(separator = "\n", suffix = "\n")
             )
             .addStatement("%L(", name)
             .indent()
             .add(
-                fields.map { field ->
-                  if (field.isOptional) {
-                    CodeBlock.of("%L = %L", field.name, field.name)
+                fields.map { fragmentField ->
+                  if (fragmentField.isOptional) {
+                    CodeBlock.of("%L = %L", fragmentField.name, fragmentField.name)
                   } else {
-                    CodeBlock.of("%L = %L", field.name, field.name)
+                    CodeBlock.of("%L = %L", fragmentField.name, fragmentField.name)
                   }
 
                 }.joinToCode(separator = ",\n", suffix = "\n")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -135,7 +135,7 @@ data class Field(
 
   private fun toTypeName(responseType: String, context: CodeGenerationContext): TypeName {
     val packageName = if (isNonScalar()) "" else context.packageNameProvider.typesPackageName
-    return JavaTypeResolver(context, packageName, isDeprecated ?: false).resolve(responseType, isOptional())
+    return JavaTypeResolver(context, packageName, isDeprecated).resolve(responseType, isOptional())
   }
 
   private fun methodResponseType(): String {


### PR DESCRIPTION
They were all suggested by IntelliJ and used Option + Enter mostly for quick fix. These were output in Gralde with the Kotlin compilation task.

Mostly self-explanatory.