### PR TITLE
[Incubating plugin] CompilerParams overrides + SourceDirectorySet all the things 

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -4,11 +4,40 @@ import com.apollographql.apollo.gradle.internal.DefaultService
 import org.gradle.api.Action
 import org.gradle.api.provider.Property
 
+/**
+ * The entry point for configuring the apollo plugin.
+ *
+ * The apollo plugin creates a ApolloGenerateSourcesTask for each [CompilationUnit]. A [CompilationUnit]
+ * is the combination of:
+ * - a [Service]: an entity that describes a particular schema and GraphQL endpoint. If your project
+ * interacts with several endpoints, you will needed several [Service].
+ * - a variant: for android, this is the different variants as in https://developer.android.com/studio/build/build-variants.
+ * For JVM, this is only main right now.
+ *
+ * Most of the configuration relies on [CompilerParams]. The [CompilerParams] are resolved in this order:
+ * - ApolloExtension
+ * - Service
+ * - CompilationUnit
+ *
+ * CompilationUnit values override Service values which override the global ApolloExtension values.
+ */
 interface ApolloExtension: CompilerParams {
 
-  fun onCompilationUnits(action: Action<CompilationUnit>)
-
+  /**
+   * registers a new service
+   *
+   * @param name: the name of the service, must be unique
+   * @param action: the configure action for the [Service]
+   */
   fun service(name: String, action: Action<DefaultService>)
+
+  /**
+   * [CompilationUnit] are created by the plugin based on the registered [Service]s and variants.
+   * [onCompilationUnits] allows to retrieve and configure them.
+   *
+   * @param action: the configure action for the [CompilationUnit]
+   */
+  fun onCompilationUnits(action: Action<CompilationUnit>)
 
   /**
    * @Deprecated

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -7,33 +7,12 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import java.io.File
 
-interface CompilationUnit {
+interface CompilationUnit: CompilerParams {
   val name: String
   val serviceName: String
   val variantName: String
   val androidVariant: Any?
-  val compilerParams: CompilerParams
+
   val outputDir: Provider<Directory>
   val transformedQueriesDir: Provider<Directory>
-
-  fun compilerParams(action: Action<CompilerParams>)
-  fun sources(action: Action<Sources>)
-
-  class Sources(
-      val schemaFile: RegularFileProperty,
-      val graphqlDir: DirectoryProperty
-  ) {
-    fun schemaFile(schemaFile: File) {
-      this.schemaFile.set(schemaFile)
-    }
-
-    fun graphqlDir(graphqlDir: File) {
-      require(graphqlDir.isDirectory) { "graphqlDir must be a directory: ${graphqlDir.absolutePath}"}
-      this.graphqlDir.set(graphqlDir)
-    }
-
-    fun graphqlDir(graphqlDir: Provider<out Directory>) {
-      this.graphqlDir.set(graphqlDir)
-    }
-  }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -1,18 +1,39 @@
 package com.apollographql.apollo.gradle.api
 
-import org.gradle.api.Action
 import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
-import java.io.File
 
+/**
+ * A [CompilationUnit] is a single invocation of the compiler. It is used by
+ * [com.apollographql.apollo.gradle.internal.ApolloGenerateSourcesTask] to generate models.
+ *
+ * It inherits [CompilerParams] so individual parameters can be directly set on the [CompilationUnit]
+ */
 interface CompilationUnit: CompilerParams {
+  /**
+   * The name of the [CompilationUnit]
+   */
   val name: String
+  /**
+   * The name of the [Service] used by this [CompilationUnit]
+   */
   val serviceName: String
+  /**
+   * The name of the variant used by this [CompilationUnit]
+   */
   val variantName: String
+  /**
+   * If on Android, this will contain the Android Variant. It is safe to cast it to [com.android.build.gradle.api.BaseVariant]
+   */
   val androidVariant: Any?
 
+  /**
+   * The directory where the generated models will be written
+   */
   val outputDir: Provider<Directory>
+
+  /**
+   * The directory where the transformed queries will be written
+   */
   val transformedQueriesDir: Provider<Directory>
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -20,7 +20,7 @@ interface CompilerParams {
   fun generateTransformedQueries(generateTransformedQueries: Boolean)
   fun setGenerateTransformedQueries(generateTransformedQueries: Boolean)
 
-  val customTypeMapping: MapProperty<String, String>
+  val customTypeMapping: Property<Map<String, String>>
   fun customTypeMapping(customTypeMapping: Map<String, String>)
   fun setCustomTypeMapping(customTypeMapping: Map<String, String>)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -36,7 +36,7 @@ interface CompilerParams {
    *
    * empty by default.
    */
-  val customTypeMapping: Property<Map<String, String>>
+  val customTypeMapping: MapProperty<String, String>
   fun customTypeMapping(customTypeMapping: Map<String, String>)
   fun setCustomTypeMapping(customTypeMapping: Map<String, String>)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -110,11 +110,17 @@ interface CompilerParams {
    * The graphql files containing the queries.
    *
    * This SourceDirectorySet includes .graphql and .gql files by default.
+   *
+   * By default, it will use [Service.sourceFolder] to populate the SourceDirectorySet.
+   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
    */
   val graphqlSourceDirectorySet: SourceDirectorySet
 
   /**
    * The schema file
+   *
+   * By default, it will use [Service.schemaFile] to set schemaFile.
+   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
    */
   val schemaFile: RegularFileProperty
   fun schemaFile(path: Any)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -6,48 +6,116 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
+/**
+ * CompilerParams contains all the parameters needed to invoke the apollo compiler.
+ *
+ * The setters are present for backward compatibility with kotlin ubild scripts and will go away
+ * in a future release.
+ */
 interface CompilerParams {
-  val graphqlSourceDirectorySet: SourceDirectorySet
-
-  val schemaFile: RegularFileProperty
-  fun schemaFile(path: Any)
-
+  /**
+   * Whether to generate java (default) or kotlin models
+   */
   val generateKotlinModels: Property<Boolean>
   fun generateKotlinModels(generateKotlinModels: Boolean)
   fun setGenerateKotlinModels(generateKotlinModels: Boolean)
 
+  /**
+   * Whether to generate the transformed queries. Transformed queries are the queries as sent to the
+   * server. This can be useful if you need to upload a query's exact content to a server that doesn't
+   * support automatic persisted queries.
+   *
+   * The transformedQueries are written in [CompilationUnit.transformedQueriesDir]
+   */
   val generateTransformedQueries: Property<Boolean>
   fun generateTransformedQueries(generateTransformedQueries: Boolean)
   fun setGenerateTransformedQueries(generateTransformedQueries: Boolean)
 
+  /**
+   * For custom scalar types like Date, map from the GraphQL type to the jvm/kotlin type.
+   *
+   * empty by default.
+   */
   val customTypeMapping: Property<Map<String, String>>
   fun customTypeMapping(customTypeMapping: Map<String, String>)
   fun setCustomTypeMapping(customTypeMapping: Map<String, String>)
 
+  /**
+   * The custom types code generate some warnings that might make the build fail.
+   * suppressRawTypesWarning will add the appropriate SuppressWarning annotation
+   *
+   * false by default
+   */
   val suppressRawTypesWarning: Property<Boolean>
   fun suppressRawTypesWarning(suppressRawTypesWarning: Boolean)
   fun setSuppressRawTypesWarning(suppressRawTypesWarning: Boolean)
 
+  /**
+   * Whether to suffix your queries, etc.. with `Query`, etc..
+   *
+   * true by default
+   */
   val useSemanticNaming: Property<Boolean>
   fun useSemanticNaming(useSemanticNaming: Boolean)
   fun setUseSemanticNaming(useSemanticNaming: Boolean)
 
+  /**
+   * The nullable value type to use. One of: annotated, apolloOptional, guavaOptional, javaOptional, inputType
+   *
+   * annotated by default
+   * only valid for java models as kotlin has nullable support
+   */
   val nullableValueType: Property<String>
   fun nullableValueType(nullableValueType: String)
   fun setNullableValueType(nullableValueType: String)
 
+  /**
+   * Whether to generate builders for java models
+   *
+   * false by default
+   * only valid for java models as kotlin has data classes
+   */
   val generateModelBuilder: Property<Boolean>
   fun generateModelBuilder(generateModelBuilder: Boolean)
   fun setGenerateModelBuilder(generateModelBuilder: Boolean)
 
+  /**
+   * Whether to use java beans getters in the models.
+   *
+   * false by default
+   * only valif for java as kotlin has properties
+   */
   val useJavaBeansSemanticNaming: Property<Boolean>
   fun useJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean)
   fun setUseJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean)
 
+  /**
+   *
+   */
   val generateVisitorForPolymorphicDatatypes: Property<Boolean>
   fun generateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean)
   fun setGenerateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean)
 
+  /**
+   * The package name of the models is computed from their folder hierarchy like for java sources.
+   *
+   * If you want, you can prepend a custom package name here to namespace your models.
+   *
+   * The empty string by default.
+   */
   val rootPackageName: Provider<String>
   fun rootPackageName(rootPackageName: String)
+
+  /**
+   * The graphql files containing the queries.
+   *
+   * This SourceDirectorySet includes .graphql and .gql files by default.
+   */
+  val graphqlSourceDirectorySet: SourceDirectorySet
+
+  /**
+   * The schema file
+   */
+  val schemaFile: RegularFileProperty
+  fun schemaFile(path: Any)
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -1,10 +1,17 @@
 package com.apollographql.apollo.gradle.api
 
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
 interface CompilerParams {
+  val graphqlSourceDirectorySet: SourceDirectorySet
+
+  val schemaFile: RegularFileProperty
+  fun schemaFile(path: Any)
+
   val generateKotlinModels: Property<Boolean>
   fun generateKotlinModels(generateKotlinModels: Boolean)
   fun setGenerateKotlinModels(generateKotlinModels: Boolean)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Introspection.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Introspection.kt
@@ -3,16 +3,38 @@ package com.apollographql.apollo.gradle.api
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 
+/**
+ * [Introspection] represents a GraphQL endpoint and its introspection query used to retrieve a schema.
+ */
 interface Introspection {
+  /**
+   * The HTTP endpoint url
+   *
+   * This parameter is mandatory
+   */
   val endpointUrl: Property<String>
   fun endpointUrl(endpointUrl: String)
 
+  /**
+   * query parameters if any required to get the introspection response
+   *
+   * empty by default
+   */
   val queryParameters: MapProperty<String, String>
   fun queryParameters(queryParameters: Map<String, String>)
 
+  /**
+   * HTTP headers if any required to get the introspection response
+   *
+   * empty by default
+   */
   val headers: MapProperty<String, String>
   fun headers(headers: Map<String, String>)
 
+  /**
+   * The name of the sourceSet where to download the schema. By default it will be downloaded
+   * in the "main" sourceSet (src/main/graphql)
+   */
   val sourceSetName: Property<String>
   fun sourceSetName(sourceSetName: String)
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -4,15 +4,40 @@ import org.gradle.api.Action
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
+/**
+ * A [Service] represents a GraphQL endpoint and its associated schema.
+ *
+ * It inherits [Service] so individual parameters can be directly set on the [Service] and will be the
+ * default for all [CompilationUnit] based on this service.
+ */
 interface Service : CompilerParams {
+  /**
+   * Configures the [Introspection]
+   */
   fun introspection(configure: Action<in Introspection>)
 
-  val schemaPath: Property<String>
-  fun schemaPath(schemaPath: String)
-
+  /**
+   * path to the folder containing the graphql files relative to the current source set
+   * (src/$foo/graphql/$sourceFolder). The plugin will compile all graphql files accross all source sets
+   * in each variant.
+   *
+   * By default sourceFolder is ".", i.e it uses everything under src/$foo/graphql
+   */
   val sourceFolder: Property<String>
   fun sourceFolder(sourceFolder: String)
 
+  /**
+   * path to the schema file relative to the current source set (src/$foo/graphql/$schemaPath). The plugin
+   * will search all possible source sets in the variant.
+   *
+   * By default, the plugin looks for a "schema.json" file in the sourceFolders
+   */
+  val schemaPath: Property<String>
+  fun schemaPath(schemaPath: String)
+
+  /**
+   * Files to exclude from the graphql files as in [org.gradle.api.tasks.util.PatternFilterable]
+   */
   val exclude: ListProperty<String>
   fun exclude(exclude: List<String>)
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -8,10 +8,10 @@ interface Service : CompilerParams {
   fun introspection(configure: Action<in Introspection>)
 
   val schemaPath: Property<String>
-  fun schemaPath(schemaFilePath: String)
+  fun schemaPath(schemaPath: String)
 
   val sourceFolder: Property<String>
-  fun sourceFolder(sourceFolderPath: String)
+  fun sourceFolder(sourceFolder: String)
 
   val exclude: ListProperty<String>
   fun exclude(exclude: List<String>)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -48,9 +48,8 @@ object AndroidTaskConfigurator {
       compilationUnit: DefaultCompilationUnit,
       codegenProvider: TaskProvider<ApolloGenerateSourcesTask>
   ) {
-
     val variant = compilationUnit.androidVariant as BaseVariant
-    if (compilationUnit.compilerParams.generateKotlinModels.get()) {
+    if (compilationUnit.generateKotlinModels()) {
       variant.addJavaSourceFoldersToModel(codegenProvider.get().outputDir.get().asFile)
       androidExtension as BaseExtension
       androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(codegenProvider.get().outputDir)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -3,8 +3,16 @@ package com.apollographql.apollo.gradle.internal
 import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.model.ObjectFactory
 
-fun CompilerParams.withFallback(other: CompilerParams, factory: ObjectFactory): CompilerParams {
-  val merge = DefaultCompilerParams(factory)
+fun CompilerParams.withFallback(objects: ObjectFactory, other: CompilerParams): CompilerParams {
+  val merge = objects.newInstance(DefaultCompilerParams::class.java)
+
+  if (this.graphqlSourceDirectorySet.srcDirs.isEmpty()) {
+    merge.graphqlSourceDirectorySet.source(other.graphqlSourceDirectorySet)
+  } else {
+    merge.graphqlSourceDirectorySet.source(this.graphqlSourceDirectorySet)
+  }
+  merge.schemaFile.set(this.schemaFile.orElse(other.schemaFile))
+
   merge.generateKotlinModels.set(this.generateKotlinModels.orElse(other.generateKotlinModels))
   merge.generateTransformedQueries.set(this.generateTransformedQueries.orElse(other.generateTransformedQueries))
   merge.customTypeMapping.set(this.customTypeMapping.orElse(other.customTypeMapping))
@@ -15,6 +23,7 @@ fun CompilerParams.withFallback(other: CompilerParams, factory: ObjectFactory): 
   merge.useJavaBeansSemanticNaming.set(this.useJavaBeansSemanticNaming.orElse(other.useJavaBeansSemanticNaming))
   merge.generateVisitorForPolymorphicDatatypes.set(this.generateVisitorForPolymorphicDatatypes.orElse(other.generateVisitorForPolymorphicDatatypes))
   merge.rootPackageName.set(this.rootPackageName.orElse(other.rootPackageName))
+
   return merge
 }
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -6,7 +6,9 @@ import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.Action
 import org.gradle.api.Project
 
-open class DefaultApolloExtension(val project: Project) : CompilerParams by DefaultCompilerParams(project.objects), ApolloExtension {
+open class DefaultApolloExtension(val project: Project)
+  : CompilerParams by project.objects.newInstance(DefaultCompilerParams::class.java)
+    , ApolloExtension {
   /**
    * This is the input to the apollo plugin. Users will populate the services from their gradle files
    */

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -2,287 +2,126 @@ package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
-import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.RegularFile
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
+import org.gradle.api.file.*
 import java.io.File
 import javax.inject.Inject
 
-open class DefaultCompilationUnit @Inject constructor(
-    override val serviceName: String,
-    override val variantName: String,
-    override val compilerParams: CompilerParams,
-    private val sourcesLocator: SourcesLocator,
-    private val sourceSetNames: List<String>,
-    private val project: Project
-) : CompilationUnit {
-  sealed class SourcesLocator {
-    class FromService(
-        val schemaPath: Property<String>,
-        val sourceFolder: Property<String>,
-        val exclude: ListProperty<String>
-    ) : SourcesLocator()
+abstract class DefaultCompilationUnit @Inject constructor(
+    val project: Project,
+    val apolloExtension: DefaultApolloExtension,
+    val apolloVariant: ApolloVariant,
+    val service: DefaultService
+) : CompilationUnit, CompilerParams by project.objects.newInstance(DefaultCompilerParams::class.java) {
 
-    class FromFiles(
-        val schema: File
-    ) : SourcesLocator()
-  }
+  final override val androidVariant = apolloVariant.androidVariant
+  final override val variantName = apolloVariant.name
+  final override val serviceName = service.name
 
-  internal class Sources(
-      val schemaFile: Provider<RegularFile>,
-      val graphqlFiles: FileCollection,
-      val rootFolders: FileCollection
-  )
-
-  override var androidVariant: Any? = null
   override val name = "${variantName}${serviceName.capitalize()}"
 
-  private var sources: Sources? = null
+  abstract override val outputDir: DirectoryProperty
+  abstract override val transformedQueriesDir: DirectoryProperty
 
-  override val outputDir = project.objects.directoryProperty()
-  override val transformedQueriesDir = project.objects.directoryProperty()
-
-  init {
-    if (!compilerParams.generateKotlinModels.isPresent) {
-      compilerParams.generateKotlinModels.set(false)
-    }
-  }
-
-  internal fun sources(): Sources {
-    if (sources != null) {
-      return sources!!
-    }
-
-    when (val locator = sourcesLocator) {
-      is SourcesLocator.FromFiles -> {
-        sourcesFromFiles(locator)
-      }
-      is SourcesLocator.FromService -> {
-        sourcesFromService(locator)
-      }
-    }
-    return sources!!
-  }
-
-  override fun compilerParams(action: Action<CompilerParams>) {
-    action.execute(compilerParams)
-  }
-
-  override fun sources(action: Action<CompilationUnit.Sources>) {
-    val params = CompilationUnit.Sources(
-        project.objects.fileProperty(),
-        project.objects.directoryProperty()
-    )
-    action.execute(params)
-    customSources(params)
-  }
-
-  private fun customSources(params: CompilationUnit.Sources) {
-    require(params.graphqlDir.isPresent) { "rootFolder must be specified" }
-
-    if (params.schemaFile.isPresent.not()) {
-      params.schemaFile.value {
-        val root = params.graphqlDir.get().asFile
-        root.walkTopDown().find {
-          it.name.endsWith(".json")
-        } ?: throw IllegalArgumentException("cannot find a schema in ${root.absolutePath}")
-      }
-    }
-
-    val graphqlFiles = project.objects.fileCollection()
-    graphqlFiles.setFrom(params.graphqlDir.map { dir ->
-      dir.asFileTree.filter(::isGraphQL)
-    })
-
-    val rootFolders = project.objects.fileCollection()
-    rootFolders.setFrom(params.graphqlDir)
-
-    sources = Sources(params.schemaFile, graphqlFiles, rootFolders)
-  }
-
-  private fun sourcesFromService(fromService: SourcesLocator.FromService) {
-    val sourceFolder = fromService.sourceFolder.orElse(".").get()
-    val rootFolders = project.objects.fileCollection()
-    if (sourceFolder.startsWith(File.separator)) {
-      rootFolders.setFrom(File(sourceFolder))
-    } else {
-      rootFolders.setFrom({
-        sourceSetNames.map {
-          project.projectDir.child("src", it, "graphql", sourceFolder)
-        }
-      })
-    }
-
-    val schemaFile = project.objects.fileProperty().value {
-      if (fromService.schemaPath.isPresent) {
-        val schemaPath = fromService.schemaPath.get()
-        if (schemaPath.startsWith(File.separator)) {
-          File(schemaPath).also {
-            require(it.exists()) { "Provided schema with absolute path does not exist: ${it.absolutePath}" }
-          }
+  fun setSourcesIfNeeded(graphqlSourceDirectorySet: SourceDirectorySet, schemaFile: RegularFileProperty) {
+    if (graphqlSourceDirectorySet.isEmpty) {
+      if (schemaFile.isPresent) {
+        graphqlSourceDirectorySet.srcDir(schemaFile.asFile.get().parent)
+      } else {
+        val sourceFolder = service.sourceFolder.orElse(".").get()
+        if (sourceFolder.startsWith(File.separator)) {
+          graphqlSourceDirectorySet.srcDir(sourceFolder)
+        } else if (sourceFolder.startsWith("..")) {
+          graphqlSourceDirectorySet.srcDir(project.file("src/main/graphql/$sourceFolder").normalize())
         } else {
-          val map = findFilesInSourceSets(project, sourceSetNames, schemaPath, { true })
-          if (map.isEmpty()) {
-            val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", schemaPath).absolutePath }
-            throw IllegalArgumentException("cannot find a schema. Tried:\n${tried.joinToString("\n")}")
+          apolloVariant.sourceSetNames.forEach {
+            graphqlSourceDirectorySet.srcDir("src/$it/graphql/$sourceFolder")
           }
-          map.values.first()
+        }
+      }
+
+      graphqlSourceDirectorySet.include("**/*.graphql", "**/*.gql")
+      graphqlSourceDirectorySet.exclude(service.exclude.getOrElse(emptyList()))
+    }
+
+    if (!schemaFile.isPresent) {
+      if (service.schemaPath.isPresent) {
+        val schemaPath = service.schemaPath.get()
+        if (schemaPath.startsWith(File.separator)) {
+          schemaFile.set(project.file(schemaPath))
+        } else if (schemaPath.startsWith("..")) {
+          schemaFile.set(project.file("src/main/graphql/$schemaPath").normalize())
+        } else {
+          val all = apolloVariant.sourceSetNames.map {
+            project.file("src/$it/graphql/$schemaPath")
+          }
+
+          val candidates = all.filter {
+            it.exists()
+          }
+
+          require(candidates.size <= 1) {
+            "ApolloGraphQL: duplicate(s) schema file(s) found:\n${candidates.map { it.absolutePath }.joinToString("\n")}"
+          }
+          require(candidates.size == 1) {
+            "ApolloGraphQL: cannot find a schema file at $schemaPath. Tried:\n${all.map { it.absolutePath }.joinToString("\n")}"
+          }
+
+          schemaFile.set(candidates.first())
         }
       } else {
-        if (sourceFolder.startsWith(File.separator)) {
-          File(sourceFolder).findFiles(::isJsonFile).first()
-        } else {
-          val map = findFilesInSourceSets(project, sourceSetNames, sourceFolder, ::isJsonFile)
-          if (map.isEmpty()) {
-            val tried = sourceSetNames.map { project.projectDir.child("src", it, "graphql", sourceFolder).absolutePath }
-            throw IllegalArgumentException("cannot find a schema. Please specify service.schemaPath. Tried:\n${tried.joinToString("\n")}")
-          }
-          map.values.first()
+        val candidates = graphqlSourceDirectorySet.filter {
+          it.name == "schema.json"
+        }.files
+
+        require(candidates.size <= 1) {
+          multipleSchemaError(candidates)
+        }
+        require(candidates.size == 1) {
+          "ApolloGraphQL: cannot find schema.json. Please specify it explicitely. Looked under:\n" +
+              graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.joinToString("\n")
         }
       }
     }
-
-    val graphqlFiles = project.objects.fileCollection().apply {
-      setFrom({
-        val candidates = if (sourceFolder.startsWith(File.separator)) {
-          File(sourceFolder).findFiles(::isGraphQL)
-        } else {
-          findFilesInSourceSets(project, sourceSetNames, sourceFolder, ::isGraphQL).values
-        }
-        project.files(candidates).asFileTree.matching {
-          it.exclude(fromService.exclude.get())
-        }.files
-      })
-    }
-
-    sources = Sources(
-        schemaFile = schemaFile,
-        graphqlFiles = graphqlFiles,
-        rootFolders = rootFolders
-    )
   }
 
-  private fun sourcesFromFiles(fromFiles: SourcesLocator.FromFiles) {
-    val rootFolders = project.objects.fileCollection().apply {
-      setFrom({
-        sourceSetNames.map {
-          project.projectDir.child("src", it, "graphql")
-        }
-      })
-    }
-    val schemaFile = project.objects.fileProperty().value { fromFiles.schema }
-    val graphqlFiles = project.objects.fileCollection().apply {
-      setFrom({
-        findFilesInSourceSets(project, sourceSetNames, ".", ::isGraphQL).values
-      })
-    }
-
-    sources = Sources(
-        schemaFile = schemaFile,
-        graphqlFiles = graphqlFiles,
-        rootFolders = rootFolders
-    )
+  fun generateKotlinModels(): Boolean {
+    return generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(false)
   }
 
   companion object {
-    fun fromService(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant, service: DefaultService): DefaultCompilationUnit {
-      val compilerParams = service.withFallback(apolloExtension, project.objects)
-
-      val sourcesLocator = SourcesLocator.FromService(
-          schemaPath = service.schemaPath,
-          sourceFolder = service.sourceFolder,
-          exclude = service.exclude
-      )
-
+    fun createDefaultCompilationUnit(
+        project: Project,
+        apolloExtension: DefaultApolloExtension,
+        apolloVariant: ApolloVariant,
+        service: DefaultService
+    ): DefaultCompilationUnit {
       return project.objects.newInstance(DefaultCompilationUnit::class.java,
-          service.name,
-          apolloVariant.name,
-          compilerParams,
-          sourcesLocator,
-          apolloVariant.sourceSetNames,
-          project
-      ).apply {
-        androidVariant = apolloVariant.androidVariant
-      }
+          project,
+          apolloExtension,
+          apolloVariant,
+          service
+      )
+    }
+
+    fun fromService(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant, service: DefaultService): DefaultCompilationUnit {
+      return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
     }
 
     fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): DefaultCompilationUnit? {
-      val sourceSetNames = apolloVariant.sourceSetNames
-      val schemaFiles = findFilesInSourceSets(project, sourceSetNames, ".") {
-        it.name == "schema.json"
-      }
-      require(schemaFiles.size <= 1) { multipleSchemaError(schemaFiles.keys) }
-
-      val schema = schemaFiles.values.firstOrNull() ?: return null
-      return project.objects.newInstance(DefaultCompilationUnit::class.java,
-          "service",
-          apolloVariant.name,
-          apolloExtension,
-          SourcesLocator.FromFiles(schema),
-          apolloVariant.sourceSetNames,
-          project
-      ).apply {
-        androidVariant = apolloVariant.androidVariant
-      }
+      val service = project.objects.newInstance(DefaultService::class.java, project.objects, "service")
+      return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
     }
 
-    fun isGraphQL(file: File): Boolean {
-      return file.name.endsWith(".graphql") || file.name.endsWith(".gql")
-    }
-
-    fun isJsonFile(file: File) = file.name.endsWith(".json")
-
-    /**
-     * Finds the files in the given sourceSets.
-     *
-     * Returns a map with the relative path to the path as key and the file as value
-     *
-     * @throws [kotlin.IllegalArgumentException] if there are multiple files with the same relative path
-     */
-    private fun findFilesInSourceSets(project: Project, sourceSetNames: List<String>, path: String, predicate: (File) -> Boolean): Map<String, File> {
-      val candidates = mutableMapOf<String, File>()
-      sourceSetNames.forEach { sourceSetName ->
-        val root = project.projectDir.child("src", sourceSetName, "graphql", path)
-        val files = root.findFiles(predicate)
-
-        files.forEach {
-          val key = if (root.isFile) {
-            // toRelativeString only works on directories.
-            ""
-          } else {
-            it.toRelativeString(root)
-          }
-
-          if (candidates[key] != null) {
-            throw IllegalArgumentException("ApolloGraphQL: duplicate file found:\n${it.absolutePath}\n${candidates[key]?.absolutePath}")
-          }
-          candidates[key] = it
-        }
-      }
-      return candidates
-    }
-
-    private fun File.findFiles(predicate: (File) -> Boolean): List<File> {
-      return when {
-        isDirectory -> listFiles()?.flatMap { it.findFiles(predicate) } ?: emptyList()
-        isFile && predicate(this) -> listOf(this)
-        else -> emptyList()
-      }
-    }
-
-    private fun multipleSchemaError(schemaPaths: Set<String>): String {
-      val service = schemaPaths.joinToString("\n") {
+    private fun multipleSchemaError(schemaList: Set<File>): String {
+      val services = schemaList.joinToString("\n") {
         """|
-          |  service("serviceName") {
-          |    sourceFolder = "${it.replace("/schema.json", "")}"
+          |  service("${it.parentFile.name}") {
+          |    sourceFolder = "${it.parentFile.normalize().absolutePath}"
           |  }
         """.trimMargin()
       }
-      return "By default only one schema.json file is supported.\nPlease use multiple services instead:\napollo {\n$service\n}"
+      return "ApolloGraphQL: By default only one schema.json file is supported.\nPlease use multiple services instead:\napollo {\n$services\n}"
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -106,7 +106,9 @@ abstract class DefaultCompilationUnit @Inject constructor(
           apolloExtension,
           apolloVariant,
           service
-      )
+      ).apply {
+        graphqlSourceDirectorySet.include("**/*.graphql", "**/*.gql")
+      }
     }
 
     fun fromService(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant, service: DefaultService): DefaultCompilationUnit {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -25,10 +25,12 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory,
     this.generateTransformedQueries.set(generateTransformedQueries)
   }
 
-  // I'm not using a MapProperty here since I didn't find a way to represent the difference between absent and empty
-  // This triggers a warning in gradle 6.0 unfortunately but we really need to differentiate absent and empty in
-  // CompilerParams.withFallback
-  override val customTypeMapping = objects.property(Map::class.java) as Property<Map<String, String>>
+  override val customTypeMapping = objects.mapProperty(String::class.java, String::class.java)
+
+  init {
+    // see https://github.com/gradle/gradle/issues/7485
+    customTypeMapping.set(null as Map<String, String>?)
+  }
 
   override fun customTypeMapping(customTypeMapping: Map<String, String>) {
     this.customTypeMapping.set(customTypeMapping)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -1,67 +1,67 @@
 package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilerParams
-import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.provider.MapProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-abstract class DefaultCompilerParams @Inject constructor(val project: Project) : CompilerParams {
-  abstract override val graphqlSourceDirectorySet: SourceDirectorySet
+abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory, val projectLayout: ProjectLayout) : CompilerParams {
+  override val graphqlSourceDirectorySet = objects.sourceDirectorySet("graphql", "graphql")
 
   abstract override val schemaFile: RegularFileProperty
   override fun schemaFile(path: Any) {
-    this.schemaFile.set { project.file(path) }
+    this.schemaFile.set {projectLayout.files(path).first()}
   }
 
-  abstract override val generateKotlinModels: Property<Boolean>
+  override val generateKotlinModels = objects.property(Boolean::class.java)
   override fun generateKotlinModels(generateKotlinModels: Boolean) {
     this.generateKotlinModels.set(generateKotlinModels)
   }
 
-  abstract override val generateTransformedQueries: Property<Boolean>
+  override val generateTransformedQueries= objects.property(Boolean::class.java)
   override fun generateTransformedQueries(generateTransformedQueries: Boolean) {
     this.generateTransformedQueries.set(generateTransformedQueries)
   }
 
-  override val customTypeMapping = project.objects.mapProperty(String::class.java, String::class.java)
+  // I'm not using a MapProperty here since I didn't find a way to represent the difference between absent and empty
+  override val customTypeMapping = objects.property(Map::class.java) as Property<Map<String, String>>
   override fun customTypeMapping(customTypeMapping: Map<String, String>) {
     this.customTypeMapping.set(customTypeMapping)
   }
 
-  abstract override val suppressRawTypesWarning: Property<Boolean>
+  override val suppressRawTypesWarning= objects.property(Boolean::class.java)
   override fun suppressRawTypesWarning(suppressRawTypesWarning: Boolean) {
     this.suppressRawTypesWarning.set(suppressRawTypesWarning)
   }
 
-  abstract override val useSemanticNaming: Property<Boolean>
+  override val useSemanticNaming= objects.property(Boolean::class.java)
   override fun useSemanticNaming(useSemanticNaming: Boolean) {
     this.useSemanticNaming.set(useSemanticNaming)
   }
 
-  abstract override val nullableValueType: Property<String>
+  override val nullableValueType= objects.property(String::class.java)
   override fun nullableValueType(nullableValueType: String) {
     this.nullableValueType.set(nullableValueType)
   }
 
-  abstract override val generateModelBuilder: Property<Boolean>
+  override val generateModelBuilder= objects.property(Boolean::class.java)
   override fun generateModelBuilder(generateModelBuilder: Boolean) {
     this.generateModelBuilder.set(generateModelBuilder)
   }
 
-  abstract override val useJavaBeansSemanticNaming: Property<Boolean>
+  override val useJavaBeansSemanticNaming= objects.property(Boolean::class.java)
   override fun useJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean) {
     this.useJavaBeansSemanticNaming.set(useJavaBeansSemanticNaming)
   }
 
-  abstract override val generateVisitorForPolymorphicDatatypes: Property<Boolean>
+  override val generateVisitorForPolymorphicDatatypes= objects.property(Boolean::class.java)
   override fun generateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean) {
     this.generateVisitorForPolymorphicDatatypes.set(generateVisitorForPolymorphicDatatypes)
   }
 
-  abstract override val rootPackageName: Property<String>
+  override val rootPackageName= objects.property(String::class.java)
   override fun rootPackageName(rootPackageName: String) {
     this.rootPackageName.set(rootPackageName)
   }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -12,7 +12,7 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory,
 
   abstract override val schemaFile: RegularFileProperty
   override fun schemaFile(path: Any) {
-    this.schemaFile.set {projectLayout.files(path).first()}
+    this.schemaFile.set { projectLayout.files(path).first() }
   }
 
   override val generateKotlinModels = objects.property(Boolean::class.java)
@@ -20,7 +20,7 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory,
     this.generateKotlinModels.set(generateKotlinModels)
   }
 
-  override val generateTransformedQueries= objects.property(Boolean::class.java)
+  override val generateTransformedQueries = objects.property(Boolean::class.java)
   override fun generateTransformedQueries(generateTransformedQueries: Boolean) {
     this.generateTransformedQueries.set(generateTransformedQueries)
   }
@@ -29,41 +29,42 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory,
   // This triggers a warning in gradle 6.0 unfortunately but we really need to differentiate absent and empty in
   // CompilerParams.withFallback
   override val customTypeMapping = objects.property(Map::class.java) as Property<Map<String, String>>
+
   override fun customTypeMapping(customTypeMapping: Map<String, String>) {
     this.customTypeMapping.set(customTypeMapping)
   }
 
-  override val suppressRawTypesWarning= objects.property(Boolean::class.java)
+  override val suppressRawTypesWarning = objects.property(Boolean::class.java)
   override fun suppressRawTypesWarning(suppressRawTypesWarning: Boolean) {
     this.suppressRawTypesWarning.set(suppressRawTypesWarning)
   }
 
-  override val useSemanticNaming= objects.property(Boolean::class.java)
+  override val useSemanticNaming = objects.property(Boolean::class.java)
   override fun useSemanticNaming(useSemanticNaming: Boolean) {
     this.useSemanticNaming.set(useSemanticNaming)
   }
 
-  override val nullableValueType= objects.property(String::class.java)
+  override val nullableValueType = objects.property(String::class.java)
   override fun nullableValueType(nullableValueType: String) {
     this.nullableValueType.set(nullableValueType)
   }
 
-  override val generateModelBuilder= objects.property(Boolean::class.java)
+  override val generateModelBuilder = objects.property(Boolean::class.java)
   override fun generateModelBuilder(generateModelBuilder: Boolean) {
     this.generateModelBuilder.set(generateModelBuilder)
   }
 
-  override val useJavaBeansSemanticNaming= objects.property(Boolean::class.java)
+  override val useJavaBeansSemanticNaming = objects.property(Boolean::class.java)
   override fun useJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean) {
     this.useJavaBeansSemanticNaming.set(useJavaBeansSemanticNaming)
   }
 
-  override val generateVisitorForPolymorphicDatatypes= objects.property(Boolean::class.java)
+  override val generateVisitorForPolymorphicDatatypes = objects.property(Boolean::class.java)
   override fun generateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean) {
     this.generateVisitorForPolymorphicDatatypes.set(generateVisitorForPolymorphicDatatypes)
   }
 
-  override val rootPackageName= objects.property(String::class.java)
+  override val rootPackageName = objects.property(String::class.java)
   override fun rootPackageName(rootPackageName: String) {
     this.rootPackageName.set(rootPackageName)
   }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -1,60 +1,71 @@
 package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilerParams
+import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import javax.inject.Inject
 
-class DefaultCompilerParams(val factory: ObjectFactory) : CompilerParams {
-  override val generateKotlinModels = factory.property(Boolean::class.java)
+abstract class DefaultCompilerParams @Inject constructor(val project: Project) : CompilerParams {
+  abstract override val graphqlSourceDirectorySet: SourceDirectorySet
+
+  abstract override val schemaFile: RegularFileProperty
+  override fun schemaFile(path: Any) {
+    this.schemaFile.set { project.file(path) }
+  }
+
+  abstract override val generateKotlinModels: Property<Boolean>
   override fun generateKotlinModels(generateKotlinModels: Boolean) {
     this.generateKotlinModels.set(generateKotlinModels)
   }
 
-  override val generateTransformedQueries = factory.property(Boolean::class.java)
+  abstract override val generateTransformedQueries: Property<Boolean>
   override fun generateTransformedQueries(generateTransformedQueries: Boolean) {
     this.generateTransformedQueries.set(generateTransformedQueries)
   }
 
-  override val customTypeMapping = factory.mapProperty(String::class.java, String::class.java)
+  override val customTypeMapping = project.objects.mapProperty(String::class.java, String::class.java)
   override fun customTypeMapping(customTypeMapping: Map<String, String>) {
     this.customTypeMapping.set(customTypeMapping)
   }
 
-  override val suppressRawTypesWarning = factory.property(Boolean::class.java)
+  abstract override val suppressRawTypesWarning: Property<Boolean>
   override fun suppressRawTypesWarning(suppressRawTypesWarning: Boolean) {
     this.suppressRawTypesWarning.set(suppressRawTypesWarning)
   }
 
-  override val useSemanticNaming = factory.property(Boolean::class.java)
+  abstract override val useSemanticNaming: Property<Boolean>
   override fun useSemanticNaming(useSemanticNaming: Boolean) {
     this.useSemanticNaming.set(useSemanticNaming)
   }
 
-  override val nullableValueType = factory.property(String::class.java)
+  abstract override val nullableValueType: Property<String>
   override fun nullableValueType(nullableValueType: String) {
     this.nullableValueType.set(nullableValueType)
   }
 
-  override val generateModelBuilder = factory.property(Boolean::class.java)
+  abstract override val generateModelBuilder: Property<Boolean>
   override fun generateModelBuilder(generateModelBuilder: Boolean) {
     this.generateModelBuilder.set(generateModelBuilder)
   }
 
-  override val useJavaBeansSemanticNaming = factory.property(Boolean::class.java)
+  abstract override val useJavaBeansSemanticNaming: Property<Boolean>
   override fun useJavaBeansSemanticNaming(useJavaBeansSemanticNaming: Boolean) {
     this.useJavaBeansSemanticNaming.set(useJavaBeansSemanticNaming)
   }
 
-  override val generateVisitorForPolymorphicDatatypes = factory.property(Boolean::class.java)
+  abstract override val generateVisitorForPolymorphicDatatypes: Property<Boolean>
   override fun generateVisitorForPolymorphicDatatypes(generateVisitorForPolymorphicDatatypes: Boolean) {
     this.generateVisitorForPolymorphicDatatypes.set(generateVisitorForPolymorphicDatatypes)
   }
 
-  override val rootPackageName = factory.property(String::class.java)
+  abstract override val rootPackageName: Property<String>
   override fun rootPackageName(rootPackageName: String) {
     this.rootPackageName.set(rootPackageName)
   }
-  
+
   @Deprecated(message = "please use generateKotlinModels instead", replaceWith = ReplaceWith("generateKotlinModels"))
   override fun setGenerateKotlinModels(generateKotlinModels: Boolean) {
     System.err.println("setGenerateKotlinModels(Boolean) is deprecated, please use generateKotlinModels(Boolean) instead")

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -26,6 +26,8 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory,
   }
 
   // I'm not using a MapProperty here since I didn't find a way to represent the difference between absent and empty
+  // This triggers a warning in gradle 6.0 unfortunately but we really need to differentiate absent and empty in
+  // CompilerParams.withFallback
   override val customTypeMapping = objects.property(Map::class.java) as Property<Map<String, String>>
   override fun customTypeMapping(customTypeMapping: Map<String, String>) {
     this.customTypeMapping.set(customTypeMapping)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -7,7 +7,9 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import javax.inject.Inject
 
-open class DefaultService @Inject constructor(val objects: ObjectFactory, val name: String) : CompilerParams by DefaultCompilerParams(objects), Service {
+open class DefaultService @Inject constructor(val objects: ObjectFactory, val name: String)
+  : CompilerParams by objects.newInstance(DefaultCompilerParams::class.java), Service {
+
   override val schemaPath = objects.property(String::class.java)
   override fun schemaPath(schemaPath: String) {
     this.schemaPath.set(schemaPath)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -27,13 +27,13 @@ object JvmTaskConfigurator {
     val sourceSets = javaPlugin.sourceSets
     val name = compilationUnit.variantName
 
-    val sourceDirectorySet = if (!compilationUnit.compilerParams.generateKotlinModels.get()) {
+    val sourceDirectorySet = if (!compilationUnit.generateKotlinModels()) {
       sourceSets.getByName(name).java
     } else {
       sourceSets.getByName(name).kotlin!!
     }
 
-    val compileTaskName = if (!compilationUnit.compilerParams.generateKotlinModels.get()) {
+    val compileTaskName = if (!compilationUnit.generateKotlinModels()) {
       "compileJava"
     } else {
       "compileKotlin"

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/AndroidTests.kt
@@ -62,7 +62,7 @@ class AndroidTests {
         TestUtils.executeTask("generateDebugApolloSources", dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        assertThat(e.message, containsString("duplicate file found"))
+        assertThat(e.message, containsString("duplicate(s) graphql file(s) found"))
       }
 
       assertNotNull(exception)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -316,9 +316,7 @@ class ConfigurationTests {
           rootPackageName "com.starwars"
         }
         onCompilationUnits {
-          compilerParams {
-            rootPackageName.set("com.overrides")
-          }
+          rootPackageName.set("com.overrides")
         }
       }
     """.trimIndent()) { dir ->
@@ -339,10 +337,9 @@ class ConfigurationTests {
         }
         
         onCompilationUnits {
-          sources {
-            schemaFile(file("src/main/graphql/com/example/schema.json"))
-            graphqlDir(file("src/main/graphql/"))
-          }
+          schemaFile(file("src/main/graphql/com/example/schema.json"))
+          graphqlSourceDirectorySet.srcDir(file("src/main/graphql/"))
+          graphqlSourceDirectorySet.include("**/*.graphql")
         }
       }
     """.trimIndent()) { dir ->

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
@@ -48,7 +48,6 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
 configure<ApolloExtension> {
   onCompilationUnits {
     graphqlSourceDirectorySet.srcDir(installTask.flatMap { it.outputDir })
-    graphqlSourceDirectorySet.include("**/*.graphql")
   }
 }
 """.trimIndent()

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
@@ -47,9 +47,8 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
 
 configure<ApolloExtension> {
   onCompilationUnits {
-    sources {
-      graphqlDir(installTask.flatMap { it.outputDir })
-    }
+    graphqlSourceDirectorySet.srcDir(installTask.flatMap { it.outputDir })
+    graphqlSourceDirectorySet.include("**/*.graphql")
   }
 }
 """.trimIndent()

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/UpToDateTests.kt
@@ -14,7 +14,7 @@ import java.io.File
 
 class UpToDateTests {
   @Test
-  fun test() {
+  fun `complete test`() {
     withSimpleProject { dir ->
       `builds successfully and generates expected outputs`(dir)
       `nothing changed, task up to date`(dir)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -26,7 +26,9 @@ object TestUtils {
 
     block(dest)
 
-    dest.deleteRecursively()
+    // It's ok to not delete the directory as it will be deleted before next test
+    // During developement, it's easy to keep the testProject around to investigate if something goes wrong
+    // dest.deleteRecursively()
   }
 
   fun withProject(usesKotlinDsl: Boolean,


### PR DESCRIPTION
This pull request moves the sources configuration to `CompilerParams`. All of `ApolloExtension`, `Service` and `CompilationUnit` implement `CompilerParams` so we can have a nice cascade of params overrides:

- global params are in the `ApolloExtension`. This is also were they used to be so it's backward compatible.
- service params are in `Service`.
- lastly, users can override on a `CompilationUnit` basis.

Also the graphql sources are now a `SourceDirectorySet` so it's easier to add multiple folders, includes, excludes, etc... for more advanced use cases.

Very basic use case:
```kotlin
// no apollo block, one service, reads everything under src/$foo/graphql
```

Simple use case:
```kotlin
// multiple service, the plugin will find the graphql files and schema:
apollo {
  service("starwars") {
    sourceFolder = "starwars"
  }
  service("githunt") {
    sourceFolder = "githunt"
  }
}
```

Advanced use case:
```kotlin
// task inputs wiring, SourceDirectorySet customization etc...
apollo {
  service("starwars") {
  }
  service("githunt") {
  }

  onCompilationUnits {
    graphqlSourceDirectorySet.srcDir(installTask.flatMap { it.outputDir })
    graphqlSourceDirectorySet.exclude("**/*.gql")
    // do something with androidVariant, outputDir and/or transformedQueries
  }
}
```
