### PR TITLE
New Kotlin extensions to RxJava2 support and Input API

### DIFF
--- a/apollo-api/build.gradle.kts
+++ b/apollo-api/build.gradle.kts
@@ -1,4 +1,5 @@
 apply(plugin = "java")
+apply(plugin = "kotlin")
 
 withConvention(JavaPluginConvention::class) {
   targetCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputExtensions.kt
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputExtensions.kt
@@ -1,4 +1,5 @@
 @file:Suppress("NOTHING_TO_INLINE")
+@file:JvmName("KotlinExtensions")
 
 package com.apollographql.apollo.api
 

--- a/apollo-rx2-support/build.gradle.kts
+++ b/apollo-rx2-support/build.gradle.kts
@@ -6,15 +6,11 @@ withConvention(JavaPluginConvention::class) {
 }
 
 dependencies {
+  add("compileOnly", groovy.util.Eval.x(project, "x.dep.kotlin.stdLib"))
   add("api", groovy.util.Eval.x(project, "x.dep.rx.java"))
   add("compileOnly", groovy.util.Eval.x(project, "x.dep.jetbrainsAnnotations"))
   add("compileOnly", project(":apollo-runtime"))
   add("compileOnly", project(":apollo-api"))
-
-  add("testImplementation", groovy.util.Eval.x(project, "x.dep.junit"))
-  add("testImplementation", groovy.util.Eval.x(project, "x.dep.okHttp.mockWebServer"))
-  add("testImplementation", groovy.util.Eval.x(project, "x.dep.okHttp.testSupport"))
-  add("testImplementation", groovy.util.Eval.x(project, "x.dep.truth"))
 }
 
 apply {

--- a/apollo-rx2-support/build.gradle.kts
+++ b/apollo-rx2-support/build.gradle.kts
@@ -1,4 +1,5 @@
 apply(plugin = "java-library")
+apply(plugin = "org.jetbrains.kotlin.jvm")
 
 withConvention(JavaPluginConvention::class) {
   targetCompatibility = JavaVersion.VERSION_1_7

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -9,9 +9,6 @@ import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.internal.subscription.ApolloSubscriptionTerminatedException;
 import com.apollographql.apollo.internal.util.Cancelable;
-
-import org.jetbrains.annotations.NotNull;
-
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Completable;
 import io.reactivex.CompletableEmitter;
@@ -25,8 +22,10 @@ import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.Single;
 import io.reactivex.SingleEmitter;
 import io.reactivex.SingleOnSubscribe;
+import io.reactivex.annotations.CheckReturnValue;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.exceptions.Exceptions;
+import org.jetbrains.annotations.NotNull;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
@@ -48,6 +47,8 @@ public class Rx2Apollo {
    * @return the converted Observable
    * @throws NullPointerException if watcher == null
    */
+  @NotNull
+  @CheckReturnValue
   public static <T> Observable<Response<T>> from(@NotNull final ApolloQueryWatcher<T> watcher) {
     checkNotNull(watcher, "watcher == null");
     return Observable.create(new ObservableOnSubscribe<Response<T>>() {
@@ -81,7 +82,9 @@ public class Rx2Apollo {
    * @return the converted Observable
    * @throws NullPointerException if originalCall == null
    */
-  @NotNull public static <T> Observable<Response<T>> from(@NotNull final ApolloCall<T> call) {
+  @NotNull
+  @CheckReturnValue
+  public static <T> Observable<Response<T>> from(@NotNull final ApolloCall<T> call) {
     checkNotNull(call, "call == null");
 
     return Observable.create(new ObservableOnSubscribe<Response<T>>() {
@@ -118,7 +121,9 @@ public class Rx2Apollo {
    * @return the converted Completable
    * @throws NullPointerException if prefetch == null
    */
-  @NotNull public static Completable from(@NotNull final ApolloPrefetch prefetch) {
+  @NotNull
+  @CheckReturnValue
+  public static Completable from(@NotNull final ApolloPrefetch prefetch) {
     checkNotNull(prefetch, "prefetch == null");
 
     return Completable.create(new CompletableOnSubscribe() {
@@ -142,11 +147,15 @@ public class Rx2Apollo {
     });
   }
 
-  @NotNull public static <T> Flowable<Response<T>> from(@NotNull ApolloSubscriptionCall<T> call) {
+  @NotNull
+  @CheckReturnValue
+  public static <T> Flowable<Response<T>> from(@NotNull ApolloSubscriptionCall<T> call) {
     return from(call, BackpressureStrategy.LATEST);
   }
 
-  @NotNull public static <T> Flowable<Response<T>> from(@NotNull final ApolloSubscriptionCall<T> call,
+  @NotNull
+  @CheckReturnValue
+  public static <T> Flowable<Response<T>> from(@NotNull final ApolloSubscriptionCall<T> call,
       @NotNull BackpressureStrategy backpressureStrategy) {
     checkNotNull(call, "originalCall == null");
     checkNotNull(backpressureStrategy, "backpressureStrategy == null");
@@ -194,7 +203,9 @@ public class Rx2Apollo {
    * @param <T>       the value type
    * @return the converted Single
    */
-  @NotNull public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {
+  @NotNull
+  @CheckReturnValue
+  public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {
     checkNotNull(operation, "operation == null");
     return Single.create(new SingleOnSubscribe<T>() {
       @Override

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
@@ -1,29 +1,50 @@
 @file:Suppress("NOTHING_TO_INLINE")
+@file:JvmName("KotlinExtensions")
 
 package com.apollographql.apollo.rx2
 
-import com.apollographql.apollo.*
-import com.apollographql.apollo.api.*
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.ApolloMutationCall
+import com.apollographql.apollo.ApolloPrefetch
+import com.apollographql.apollo.ApolloQueryCall
+import com.apollographql.apollo.ApolloQueryWatcher
+import com.apollographql.apollo.ApolloSubscriptionCall
+import com.apollographql.apollo.api.Mutation
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.api.Subscription
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation
-import io.reactivex.*
+import io.reactivex.BackpressureStrategy
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.annotations.CheckReturnValue
 
 @JvmSynthetic
+@CheckReturnValue
 inline fun ApolloPrefetch.rx(): Completable =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
+@CheckReturnValue
 inline fun <T> ApolloStoreOperation<T>.rx(): Single<T> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
+@CheckReturnValue
 inline fun <T> ApolloQueryWatcher<T>.rx(): Observable<Response<T>> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
+@CheckReturnValue
 inline fun <T> ApolloCall<T>.rx(): Observable<Response<T>> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
+@CheckReturnValue
 inline fun <T> ApolloSubscriptionCall<T>.rx(
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
 ): Flowable<Response<T>> = Rx2Apollo.from(this, backpressureStrategy)
@@ -35,6 +56,7 @@ inline fun <T> ApolloSubscriptionCall<T>.rx(
  * [com.apollographql.apollo.fetcher.ResponseFetcher] used with the call.
  */
 @JvmSynthetic
+@CheckReturnValue
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery(
     query: Query<D, T, V>,
     configure: ApolloQueryCall<T>.() -> Unit = {}
@@ -44,6 +66,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
  */
 @JvmSynthetic
+@CheckReturnValue
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
     mutation: Mutation<D, T, V>,
     configure: ApolloMutationCall<T>.() -> Unit = {}
@@ -57,6 +80,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutat
  * be re-fetched.
  */
 @JvmSynthetic
+@CheckReturnValue
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
     mutation: Mutation<D, T, V>,
     withOptimisticUpdates: D,
@@ -67,6 +91,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutat
  * Creates the [ApolloPrefetch] by wrapping the operation object inside and then converts it to a [Completable].
  */
 @JvmSynthetic
+@CheckReturnValue
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefetch(
     operation: Operation<D, T, V>
 ): Completable = prefetch(operation).rx()
@@ -77,6 +102,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefe
  * Back-pressure strategy can be provided via [backpressureStrategy] parameter. The default value is [BackpressureStrategy.LATEST]
  */
 @JvmSynthetic
+@CheckReturnValue
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxSubscribe(
     subscription: Subscription<D, T, V>,
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
@@ -36,16 +36,18 @@ inline fun <T> ApolloSubscriptionCall<T>.rx(
  */
 @JvmSynthetic
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery(
-    query: Query<D, T, V>
-): Observable<Response<T>> = query(query).rx()
+    query: Query<D, T, V>,
+    configure: ApolloQueryCall<T>.() -> Unit = {}
+): Observable<Response<T>> = query(query).apply(configure).rx()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
  */
 @JvmSynthetic
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, T, V>
-): Single<Response<T>> = mutate(mutation).rx().singleOrError()
+    mutation: Mutation<D, T, V>,
+    configure: ApolloMutationCall<T>.() -> Unit = {}
+): Single<Response<T>> = mutate(mutation).apply(configure).rx().singleOrError()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
@@ -57,8 +59,9 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutat
 @JvmSynthetic
 inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
     mutation: Mutation<D, T, V>,
-    withOptimisticUpdates: D
-): Single<Response<T>> = mutate(mutation, withOptimisticUpdates).rx().singleOrError()
+    withOptimisticUpdates: D,
+    configure: ApolloMutationCall<T>.() -> Unit = {}
+): Single<Response<T>> = mutate(mutation, withOptimisticUpdates).apply(configure).rx().singleOrError()
 
 /**
  * Creates the [ApolloPrefetch] by wrapping the operation object inside and then converts it to a [Completable].

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
@@ -1,0 +1,80 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.apollographql.apollo.rx2
+
+import com.apollographql.apollo.*
+import com.apollographql.apollo.api.*
+import com.apollographql.apollo.cache.normalized.ApolloStoreOperation
+import io.reactivex.*
+
+@JvmSynthetic
+inline fun ApolloPrefetch.rx(): Completable =
+    Rx2Apollo.from(this)
+
+@JvmSynthetic
+inline fun <T> ApolloStoreOperation<T>.rx(): Single<T> =
+    Rx2Apollo.from(this)
+
+@JvmSynthetic
+inline fun <T> ApolloQueryWatcher<T>.rx(): Observable<Response<T>> =
+    Rx2Apollo.from(this)
+
+@JvmSynthetic
+inline fun <T> ApolloCall<T>.rx(): Observable<Response<T>> =
+    Rx2Apollo.from(this)
+
+@JvmSynthetic
+inline fun <T> ApolloSubscriptionCall<T>.rx(
+    backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
+): Flowable<Response<T>> = Rx2Apollo.from(this, backpressureStrategy)
+
+/**
+ * Creates a new [ApolloQueryCall] call and then converts it to an [Observable].
+ *
+ * The number of emissions this Observable will have is based on the
+ * [com.apollographql.apollo.fetcher.ResponseFetcher] used with the call.
+ */
+@JvmSynthetic
+inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery(
+    query: Query<D, T, V>
+): Observable<Response<T>> = query(query).rx()
+
+/**
+ * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
+ */
+@JvmSynthetic
+inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, T, V>
+): Single<Response<T>> = mutate(mutation).rx().singleOrError()
+
+/**
+ * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
+ *
+ * Provided optimistic updates will be stored in [com.apollographql.apollo.cache.normalized.ApolloStore]
+ * immediately before mutation execution. Any [ApolloQueryWatcher] dependent on the changed cache records will
+ * be re-fetched.
+ */
+@JvmSynthetic
+inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, T, V>,
+    withOptimisticUpdates: D
+): Single<Response<T>> = mutate(mutation, withOptimisticUpdates).rx().singleOrError()
+
+/**
+ * Creates the [ApolloPrefetch] by wrapping the operation object inside and then converts it to a [Completable].
+ */
+@JvmSynthetic
+inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefetch(
+    operation: Operation<D, T, V>
+): Completable = prefetch(operation).rx()
+
+/**
+ * Creates a new [ApolloSubscriptionCall] call and then converts it to a [Flowable].
+ *
+ * Back-pressure strategy can be provided via [backpressureStrategy] parameter. The default value is [BackpressureStrategy.LATEST]
+ */
+@JvmSynthetic
+inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxSubscribe(
+    subscription: Subscription<D, T, V>,
+    backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
+): Flowable<Response<T>> = subscribe(subscription).rx(backpressureStrategy)

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.kotlinsample.data
 
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy
 import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
 import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
 import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
@@ -63,7 +64,10 @@ class ApolloRxService(
         .name(repositoryName)
         .build()
 
-    val disposable = apolloClient.rxQuery(commitsQuery)
+    val disposable = apolloClient
+        .rxQuery(commitsQuery) {
+          httpCachePolicy(HttpCachePolicy.NETWORK_FIRST)
+        }
         .subscribeOn(processScheduler)
         .observeOn(resultScheduler)
         .map { response ->

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
 import com.apollographql.apollo.kotlinsample.type.OrderDirection
 import com.apollographql.apollo.kotlinsample.type.PullRequestState
 import com.apollographql.apollo.kotlinsample.type.RepositoryOrderField
-import com.apollographql.apollo.rx2.Rx2Apollo
+import com.apollographql.apollo.rx2.rxQuery
 import io.reactivex.Scheduler
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
@@ -29,9 +29,7 @@ class ApolloRxService(
         .orderDirection(OrderDirection.DESC)
         .build()
 
-    val call = apolloClient.query(repositoriesQuery)
-
-    val disposable = Rx2Apollo.from(call)
+    val disposable = apolloClient.rxQuery(repositoriesQuery)
         .subscribeOn(processScheduler)
         .observeOn(resultScheduler)
         .map(this::mapRepositoriesResponseToRepositories)
@@ -49,9 +47,7 @@ class ApolloRxService(
         .pullRequestStates(listOf(PullRequestState.OPEN))
         .build()
 
-    val call = apolloClient.query(repositoryDetailQuery)
-
-    val disposable = Rx2Apollo.from(call)
+    val disposable = apolloClient.rxQuery(repositoryDetailQuery)
         .subscribeOn(processScheduler)
         .observeOn(resultScheduler)
         .subscribe(
@@ -67,9 +63,7 @@ class ApolloRxService(
         .name(repositoryName)
         .build()
 
-    val call = apolloClient.query(commitsQuery)
-
-    val disposable = Rx2Apollo.from(call)
+    val disposable = apolloClient.rxQuery(commitsQuery)
         .subscribeOn(processScheduler)
         .observeOn(resultScheduler)
         .map { response ->


### PR DESCRIPTION
Add Kotlin extensions to RxJava artifact. 

## Note

Added the extensions followed by a method used by Refrofit, AutoDispose and others. With this approach, there is not need to publish a new artifact. AutoDispose deprecated their `ktx` artifacts earlier this year. 
https://github.com/uber/AutoDispose/

This is done basically with combination of `compileOnly` Kotlin stdlib and `@JvmSyncthetic` annotation. The annotation makes it impossible for Java callers to call these methods.

Kotlin needs to be configured for them to be called. It then magically works. 🎉 

## Extension Function API (Feedback needed)

Just `rx()` function is added to replace `Rx2Apollo.from()`. These are mere replacements and are not the best. 

`rxQuery`, `rxMutate`, `rxPrefetch` and `rxSubscribe` are extensions on `ApolloClient` and imitates the already available API in `ApolloClient` and provides much better API for Kotlin users.

Samples are also updated to demonstrate the new API. Here is a gist of the diff:

```
val call = apolloClient.query(repositoryDetailQuery)
Rx2Apollo.from(call)
```

becomes

```
apolloClient.rxQuery(repositoryDetailQuery)
```

If you need to configure the `call` that has been created. You could also do:

```
apolloClient.rxQuery(query) {
    httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
}
```

