### PR TITLE
Make java models accessible from kotlin

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -66,7 +66,9 @@ object AndroidTaskConfigurator {
        *
        * To workaround this, we're adding the java generated models folder here
        */
-      project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure {
+      project.tasks.matching {
+        it.name == "compile${variant.name.capitalize()}Kotlin"
+      }.configureEach{
         it.dependsOn(codegenProvider)
         (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
       }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -4,6 +4,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 object JvmTaskConfigurator {
 
@@ -37,6 +38,19 @@ object JvmTaskConfigurator {
       "compileJava"
     } else {
       "compileKotlin"
+    }
+
+    if (!compilationUnit.generateKotlinModels()) {
+      /**
+       * By the time we come here, the KotlinCompile task has been configured by the kotlin plugin already.
+       *
+       * Right now this is done in [org.jetbrains.kotlin.gradle.plugin.AbstractAndroidProjectHandler.configureSources].
+       *
+       * To workaround this, we're adding the java generated models folder here
+       */
+      project.tasks.named("compileKotlin").configure {
+        (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
+      }
     }
     sourceDirectorySet.srcDir(codegenProvider.flatMap { it.outputDir })
     project.tasks.named(compileTaskName) { it.dependsOn(codegenProvider) }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -40,7 +40,7 @@ object JvmTaskConfigurator {
       "compileKotlin"
     }
 
-    if (!compilationUnit.generateKotlinModels()) {
+    if (!compilationUnit.compilerParams.generateKotlinModels.get()) {
       /**
        * By the time we come here, the KotlinCompile task has been configured by the kotlin plugin already.
        *

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -48,7 +48,9 @@ object JvmTaskConfigurator {
        *
        * To workaround this, we're adding the java generated models folder here
        */
-      project.tasks.named("compileKotlin").configure {
+      project.tasks.matching {
+        it.name == "compileKotlin"
+      }.configureEach{
         (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
       }
     }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -55,6 +55,52 @@ class SourceDirectorySetTests {
   }
 
   @Test
+  fun `pure-jvm java models are reachable from kotlin code`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
+
+      TestUtils.executeTask("build", dir)
+
+      Assert.assertTrue(File(dir, "build/classes/java/main/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/kotlin/main/com/example/Main.class").isFile)
+      Assert.assertTrue(dir.generatedChild("main/service/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
+    }
+  }
+
+  @Test
+  fun `android java models are reachable from kotlin code`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.kotlinAndroidPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("kotlin").copyRecursively(dir.child("src", "main", "kotlin"))
+
+      TestUtils.executeTask("assembleDebug", dir)
+
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/Main.class").isFile)
+      Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
+      Assert.assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
+    }
+  }
+
+  @Test
   fun `android-java builds an apk`() {
     val apolloConfiguration = """
       apollo {


### PR DESCRIPTION
When we call `registerJavaSources()`, the kotlin plugin has already configured its sources and therefore misses the new generated folder.

This comes from the fact that we use `project.afterEvaluate{}` to make sure   apolloExtension.generateKotlinModels has been populated correctly and we therefore postpone the task registration to after the Android and Kotlin plugins have done their magic.

This feels a bit awkward but I'm not sure there's a nice solution here. Maybe have 2 different plugins: one that generates Kotlin and the other one that generates Java. That would simplify things quite a bit at the expense of breaking a bit more backward compatibility. 

Also that would mean users woulnd't be able to configure java/kotlin models on a per-service anymore but maybe it's not that bad. Actually defaulting to generating kotlin models if the kotlin plugin is applied would certainly be a better first experience for most users.