### PR TITLE
Generate function to parse operation response

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Apollo-Android is designed primarily with Android in mind but you can use it in 
 - [RxJava2 Support](#rxjava2-support)
 - [Coroutines Support](#coroutines-support)
 - [Android Espresso Support](#android-espresso-support)
+- [Use generated models only](#use-generated-models-only)
 - [Gradle Configuration of Apollo Android](#gradle-configuration-of-apollo-android)
   - [Optional Support](#optional-support)
   - [Semantic Naming](#semantic-naming)
@@ -556,6 +557,28 @@ Add the following `dependency`:
 ```gradle
 implementation 'com.apollographql.apollo:apollo-espresso-support:x.y.z'
 ```
+
+##  Use generated models only
+
+Any `Operation` instance provides API to parse `Response` from raw data `Map<String, Object>` that represents GraphQL operation response returned by server.
+If for some reason you want to use your own network layer and don't want to use fully featured `ApolloClient` provided by `apollo-runtime` you can use this API:
+
+```java
+    String json = "...";
+    
+    //  we use Moshi json library here to simplify JSON string deserialization into Map 
+    Moshi moshi = new Moshi.Builder().build();
+    Type type = Types.newParameterizedType(Map.class, String.class, Object.class);
+    JsonAdapter<Map<String, Object>> adapter = moshi.adapter(type);
+    Map<String, Object> data = adapter.fromJson(json);
+
+    // if you have custom scalar types, provide proper instance of ScalarTypeAdapters with your own custom adapters
+    ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap())
+
+    Response<Query.Data> response = new Query().parse(data, scalarTypeAdapters);
+```
+
+Just make sure you added `apollo-api` dependency to your project's build.gradle file.
 
 ##  Gradle Configuration of Apollo Android
 Apollo Android comes with logical defaults that will work for the majority of use cases, below you will find additional configuration that will add Optional Support & Semantic Query Naming.

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -44,6 +44,13 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
    */
   @NotNull String operationId();
 
+  /**
+   * Parses provided GraphQL operation raw response
+   *
+   * @param response operation raw response to parse
+   * @param scalarTypeAdapters configured instance of custom GraphQL scalar type adapters
+   * @return parsed GraphQL operation {@link Response}
+   */
   @NotNull Response<T> parse(@NotNull Map<String, Object> response, @NotNull ScalarTypeAdapters scalarTypeAdapters);
 
   /**

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -1,9 +1,9 @@
 package com.apollographql.apollo.api;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Collections;
 import java.util.Map;
-
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents a GraphQL operation (mutation or query).
@@ -43,6 +43,8 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
    * @return operation identifier.
    */
   @NotNull String operationId();
+
+  @NotNull Response<T> parse(@NotNull Map<String, Object> response, @NotNull ScalarTypeAdapters scalarTypeAdapters);
 
   /**
    * Abstraction for data returned by the server in response to this operation.

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
@@ -1,0 +1,93 @@
+package com.apollographql.apollo.api.internal;
+
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
+
+public final class SimpleOperationResponseParser {
+  private SimpleOperationResponseParser() {
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <D extends Operation.Data, W> Response<W> parse(@NotNull final Map<String, Object> response,
+      @NotNull final Operation<D, W, ?> operation, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    checkNotNull(response, "response == null");
+    checkNotNull(operation, "operation == null");
+    checkNotNull(scalarTypeAdapters, "scalarTypeAdapters == null");
+
+    final D data;
+    final Map<String, Object> responseData = (Map<String, Object>) response.get("data");
+    if (responseData != null) {
+      final SimpleResponseReader responseReader = new SimpleResponseReader(responseData, operation.variables(), scalarTypeAdapters);
+      data = operation.responseFieldMapper().map(responseReader);
+    } else {
+      data = null;
+    }
+
+    final List<Error> errors;
+    final List<Map<String, Object>> responseErrors = (List<Map<String, Object>>) response.get("errors");
+    if (responseErrors != null) {
+      errors = new ArrayList<>();
+      for (Map<String, Object> errorPayload : responseErrors) {
+        errors.add(readError(errorPayload));
+      }
+    } else {
+      errors = null;
+    }
+
+    return Response.<W>builder(operation)
+        .data(operation.wrapData(data))
+        .errors(errors)
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Error readError(final Map<String, Object> payload) {
+    String message = null;
+    final List<Error.Location> locations = new ArrayList<>();
+    final Map<String, Object> customAttributes = new HashMap<>();
+    for (Map.Entry<String, Object> entry : payload.entrySet()) {
+      if ("message".equals(entry.getKey())) {
+        Object value = entry.getValue();
+        message = value != null ? value.toString() : null;
+      } else if ("locations".equals(entry.getKey())) {
+        List<Map<String, Object>> locationItems = (List<Map<String, Object>>) entry.getValue();
+        if (locationItems != null) {
+          for (Map<String, Object> item : locationItems) {
+            locations.add(readErrorLocation(item));
+          }
+        }
+      } else {
+        if (entry.getValue() != null) {
+          customAttributes.put(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+    return new Error(message, locations, customAttributes);
+  }
+
+  private static Error.Location readErrorLocation(final Map<String, Object> data) {
+    long line = -1;
+    long column = -1;
+    if (data != null) {
+      for (Map.Entry<String, Object> entry : data.entrySet()) {
+        if ("line".equals(entry.getKey())) {
+          line = ((BigDecimal) entry.getValue()).longValue();
+        } else if ("column".equals(entry.getKey())) {
+          column = ((BigDecimal) entry.getValue()).longValue();
+        }
+      }
+    }
+    return new Error.Location(line, column);
+  }
+}

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
@@ -82,9 +82,9 @@ public final class SimpleOperationResponseParser {
     if (data != null) {
       for (Map.Entry<String, Object> entry : data.entrySet()) {
         if ("line".equals(entry.getKey())) {
-          line = ((BigDecimal) entry.getValue()).longValue();
+          line = ((Number) entry.getValue()).longValue();
         } else if ("column".equals(entry.getKey())) {
-          column = ((BigDecimal) entry.getValue()).longValue();
+          column = ((Number) entry.getValue()).longValue();
         }
       }
     }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
@@ -6,7 +6,6 @@ import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
 import org.jetbrains.annotations.NotNull;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/internal/SimpleResponseReaderTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/internal/SimpleResponseReaderTest.java
@@ -4,13 +4,12 @@ import com.apollographql.apollo.api.CustomTypeAdapter;
 import com.apollographql.apollo.api.CustomTypeValue;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
-import com.apollographql.apollo.api.internal.SimpleResponseReader;
-import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
@@ -18,7 +17,6 @@ import java.math.BigDecimal;
 import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -848,6 +846,10 @@ public class SimpleResponseReaderTest {
 
     @NotNull @Override public String operationId() {
       return "";
+    }
+
+    @NotNull @Override public Response parse(@NotNull Map response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   };
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.compiler.codegen.kotlin
 
 import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.compiler.applyIf
 import com.apollographql.apollo.compiler.ast.InputType
 import com.apollographql.apollo.compiler.ast.ObjectType
@@ -68,6 +69,20 @@ internal fun OperationType.typeSpec(targetPackage: String) = TypeSpec
         .beginControlFlow("return %T {", ResponseFieldMapper::class)
         .addStatement("%T(it)", data.asTypeName())
         .endControlFlow()
+        .build()
+    )
+    .addFunction(FunSpec.builder("parse")
+        .addModifiers(KModifier.OVERRIDE)
+        .addParameter(ParameterSpec
+            .builder("response", Map::class.asClassName().parameterizedBy(String::class.asTypeName(), Any::class.asClassName()))
+            .build()
+        )
+        .addParameter(ParameterSpec
+            .builder("scalarTypeAdapters", ScalarTypeAdapters::class.asClassName())
+            .build()
+        )
+        .returns(Response::class.asClassName().parameterizedBy(data.asTypeName()))
+        .addStatement("return %T.parse(response, this, scalarTypeAdapters)", SimpleOperationResponseParser::class.asTypeName())
         .build()
     )
     .addTypes(nestedObjects.map { (ref, type) ->

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -11,12 +11,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -92,6 +95,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -10,10 +10,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.arguments_complex.type.Episode
 import kotlin.Any
@@ -55,6 +58,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class HeroWithReview(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.arguments_hardcoded;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -84,6 +88,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.arguments_hardcoded
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Review(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -12,12 +12,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -115,6 +118,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -10,10 +10,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.arguments_simple.fragment.HeroDetails
 import com.example.arguments_simple.type.Episode
@@ -68,6 +71,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.custom_scalar_type;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.custom_scalar_type.type.CustomType;
@@ -24,6 +27,7 @@ import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -89,6 +93,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -8,10 +8,13 @@ package com.example.custom_scalar_type
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.custom_scalar_type.type.CustomType
 import java.util.Date
@@ -20,6 +23,7 @@ import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -32,6 +36,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.custom_scalar_type_warnings;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.custom_scalar_type_warnings.type.CustomType;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -83,6 +87,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -8,10 +8,13 @@ package com.example.custom_scalar_type_warnings
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.custom_scalar_type_warnings.type.CustomType
 import kotlin.Any
@@ -19,6 +22,7 @@ import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -11,12 +11,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -93,6 +96,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -10,10 +10,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.deprecation.type.Episode
 import kotlin.Any
@@ -49,6 +52,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.io.IOException;
@@ -92,6 +95,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import kotlin.Any
 import kotlin.Array
@@ -50,6 +53,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class FriendsConnection(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.enum_type;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.enum_type.type.Episode;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,6 +89,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.enum_type
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.enum_type.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.fragment_friends_connection.fragment.HeroDetails;
@@ -24,6 +27,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -99,6 +103,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.fragment_friends_connection
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragment_friends_connection.fragment.HeroDetails
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -26,6 +29,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -119,6 +123,13 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<AllStarships.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -8,16 +8,21 @@ package com.example.fragment_in_fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragment_in_fragment.fragment.StarshipFragment
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.fragment_used_twice.fragment.HeroDetails;
@@ -25,6 +28,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -101,6 +105,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.fragment_used_twice
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragment_used_twice.fragment.HeroDetails
 import com.example.fragment_used_twice.fragment.HumanDetails
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -9,13 +9,16 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Mutator;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails;
@@ -27,6 +30,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -112,6 +116,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -8,17 +8,22 @@ package com.example.fragment_with_inline_fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragment_with_inline_fragment.fragment.HeroDetails
 import com.example.fragment_with_inline_fragment.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +36,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.fragments_with_type_condition.fragment.DroidDetails;
@@ -25,6 +28,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -101,6 +105,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.fragments_with_type_condition
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragments_with_type_condition.fragment.DroidDetails
 import com.example.fragments_with_type_condition.fragment.HumanDetails
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class R2(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
@@ -9,11 +9,14 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.fragments_with_type_condition_nullable.fragment.DroidDetails;
@@ -24,6 +27,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,6 +104,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<TestQuery.Data> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.fragments_with_type_condition_nullable
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.fragments_with_type_condition_nullable.fragment.DroidDetails
 import com.example.fragments_with_type_condition_nullable.fragment.HumanDetails
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class R2(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
@@ -8,12 +8,15 @@ package com.example.hero_details;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Integer;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,6 +98,13 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<HeroDetails.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -8,16 +8,21 @@ package com.example.hero_details
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -8,11 +8,14 @@ package com.example.hero_details_guava;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.google.common.base.Optional;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,6 +98,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.hero_details_guava
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -8,11 +8,14 @@ package com.example.hero_details_java_optional;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Integer;
@@ -22,6 +25,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -94,6 +98,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.hero_details_java_optional
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -8,11 +8,14 @@ package com.example.hero_details_nullable;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Integer;
@@ -22,6 +25,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -93,6 +97,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<TestQuery.Data> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.hero_details_nullable
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
@@ -8,12 +8,15 @@ package com.example.hero_details_semantic_naming;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Integer;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,6 +98,13 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<HeroDetailsQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -8,16 +8,21 @@ package com.example.hero_details_semantic_naming
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.hero_name;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.hero_name.type.CustomType;
@@ -22,6 +25,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -87,6 +91,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.hero_name
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.hero_name.type.CustomType
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -90,6 +93,13 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.hero_with_review.type.Episode
 import kotlin.Any
@@ -47,6 +50,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class CreateReview(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.inline_fragment_for_non_optional_field;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Double;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,6 +89,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.inline_fragment_for_non_optional_field
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface HeroCharacter {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.inline_fragment_merge_fields;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.inline_fragment_merge_fields.type.CustomType;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -107,6 +111,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -8,10 +8,13 @@ package com.example.inline_fragment_merge_fields
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.inline_fragment_merge_fields.type.CustomType
 import kotlin.Any
@@ -19,6 +22,7 @@ import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.inline_fragments_with_friends;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.inline_fragments_with_friends.type.CustomType;
@@ -26,6 +29,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -100,6 +104,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -8,18 +8,23 @@ package com.example.inline_fragments_with_friends
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.inline_fragments_with_friends.type.CustomType
 import com.example.inline_fragments_with_friends.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -32,6 +37,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface HeroCharacter {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -92,6 +95,13 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.input_object_type.type.Episode
 import com.example.input_object_type.type.ReviewInput
@@ -51,6 +54,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class CreateReview(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.introspection_query;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -94,6 +98,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.introspection_query
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class QueryType(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.java_beans_semantic_naming.fragment.HeroDetails;
@@ -26,6 +29,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -112,6 +116,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -8,17 +8,22 @@ package com.example.java_beans_semantic_naming
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.java_beans_semantic_naming.fragment.HeroDetails
 import com.example.java_beans_semantic_naming.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +36,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -102,6 +105,13 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<CreateReviewForEpisode.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.mutation_create_review.type.CustomType
 import com.example.mutation_create_review.type.Episode
@@ -54,6 +57,9 @@ data class CreateReviewForEpisode(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class ListOfListOfObject(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -92,6 +95,13 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<CreateReviewForEpisodeMutation.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Mutation
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.mutation_create_review_semantic_naming.type.Episode
 import com.example.mutation_create_review_semantic_naming.type.ReviewInput
@@ -52,6 +55,9 @@ data class CreateReviewForEpisodeMutation(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class CreateReview(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -11,12 +11,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -111,6 +114,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -10,10 +10,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.nested_conditional_inline.type.Episode
 import kotlin.Any
@@ -49,6 +52,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface HeroCharacter {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.nested_inline_fragment.fragment.TestSetting;
 import java.lang.Object;
@@ -23,6 +26,8 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
@@ -97,6 +102,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_inline_fragment/TestQuery.kt
@@ -5,13 +5,8 @@
 //
 package com.example.nested_inline_fragment
 
-import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.api.OperationName
-import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.ResponseFieldMapper
-import com.apollographql.apollo.api.ResponseFieldMarshaller
-import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.example.nested_inline_fragment.fragment.TestSetting
 import kotlin.Array
 import kotlin.String
@@ -28,6 +23,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+    Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Setting(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.reserved_words.type.TestInputType;
 import java.io.IOException;
@@ -79,6 +82,13 @@ public final class TestMutation implements Mutation<TestMutation.Data, Optional<
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_words/TestMutation.kt
@@ -5,14 +5,8 @@
 //
 package com.example.reserved_words
 
-import com.apollographql.apollo.api.InputFieldMarshaller
-import com.apollographql.apollo.api.Mutation
-import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.api.OperationName
-import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.ResponseFieldMapper
-import com.apollographql.apollo.api.ResponseFieldMarshaller
-import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.example.reserved_words.type.TestInputType
 import kotlin.Any
 import kotlin.Array
@@ -46,6 +40,9 @@ data class TestMutation(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+    Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Operation(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.scalar_types;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.example.scalar_types.type.CustomType;
 import com.example.scalar_types.type.Episode;
@@ -26,6 +29,8 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -79,6 +84,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/scalar_types/TestQuery.kt
@@ -5,13 +5,8 @@
 //
 package com.example.scalar_types
 
-import com.apollographql.apollo.api.Operation
-import com.apollographql.apollo.api.OperationName
-import com.apollographql.apollo.api.Query
-import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.ResponseFieldMapper
-import com.apollographql.apollo.api.ResponseFieldMarshaller
-import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.*
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.example.scalar_types.type.CustomType
 import com.example.scalar_types.type.Episode
 import kotlin.Array
@@ -33,6 +28,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+    Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Data(
     val graphQlString: String?,

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.simple_fragment.fragment.HeroDetails;
@@ -25,6 +28,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -95,6 +99,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -8,16 +8,21 @@ package com.example.simple_fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.simple_fragment.fragment.HeroDetails
 import com.example.simple_fragment.fragment.HumanDetails
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -30,6 +35,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Hero(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.simple_inline_fragment;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import java.lang.Double;
@@ -23,6 +26,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -89,6 +93,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.simple_inline_fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
+import kotlin.Any
 import kotlin.Array
 import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface HeroCharacter {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
@@ -10,12 +10,15 @@ import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -93,6 +96,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -9,10 +9,13 @@ import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.starships.type.CustomType
 import kotlin.Any
@@ -48,6 +51,9 @@ data class TestQuery(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Starship(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
@@ -9,13 +9,16 @@ import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.Subscription;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -89,6 +92,13 @@ public final class TestSubscription implements Subscription<TestSubscription.Dat
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestSubscription.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -8,11 +8,14 @@ package com.example.subscriptions
 import com.apollographql.apollo.api.InputFieldMarshaller
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
 import com.apollographql.apollo.api.Subscription
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import kotlin.Any
 import kotlin.Array
@@ -46,6 +49,9 @@ data class TestSubscription(
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class CommentAdded(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.two_heroes_unique;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -23,6 +26,7 @@ import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -88,6 +92,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -8,15 +8,20 @@ package com.example.two_heroes_unique
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.two_heroes_unique.type.CustomType
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -29,6 +34,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class R2(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.two_heroes_with_friends;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -25,6 +28,7 @@ import java.lang.String;
 import java.lang.SuppressWarnings;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -112,6 +116,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -8,17 +8,22 @@ package com.example.two_heroes_with_friends
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.two_heroes_with_friends.type.CustomType
+import kotlin.Any
 import kotlin.Array
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +36,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Node(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
@@ -9,11 +9,14 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -26,6 +29,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -96,6 +100,13 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<TestQuery.Data> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -8,17 +8,22 @@ package com.example.union_fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.union_fragment.fragment.Character
 import com.example.union_fragment.fragment.Starship
+import kotlin.Any
 import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -31,6 +36,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   data class Search(
     val __typename: String,

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -8,12 +8,15 @@ package com.example.union_inline_fragments;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
@@ -27,6 +30,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -116,6 +120,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<TestQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -8,18 +8,23 @@ package com.example.union_inline_fragments
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.union_inline_fragments.type.CustomType
 import com.example.union_inline_fragments.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.Deprecated
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -32,6 +37,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface SearchSearchResult {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -9,12 +9,15 @@ import com.apollographql.apollo.api.FragmentResponseFieldMapper;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
 import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.example.unique_type_name.fragment.HeroDetails;
@@ -27,6 +30,7 @@ import java.lang.SuppressWarnings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -117,6 +121,13 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
   @Override
   public OperationName name() {
     return OPERATION_NAME;
+  }
+
+  @Override
+  @NotNull
+  public Response<Optional<HeroDetailQuery.Data>> parse(@NotNull final Map<String, Object> response,
+      @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters);
   }
 
   public static final class Builder {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -8,18 +8,23 @@ package com.example.unique_type_name
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.OperationName
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ResponseFieldMapper
 import com.apollographql.apollo.api.ResponseFieldMarshaller
 import com.apollographql.apollo.api.ResponseReader
+import com.apollographql.apollo.api.ScalarTypeAdapters
+import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.internal.QueryDocumentMinifier
 import com.example.unique_type_name.fragment.HeroDetails
 import com.example.unique_type_name.type.Episode
+import kotlin.Any
 import kotlin.Array
 import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
+import kotlin.collections.Map
 
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
@@ -32,6 +37,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper {
     Data(it)
   }
+
+  override fun parse(response: Map<String, Any>, scalarTypeAdapters: ScalarTypeAdapters):
+      Response<Data> = SimpleOperationResponseParser.parse(response, this, scalarTypeAdapters)
 
   interface HeroDetailQueryCharacter {
     fun marshaller(): ResponseFieldMarshaller

--- a/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
+++ b/apollo-espresso-support/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
@@ -10,6 +10,7 @@ import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.exception.ApolloException;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 
@@ -19,6 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -79,6 +81,10 @@ public class ApolloIdlingResourceTest {
 
     @NotNull @Override public String operationId() {
       return "";
+    }
+
+    @NotNull @Override public Response parse(@NotNull Map response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   };
 

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.okHttp.mockWebServer"))
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.okHttp.testSupport"))
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.mockito"))
+  add("testImplementation", groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
 }
 
 extensions.getByType(ApolloExtension::class.java).apply {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -160,9 +160,9 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
     if (data != null) {
       for (Map.Entry<String, Object> entry : data.entrySet()) {
         if ("line".equals(entry.getKey())) {
-          line = ((BigDecimal) entry.getValue()).longValue();
+          line = ((Number) entry.getValue()).longValue();
         } else if ("column".equals(entry.getKey())) {
-          column = ((BigDecimal) entry.getValue()).longValue();
+          column = ((Number) entry.getValue()).longValue();
         }
       }
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -12,7 +12,6 @@ import com.apollographql.apollo.internal.json.ResponseJsonStreamReader;
 import com.apollographql.apollo.internal.response.RealResponseReader;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -2,8 +2,10 @@ package com.apollographql.apollo;
 
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.exception.ApolloHttpException;
 import com.apollographql.apollo.exception.ApolloNetworkException;
 import com.apollographql.apollo.exception.ApolloParseException;
@@ -15,6 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.SocketTimeoutException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -77,6 +80,10 @@ import static com.google.common.truth.Truth.assertThat;
 
       @Override public Object wrapData(Data data) {
         return data;
+      }
+
+      @NotNull @Override public Response parse(@NotNull Map response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+        throw new UnsupportedOperationException();
       }
     };
   }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
@@ -3,8 +3,10 @@ package com.apollographql.apollo.internal;
 import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.cache.http.HttpCachePolicy;
 
 import org.junit.Before;
@@ -13,6 +15,8 @@ import org.junit.Test;
 import org.jetbrains.annotations.NotNull;
 
 import okhttp3.OkHttpClient;
+
+import java.util.Map;
 
 import static com.apollographql.apollo.fetcher.ApolloResponseFetchers.CACHE_FIRST;
 import static com.apollographql.apollo.fetcher.ApolloResponseFetchers.NETWORK_ONLY;
@@ -57,6 +61,10 @@ public class ResponseFetcherTest {
 
       @Override public Object wrapData(Data data) {
         return data;
+      }
+
+      @NotNull @Override public Response parse(@NotNull Map response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+        throw new UnsupportedOperationException();
       }
     };
   }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
@@ -6,6 +6,7 @@ import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
@@ -20,6 +21,7 @@ import org.mockito.stubbing.Answer;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
 import java.util.concurrent.Executor;
@@ -296,6 +298,10 @@ public class ApolloAutoPersistedQueryInterceptorTest {
       @Override public ResponseFieldMarshaller marshaller() {
         throw new UnsupportedOperationException();
       }
+    }
+
+    @NotNull @Override public com.apollographql.apollo.api.Response<Data> parse(@NotNull Map<String, Object> response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
@@ -4,8 +4,10 @@ import com.apollographql.apollo.ApolloClient;
 import com.apollographql.apollo.IdleResourceCallback;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.rx2.Rx2Apollo;
 
 import org.junit.Before;
@@ -16,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,6 +69,10 @@ public class ApolloCallTrackerTest {
 
     @NotNull @Override public String operationId() {
       return "";
+    }
+
+    @NotNull @Override public Response parse(@NotNull Map response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   };
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -432,6 +433,10 @@ public class SubscriptionManagerTest {
 
     @NotNull @Override public String operationId() {
       return operationId;
+    }
+
+    @NotNull @Override public Response<Data> parse(@NotNull Map<String, Object> response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -3,6 +3,7 @@ package com.apollographql.apollo.subscription;
 import com.apollographql.apollo.api.CustomTypeAdapter;
 import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ResponseFieldMapper;
 import com.apollographql.apollo.api.ScalarType;
 import com.apollographql.apollo.api.Subscription;
@@ -221,6 +222,10 @@ public class WebSocketSubscriptionTransportMessageTest {
 
     @NotNull @Override public String operationId() {
       return "someId";
+    }
+
+    @NotNull @Override public Response<Data> parse(@NotNull Map<String, Object> response, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
     }
   }
 }


### PR DESCRIPTION
- Add new API `parse` function to `Operation` interface for parsing operation GraphQL response
- Introduce util class `SimpleOperationResponseParser` to delegate operation response parsing
- Update generated models implement `Operation.parse` function

This is final PR to make it possible use generated models without runtime module.