### PR TITLE
[Transformed Queries]: make them match Operation.queryDocument() exactly

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/DefaultPackageNameProvider.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/DefaultPackageNameProvider.kt
@@ -7,7 +7,7 @@ class DefaultPackageNameProvider(rootFolders: Collection<String>, schemaFile: Fi
   private val schemaPackageName = try {
     filePackageName(schemaFile.absolutePath)
   } catch (e: IllegalArgumentException) {
-    // Can happen if the schema is not under roots
+    // Can happen if the schema is not a child of roots
     ""
   }
 
@@ -18,7 +18,7 @@ class DefaultPackageNameProvider(rootFolders: Collection<String>, schemaFile: Fi
     return rootPackageName.appendPackageName(filePackageName(filePath))
   }
 
-  fun filePackageName(filePath: String): String {
+  private fun relativeToRoots(filePath: String): String {
     val file = File(File(filePath).absolutePath).normalize()
     roots.forEach { sourceDir ->
       try {
@@ -27,13 +27,19 @@ class DefaultPackageNameProvider(rootFolders: Collection<String>, schemaFile: Fi
           return@forEach
 
         return relative
-            .split(File.separator)
-            .filter { it.isNotBlank() }
-            .dropLast(1)
-            .joinToString(".")
       } catch (e: IllegalArgumentException) {
       }
     }
     throw IllegalArgumentException("$filePath is not found in:\n${roots.joinToString("\n")}\n")
+  }
+
+  fun filePackageName(filePath: String): String {
+    val relative = relativeToRoots(filePath)
+
+    return relative
+        .split(File.separator)
+        .filter { it.isNotBlank() }
+        .dropLast(1)
+        .joinToString(".")
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -49,7 +49,7 @@ class GraphQLCompiler {
       if (transformedQueriesOutputDir.exists()) {
         transformedQueriesOutputDir.deleteRecursively()
       }
-      val transformedQueryOutput = TransformedQueryOutput()
+      val transformedQueryOutput = TransformedQueryOutput(args.packageNameProvider)
       transformedQueryOutput.apply { visit(ir) }.writeTo(transformedQueriesOutputDir)
     }
   }

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.android.build.gradle.BaseExtension
-import com.apollographql.apollo.gradle.ApolloExtension
+import com.apollographql.apollo.gradle.api.ApolloExtension
 
 apply(plugin = "com.android.application")
-apply(plugin = "com.apollographql.android")
+apply(plugin = "com.apollographql.apollo")
 apply(plugin = "kotlin-android")
 
 extensions.findByType(BaseExtension::class.java)!!.apply {
@@ -44,9 +44,26 @@ dependencies {
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.mockito"))
 }
 
-extensions.getByType(ApolloExtension::class.java).apply {
-  setCustomTypeMapping(mapOf(
+configure<ApolloExtension> {
+  customTypeMapping(mapOf(
       "Date" to "java.util.Date",
       "Upload" to "com.apollographql.apollo.api.FileUpload"
   ))
+  generateTransformedQueries(true)
+  service("httpcache") {
+    sourceFolder("com/apollographql/apollo/integration/httpcache")
+    rootPackageName("com.apollographql.apollo.integration.httpcache")
+  }
+  service("interceptor") {
+    sourceFolder("com/apollographql/apollo/integration/interceptor")
+    rootPackageName("com.apollographql.apollo.integration.interceptor")
+  }
+  service("normalizer") {
+    sourceFolder("com/apollographql/apollo/integration/normalizer")
+    rootPackageName("com.apollographql.apollo.integration.normalizer")
+  }
+  service("upload") {
+    sourceFolder("com/apollographql/apollo/integration/upload")
+    rootPackageName("com.apollographql.apollo.integration.upload")
+  }
 }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/TransformedQueriesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/TransformedQueriesTest.kt
@@ -1,0 +1,14 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.integration.httpcache.AllFilmsQuery
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+class TransformedQueriesTest {
+  @Test
+  fun transformedQueriesMatchTheModels() {
+    val transformedQuery = File("build/generated/transformedQueries/apollo/debug/httpcache/com/apollographql/apollo/integration/httpcache/AllFilms.graphql")
+    assertThat(AllFilmsQuery.builder().build().queryDocument()).isEqualTo(transformedQuery.readText())
+  }
+}

--- a/composite/build.gradle.kts
+++ b/composite/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    classpath("com.apollographql.apollo:apollo-gradle-plugin")
+    classpath("com.apollographql.apollo:apollo-gradle-plugin-incubating")
   }
 }
 

--- a/samples/java-sample/build.gradle.kts
+++ b/samples/java-sample/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.android.build.gradle.BaseExtension
 apply(plugin = "com.android.application")
-apply(plugin = "com.apollographql.android")
+apply(plugin = "com.apollographql.apollo")
 
 extensions.findByType(BaseExtension::class.java)!!.apply {
   compileSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.compileSdkVersion").toString().toInt())

--- a/samples/kotlin-sample/build.gradle.kts
+++ b/samples/kotlin-sample/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.android.build.gradle.BaseExtension
 apply(plugin = "com.android.application")
-apply(plugin = "com.apollographql.android")
+apply(plugin = "com.apollographql.apollo")
 apply(plugin = "kotlin-android")
 apply(plugin = "kotlin-android-extensions")
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/issues/1748#issuecomment-552508744 for the background info.

Also, this Pull Request enables the incubating plugin in the composite build by default (samples + integration tests)