### PR TITLE
[Incubating Plugin] Also compile test variants

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -61,10 +61,13 @@ object AndroidTaskConfigurator {
   ) {
     val variant = compilationUnit.androidVariant as BaseVariant
     if (compilationUnit.generateKotlinModels()) {
+      // This is apparently needed for intelliJ to find the generated files
       variant.addJavaSourceFoldersToModel(codegenProvider.get().outputDir.get().asFile)
-      androidExtension as BaseExtension
-      androidExtension.sourceSets.first { it.name == variant.name }.kotlin!!.srcDir(codegenProvider.get().outputDir)
-      project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure { it.dependsOn(codegenProvider) }
+      // Tell the kotlin compiler to compile our files
+      project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure {
+        it.dependsOn(codegenProvider)
+        (it as KotlinCompile).source(codegenProvider.get().outputDir.asFile.get())
+      }
     } else {
       variant.registerJavaGeneratingTask(codegenProvider.get(), codegenProvider.get().outputDir.get().asFile)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -10,28 +10,38 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 object AndroidTaskConfigurator {
+  private fun apolloVariant(baseVariant: BaseVariant): ApolloVariant {
+    return ApolloVariant(
+        name = baseVariant.name,
+        sourceSetNames = baseVariant.sourceSets.map { it.name }.distinct(),
+        androidVariant = baseVariant
+    )
+  }
+
   fun getVariants(project: Project, androidExtension: Any): NamedDomainObjectContainer<ApolloVariant> {
     val container = project.container(ApolloVariant::class.java)
 
-    when {
-      androidExtension is LibraryExtension -> {
-        // TODO: add test variants ?
+    when (androidExtension) {
+      is LibraryExtension -> {
         androidExtension.libraryVariants.all { variant ->
-          container.add(ApolloVariant(
-              name = variant.name,
-              sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
-              androidVariant = variant
-          ))
+          container.add(apolloVariant(variant))
+        }
+        androidExtension.testVariants.all { variant ->
+          container.add(apolloVariant(variant))
+        }
+        androidExtension.unitTestVariants.all { variant ->
+          container.add(apolloVariant(variant))
         }
       }
-      androidExtension is AppExtension -> {
-        // TODO: add test variants ?
+      is AppExtension -> {
         androidExtension.applicationVariants.all { variant ->
-          container.add(ApolloVariant(
-              name = variant.name,
-              sourceSetNames = variant.sourceSets.map { it.name }.distinct(),
-              androidVariant = variant
-          ))
+          container.add(apolloVariant(variant))
+        }
+        androidExtension.testVariants.all { variant ->
+          container.add(apolloVariant(variant))
+        }
+        androidExtension.unitTestVariants.all { variant ->
+          container.add(apolloVariant(variant))
         }
       }
       else -> {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -83,7 +83,7 @@ open class ApolloPlugin : Plugin<Project> {
         val variantProvider = registerVariantTask(project, apolloVariant.name)
 
         val compilationUnits = if (apolloExtension.services.isEmpty()) {
-          listOfNotNull(DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant))
+          listOf(DefaultCompilationUnit.fromFiles(project, apolloExtension, apolloVariant))
         } else {
           apolloExtension.services.map {
             DefaultCompilationUnit.fromService(project, apolloExtension, apolloVariant, it)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -115,7 +115,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
       return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
     }
 
-    fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): DefaultCompilationUnit? {
+    fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): DefaultCompilationUnit{
       val service = project.objects.newInstance(DefaultService::class.java, project.objects, "service")
       return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
     }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -11,7 +11,10 @@ object JvmTaskConfigurator {
   fun getVariants(project: Project): NamedDomainObjectContainer<ApolloVariant> {
     val container = project.container(ApolloVariant::class.java)
 
-    listOf("main", "test").forEach {name ->
+    val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
+    val sourceSets = javaPlugin.sourceSets
+
+    sourceSets.map { it.name }.forEach {name ->
       val apolloVariant = ApolloVariant(
           name = name,
           sourceSetNames = listOf(name),

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -11,33 +11,39 @@ object JvmTaskConfigurator {
   fun getVariants(project: Project): NamedDomainObjectContainer<ApolloVariant> {
     val container = project.container(ApolloVariant::class.java)
 
-    // TODO: should we add tasks for the test sourceSet ?
-    val name = "main"
-    val apolloVariant = ApolloVariant(
-        name = name,
-        sourceSetNames = listOf(name),
-        androidVariant = null
-    )
+    listOf("main", "test").forEach {name ->
+      val apolloVariant = ApolloVariant(
+          name = name,
+          sourceSetNames = listOf(name),
+          androidVariant = null
+      )
 
-    container.add(apolloVariant)
+      container.add(apolloVariant)
+    }
+
     return container
   }
 
   fun registerGeneratedDirectory(project: Project, compilationUnit: DefaultCompilationUnit, codegenProvider: TaskProvider<ApolloGenerateSourcesTask>) {
     val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
     val sourceSets = javaPlugin.sourceSets
-    val name = compilationUnit.variantName
+    val sourceSetName = compilationUnit.variantName
+
+    val taskName = when(compilationUnit.variantName) {
+      "main" -> ""
+      else -> compilationUnit.variantName
+    }.capitalize()
 
     val sourceDirectorySet = if (!compilationUnit.generateKotlinModels()) {
-      sourceSets.getByName(name).java
+      sourceSets.getByName(sourceSetName).java
     } else {
-      sourceSets.getByName(name).kotlin!!
+      sourceSets.getByName(sourceSetName).kotlin!!
     }
 
     val compileTaskName = if (!compilationUnit.generateKotlinModels()) {
-      "compileJava"
+      "compile${taskName}Java"
     } else {
-      "compileKotlin"
+      "compile${taskName}Kotlin"
     }
 
     if (!compilationUnit.generateKotlinModels()) {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -32,10 +32,11 @@ object JvmTaskConfigurator {
     val sourceSets = javaPlugin.sourceSets
     val sourceSetName = compilationUnit.variantName
 
-    val taskName = when(compilationUnit.variantName) {
-      "main" -> ""
-      else -> compilationUnit.variantName
-    }.capitalize()
+    var taskName = compilationUnit.variantName.capitalize()
+    if (taskName == "Main") {
+      // Special case: The main variant will use "compileJava" and not "compileMainJava"
+      taskName = ""
+    }
 
     val sourceDirectorySet = if (!compilationUnit.generateKotlinModels()) {
       sourceSets.getByName(sourceSetName).java

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.gradle.test
 import com.apollographql.apollo.gradle.internal.child
 import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Test
 import java.io.File
@@ -196,11 +197,16 @@ class SourceDirectorySetTests {
       dir.child("src/main/graphql").copyRecursively(dir.child("src/foo/graphql"))
       dir.child("src/main/graphql").deleteRecursively()
 
-      TestUtils.executeTask("compileFooJava", dir)
+      val result = TestUtils.executeTask("compileFooJava", dir)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":compileFooJava")!!.outcome)
 
       Assert.assertTrue(File(dir, "build/classes/java/foo/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/classes/java/foo/com/example/Main.class").isFile)
       Assert.assertTrue(dir.generatedChild("foo/service/com/example/DroidDetailsQuery.java").isFile)
+
+      // Also verify that the compile task is compileJava and not compileMainJava
+      val resultMain = TestUtils.executeTask("compileJava", dir)
+      Assert.assertEquals(TaskOutcome.NO_SOURCE, resultMain.task(":compileJava")!!.outcome)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -145,4 +145,79 @@ class SourceDirectorySetTests {
       Assert.assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }
+
+  @Test
+  fun `non-android jvm can add queries to the test variant`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("java").copyRecursively(dir.child("src", "test", "java"))
+
+      dir.child("src/main/graphql").copyRecursively(dir.child("src/test/graphql"))
+      dir.child("src/main/graphql").deleteRecursively()
+
+      TestUtils.executeTask("test", dir)
+
+      Assert.assertTrue(File(dir, "build/classes/java/test/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/java/test/com/example/Main.class").isFile)
+      Assert.assertTrue(dir.generatedChild("test/service/com/example/DroidDetailsQuery.java").isFile)
+    }
+  }
+
+  @Test
+  fun `android can add queries to the test variant`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("java").copyRecursively(dir.child("src", "test", "java"))
+
+      dir.child("src/main/graphql").copyRecursively(dir.child("src/test/graphql"))
+      dir.child("src/main/graphql").deleteRecursively()
+
+      TestUtils.executeTask("test", dir)
+
+      Assert.assertTrue(File(dir, "build/classes/java/test/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/classes/java/test/com/example/Main.class").isFile)
+      Assert.assertTrue(dir.generatedChild("test/service/com/example/DroidDetailsQuery.java").isFile)
+    }
+  }
+
+  @Test
+  fun `android can add queries to the androidTest variant`() {
+    val apolloConfiguration = """
+      apollo {
+        generateKotlinModels = false
+      }
+    """.trimIndent()
+    TestUtils.withProject(usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin)) { dir ->
+
+      val source = TestUtils.fixturesDirectory()
+      source.child("java").copyRecursively(dir.child("src", "androidTest", "java"))
+
+      dir.child("src/main/graphql").copyRecursively(dir.child("src/androidTest/graphql"))
+      dir.child("src/main/graphql").deleteRecursively()
+
+      TestUtils.executeTask("assembleAndroidTest", dir)
+
+      Assert.assertTrue(dir.generatedChild("debugAndroidTest/service/com/example/DroidDetailsQuery.java").isFile)
+      Assert.assertTrue(dir.child("build/outputs/apk/androidTest/debug/testProject-debug-androidTest.apk").isFile)
+
+    }
+  }
 }


### PR DESCRIPTION
This adds `generateTest${service}ApolloSources` tasks and makes the compileJava/Kotlin tasks depend on it. This will compile files in:

```
src/test/graphql/com/example/schema.json
src/test/graphql/com/example/query.graphql
```

Also, on non-android projects, adding a sourceSet will also compile the associated graphql files:

```
configurations {
    fooCompile
}

sourceSets {
   foo { // the plugin will create generateFoo${service}ApolloSources
     compileClasspath = fooCompile
   }
}

// You'll need to add apollo-api to the foo configuration
dependencies {
   fooCompile "com.apollographql.apollo:apollo-api:$versions.apollo"
}
```

