### PR TITLE
unbreak master

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -40,7 +40,7 @@ object JvmTaskConfigurator {
       "compileKotlin"
     }
 
-    if (!compilationUnit.compilerParams.generateKotlinModels.get()) {
+    if (!compilationUnit.generateKotlinModels()) {
       /**
        * By the time we come here, the KotlinCompile task has been configured by the kotlin plugin already.
        *


### PR DESCRIPTION
https://github.com/apollographql/apollo-android/pull/1755 was made on an old master and compiled ok. 

Then https://github.com/apollographql/apollo-android/pull/1753 was merged which changed the way we access generateKotlinModels . 

Then https://github.com/apollographql/apollo-android/pull/1755 was merged. It could still apply without conflict but used some code from before https://github.com/apollographql/apollo-android/pull/1753