### PR TITLE
[Incubating Plugin] Gradle version tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ apply plugin: 'com.apollographql.android'
 The Android Plugin must be applied before the Apollo plugin.
 For Kotlin users, the Apollo plugin must be applied before the Kotlin plugins.
 
-**NOTE: Apollo Gradle plugin requires Gradle 5.1.1 or higher.**
+**NOTE: Apollo Gradle plugin requires Gradle 5.6 or higher.**
 
 ## Generate Code using Apollo
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.util.GradleVersion
 
 open class ApolloPlugin : Plugin<Project> {
   companion object {
@@ -224,6 +225,10 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   override fun apply(project: Project) {
+    require (GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0) {
+      "apollo-android requires Gradle version 5.6 or greater"
+    }
+
     val apolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project) as DefaultApolloExtension
     // for backward compatibility
     val apolloSourceSetExtension = (apolloExtension as ExtensionAware).extensions.create("sourceSet", ApolloSourceSetExtension::class.java, project.objects)

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleVersionTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleVersionTests.kt
@@ -1,0 +1,47 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.internal.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.junit.Assert
+import org.junit.Test
+import java.nio.file.Files
+
+class GradleVersionTests  {
+  @Test
+  fun `gradle 5-6 is working`() {
+    TestUtils.withSimpleProject { dir ->
+      val result = TestUtils.executeGradleWithVersion(dir, "5.6","generateApolloSources")
+
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `gradle below 5-6 shows an error`() {
+    TestUtils.withSimpleProject { dir ->
+      var exception: Exception? = null
+      try {
+        TestUtils.executeGradleWithVersion(dir, "5.5","generateApolloSources")
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        Assert.assertThat(e.message, CoreMatchers.containsString("apollo-android requires Gradle version 5.6 or greater"))
+      }
+      Assert.assertNotNull(exception)
+    }
+  }
+
+  @Test
+  fun `gradle 6-0 does not show warnings`() {
+    TestUtils.withSimpleProject { dir ->
+      val result = TestUtils.executeGradleWithVersion(dir, "6.0","generateApolloSources")
+
+      Assert.assertThat(result.output, not(containsString("Deprecated Gradle features were used in this build")))
+    }
+  }
+}

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -153,16 +153,25 @@ object TestUtils {
   }
 
   fun executeGradle(projectDir: File, vararg args: String): BuildResult {
+    return executeGradleWithVersion(projectDir, null, *args)
+  }
+
+  fun executeGradleWithVersion(projectDir: File, gradleVersion: String?, vararg args: String): BuildResult {
     return GradleRunner.create()
         .forwardStdOutput(System.out.writer())
         .forwardStdError(System.err.writer())
         .withProjectDir(projectDir)
         .withArguments("--stacktrace", *args)
+        .apply {
+          if (gradleVersion != null) {
+            withGradleVersion(gradleVersion)
+          }
+        }
         .build()
   }
 
   fun executeTask(task: String, projectDir: File, vararg args: String): BuildResult {
-    return executeGradle(projectDir, task, *args)
+    return executeGradleWithVersion(projectDir, null, task, *args)
   }
 
   fun assertFileContains(projectDir: File, path: String, content: String) {


### PR DESCRIPTION
Added tests to check the incubating plugin against different versions of gradle. This shows that the incubating plugin requires gradle 5.6 (compared to 5.1.1 before). Mainly to use managed properties (5.5) and `Provider.orElse` (5.6).

I would say that's ok , I don't think there's a reason to stay on 5.1.1. Unless I'm missing something ?