### PR TITLE
[Incubating plugin] Add manual schema download

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -26,6 +26,15 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
   @get:Input
   abstract val queryParameters: MapProperty<String, String>
 
+  init {
+    /**
+     * We cannot know in advance if the backend schema changed so don't cache or mark this task up-to-date
+     * This code actually redundant because the task has no output but adding it make it explicit.
+     */
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+  }
+
   @TaskAction
   fun taskAction() {
     if (!schemaFilePath.isPresent) {

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/DownloadSchemaTests.kt
@@ -89,4 +89,20 @@ class DownloadSchemaTests {
       assertEquals(content2, schemaFile.readText())
     }
   }
+
+  @Test
+  fun `manually downloading a schema is working`() {
+
+    withSimpleProject(apolloConfiguration = "") { dir ->
+      val content = "schema should be here"
+      val mockResponse = MockResponse().setBody(content)
+      mockServer.enqueue(mockResponse)
+
+      TestUtils.executeGradle(dir, "downloadApolloSchema",
+          "-Pcom.apollographql.apollo.schema=schema.json",
+          "-Pcom.apollographql.apollo.endpoint=${mockServer.url("/")}")
+
+      assertEquals(content, dir.child("schema.json").readText())
+    }
+  }
 }


### PR DESCRIPTION
Add 
```
./gradlew downloadApolloSchema -Pcom.apollographql.apollo.schema=/path/to/your/schema.json
-Pcom.apollographql.apollo.endpoint=https://your.graphq.enpoint
```

This should help users onboard by allowing them to download a schema with a simple command line.