### PR TITLE
Update RxJava docs to include Kotlin extensions

### DIFF
--- a/doc/rxjava2.md
+++ b/doc/rxjava2.md
@@ -1,7 +1,7 @@
 # RxJava2 support
 The Apollo GraphQL client comes with RxJava2 support.
 
-Apollo types can be converted to RxJava2 `Observable` *types* using wrapper functions `Rx2Apollo.from(...)`.
+Apollo types can be converted to RxJava2 `Observable` *types* using wrapper functions `Rx2Apollo.from(...)` in Java or using extension functions in Kotlin.
 
 Conversion is done according to the following table:
 
@@ -25,22 +25,33 @@ implementation 'com.apollographql.apollo:apollo-rx2-support:x.y.z'
 
 ## Usage examples
 
-### Converting `ApolloCall` to an `Observable`:
+### Converting `ApolloCall` to an `Observable`
+
+Java:
 ```java
-//Create a query object
+// Create a query object
 EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
 
-//Create an ApolloCall object
+// Create an ApolloCall object
 ApolloCall<EpisodeHeroName.Data> apolloCall = apolloClient.query(query);
 
-//RxJava1 Observable
-Observable<Response<EpisodeHeroName.Data>> observable1 = RxApollo.from(apolloCall);
-
-//RxJava2 Observable
+// RxJava2 Observable
 Observable<Response<EpisodeHeroName.Data>> observable2 = Rx2Apollo.from(apolloCall);
 ```
 
-### Converting `ApolloPrefetch` to a `Completable`:
+Kotlin:
+```kotlin
+// Create a query object
+val query = EpisodeHeroNameQuery(episode = Episode.EMPIRE.toInput())
+
+// Directly create Observable with Kotlin extension
+val observable = apolloClient.rxQuery(query)
+```
+
+
+### Converting `ApolloPrefetch` to a `Completable`
+
+Java:
 ```java
 //Create a query object
 EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build();
@@ -48,11 +59,17 @@ EpisodeHeroName query = EpisodeHeroName.builder().episode(Episode.EMPIRE).build(
 //Create an ApolloPrefetch object
 ApolloPrefetch<EpisodeHeroName.Data> apolloPrefetch = apolloClient.prefetch(query);
 
-//RxJava1 Completable
-Completable completable1 = RxApollo.from(apolloPrefetch);
-
 //RxJava2 Completable
 Completable completable2 = Rx2Apollo.from(apolloPrefetch);
+```
+
+Kotlin:
+```kotlin
+// Create a query object
+val query = EpisodeHeroNameQuery(episode = Episode.EMPIRE.toInput())
+
+// Create Observable for prefetch with Kotlin extension
+val observable = apolloClient.rxPrefetch(query)
 ```
 
 Also, don't forget to dispose of your Observer/Subscriber when you are finished:


### PR DESCRIPTION
Update RxJava docs to include Kotlin extensions

Also remove RxJava1 examples.