### PR TITLE
[Build scripts] Introduce japicmp 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,14 +6,34 @@ buildscript {
   repositories {
     maven { url = uri("https://plugins.gradle.org/m2/") }
     google()
+    jcenter()
   }
 
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.gradleErrorpronePlugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
   }
 }
+
+fun baselineJar(project: Project, version: String): File {
+  val group = project.property("GROUP")
+  val artifactId = project.property("POM_ARTIFACT_ID")
+  try {
+    val jarFile = "$artifactId-${version}.jar"
+    project.group = "virtual_group_for_japicmp" // Prevent it from resolving the current version.
+    // see https://github.com/apollographql/apollo-android/issues/1325
+    project.repositories.maven("https://dl.bintray.com/apollographql/android")
+    val dependency = project.dependencies.create("$group:$artifactId:$version@jar")
+    return project.configurations.detachedConfiguration(dependency).files
+        .first { (it.name == jarFile) }
+  } finally {
+    project.group = group!!
+  }
+}
+
+val rootJapiCmp = tasks.register("japicmp")
 
 subprojects {
   apply {
@@ -44,6 +64,24 @@ subprojects {
 
   configurations.named("errorprone") {
     resolutionStrategy.force(groovy.util.Eval.x(this@subprojects, "x.dep.errorProneCore"))
+  }
+
+  // TODO: Make this lazy
+  this@subprojects.afterEvaluate {
+    val jarTask = this@subprojects.tasks.findByName("jar") as? org.gradle.jvm.tasks.Jar
+    if (jarTask != null) {
+      val japiCmp = this@subprojects.tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
+        oldClasspath = this@subprojects.files(baselineJar(this@subprojects, "1.2.1"))
+        newClasspath = this@subprojects.files(jarTask.archiveFile)
+        ignoreMissingClasses = true
+        packageExcludes = listOf("*.internal*")
+        onlyModified = true
+        txtOutputFile = this@subprojects.file("$buildDir/reports/japi.txt")
+      }
+      rootJapiCmp.configure {
+        dependsOn(japiCmp)
+      }
+    }
   }
 
   group = property("GROUP")!!

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -51,6 +51,7 @@ ext.dep = [
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     errorProneCore        : "com.google.errorprone:error_prone_core:2.1.1",
+    gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
     gradleErrorpronePlugin: "net.ltgt.gradle:gradle-errorprone-plugin:0.0.12",
     guavaJre              : "com.google.guava:guava:$versions.guava",
     jetbrainsAnnotations  : "org.jetbrains:annotations:$versions.jetbrainsAnnotations",


### PR DESCRIPTION
While testing the incubating plugin, I realized that https://github.com/apollographql/apollo-android/pull/1759 broke some of the API compatibility by moving classes from the `com.apollographql.apollo.response` package to the `com.apollographql.apollo.api` package.

~I moved the classes back to their original packageName while still keeping them in `apollo-api` so that they are still usable for anyone depending on `apollo-runtime`~ (EDIT: this will come in a separate PR)

Introducing jcmpapi will help detect such cases more easily. This should also help with the kotlin migration (https://github.com/apollographql/apollo-android/pull/1784). 

Feedback welcome. ~If there's no objection, I'll make the build fail on API/ABI differences starting with 1.2.2 (or 1.3 whichever comes first).~

Right now, the way to run japicmp is to do it manually by running `./gradlew japicmp` from the root of the project. I'm looking into ways to automate this. Breaking the build might be a bit overeacting as we have some internal classes that are allowed to break. Also the incubating plugin will most likely break a lot of public api so we'll need to have a way to override japicmp if needed.

I created https://github.com/apollographql/apollo-android/issues/1814 to discuss this further