### PR TITLE
Provide API to serialize GraphQL operation variables as JSON string

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,7 @@
     <option name="RIGHT_MARGIN" value="140" />
     <JavaCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
+      <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
     </JavaCodeStyleSettings>
     <XML>
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -107,6 +107,16 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
     /**
      * Serializes variables as JSON string to be sent to the GraphQL server.
      *
+     * @return JSON string
+     * @throws IOException
+     */
+    public final String marshal() throws IOException {
+      return marshal(ScalarTypeAdapters.DEFAULT);
+    }
+
+    /**
+     * Serializes variables as JSON string to be sent to the GraphQL server.
+     *
      * @param scalarTypeAdapters adapters for custom GraphQL scalar types
      * @return JSON string
      * @throws IOException

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -1,5 +1,8 @@
 package com.apollographql.apollo.api;
 
+import com.apollographql.apollo.api.internal.json.InputFieldJsonWriter;
+import com.apollographql.apollo.api.internal.json.JsonWriter;
+import okio.Buffer;
 import okio.BufferedSource;
 import org.jetbrains.annotations.NotNull;
 
@@ -49,7 +52,7 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
   /**
    * Parses provided GraphQL operation raw response
    *
-   * @param source for operation raw response to parse
+   * @param source             for operation raw response to parse
    * @param scalarTypeAdapters configured instance of custom GraphQL scalar type adapters
    * @return parsed GraphQL operation {@link Response}
    */
@@ -99,6 +102,24 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
         @Override public void marshal(InputFieldWriter writer) {
         }
       };
+    }
+
+    /**
+     * Serializes variables as JSON string to be sent to the GraphQL server.
+     *
+     * @param scalarTypeAdapters adapters for custom GraphQL scalar types
+     * @return JSON string
+     * @throws IOException
+     */
+    public final String marshal(@NotNull final ScalarTypeAdapters scalarTypeAdapters) throws IOException {
+      final Buffer buffer = new Buffer();
+      final JsonWriter jsonWriter = JsonWriter.of(buffer);
+      jsonWriter.setSerializeNulls(true);
+      jsonWriter.beginObject();
+      marshaller().marshal(new InputFieldJsonWriter(jsonWriter, scalarTypeAdapters));
+      jsonWriter.endObject();
+      jsonWriter.close();
+      return buffer.readUtf8();
     }
   }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Operation.java
@@ -52,7 +52,7 @@ public interface Operation<D extends Operation.Data, T, V extends Operation.Vari
   /**
    * Parses provided GraphQL operation raw response
    *
-   * @param source             for operation raw response to parse
+   * @param source for operation raw response to parse
    * @param scalarTypeAdapters configured instance of custom GraphQL scalar type adapters
    * @return parsed GraphQL operation {@link Response}
    */

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarTypeAdapters.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarTypeAdapters.java
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -10,6 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ScalarTypeAdapters {
+  public static ScalarTypeAdapters DEFAULT = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
   private static final Map<Class, CustomTypeAdapter> DEFAULT_ADAPTERS = defaultAdapters();
   private final Map<String, CustomTypeAdapter> customAdapters;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarTypeAdapters.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/ScalarTypeAdapters.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 public final class ScalarTypeAdapters {
-  public static ScalarTypeAdapters DEFAULT = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
+  public static final ScalarTypeAdapters DEFAULT = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
   private static final Map<Class, CustomTypeAdapter> DEFAULT_ADAPTERS = defaultAdapters();
   private final Map<String, CustomTypeAdapter> customAdapters;
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriter.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.json;
+package com.apollographql.apollo.api.internal.json;
 
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
@@ -10,12 +10,10 @@ import com.apollographql.apollo.api.ScalarTypeAdapters;
 import java.io.IOException;
 import java.util.Map;
 
-import com.apollographql.apollo.api.internal.json.JsonWriter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
-import static com.apollographql.apollo.internal.json.Utils.writeToJson;
 
 public class InputFieldJsonWriter implements InputFieldWriter {
   private final JsonWriter jsonWriter;
@@ -96,7 +94,7 @@ public class InputFieldJsonWriter implements InputFieldWriter {
       } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject
           || customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
         jsonWriter.name(fieldName);
-        writeToJson(value, jsonWriter);
+        Utils.writeToJson(value, jsonWriter);
       } else {
         throw new IllegalArgumentException("Unsupported custom value type: " + customTypeValue);
       }
@@ -134,7 +132,7 @@ public class InputFieldJsonWriter implements InputFieldWriter {
       jsonWriter.name(fieldName).nullValue();
     } else {
       jsonWriter.name(fieldName);
-      writeToJson(value, jsonWriter);
+      Utils.writeToJson(value, jsonWriter);
     }
   }
 
@@ -196,7 +194,7 @@ public class InputFieldJsonWriter implements InputFieldWriter {
     }
 
     @Override public void writeMap(@Nullable Map<String, Object> value) throws IOException {
-      writeToJson(value, jsonWriter);
+      Utils.writeToJson(value, jsonWriter);
     }
 
     @SuppressWarnings("unchecked")
@@ -214,7 +212,7 @@ public class InputFieldJsonWriter implements InputFieldWriter {
           writeNumber(((CustomTypeValue.GraphQLNumber) customTypeValue).value);
         } else if (customTypeValue instanceof CustomTypeValue.GraphQLJsonObject
             || customTypeValue instanceof CustomTypeValue.GraphQLJsonList) {
-          writeToJson(value, jsonWriter);
+          Utils.writeToJson(value, jsonWriter);
         } else {
           throw new IllegalArgumentException("Unsupported custom value type: " + customTypeValue);
         }

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/JsonUtf8Writer.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/JsonUtf8Writer.java
@@ -170,6 +170,20 @@ final class JsonUtf8Writer extends JsonWriter {
     return this;
   }
 
+  @Override public JsonWriter jsonValue(String value) throws IOException {
+    if (value == null) {
+      return nullValue();
+    }
+    if (promoteValueToName) {
+      return name(value);
+    }
+    writeDeferredName();
+    beforeValue();
+    sink.writeUtf8(value);
+    pathIndices[stackSize - 1]++;
+    return this;
+  }
+
   @Override public JsonWriter nullValue() throws IOException {
     if (deferredName != null) {
       if (serializeNulls) {

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/JsonWriter.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/JsonWriter.java
@@ -275,6 +275,8 @@ public abstract class JsonWriter implements Closeable, Flushable {
    */
   public abstract JsonWriter value(@Nullable String value) throws IOException;
 
+  public abstract JsonWriter jsonValue(String value) throws IOException;
+
   /**
    * Encodes {@code null}.
    *

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/Utils.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/json/Utils.java
@@ -1,28 +1,10 @@
-package com.apollographql.apollo.internal.json;
+package com.apollographql.apollo.api.internal.json;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.apollographql.apollo.api.internal.json.JsonWriter;
-import org.jetbrains.annotations.NotNull;
-
-import okio.Buffer;
-
-import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
-
 public final class Utils {
-
-  public static String toJsonString(@NotNull Object data) throws IOException {
-    checkNotNull(data, "data == null");
-
-    Buffer buffer = new Buffer();
-    JsonWriter jsonWriter = JsonWriter.of(buffer);
-    writeToJson(data, jsonWriter);
-    jsonWriter.close();
-
-    return buffer.readUtf8();
-  }
 
   @SuppressWarnings("unchecked")
   public static void writeToJson(Object value, JsonWriter jsonWriter) throws IOException {

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.java
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.json;
+package com.apollographql.apollo.api.internal.json;
 
 import com.apollographql.apollo.api.InputFieldMarshaller;
 import com.apollographql.apollo.api.InputFieldWriter;
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.CustomTypeAdapter;
 import com.apollographql.apollo.api.CustomTypeValue;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
 
+import com.apollographql.apollo.api.internal.json.InputFieldJsonWriter;
 import com.apollographql.apollo.api.internal.json.JsonWriter;
 import org.junit.Before;
 import org.junit.Test;

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -321,15 +321,13 @@ public class IntegrationTest {
   @Test public void writeOperationRawRequest() throws Exception {
     final EpisodeHeroNameQuery query = new EpisodeHeroNameQuery(Input.fromNullable(EMPIRE));
 
-    final ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
-
     final String payload = "{" +
         "\"operationName\": " + query.name().name() + ", " +
         "\"query\": " + query.queryDocument() + ", " +
-        "\"variables\": " + query.variables().marshal(scalarTypeAdapters) +
+        "\"variables\": " + query.variables().marshal() +
         "}";
 
-    assertThat(payload).isEqualTo("{\"operationName\":\"EpisodeHeroName\",\"query\":\"query EpisodeHeroName($episode: Episode) { hero(episode: $episode) { __typename name } }\",\"variables\":{\"episode\":\"EMPIRE\"}}");
+    assertThat(payload).isEqualTo("{\"operationName\": EpisodeHeroName, \"query\": query EpisodeHeroName($episode: Episode) { hero(episode: $episode) { __typename name } }, \"variables\": {\"episode\":\"EMPIRE\"}}");
   }
 
   private MockResponse mockResponse(String fileName) throws IOException {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -318,6 +318,20 @@ public class IntegrationTest {
     );
   }
 
+  @Test public void writeOperationRawRequest() throws Exception {
+    final EpisodeHeroNameQuery query = new EpisodeHeroNameQuery(Input.fromNullable(EMPIRE));
+
+    final ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
+
+    final String payload = "{" +
+        "\"operationName\": " + query.name().name() + ", " +
+        "\"query\": " + query.queryDocument() + ", " +
+        "\"variables\": " + query.variables().marshal(scalarTypeAdapters) +
+        "}";
+
+    assertThat(payload).isEqualTo("{\"operationName\":\"EpisodeHeroName\",\"query\":\"query EpisodeHeroName($episode: Episode) { hero(episode: $episode) { __typename name } }\",\"variables\":{\"episode\":\"EMPIRE\"}}");
+  }
+
   private MockResponse mockResponse(String fileName) throws IOException {
     return new MockResponse().setChunkedBody(Utils.INSTANCE.readFileToString(getClass(), "/" + fileName), 32);
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealCacheKeyBuilder.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/cache/normalized/RealCacheKeyBuilder.java
@@ -5,7 +5,7 @@ import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.ResponseField;
 import com.apollographql.apollo.api.internal.json.JsonWriter;
 import com.apollographql.apollo.internal.json.SortedInputFieldMapWriter;
-import com.apollographql.apollo.internal.json.Utils;
+import com.apollographql.apollo.api.internal.json.Utils;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -14,7 +14,7 @@ import com.apollographql.apollo.exception.ApolloNetworkException;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.internal.ApolloLogger;
-import com.apollographql.apollo.internal.json.InputFieldJsonWriter;
+import com.apollographql.apollo.api.internal.json.InputFieldJsonWriter;
 import com.apollographql.apollo.api.internal.json.JsonWriter;
 import com.apollographql.apollo.request.RequestHeaders;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
@@ -212,9 +212,7 @@ public final class ApolloServerInterceptor implements ApolloInterceptor {
     jsonWriter.setSerializeNulls(true);
     jsonWriter.beginObject();
     jsonWriter.name("operationName").value(operation.name().name());
-    jsonWriter.name("variables").beginObject();
-    operation.variables().marshaller().marshal(new InputFieldJsonWriter(jsonWriter, scalarTypeAdapters));
-    jsonWriter.endObject();
+    jsonWriter.name("variables").jsonValue(operation.variables().marshal(scalarTypeAdapters));
     if (autoPersistQueries) {
       jsonWriter.name("extensions")
           .beginObject()

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.java
@@ -1,9 +1,8 @@
 package com.apollographql.apollo.subscription;
 
 import com.apollographql.apollo.api.Subscription;
-import com.apollographql.apollo.internal.json.InputFieldJsonWriter;
 import com.apollographql.apollo.api.internal.json.JsonWriter;
-import com.apollographql.apollo.internal.json.Utils;
+import com.apollographql.apollo.api.internal.json.Utils;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
 
 import java.io.IOException;
@@ -81,9 +80,7 @@ public abstract class OperationClientMessage {
       writer.name(JSON_KEY_TYPE).value(TYPE);
       writer.name(JSON_KEY_PAYLOAD).beginObject();
       writer.name(JSON_KEY_QUERY).value(subscription.queryDocument());
-      writer.name(JSON_KEY_VARIABLES).beginObject();
-      subscription.variables().marshaller().marshal(new InputFieldJsonWriter(writer, scalarTypeAdapters));
-      writer.endObject();
+      writer.name(JSON_KEY_VARIABLES).jsonValue(subscription.variables().marshal(scalarTypeAdapters));
       writer.name(JSON_KEY_OPERATION_NAME).value(subscription.name().name());
       writer.endObject();
     }

--- a/doc/no-runtime.md
+++ b/doc/no-runtime.md
@@ -26,12 +26,9 @@ To compose a GraphQL POST request along with operation variables to be sent to t
     // Generated GraphQL query, mutation, subscription
     final Query query = ...;
 
-    // if you have custom scalar types, provide proper instance of ScalarTypeAdapters with your own custom adapters
-    final ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
-
     final String requestPayload = "{" +
         "\"operationName\": " + query.name().name() + ", " +
         "\"query\": " + query.queryDocument() + ", " +
-        "\"variables\": " + query.variables().marshal(scalarTypeAdapters) +
+        "\"variables\": " + query.variables().marshal() +
         "}";
 ```

--- a/doc/no-runtime.md
+++ b/doc/no-runtime.md
@@ -5,7 +5,7 @@
 For this, remove the `com.apollographql.apollo:apollo-runtime`dependency and replace it with:
 
 ```
-  com.apollographql.apollo:apollo-api
+  implementation("com.apollographql.apollo:apollo-api:x.y.z")
 ```
 
 All `Operation` instances provide an API to parse `Response` from raw `okio.BufferedSource` source that represents http response body returned by the GraphQL server.
@@ -15,9 +15,23 @@ If for some reason you want to use your own network layer and don't want to use 
     okhttp3.Response httpResponse = ...;
 
     // if you have custom scalar types, provide proper instance of ScalarTypeAdapters with your own custom adapters
-    ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap())
+    ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
 
     Response<Query.Data> response = new Query().parse(httpResponse.body().source(), scalarTypeAdapters);
 ```
 
-Just make sure you added `apollo-api` dependency to your project's build.gradle file.
+To compose a GraphQL POST request along with operation variables to be sent to the server, you can use `Operation.Variables#marshal()` API: 
+
+```java
+    // Generated GraphQL query, mutation, subscription
+    final Query query = ...;
+
+    // if you have custom scalar types, provide proper instance of ScalarTypeAdapters with your own custom adapters
+    final ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap());
+
+    final String requestPayload = "{" +
+        "\"operationName\": " + query.name().name() + ", " +
+        "\"query\": " + query.queryDocument() + ", " +
+        "\"variables\": " + query.variables().marshal(scalarTypeAdapters) +
+        "}";
+```


### PR DESCRIPTION
This is the final piece  to make possible usage of Apollo generated models without runtime.

- Move supporting files to work with JSON into `apollo-api` module
- Introduce new API `Operation.Variable#marshal` to serialize variables as JSON string
- Update docs

Another step towards KN.