### PR TITLE
Add support of normalized cache to subscriptions

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Supplier.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/Supplier.java
@@ -1,0 +1,11 @@
+package com.apollographql.apollo.api.internal;
+
+public interface Supplier<T> {
+
+    /**
+     * Gets a result.
+     *
+     * @return a result
+     */
+    T get();
+}

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -67,4 +67,8 @@ configure<ApolloExtension> {
     sourceFolder.set("com/apollographql/apollo/integration/upload")
     rootPackageName.set("com.apollographql.apollo.integration.upload")
   }
+  service("subscription") {
+    sourceFolder.set("com/apollographql/apollo/integration/subscription")
+    rootPackageName.set("com.apollographql.apollo.integration.subscription")
+  }
 }

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/subscription/NewRepoCommentSubscription.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/subscription/NewRepoCommentSubscription.graphql
@@ -1,0 +1,9 @@
+subscription NewRepoCommentSubscription($repo: String!) {
+  commentAdded(repoFullName: $repo) {
+    id
+    content
+    postedBy {
+        login
+    }
+  }
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/subscription/schema.json
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/subscription/schema.json
@@ -1,0 +1,1740 @@
+{
+  "data": {
+    "__schema": {
+      "directives": [
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Skipped when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "skip"
+        },
+        {
+          "args": [
+            {
+              "defaultValue": null,
+              "description": "Included when true.",
+              "name": "if",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "name": "include"
+        },
+        {
+          "args": [
+            {
+              "defaultValue": "\"No longer supported\"",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "name": "reason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "name": "deprecated"
+        }
+      ],
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "queryType": {
+        "name": "Query"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "description": "",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The sort order for the feed",
+                  "name": "type",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "FeedType",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The number of items to skip, for pagination",
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The number of items to fetch starting from the offset, for pagination",
+                  "name": "limit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "A feed of repository submissions",
+              "isDeprecated": false,
+              "name": "feed",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "A single entry",
+              "isDeprecated": false,
+              "name": "entry",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Return the currently logged in user, or null if nobody is logged in",
+              "isDeprecated": false,
+              "name": "currentUser",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Query",
+          "possibleTypes": null
+        },
+        {
+          "description": "A list of options for the sort order of the feed",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
+              "isDeprecated": false,
+              "name": "HOT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Newest entries first",
+              "isDeprecated": false,
+              "name": "NEW"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Highest score entries first",
+              "isDeprecated": false,
+              "name": "TOP"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "FeedType",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Int",
+          "possibleTypes": null
+        },
+        {
+          "description": "Information about a GitHub repository submitted to GitHunt",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Information about the repository from GitHub",
+              "isDeprecated": false,
+              "name": "repository",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Repository",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The GitHub user who submitted this entry",
+              "isDeprecated": false,
+              "name": "postedBy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A timestamp of when the entry was submitted",
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The score of this repository, upvotes - downvotes",
+              "isDeprecated": false,
+              "name": "score",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The hot score of this repository",
+              "isDeprecated": false,
+              "name": "hotScore",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "",
+                  "name": "limit",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "",
+                  "name": "offset",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Comments posted about this repository",
+              "isDeprecated": false,
+              "name": "comments",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Comment",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of comments posted about this repository",
+              "isDeprecated": false,
+              "name": "commentCount",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The SQL ID of this entry",
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "XXX to be changed",
+              "isDeprecated": false,
+              "name": "vote",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vote",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Entry",
+          "possibleTypes": null
+        },
+        {
+          "description": "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "Just the name of the repository, e.g. GitHunt-API",
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
+              "isDeprecated": false,
+              "name": "full_name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The description of the repository",
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The link to the repository on GitHub",
+              "isDeprecated": false,
+              "name": "html_url",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of people who have starred this repository on GitHub",
+              "isDeprecated": false,
+              "name": "stargazers_count",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The number of open issues on this repository on GitHub",
+              "isDeprecated": false,
+              "name": "open_issues_count",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The owner of this repository on GitHub, e.g. apollostack",
+              "isDeprecated": false,
+              "name": "owner",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Repository",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "String",
+          "possibleTypes": null
+        },
+        {
+          "description": "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The name of the user, e.g. apollostack",
+              "isDeprecated": false,
+              "name": "login",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The URL to a directly embeddable image for this user's avatar",
+              "isDeprecated": false,
+              "name": "avatar_url",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The URL of this user's GitHub page",
+              "isDeprecated": false,
+              "name": "html_url",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "User",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Float",
+          "possibleTypes": null
+        },
+        {
+          "description": "A comment about an entry, submitted by a user",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The SQL ID of this entry",
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The GitHub user who posted the comment",
+              "isDeprecated": false,
+              "name": "postedBy",
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A timestamp of when the comment was posted",
+              "isDeprecated": false,
+              "name": "createdAt",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The text of the comment",
+              "isDeprecated": false,
+              "name": "content",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The repository which this comment is about",
+              "isDeprecated": false,
+              "name": "repoName",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Comment",
+          "possibleTypes": null
+        },
+        {
+          "description": "XXX to be removed",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "vote_value",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Vote",
+          "possibleTypes": null
+        },
+        {
+          "description": "",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Submit a new repository, returns the new submission",
+              "isDeprecated": false,
+              "name": "submitRepository",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The type of vote - UP, DOWN, or CANCEL",
+                  "name": "type",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "VoteType",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Vote on a repository submission, returns the submission that was voted on",
+              "isDeprecated": false,
+              "name": "vote",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "name": "repoFullName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": "The text content for the new comment",
+                  "name": "commentContent",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Comment on a repository, returns the new comment",
+              "isDeprecated": false,
+              "name": "submitComment",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "possibleTypes": null
+        },
+        {
+          "description": "The type of vote to record, when submitting a vote",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "UP"
+            },
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "DOWN"
+            },
+            {
+              "deprecationReason": null,
+              "description": "",
+              "isDeprecated": false,
+              "name": "CANCEL"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "VoteType",
+          "possibleTypes": null
+        },
+        {
+          "description": "",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": "",
+                  "name": "repoFullName",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Subscription fires on every comment added",
+              "isDeprecated": false,
+              "name": "commentAdded",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "possibleTypes": null
+        },
+        {
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of all types supported by this server.",
+              "isDeprecated": false,
+              "name": "types",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "The type that query operations will be rooted at.",
+              "isDeprecated": false,
+              "name": "queryType",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "isDeprecated": false,
+              "name": "mutationType",
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "isDeprecated": false,
+              "name": "subscriptionType",
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A list of all directives supported by this server.",
+              "isDeprecated": false,
+              "name": "directives",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "possibleTypes": null
+        },
+        {
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "kind",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "description": null,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "fields",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "interfaces",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "possibleTypes",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "description": null,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "enumValues",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "inputFields",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "ofType",
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__Type",
+          "possibleTypes": null
+        },
+        {
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "name": "SCALAR"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "name": "OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "name": "INTERFACE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "name": "UNION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "name": "ENUM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "name": "LIST"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "name": "NON_NULL"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "possibleTypes": null
+        },
+        {
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "enumValues": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "possibleTypes": null
+        },
+        {
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__Field",
+          "possibleTypes": null
+        },
+        {
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "type",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "isDeprecated": false,
+              "name": "defaultValue",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "possibleTypes": null
+        },
+        {
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "deprecationReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "possibleTypes": null
+        },
+        {
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "name",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "description",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "locations",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "args",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onOperation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onFragment",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": "Use `locations`.",
+              "description": null,
+              "isDeprecated": true,
+              "name": "onField",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "possibleTypes": null
+        },
+        {
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "enumValues": [
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "name": "QUERY"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "name": "MUTATION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "name": "SUBSCRIPTION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "name": "FIELD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "name": "FRAGMENT_SPREAD"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "name": "INLINE_FRAGMENT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "name": "SCHEMA"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "name": "SCALAR"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "name": "OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "name": "FIELD_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "name": "ARGUMENT_DEFINITION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "name": "INTERFACE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "name": "UNION"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "name": "ENUM"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "name": "ENUM_VALUE"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "deprecationReason": null,
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "name": "INPUT_FIELD_DEFINITION"
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "possibleTypes": null
+        }
+      ]
+    }
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IdFieldCacheKeyResolver.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IdFieldCacheKeyResolver.java
@@ -12,12 +12,22 @@ import org.jetbrains.annotations.NotNull;
 public class IdFieldCacheKeyResolver extends CacheKeyResolver {
   @NotNull @Override
   public CacheKey fromFieldRecordSet(@NotNull ResponseField field, @NotNull Map<String, Object> recordSet) {
-    return formatCacheKey((String) recordSet.get("id"));
+    Object id = recordSet.get("id");
+    if (id != null) {
+      return formatCacheKey(id.toString());
+    } else {
+      return formatCacheKey(null);
+    }
   }
 
   @NotNull @Override
   public CacheKey fromFieldArguments(@NotNull ResponseField field, @NotNull Operation.Variables variables) {
-    return formatCacheKey((String) field.resolveArgument("id", variables));
+    Object id = field.resolveArgument("id", variables);
+    if (id != null) {
+      return formatCacheKey(id.toString());
+    } else {
+      return formatCacheKey(null);
+    }
   }
 
   private CacheKey formatCacheKey(String id) {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionNormalizedCacheTest.kt
@@ -1,0 +1,275 @@
+package com.apollographql.apollo.internal.subscription
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.ApolloSubscriptionCall
+import com.apollographql.apollo.IdFieldCacheKeyResolver
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.cache.normalized.NormalizedCache
+import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.integration.subscription.NewRepoCommentSubscription
+import com.apollographql.apollo.subscription.OperationClientMessage
+import com.apollographql.apollo.subscription.OperationServerMessage
+import com.apollographql.apollo.subscription.SubscriptionTransport
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+import java.math.BigDecimal
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.TimeUnit
+
+class SubscriptionNormalizedCacheTest {
+  private lateinit var subscriptionTransportFactory: MockSubscriptionTransportFactory
+  private lateinit var apolloClient: ApolloClient
+  private lateinit var subscriptionCall: ApolloSubscriptionCall<NewRepoCommentSubscription.Data>
+  private lateinit var networkOperationData: Map<String, Any>
+
+  @Before
+  fun setUp() {
+    subscriptionTransportFactory = MockSubscriptionTransportFactory()
+    apolloClient = ApolloClient.builder()
+        .serverUrl("http://google.com")
+        .dispatcher(TrampolineExecutor())
+        .subscriptionTransportFactory(subscriptionTransportFactory)
+        .normalizedCache(LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION), IdFieldCacheKeyResolver())
+        .build()
+    subscriptionCall = apolloClient.subscribe(NewRepoCommentSubscription("repo"))
+    networkOperationData = mapOf(
+        "data" to mapOf(
+            "commentAdded" to mapOf(
+                "__typename" to "Comment",
+                "id" to BigDecimal(100),
+                "content" to "Network comment content",
+                "postedBy" to mapOf(
+                    "__typename" to "User",
+                    "login" to "user@user.com"
+                )
+            )
+        )
+    )
+  }
+
+  @Test
+  fun `when no cache policy then response not cached`() {
+    val callback = SubscriptionManagerCallbackAdapter<NewRepoCommentSubscription.Data>()
+    subscriptionCall.execute(callback)
+
+    with(subscriptionTransportFactory.callback!!) {
+      onConnected()
+      onMessage(OperationServerMessage.ConnectionAcknowledge())
+    }
+
+    val uuid = (apolloClient.subscriptionManager as RealSubscriptionManager).subscriptions.keys.first()
+    subscriptionTransportFactory.callback?.onMessage(
+        OperationServerMessage.Data(uuid.toString(), networkOperationData)
+    )
+
+    callback.response.assertResponse(
+        expectedFromCache = false,
+        expectedContent = "Network comment content"
+    )
+
+    val cacheDump = apolloClient.apolloStore().normalizedCache().dump()
+    assertThat(NormalizedCache.prettifyDump(cacheDump)).isEqualTo("""
+      OptimisticNormalizedCache {}
+      LruNormalizedCache {}
+      
+    """.trimIndent())
+  }
+
+  @Test
+  fun `when network only cache policy then response is cached`() {
+    val operation = NewRepoCommentSubscription("repo")
+    val data = NewRepoCommentSubscription.Data(
+        NewRepoCommentSubscription.CommentAdded(
+            "Comment", 100, "Cached comment content", NewRepoCommentSubscription.PostedBy("User", "user@user.com")
+        )
+    )
+    apolloClient.apolloStore().write(operation, data).execute()
+
+    val callback = SubscriptionManagerCallbackAdapter<NewRepoCommentSubscription.Data>()
+    subscriptionCall.cachePolicy(ApolloSubscriptionCall.CachePolicy.NETWORK_ONLY).execute(callback)
+
+    with(subscriptionTransportFactory.callback!!) {
+      onConnected()
+      onMessage(OperationServerMessage.ConnectionAcknowledge())
+    }
+
+    val uuid = (apolloClient.subscriptionManager as RealSubscriptionManager).subscriptions.keys.first()
+    subscriptionTransportFactory.callback?.onMessage(
+        OperationServerMessage.Data(uuid.toString(), networkOperationData)
+    )
+
+    callback.response.assertResponse(
+        expectedFromCache = false,
+        expectedContent = "Network comment content"
+    )
+
+    val cacheDump = apolloClient.apolloStore().normalizedCache().dump()
+    assertThat(NormalizedCache.prettifyDump(cacheDump)).isEqualTo("""
+      OptimisticNormalizedCache {}
+      LruNormalizedCache {
+        "100" : {
+          "__typename" : Comment
+          "id" : 100
+          "content" : Network comment content
+          "postedBy" : CacheRecordRef(100.postedBy)
+        }
+      
+        "QUERY_ROOT" : {
+          "commentAdded({"repoFullName":"repo"})" : CacheRecordRef(100)
+        }
+      
+        "100.postedBy" : {
+          "__typename" : User
+          "login" : user@user.com
+        }
+      }
+      
+    """.trimIndent())
+  }
+
+  @Test
+  fun `when cache and network policy then first response from cache next one from network`() {
+    val operation = NewRepoCommentSubscription("repo")
+    val data = NewRepoCommentSubscription.Data(
+        NewRepoCommentSubscription.CommentAdded(
+            "Comment", 100, "Cached comment content", NewRepoCommentSubscription.PostedBy("User", "user@user.com")
+        )
+    )
+    apolloClient.apolloStore().write(operation, data).execute()
+
+    val callback = SubscriptionManagerCallbackAdapter<NewRepoCommentSubscription.Data>()
+    subscriptionCall.cachePolicy(ApolloSubscriptionCall.CachePolicy.CACHE_AND_NETWORK).execute(callback)
+
+    callback.response.assertResponse(
+        expectedFromCache = true,
+        expectedContent = "Cached comment content"
+    )
+
+    subscriptionTransportFactory.callback?.onConnected()
+    subscriptionTransportFactory.callback?.onMessage(OperationServerMessage.ConnectionAcknowledge())
+
+    val uuid = (apolloClient.subscriptionManager as RealSubscriptionManager).subscriptions.keys.first()
+    subscriptionTransportFactory.callback?.onMessage(
+        OperationServerMessage.Data(uuid.toString(), networkOperationData)
+    )
+
+    callback.response.assertResponse(
+        expectedFromCache = false,
+        expectedContent = "Network comment content"
+    )
+
+    val cacheDump = apolloClient.apolloStore().normalizedCache().dump()
+    assertThat(NormalizedCache.prettifyDump(cacheDump)).isEqualTo("""
+      OptimisticNormalizedCache {}
+      LruNormalizedCache {
+        "100" : {
+          "__typename" : Comment
+          "id" : 100
+          "content" : Network comment content
+          "postedBy" : CacheRecordRef(100.postedBy)
+        }
+      
+        "QUERY_ROOT" : {
+          "commentAdded({"repoFullName":"repo"})" : CacheRecordRef(100)
+        }
+      
+        "100.postedBy" : {
+          "__typename" : User
+          "login" : user@user.com
+        }
+      }
+      
+    """.trimIndent())
+  }
+
+  private fun Response<NewRepoCommentSubscription.Data>?.assertResponse(expectedFromCache: Boolean, expectedContent: String) {
+    assertThat(this).isNotNull()
+    assertThat(this!!.fromCache()).isEqualTo(expectedFromCache)
+    assertThat(data()).isNotNull()
+    with(data()!!) {
+      assertThat(commentAdded()!!.id()).isEqualTo(100)
+      assertThat(commentAdded()!!.content()).isEqualTo(expectedContent)
+      assertThat(commentAdded()!!.postedBy()!!.login()).isEqualTo("user@user.com")
+    }
+  }
+}
+
+private class TrampolineExecutor : AbstractExecutorService() {
+  override fun shutdown() {}
+
+  override fun shutdownNow(): List<Runnable> {
+    return emptyList()
+  }
+
+  override fun isShutdown(): Boolean {
+    return false
+  }
+
+  override fun isTerminated(): Boolean {
+    return false
+  }
+
+  override fun awaitTermination(l: Long, timeUnit: TimeUnit): Boolean {
+    return false
+  }
+
+  override fun execute(runnable: Runnable) {
+    runnable.run()
+  }
+}
+
+private class MockSubscriptionTransportFactory : SubscriptionTransport.Factory {
+  var subscriptionTransport: MockSubscriptionTransport? = null
+  var callback: SubscriptionTransport.Callback? = null
+
+  override fun create(callback: SubscriptionTransport.Callback): SubscriptionTransport {
+    this.callback = callback
+    return MockSubscriptionTransport().also { subscriptionTransport = it }
+  }
+}
+
+private class MockSubscriptionTransport : SubscriptionTransport {
+  var lastSentMessage: OperationClientMessage? = null
+  var disconnectMessage: OperationClientMessage? = null
+
+  override fun connect() {
+  }
+
+  override fun disconnect(message: OperationClientMessage) {
+    disconnectMessage = message
+  }
+
+  override fun send(message: OperationClientMessage) {
+    lastSentMessage = message
+  }
+}
+
+private class SubscriptionManagerCallbackAdapter<T> : ApolloSubscriptionCall.Callback<T> {
+  var response: Response<T>? = null
+  var completed = false
+  var terminated = false
+  var connected = false
+
+  override fun onResponse(response: Response<T>) {
+    this.response = response
+  }
+
+  override fun onFailure(e: ApolloException) {
+    throw UnsupportedOperationException()
+  }
+
+  override fun onCompleted() {
+    completed = true
+  }
+
+  override fun onTerminated() {
+    terminated = true
+  }
+
+  override fun onConnected() {
+    connected = true
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
@@ -36,6 +36,14 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
   ApolloSubscriptionCall<T> clone();
 
   /**
+   * Sets the cache policy for response/request cache.
+   *
+   * @param cachePolicy {@link CachePolicy} to set
+   * @return {@link ApolloSubscriptionCall} with the provided {@link CachePolicy}
+   */
+  @NotNull ApolloSubscriptionCall<T> cachePolicy(@NotNull CachePolicy cachePolicy);
+
+  /**
    * Factory for creating {@link ApolloSubscriptionCall} calls.
    */
   interface Factory {
@@ -47,6 +55,26 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
      */
     <D extends Subscription.Data, T, V extends Subscription.Variables> ApolloSubscriptionCall<T> subscribe(
         @NotNull Subscription<D, T, V> subscription);
+  }
+
+  /**
+   * Subscription normalized cache policy.
+   */
+  enum CachePolicy {
+    /**
+     * Signals the apollo subscription client to bypass normalized cache. Fetch GraphQL response from the network only and don't cache it.
+     */
+    NO_CACHE,
+
+    /**
+     * Signals the apollo subscription client to fetch the GraphQL response from the network only and cache it to normalized cache.
+     */
+    NETWORK_ONLY,
+
+    /**
+     * Signals the apollo subscription client to first fetch the GraphQL response from the cache, then fetch it from network.
+     */
+    CACHE_AND_NETWORK
   }
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -402,7 +402,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     ResponseFetcher responseFetcher;
     CacheHeaders cacheHeaders;
     RequestHeaders requestHeaders = RequestHeaders.NONE;
-    ApolloInterceptorChain interceptorChain;
     Executor dispatcher;
     ApolloLogger logger;
     List<ApolloInterceptor> applicationInterceptors;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.internal.subscription;
 
-import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.Subscription;
 import com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener;
 import com.apollographql.apollo.subscription.SubscriptionManagerState;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
@@ -57,7 +57,7 @@ public interface SubscriptionManager {
   void stop();
 
   interface Callback<T> {
-    void onResponse(@NotNull Response<T> response);
+    void onResponse(@NotNull SubscriptionResponse<T> response);
 
     void onError(@NotNull ApolloSubscriptionException error);
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
@@ -1,0 +1,21 @@
+package com.apollographql.apollo.internal.subscription;
+
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.Subscription;
+import com.apollographql.apollo.cache.normalized.Record;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public final class SubscriptionResponse<T> {
+  @NotNull public final Subscription<?, T, ?> subscription;
+  @NotNull public final Response<T> response;
+  @NotNull public final Collection<Record> cacheRecords;
+
+  public SubscriptionResponse(@NotNull Subscription<?, T, ?> subscription, @NotNull Response<T> response,
+      @NotNull Collection<Record> cacheRecords) {
+    this.subscription = subscription;
+    this.response = response;
+    this.cacheRecords = cacheRecords;
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -47,6 +47,8 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
   public Response<W> parse(@NotNull Map<String, Object> payload) {
     checkNotNull(payload, "payload == null");
 
+    responseNormalizer.willResolveRootQuery(operation);
+
     D data = null;
     Map<String, Object> buffer = (Map<String, Object>) payload.get("data");
     if (buffer != null) {


### PR DESCRIPTION
Enable and provide new API to set subscription normalized cache policies:
- `NO_CACHE` bypass cache, don't fetch or cache from / to normalized cache
- `NETWORK_ONLY` always fetch from network but cache response to normalized cache
- `CACHE_AND_NETWORK` fetch from cache first then from network

Closes https://github.com/apollographql/apollo-android/issues/1722