### PR TITLE
[Gradle Plugin] Do not deploy to the gradle plugin portal yet 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -29,7 +29,7 @@ echo ${YELLOW}Deploying Gradle Plugin ...${CLEAR}
 echo ${YELLOW}Deploying Gradle Plugin - ${GREEN}Done!${CLEAR}
 
 echo ${YELLOW}Deploying Gradle Plugin Incubating...${CLEAR}
-./gradlew clean :apollo-gradle-plugin-incubating:bintrayUpload publishPlugins
+./gradlew clean :apollo-gradle-plugin-incubating:bintrayUpload
 echo ${YELLOW}Deploying Gradle Plugin Incubating - ${GREEN}Done!${CLEAR}
 
 echo ${YELLOW}Deploying Http Cache ...${CLEAR}


### PR DESCRIPTION
Do not deploy on the gradle plugin portal yet because:
1. credentials are not setup in travis
2. it deploys the incubating artifact while jcenter still hosts the regular plugin so the plugins would be out of sync and that's confusing.

I'll enable it again once the incubating plugin is in jcenter (maybe for 1.3.1 or so) 


