### PR TITLE
Add support for GraphQL extensions

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Response.java
@@ -1,23 +1,27 @@
 package com.apollographql.apollo.api;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableSet;
 
-/** Represents either a successful or failed response received from the GraphQL server. */
+/**
+ * Represents either a successful or failed response received from the GraphQL server.
+ */
 public final class Response<T> {
   private final Operation operation;
   private final T data;
   private final List<Error> errors;
   private Set<String> dependentKeys;
   private final boolean fromCache;
+  private final Map<String, Object> extensions;
 
   public static <T> Response.Builder<T> builder(@NotNull final Operation operation) {
     return new Builder<>(operation);
@@ -30,6 +34,7 @@ public final class Response<T> {
     dependentKeys = builder.dependentKeys != null ? unmodifiableSet(builder.dependentKeys)
         : Collections.<String>emptySet();
     fromCache = builder.fromCache;
+    extensions = builder.extensions;
   }
 
   public Operation operation() {
@@ -56,12 +61,17 @@ public final class Response<T> {
     return fromCache;
   }
 
+  @Nullable public Map<String, Object> extensions() {
+    return extensions;
+  }
+
   public Builder<T> toBuilder() {
     return new Builder<T>(operation)
         .data(data)
         .errors(errors)
         .dependentKeys(dependentKeys)
-        .fromCache(fromCache);
+        .fromCache(fromCache)
+        .extensions(extensions);
   }
 
   public static final class Builder<T> {
@@ -70,6 +80,7 @@ public final class Response<T> {
     List<Error> errors;
     Set<String> dependentKeys;
     boolean fromCache;
+    Map<String, Object> extensions;
 
     Builder(@NotNull final Operation operation) {
       this.operation = checkNotNull(operation, "operation == null");
@@ -92,6 +103,11 @@ public final class Response<T> {
 
     public Builder<T> fromCache(boolean fromCache) {
       this.fromCache = fromCache;
+      return this;
+    }
+
+    public Builder<T> extensions(Map<String, Object> extensions) {
+      this.extensions = extensions;
       return this;
     }
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.java
@@ -71,6 +71,7 @@ public final class SimpleOperationResponseParser {
     return Response.<W>builder(operation)
         .data(operation.wrapData(data))
         .errors(errors)
+        .extensions((Map<String, Object>) response.get("extensions"))
         .build();
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -330,6 +330,24 @@ public class IntegrationTest {
     assertThat(payload).isEqualTo("{\"operationName\": EpisodeHeroName, \"query\": query EpisodeHeroName($episode: Episode) { hero(episode: $episode) { __typename name } }, \"variables\": {\"episode\":\"EMPIRE\"}}");
   }
 
+  @SuppressWarnings("ConstantConditions")
+  @Test public void operationResponseParserParseResponseWithExtensions() throws Exception {
+    final Buffer source = new Buffer().readFrom(getClass().getResourceAsStream("/HeroNameResponse.json"));
+
+    final HeroNameQuery query = new HeroNameQuery();
+    final Response<HeroNameQuery.Data> response = new OperationResponseParser<>(query, query.responseFieldMapper(),
+        new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap())).parse(source);
+
+    assertThat(response.extensions().toString()).isEqualTo("{cost={requestedQueryCost=3, actualQueryCost=3, throttleStatus={maximumAvailable=1000, currentlyAvailable=997, restoreRate=50}}}");
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  @Test public void operationParseResponseWithExtensions() throws Exception {
+    final Buffer source = new Buffer().readFrom(getClass().getResourceAsStream("/HeroNameResponse.json"));
+    final Response<HeroNameQuery.Data> response = new HeroNameQuery().parse(source);
+    assertThat(response.extensions().toString()).isEqualTo("{cost={requestedQueryCost=3, actualQueryCost=3, throttleStatus={maximumAvailable=1000, currentlyAvailable=997, restoreRate=50}}}");
+  }
+
   private MockResponse mockResponse(String fileName) throws IOException {
     return new MockResponse().setChunkedBody(Utils.INSTANCE.readFileToString(getClass(), "/" + fileName), 32);
   }

--- a/apollo-integration/src/test/resources/HeroNameResponse.json
+++ b/apollo-integration/src/test/resources/HeroNameResponse.json
@@ -4,5 +4,16 @@
       "__typename": "Droid",
       "name": "R2-D2"
     }
+  },
+  "extensions": {
+    "cost": {
+      "requestedQueryCost": 3,
+      "actualQueryCost": 3,
+      "throttleStatus": {
+        "maximumAvailable": 1000,
+        "currentlyAvailable": 997,
+        "restoreRate": 50
+      }
+    }
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -72,6 +72,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
         .data(operation.wrapData(data))
         .errors(errors)
         .dependentKeys(responseNormalizer.dependentKeys())
+        .extensions((Map<String, Object>) payload.get("extensions"))
         .build();
   }
 
@@ -84,6 +85,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
 
       D data = null;
       List<Error> errors = null;
+      Map<String, Object> extensions = null;
       ResponseJsonStreamReader responseStreamReader = responseJsonStreamReader(jsonReader);
       while (responseStreamReader.hasNext()) {
         String name = responseStreamReader.nextName();
@@ -99,6 +101,12 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
           });
         } else if ("errors".equals(name)) {
           errors = readResponseErrors(responseStreamReader);
+        } else if ("extensions".equals(name)) {
+          extensions = responseStreamReader.nextObject(true, new ResponseJsonStreamReader.ObjectReader<Map<String, Object>>() {
+            @Override public Map<String, Object> read(ResponseJsonStreamReader reader) throws IOException {
+              return reader.toMap();
+            }
+          });
         } else {
           responseStreamReader.skipNext();
         }
@@ -108,6 +116,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
           .data(operation.wrapData(data))
           .errors(errors)
           .dependentKeys(responseNormalizer.dependentKeys())
+          .extensions(extensions)
           .build();
     } finally {
       if (jsonReader != null) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,22 +66,20 @@ subprojects {
     resolutionStrategy.force(groovy.util.Eval.x(this@subprojects, "x.dep.errorProneCore"))
   }
 
-  if (name != "apollo-compiler" && name != "apollo-gradle-plugin-incubating" && name != "apollo-coroutines-support") {
-    // TODO: Make this lazy
-    this@subprojects.afterEvaluate {
-      val jarTask = this@subprojects.tasks.findByName("jar") as? org.gradle.jvm.tasks.Jar
-      if (jarTask != null) {
-        val japiCmp = this@subprojects.tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
-          oldClasspath = this@subprojects.files(baselineJar(this@subprojects, "1.2.1"))
-          newClasspath = this@subprojects.files(jarTask.archiveFile)
-          ignoreMissingClasses = true
-          packageExcludes = listOf("*.internal*")
-          onlyModified = true
-          txtOutputFile = this@subprojects.file("$buildDir/reports/japi.txt")
-        }
-        rootJapiCmp.configure {
-          dependsOn(japiCmp)
-        }
+  // TODO: Make this lazy
+  this@subprojects.afterEvaluate {
+    val jarTask = this@subprojects.tasks.findByName("jar") as? org.gradle.jvm.tasks.Jar
+    if (jarTask != null) {
+      val japiCmp = this@subprojects.tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
+        oldClasspath = this@subprojects.files(baselineJar(this@subprojects, "1.2.1"))
+        newClasspath = this@subprojects.files(jarTask.archiveFile)
+        ignoreMissingClasses = true
+        packageExcludes = listOf("*.internal*")
+        onlyModified = true
+        txtOutputFile = this@subprojects.file("$buildDir/reports/japi.txt")
+      }
+      rootJapiCmp.configure {
+        dependsOn(japiCmp)
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,20 +66,22 @@ subprojects {
     resolutionStrategy.force(groovy.util.Eval.x(this@subprojects, "x.dep.errorProneCore"))
   }
 
-  // TODO: Make this lazy
-  this@subprojects.afterEvaluate {
-    val jarTask = this@subprojects.tasks.findByName("jar") as? org.gradle.jvm.tasks.Jar
-    if (jarTask != null) {
-      val japiCmp = this@subprojects.tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
-        oldClasspath = this@subprojects.files(baselineJar(this@subprojects, "1.2.1"))
-        newClasspath = this@subprojects.files(jarTask.archiveFile)
-        ignoreMissingClasses = true
-        packageExcludes = listOf("*.internal*")
-        onlyModified = true
-        txtOutputFile = this@subprojects.file("$buildDir/reports/japi.txt")
-      }
-      rootJapiCmp.configure {
-        dependsOn(japiCmp)
+  if (name != "apollo-compiler" && name != "apollo-gradle-plugin-incubating" && name != "apollo-coroutines-support") {
+    // TODO: Make this lazy
+    this@subprojects.afterEvaluate {
+      val jarTask = this@subprojects.tasks.findByName("jar") as? org.gradle.jvm.tasks.Jar
+      if (jarTask != null) {
+        val japiCmp = this@subprojects.tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
+          oldClasspath = this@subprojects.files(baselineJar(this@subprojects, "1.2.1"))
+          newClasspath = this@subprojects.files(jarTask.archiveFile)
+          ignoreMissingClasses = true
+          packageExcludes = listOf("*.internal*")
+          onlyModified = true
+          txtOutputFile = this@subprojects.file("$buildDir/reports/japi.txt")
+        }
+        rootJapiCmp.configure {
+          dependsOn(japiCmp)
+        }
       }
     }
   }


### PR DESCRIPTION
According to the spec https://github.com/graphql/graphql-spec/blob/master/spec/Section%207%20--%20Response.md#response-format response map may also contain an entry with key extensions.

Closes https://github.com/apollographql/apollo-android/issues/1771
Closes https://github.com/apollographql/apollo-android/issues/1800