### PR TITLE
Load the bintray and kotlin plugins from the root build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ buildscript {
     classpath(groovy.util.Eval.x(project, "x.dep.gradleErrorpronePlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.bintrayGradlePlugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
   }
 }
 
@@ -45,11 +47,6 @@ subprojects {
       maven { url = uri("https://plugins.gradle.org/m2/") }
       maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
       google()
-    }
-
-    dependencies {
-      classpath(groovy.util.Eval.x(project, "x.dep.bintrayGradlePlugin"))
-      classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
     }
   }
 


### PR DESCRIPTION
This fixes this error while trying to rrun `bintrayUpload`

Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'task ':apollo-api:bintrayUpload'' with class 'com.jfrog.bintray.gradle.tasks.BintrayUploadTask_Decorated' to class 'com.jfrog.bintray.gradle.tasks.BintrayUploadTask'