### PR TITLE
Add Incubating plugin doc again

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Advanced topics are available in the [doc folder](doc):
 * [doc/persisted-queries.md](doc/no-runtime.md)
 * [doc/no-runtime.md](doc/no-runtime.md) 
 * [doc/subscriptions.md](doc/subscriptions.md) 
+* [doc/incubating-plugin.md](doc/subscriptions.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Advanced topics are available in the [doc folder](doc):
 * [doc/persisted-queries.md](doc/no-runtime.md)
 * [doc/no-runtime.md](doc/no-runtime.md) 
 * [doc/subscriptions.md](doc/subscriptions.md) 
-* [doc/incubating-plugin.md](doc/subscriptions.md)
+* [doc/incubating-plugin.md](doc/incubating-plugin.md)
 
 ## License
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -89,7 +89,7 @@ apollo {
 }
 ```
 
-Read [plugin-configuration](plugin-configuration.md) for a complete description of what the different options do.
+Read [plugin-configuration](#configuration-reference) for a complete description of what the different options do.
 
 ### Kotlin DSL
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -1,0 +1,273 @@
+
+# Using the incubating plugin
+
+The incubating plugin is in the `apollo-gradle-plugin-incubating`artifact. It is a rewrite of the plugin in Kotlin to make it more maintainable and have better support for multiple services.
+
+```
+buildscript {
+    // Replace
+    // classpath("com.apollographql.apollo:apollo-gradle-plugin")
+
+    // By
+    classpath("com.apollographql.apollo:apollo-gradle-plugin-incubating")
+}
+```
+
+# Differences with the current plugin
+
+### Plugin id is now `com.apollographql.apollo`
+
+We renamed the plugin id from `com.apollographql.android` to `com.apollographql.apollo` to make it clear that the plugin works also for non Android projects. `com.apollographql.android` will be removed in a future revision.
+
+```groovy
+// Instead of
+// apply plugin: 'com.apollographql.android'
+
+// Do this
+apply plugin: 'com.apollographql.apollo'
+```
+
+### Using multiple services
+
+The plugin now requires that you specify multiple services explicitely. If you previously had the following layout:
+
+```bash
+src/main/graphql/com/github/schema.json
+src/main/graphql/com/github/GetRepositories.graphql
+src/main/graphql/com/starwars/schema.json
+src/main/graphql/com/starwars/GetHeroes.graphql
+```
+
+You will need to define 2 services:
+
+```kotlin
+apollo {
+  service("github") {
+    sourceFolder.set("com.github")
+    rootPackageName.set("com.github")
+  }
+  service("starwars") {
+    sourceFolder.set("com.starwars")
+    rootPackageName.set("com.starwars")
+  }
+}
+```
+
+### Specifying schema and graphql files location
+
+The root `schemaFilePath`, `outputPackageName` and `sourceSets.graphql` are removed and will throw an error if you try to use them. Instead you can use [CompilationUnit] to control what files the compiler will use as inputs.
+
+```groovy
+// Instead of
+// sourceSets {
+//  main.graphql.srcDirs += "/path/to/your/graphql/queries/dir"
+//}
+
+// Do this
+apollo {
+  onCompilationUnits {
+     graphqlSourceDirectorySet.srcDirs += "/path/to/your/graphql/queries/dir"
+  }
+}
+
+// Instead of
+// apollo {
+//  sourceSet {
+//    schemaFilePath = "/path/to/your/schema.json"
+//    exclude = "**/*.gql"
+//  }
+//  outputPackageName = "com.example"
+//}
+
+// Do this
+apollo {
+  onCompilationUnits {
+     schemaFile = "/path/to/your/schema.json"
+     graphqlSourceDirectorySet.exclude("**/*.gql")
+     rootPackageName = "com.example"
+  }
+}
+```
+
+Read [plugin-configuration](plugin-configuration.md) for a complete description of what the different options do.
+
+### Kotlin DSL
+
+The plugin uses gradle [Properties](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html) to support [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) and wiring tasks together.
+
+If you're using Groovy `build.gradle` build scripts it should work transparently but Kotlin `build.gradle.kts` build scripts will require you to use the [Property.set](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html#set-T-) API:
+
+```kotlin
+apollo {
+  // Instead of
+  // setGenerateKotlinModels(true)
+
+  // Do this
+  generateKotlinModels.set(true)
+}
+```
+
+Also, the classes of the plugin have been split between a [api](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api) part and an [internal](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal) one. If you were relying on fully qualified class names from your `build.gradle.kts` files, you will have to tweak them:
+
+```kotlin
+// Instead of
+// import com.apollographql.apollo.gradle.ApolloExtension
+
+// Never rely on internal classes, they might change without warning
+// import com.apollographql.apollo.gradle.internal.DefaultApolloExtension
+
+// Do this
+import com.apollographql.apollo.gradle.api.ApolloExtension
+```
+
+#  Configuration reference
+
+Apollo-Android comes with logical defaults that will work for the majority of use cases, below you will find additional configuration.
+
+## Service
+
+Apollo-Android can use several services for multiple schemas and endpoints. The schema and graphql files related to different services must be in different folders.
+
+You can configure services by calling `ApolloExtension.service(String)`:
+
+```groovy
+apollo {
+  service("github") {
+    // src/{foo}/graphql/github
+    sourceFolder.set("github")
+  }
+  service("starwars") {
+    // src/{foo}/graphql/starwars
+    sourceFolder.set("starwars")
+  }
+}
+```
+
+A service will compile all your graphql files for all variants in your project. For a simple JVM project it's usually just one variant but for android projects, you can define different queries for different variants.
+
+## CompilationUnit
+
+A CompilationUnit is a single invocation of the Apollo compiler. It's the combination of a service and a variant.
+
+## CompilerParams
+
+You can configure the Apollo compiler using [CompilerParams](src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt). `ApolloExtension`, `Service` and `CompilationUnit` all implement `CompilerParams` so you can overrride values as needed.
+
+* Default compiler parameters are taken from `ApolloExtension`
+* Compiler parameters from `Service` override the ones from `ApolloExtension`
+* Compiler parameters from `CompilerUnit` override the ones from `Service`
+
+
+```groovy
+apollo {
+  // rootPackageName is empty by default
+  service("github") {
+    rootPackageName.set("com.github")
+  }
+
+  onCompilationUnit {
+    if (variantName == "debug") {
+        // the debug variant will use the com.github.debug package
+        rootPackageName.set("com.github.debug")
+    } else {
+        // other variants will use "com.github"
+    }
+  }
+}
+```
+
+The complete list of parameters can be found in [CompilerParams](src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt):
+
+```kotlin
+  /**
+   * Whether to generate java (default) or kotlin models
+   */
+  val generateKotlinModels: Property<Boolean>
+
+  /**
+   * Whether to generate the transformed queries. Transformed queries are the queries as sent to the
+   * server. This can be useful if you need to upload a query's exact content to a server that doesn't
+   * support automatic persisted queries.
+   *
+   * The transformedQueries are written in [CompilationUnit.transformedQueriesDir]
+   */
+  val generateTransformedQueries: Property<Boolean>
+
+  /**
+   * For custom scalar types like Date, map from the GraphQL type to the jvm/kotlin type.
+   *
+   * empty by default.
+   */
+  val customTypeMapping: MapProperty<String, String>
+
+  /**
+   * The custom types code generate some warnings that might make the build fail.
+   * suppressRawTypesWarning will add the appropriate SuppressWarning annotation
+   *
+   * false by default
+   */
+  val suppressRawTypesWarning: Property<Boolean>
+
+  /**
+   * Whether to suffix your queries, etc.. with `Query`, etc..
+   *
+   * true by default
+   */
+  val useSemanticNaming: Property<Boolean>
+
+  /**
+   * The nullable value type to use. One of: annotated, apolloOptional, guavaOptional, javaOptional, inputType
+   *
+   * annotated by default
+   * only valid for java models as kotlin has nullable support
+   */
+  val nullableValueType: Property<String>
+
+  /**
+   * Whether to generate builders for java models
+   *
+   * false by default
+   * only valid for java models as kotlin has data classes
+   */
+  val generateModelBuilder: Property<Boolean>
+
+  /**
+   * Whether to use java beans getters in the models.
+   *
+   * false by default
+   * only valif for java as kotlin has properties
+   */
+  val useJavaBeansSemanticNaming: Property<Boolean>
+
+  /**
+   *
+   */
+  val generateVisitorForPolymorphicDatatypes: Property<Boolean>
+
+  /**
+   * The package name of the models is computed from their folder hierarchy like for java sources.
+   *
+   * If you want, you can prepend a custom package name here to namespace your models.
+   *
+   * The empty string by default.
+   */
+  val rootPackageName: Property<String>
+
+  /**
+   * The graphql files containing the queries.
+   *
+   * This SourceDirectorySet includes .graphql and .gql files by default.
+   *
+   * By default, it will use [Service.sourceFolder] to populate the SourceDirectorySet.
+   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   */
+  val graphqlSourceDirectorySet: SourceDirectorySet
+
+  /**
+   * The schema file
+   *
+   * By default, it will use [Service.schemaFile] to set schemaFile.
+   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   */
+  val schemaFile: RegularFileProperty
+```

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -20,10 +20,10 @@ buildscript {
 We renamed the plugin's ID from `com.apollographql.android` to `com.apollographql.apollo` to make it clear that the plugin works also for non-Android projects. `com.apollographql.android` will be removed in a future revision.
 
 ```groovy
-// Instead of
-// apply plugin: 'com.apollographql.android'
+// Replace:
+apply plugin: 'com.apollographql.android'
 
-// Do this
+// With:
 apply plugin: 'com.apollographql.apollo'
 ```
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -15,7 +15,7 @@ buildscript {
 
 # Differences with the current plugin
 
-### Plugin id is now `com.apollographql.apollo`
+### Plugin ID is now `com.apollographql.apollo`
 
 We renamed the plugin's ID from `com.apollographql.android` to `com.apollographql.apollo` to make it clear that the plugin works also for non-Android projects. `com.apollographql.android` will be removed in a future revision.
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -93,7 +93,7 @@ Read [plugin-configuration](plugin-configuration.md) for a complete description 
 
 ### Kotlin DSL
 
-The plugin uses gradle [Properties](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html) to support [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) and wiring tasks together.
+The plugin uses Gradle [Properties](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html) to support [lazy configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html) and wiring tasks together.
 
 If you're using Groovy `build.gradle` build scripts it should work transparently but Kotlin `build.gradle.kts` build scripts will require you to use the [Property.set](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html#set-T-) API:
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -53,7 +53,7 @@ apollo {
 }
 ```
 
-### Specifying schema and graphql files location
+### Specifying schema and GraphQL files location
 
 The root `schemaFilePath`, `outputPackageName` and `sourceSets.graphql` are removed and will throw an error if you try to use them. Instead you can use [CompilationUnit] to control what files the compiler will use as inputs.
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -17,7 +17,7 @@ buildscript {
 
 ### Plugin id is now `com.apollographql.apollo`
 
-We renamed the plugin id from `com.apollographql.android` to `com.apollographql.apollo` to make it clear that the plugin works also for non Android projects. `com.apollographql.android` will be removed in a future revision.
+We renamed the plugin's ID from `com.apollographql.android` to `com.apollographql.apollo` to make it clear that the plugin works also for non-Android projects. `com.apollographql.android` will be removed in a future revision.
 
 ```groovy
 // Instead of

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -43,11 +43,11 @@ You will need to define 2 services:
 ```kotlin
 apollo {
   service("github") {
-    sourceFolder.set("com.github")
+    sourceFolder.set("com/github")
     rootPackageName.set("com.github")
   }
   service("starwars") {
-    sourceFolder.set("com.starwars")
+    sourceFolder.set("com/starwars")
     rootPackageName.set("com.starwars")
   }
 }

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -6,7 +6,7 @@ The incubating plugin is in the `apollo-gradle-plugin-incubating` artifact. It i
 ```
 buildscript {
     // Replace
-    // classpath("com.apollographql.apollo:apollo-gradle-plugin")
+    classpath("com.apollographql.apollo:apollo-gradle-plugin")
 
     // By
     classpath("com.apollographql.apollo:apollo-gradle-plugin-incubating")
@@ -59,9 +59,9 @@ The root `schemaFilePath`, `outputPackageName` and `sourceSets.graphql` are remo
 
 ```groovy
 // Instead of
-// sourceSets {
-//  main.graphql.srcDirs += "/path/to/your/graphql/queries/dir"
-//}
+sourceSets {
+  main.graphql.srcDirs += "/path/to/your/graphql/queries/dir"
+}
 
 // Do this
 apollo {
@@ -71,13 +71,13 @@ apollo {
 }
 
 // Instead of
-// apollo {
-//  sourceSet {
-//    schemaFilePath = "/path/to/your/schema.json"
-//    exclude = "**/*.gql"
-//  }
-//  outputPackageName = "com.example"
-//}
+apollo {
+  sourceSet {
+    schemaFilePath = "/path/to/your/schema.json"
+    exclude = "**/*.gql"
+  }
+  outputPackageName = "com.example"
+}
 
 // Do this
 apollo {
@@ -100,7 +100,7 @@ If you're using Groovy `build.gradle` build scripts it should work transparently
 ```kotlin
 apollo {
   // Instead of
-  // setGenerateKotlinModels(true)
+  setGenerateKotlinModels(true)
 
   // Do this
   generateKotlinModels.set(true)
@@ -111,10 +111,7 @@ Also, the classes of the plugin have been split between a [api](https://github.c
 
 ```kotlin
 // Instead of
-// import com.apollographql.apollo.gradle.ApolloExtension
-
-// Never rely on internal classes, they might change without warning
-// import com.apollographql.apollo.gradle.internal.DefaultApolloExtension
+import com.apollographql.apollo.gradle.ApolloExtension
 
 // Do this
 import com.apollographql.apollo.gradle.api.ApolloExtension

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -29,7 +29,7 @@ apply plugin: 'com.apollographql.apollo'
 
 ### Using multiple services
 
-The plugin now requires that you specify multiple services explicitely. If you previously had the following layout:
+The plugin now requires that you specify multiple services explicitly. If you previously had the following layout:
 
 ```bash
 src/main/graphql/com/github/schema.json

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -31,7 +31,7 @@ apply plugin: 'com.apollographql.apollo'
 
 The plugin now requires that you specify multiple services explicitly. If you previously had the following layout:
 
-```bash
+```
 src/main/graphql/com/github/schema.json
 src/main/graphql/com/github/GetRepositories.graphql
 src/main/graphql/com/starwars/schema.json

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -119,7 +119,7 @@ import com.apollographql.apollo.gradle.api.ApolloExtension
 
 #  Configuration reference
 
-Apollo-Android comes with logical defaults that will work for the majority of use cases, below you will find additional configuration.
+Apollo-Android comes with logical defaults that will work for the majority of use cases. Below you will find additional configuration.
 
 ## Service
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -5,10 +5,10 @@ The incubating plugin is in the `apollo-gradle-plugin-incubating` artifact. It i
 
 ```
 buildscript {
-    // Replace
+    // Replace:
     classpath("com.apollographql.apollo:apollo-gradle-plugin")
 
-    // By
+    // With:
     classpath("com.apollographql.apollo:apollo-gradle-plugin-incubating")
 }
 ```
@@ -58,19 +58,19 @@ apollo {
 The root `schemaFilePath`, `outputPackageName` and `sourceSets.graphql` are removed and will throw an error if you try to use them. Instead you can use [CompilationUnit] to control what files the compiler will use as inputs.
 
 ```groovy
-// Instead of
+// Replace:
 sourceSets {
   main.graphql.srcDirs += "/path/to/your/graphql/queries/dir"
 }
 
-// Do this
+// With:
 apollo {
   onCompilationUnits {
      graphqlSourceDirectorySet.srcDirs += "/path/to/your/graphql/queries/dir"
   }
 }
 
-// Instead of
+// Replace
 apollo {
   sourceSet {
     schemaFilePath = "/path/to/your/schema.json"
@@ -79,7 +79,7 @@ apollo {
   outputPackageName = "com.example"
 }
 
-// Do this
+// With:
 apollo {
   onCompilationUnits {
      schemaFile = "/path/to/your/schema.json"
@@ -99,10 +99,10 @@ If you're using Groovy `build.gradle` build scripts it should work transparently
 
 ```kotlin
 apollo {
-  // Instead of
+  // Replace:
   setGenerateKotlinModels(true)
 
-  // Do this
+  // With:
   generateKotlinModels.set(true)
 }
 ```
@@ -110,10 +110,10 @@ apollo {
 Also, the classes of the plugin have been split between a [api](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api) part and an [internal](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal) one. If you were relying on fully qualified class names from your `build.gradle.kts` files, you will have to tweak them:
 
 ```kotlin
-// Instead of
+// Replace:
 import com.apollographql.apollo.gradle.ApolloExtension
 
-// Do this
+// With:
 import com.apollographql.apollo.gradle.api.ApolloExtension
 ```
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -107,7 +107,7 @@ apollo {
 }
 ```
 
-Also, the classes of the plugin have been split between a [api](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api) part and an [internal](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal) one. If you were relying on fully qualified class names from your `build.gradle.kts` files, you will have to tweak them:
+Also, the classes of the plugin have been split into an [api](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api) part and an [internal](https://github.com/apollographql/apollo-android/tree/4692659508242d64882b8bff11efa7dcd555dbcc/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal) one. If you were relying on fully qualified class names from your `build.gradle.kts` files, you will have to tweak them:
 
 ```kotlin
 // Replace:

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -140,7 +140,7 @@ apollo {
 }
 ```
 
-A service will compile all your graphql files for all variants in your project. For a simple JVM project it's usually just one variant but for android projects, you can define different queries for different variants.
+A service will compile all your GraphQL files for all variants in your project. For a simple JVM project it's usually just one variant but for Android projects, you can define different queries for different variants.
 
 ## CompilationUnit
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -123,7 +123,7 @@ Apollo-Android comes with logical defaults that will work for the majority of us
 
 ## Service
 
-Apollo-Android can use several services for multiple schemas and endpoints. The schema and graphql files related to different services must be in different folders.
+Apollo-Android can use several services for multiple schemas and endpoints. The schema and GraphQL files related to different services must be in different folders.
 
 You can configure services by calling `ApolloExtension.service(String)`:
 

--- a/doc/incubating-plugin.md
+++ b/doc/incubating-plugin.md
@@ -1,7 +1,7 @@
 
 # Using the incubating plugin
 
-The incubating plugin is in the `apollo-gradle-plugin-incubating`artifact. It is a rewrite of the plugin in Kotlin to make it more maintainable and have better support for multiple services.
+The incubating plugin is in the `apollo-gradle-plugin-incubating` artifact. It is a rewrite of the plugin in Kotlin to make it more maintainable and have better support for multiple services.
 
 ```
 buildscript {


### PR DESCRIPTION
Add the incubating plugin doc as advanced topic, I forgot to include it when reorganizing documentation in https://github.com/apollographql/apollo-android/pull/1768. 