### PR TITLE
[feature] Provide a way to look at query generated operation output.

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -53,6 +53,14 @@ class GraphQLCompiler {
       val transformedQueryOutput = TransformedQueryOutput(args.packageNameProvider)
       transformedQueryOutput.apply { visit(ir) }.writeTo(transformedQueriesOutputDir)
     }
+
+    args.operationOutputDir?.let { operationIdOutputDir ->
+      if (operationIdOutputDir.exists()) {
+        operationIdOutputDir.deleteRecursively()
+      }
+      val operationIdOutput = OperationOutput(args.packageNameProvider)
+      operationIdOutput.apply { visit(ir) }.writeTo(operationIdOutputDir)
+    }
   }
 
   private fun CodeGenerationIR.writeJavaFiles(context: CodeGenerationContext, outputDir: File) {
@@ -113,6 +121,8 @@ class GraphQLCompiler {
     val OUTPUT_DIRECTORY = listOf("generated", "source", "apollo", "classes")
     @JvmField
     val TRANSFORMED_QUERIES_OUTPUT_DIRECTORY = listOf("generated", "apollo", "transformedQueries")
+    @JvmField
+    val OPERATION_OUTPUT_DIRECTORY = listOf("generated", "apollo", "operationOutput")
   }
 
   data class Arguments(
@@ -123,6 +133,7 @@ class GraphQLCompiler {
       val packageNameProvider: PackageNameProvider,
       val generateKotlinModels: Boolean = false,
       val transformedQueriesOutputDir: File? = null,
+      val operationOutputDir: File? = null,
       val generateAsInternal: Boolean = false,
 
       // only if generateKotlinModels = false

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -54,12 +54,12 @@ class GraphQLCompiler {
       transformedQueryOutput.apply { visit(ir) }.writeTo(transformedQueriesOutputDir)
     }
 
-    args.operationOutputDir?.let { operationIdOutputDir ->
-      if (operationIdOutputDir.exists()) {
-        operationIdOutputDir.deleteRecursively()
+    args.operationOutputDir?.let { operationOutputDir ->
+      if (operationOutputDir.exists()) {
+        operationOutputDir.deleteRecursively()
       }
-      val operationIdOutput = OperationOutput(args.packageNameProvider)
-      operationIdOutput.apply { visit(ir) }.writeTo(operationIdOutputDir)
+      val operationOutput = OperationOutput(args.packageNameProvider)
+      operationOutput.apply { visit(ir) }.writeTo(operationOutputDir)
     }
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -58,8 +58,11 @@ class GraphQLCompiler {
       if (operationOutputDir.exists()) {
         operationOutputDir.deleteRecursively()
       }
+      val outputJsonFile = operationOutputDir.resolve("OperationOutput.json").also {
+        it.parentFile.mkdirs()
+      }
       val operationOutput = OperationOutput(args.packageNameProvider)
-      operationOutput.apply { visit(ir) }.writeTo(operationOutputDir)
+      operationOutput.apply { visit(ir) }.writeTo(outputJsonFile)
     }
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationOutput.kt
@@ -1,0 +1,41 @@
+package com.apollographql.apollo.compiler
+
+import com.apollographql.apollo.compiler.ir.CodeGenerationIR
+import com.apollographql.apollo.compiler.ir.Operation
+import com.apollographql.apollo.internal.QueryDocumentMinifier
+import java.io.File
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+
+internal class OperationOutput(val packageNameProvider: PackageNameProvider) {
+  private var operations: List<Operation> = emptyList()
+
+  fun visit(ir: CodeGenerationIR) {
+    operations = operations + ir.operations
+  }
+
+  fun writeTo(outputDir: File) {
+    if (operations.isEmpty()) return
+
+    val jsonMap = operations.fold(mapOf<String, Map<String, String>>()) { acc, it ->
+      val operationId = QueryDocumentMinifier.minify(it.sourceWithFragments).sha256()
+      val operationInfo = mapOf("name" to it.operationName, "source" to QueryDocumentMinifier.minify(it.sourceWithFragments))
+      acc.plus(
+          operationId to operationInfo
+      )
+    }
+
+    val nested = Types.newParameterizedType(Map::class.java, String::class.java, String::class.java)
+    val type = Types.newParameterizedType(Map::class.java, String::class.java, nested)
+    val moshi = Moshi.Builder().build()
+    val adapter = moshi.adapter<Map<String, Map<String, String>>>(type).indent("    ")
+    val json = adapter.toJson(jsonMap)
+
+    val filename = operations.first().filePath.substringAfterLast(File.separator)
+    val name = filename.split('.').first()
+    val outputFile = outputDir.resolve("$name.json").also {
+      it.parentFile.mkdirs()
+    }
+    outputFile.writeText(json)
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationOutput.kt
@@ -14,18 +14,11 @@ internal class OperationOutput(val packageNameProvider: PackageNameProvider) {
     operations = operations + ir.operations
   }
 
-  fun writeTo(outputDir: File) {
+  fun writeTo(outputJsonFile: File) {
     if (operations.isEmpty()) return
 
-    operations.groupBy { it.filePath }.forEach { filePath, operations ->
-      val json = toJson(operations)
-      val filename = filePath.substringAfterLast(File.separator)
-      val name = filename.split('.').first()
-      val outputFile = outputDir.resolve("$name.json").also {
-        it.parentFile.mkdirs()
-      }
-      outputFile.writeText(json)
-    }
+    val json = toJson(operations)
+    outputJsonFile.writeText(json)
   }
 
   private fun toJson(operations: List<Operation>): String {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -15,6 +15,7 @@ data class Operation(
     val fields: List<Field>,
     val filePath: String,
     val fragmentsReferenced: List<String>,
+    // NOTE: this property is never correctly set!
     val operationId: String
 
 ) : CodeGenerator {
@@ -68,3 +69,6 @@ data class Operation(
     val TYPE_SUBSCRIPTION = "subscription"
   }
 }
+
+
+

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -14,10 +14,7 @@ data class Operation(
     val sourceWithFragments: String,
     val fields: List<Field>,
     val filePath: String,
-    val fragmentsReferenced: List<String>,
-    // NOTE: this property is never correctly set!
-    val operationId: String
-
+    val fragmentsReferenced: List<String>
 ) : CodeGenerator {
 
   override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec =

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -66,6 +66,3 @@ data class Operation(
     val TYPE_SUBSCRIPTION = "subscription"
   }
 }
-
-
-

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
@@ -138,8 +138,7 @@ class GraphQLDocumentParser(val schema: Schema, private val packageNameProvider:
         sourceWithFragments = graphQLDocumentSource,
         fields = fields.result.filterNot { it.responseName == Field.TYPE_NAME_FIELD.responseName },
         fragmentsReferenced = emptyList(),
-        filePath = graphQLFilePath,
-        operationId = ""
+        filePath = graphQLFilePath
     ).also { it.checkVariableDefinitions() }
 
     return ParseResult(

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -36,4 +36,9 @@ interface CompilationUnit: CompilerParams {
    * The directory where the transformed queries will be written
    */
   val transformedQueriesDir: Provider<Directory>
+
+  /**
+   * The directory where the operation generation report will be written
+   */
+  val operationOutputDir: Provider<Directory>
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -28,6 +28,16 @@ interface CompilerParams {
   val generateTransformedQueries: Property<Boolean>
 
   /**
+   * Whether to generate the operation report. The report contains information such as
+   * operation id, name and transformed query. This can be useful if you need to upload
+   * a query's exact content to a server that doesn't support automatic persisted queries.
+   *
+   * The operation output is written in [CompilationUnit.operationOutputDir]
+   */
+  val generateOperationOutput: Property<Boolean>
+
+
+  /**
    * For custom scalar types like Date, map from the GraphQL type to the jvm/kotlin type.
    *
    * empty by default.

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -69,6 +69,10 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   @get:OutputDirectory
   abstract val transformedQueriesOutputDir: DirectoryProperty
 
+  @get:Optional
+  @get:OutputDirectory
+  abstract val operationOutputDir: DirectoryProperty
+
   @get:Input
   @get:Optional
   abstract val generateAsInternal: Property<Boolean>
@@ -111,6 +115,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes.getOrElse(false),
         packageNameProvider = packageNameProvider,
         transformedQueriesOutputDir = transformedQueriesOutputDir.orNull?.asFile,
+        operationOutputDir = operationOutputDir.orNull?.asFile,
         generateAsInternal = generateAsInternal.getOrElse(false)
     )
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -108,6 +108,7 @@ open class ApolloPlugin : Plugin<Project> {
 
           compilationUnit.outputDir.set(codegenProvider.flatMap { it.outputDir })
           compilationUnit.transformedQueriesDir.set(codegenProvider.flatMap { it.transformedQueriesOutputDir })
+          compilationUnit.operationOutputDir.set(codegenProvider.flatMap { it.operationOutputDir })
 
           apolloExtension.compilationUnits.add(compilationUnit)
         }
@@ -189,6 +190,15 @@ open class ApolloPlugin : Plugin<Project> {
           }
           disallowChanges()
         }
+        it.operationOutputDir.apply {
+          if (compilerParams.generateOperationOutput.getOrElse(false)) {
+            set(project.layout.buildDirectory.map {
+              it.dir("generated/operationOutput/apollo/${compilationUnit.variantName}/${compilationUnit.serviceName}")
+            })
+          }
+          disallowChanges()
+        }
+
         it.generateAsInternal.set(compilerParams.generateAsInternal)
         Unit
       }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -15,6 +15,7 @@ fun CompilerParams.withFallback(objects: ObjectFactory, other: CompilerParams): 
 
   merge.generateKotlinModels.set(this.generateKotlinModels.orElse(other.generateKotlinModels))
   merge.generateTransformedQueries.set(this.generateTransformedQueries.orElse(other.generateTransformedQueries))
+  merge.generateOperationOutput.set(this.generateOperationOutput.orElse(other.generateOperationOutput))
   merge.customTypeMapping.set(this.customTypeMapping.orElse(other.customTypeMapping))
   merge.suppressRawTypesWarning.set(this.suppressRawTypesWarning.orElse(other.suppressRawTypesWarning))
   merge.useSemanticNaming.set(this.useSemanticNaming.orElse(other.useSemanticNaming))

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.Project
 import org.gradle.api.file.*
+import org.gradle.api.provider.Provider
 import java.io.File
 import javax.inject.Inject
 
@@ -22,6 +23,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
 
   abstract override val outputDir: DirectoryProperty
   abstract override val transformedQueriesDir: DirectoryProperty
+  abstract override val operationOutputDir: DirectoryProperty
 
   private fun resolveSchema(graphqlSourceDirectorySet: SourceDirectorySet): File {
     if (service.schemaPath.isPresent) {

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -402,15 +402,51 @@ class ConfigurationTests {
   }
 
   @Test
+  fun `generateOperationOutput generates queries with __typename`() {
+    withSimpleProject("""
+      apollo {
+        generateOperationOutput = true
+      }
+    """.trimIndent()) { dir ->
+      val result = TestUtils.executeTask("generateApolloSources", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
+      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "DroidDetails.json")
+      assertThat(operationOutput.readText(), containsString("__typename"))
+    }
+  }
+
+  @Test
+  fun `generateOperationOutput uses same id as the query`() {
+    withSimpleProject("""
+      apollo {
+        generateOperationOutput = true
+      }
+    """.trimIndent()) { dir ->
+      val result = TestUtils.executeTask("generateApolloSources", dir)
+
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
+      val expectedOperationId = "260dd8d889c94e78b975e435300929027d0ad10ea55b63695b13894eb8cd8578"
+      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "DroidDetails.json")
+      assertThat(operationOutput.readText(), containsString(expectedOperationId))
+
+      val queryJavaFile = dir.generatedChild("main/service/com/example/DroidDetailsQuery.java")
+      assertThat(queryJavaFile.readText(), containsString(expectedOperationId))
+    }
+  }
+
+  @Test
   fun `compilation unit directory properties carry task dependencies`() {
     withSimpleProject("""
       apollo {
         generateTransformedQueries = true
+        generateOperationOutput = true
         
         onCompilationUnits { compilationUnit ->
           tasks.register("customTask" + compilationUnit.name.capitalize()) {
             inputs.dir(compilationUnit.outputDir)
             inputs.dir(compilationUnit.transformedQueriesDir)
+            inputs.dir(compilationUnit.operationOutputDir)
           }
         }
       }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -411,7 +411,7 @@ class ConfigurationTests {
       val result = TestUtils.executeTask("generateApolloSources", dir)
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "DroidDetails.json")
+      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "OperationOutput.json")
       assertThat(operationOutput.readText(), containsString("__typename"))
     }
   }
@@ -427,7 +427,7 @@ class ConfigurationTests {
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
       val expectedOperationId = "260dd8d889c94e78b975e435300929027d0ad10ea55b63695b13894eb8cd8578"
-      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "DroidDetails.json")
+      val operationOutput = dir.child("build", "generated", "operationOutput", "apollo", "main", "service", "OperationOutput.json")
       assertThat(operationOutput.readText(), containsString(expectedOperationId))
 
       val queryJavaFile = dir.generatedChild("main/service/com/example/DroidDetailsQuery.java")

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinDSLTests.kt
@@ -60,6 +60,7 @@ class KotlinDSLTests {
         customTypeMapping.set(mapOf("DateTime" to "java.util.Date"))
         generateKotlinModels.set(false)
         generateTransformedQueries.set(false)
+        generateOperationOutput.set(false)
         
         service("starwars") {
           sourceFolder.set("com/example")

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloCodegenTask.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloCodegenTask.groovy
@@ -31,6 +31,7 @@ class ApolloCodegenTask extends SourceTask {
   @Input Property<Boolean> generateKotlinModels = project.objects.property(Boolean.class)
   @Input Property<Boolean> generateVisitorForPolymorphicDatatypes = project.objects.property(Boolean.class)
   @Optional @OutputDirectory DirectoryProperty transformedQueriesOutputDir = project.objects.directoryProperty()
+  @Optional @OutputDirectory DirectoryProperty operationOutputDir = project.objects.directoryProperty()
   @Input ListProperty<String> excludeFiles = project.objects.listProperty(String.class)
   @Input Property<Boolean> generateAsInternal = project.objects.property(Boolean.class)
 
@@ -73,6 +74,7 @@ class ApolloCodegenTask extends SourceTask {
           packageNameProvider,
           generateKotlinModels.get(),
           transformedQueriesOutputDir.getOrNull()?.asFile,
+          operationOutputDir.getOrNull()?.asFile,
           generateAsInternal.get(),
           nullableValueType != null ? nullableValueType : NullableValueType.ANNOTATED,
           generateModelBuilder.get(),

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
@@ -18,6 +18,7 @@ class ApolloExtension {
   final Property<String> schemaFilePath
   final Property<String> outputPackageName
   final Property<Boolean> generateTransformedQueries
+  final Property<Boolean> generateOperationOutput
   final MapProperty<String, String> customTypeMapping
   final Property<Boolean> generateAsInternal
 
@@ -51,6 +52,9 @@ class ApolloExtension {
 
     generateTransformedQueries = project.objects.property(Boolean.class)
     generateTransformedQueries.set(false)
+
+    generateOperationOutput = project.objects.property(Boolean.class)
+    generateOperationOutput.set(false)
 
     customTypeMapping = project.objects.mapProperty(String.class, String.class)
     customTypeMapping.set(new LinkedHashMap())

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/ApolloExtension.groovy
@@ -99,6 +99,10 @@ class ApolloExtension {
     this.generateTransformedQueries.set(generateTransformedQueries)
   }
 
+  void setGenerateOperationOutput(Boolean generateOperationOutput) {
+    this.generateOperationOutput.set(generateOperationOutput)
+  }
+
   void setGenerateAsInternal(Boolean generateAsInternal) {
     this.generateAsInternal.set(generateAsInternal)
   }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -22,6 +22,12 @@ abstract class TaskConfigurator {
       transformedQueriesOutputFolder = new File(project.buildDir, Joiner.on(File.separator)
           .join(GraphQLCompiler.TRANSFORMED_QUERIES_OUTPUT_DIRECTORY + sourceSetOrVariantName)) // TODO service?
     }
+
+    File operationOutputDir = null
+    if (project.apollo.generateOperationOutput.get()) {
+      operationOutputDir = new File(project.buildDir, Joiner.on(File.separator)
+          .join(GraphQLCompiler.OPERATION_OUTPUT_DIRECTORY + sourceSetOrVariantName)) // TODO service?
+    }
     return project.tasks.create(taskName, ApolloCodegenTask) {
       source(sourceSets.collect { it.graphql })
       excludeFiles = project.apollo.sourceSet.exclude
@@ -42,6 +48,7 @@ abstract class TaskConfigurator {
       generateKotlinModels = project.apollo.generateKotlinModels
       generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
       transformedQueriesOutputDir.set(transformedQueriesOutputFolder)
+      operationOutputDir.set(operationOutputDir)
       generateAsInternal = project.apollo.generateAsInternal
     }
   }

--- a/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
+++ b/apollo-gradle-plugin/src/main/groovy/com/apollographql/apollo/gradle/TaskConfigurator.groovy
@@ -23,9 +23,9 @@ abstract class TaskConfigurator {
           .join(GraphQLCompiler.TRANSFORMED_QUERIES_OUTPUT_DIRECTORY + sourceSetOrVariantName)) // TODO service?
     }
 
-    File operationOutputDir = null
+    File operationOutputFolder = null
     if (project.apollo.generateOperationOutput.get()) {
-      operationOutputDir = new File(project.buildDir, Joiner.on(File.separator)
+      operationOutputFolder = new File(project.buildDir, Joiner.on(File.separator)
           .join(GraphQLCompiler.OPERATION_OUTPUT_DIRECTORY + sourceSetOrVariantName)) // TODO service?
     }
     return project.tasks.create(taskName, ApolloCodegenTask) {
@@ -48,7 +48,7 @@ abstract class TaskConfigurator {
       generateKotlinModels = project.apollo.generateKotlinModels
       generateVisitorForPolymorphicDatatypes = project.apollo.generateVisitorForPolymorphicDatatypes
       transformedQueriesOutputDir.set(transformedQueriesOutputFolder)
-      operationOutputDir.set(operationOutputDir)
+      operationOutputDir.set(operationOutputFolder)
       generateAsInternal = project.apollo.generateAsInternal
     }
   }

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -51,6 +51,7 @@ configure<ApolloExtension> {
       "Upload" to "com.apollographql.apollo.api.FileUpload"
   ))
   generateTransformedQueries.set(true)
+  generateOperationOutput.set(true)
   service("httpcache") {
     sourceFolder.set("com/apollographql/apollo/integration/httpcache")
     rootPackageName.set("com.apollographql.apollo.integration.httpcache")

--- a/docs/source/gradle/incubating-plugin.md
+++ b/docs/source/gradle/incubating-plugin.md
@@ -192,6 +192,15 @@ The complete list of parameters can be found in [CompilerParams](https://github.
   val generateTransformedQueries: Property<Boolean>
 
   /**
+   * Whether to generate the operation report. The report contains information such as
+   * operation id, name and transformed query. This can be useful if you need to upload
+   * a query's exact content to a server that doesn't support automatic persisted queries.
+   *
+   * The operation output is written in [CompilationUnit.operationOutputDir]
+   */
+  val generateOperationOutput: Property<Boolean>
+
+  /**
    * For custom scalar types like Date, map from the GraphQL type to the jvm/kotlin type.
    *
    * empty by default.

--- a/docs/source/gradle/plugin-configuration.md
+++ b/docs/source/gradle/plugin-configuration.md
@@ -117,3 +117,12 @@ apollo {
   generateTransformedQueries = true
 }
 ```
+
+## Query operation output
+When Apollo-Android generates your queries, it generates transforms your query by providing type hint as part of the information sent to the server. It uses this transformed query to generate an id for this operation. If you want to access this information, Apollo Gradle plugin can save them in a build directory in Json format. This can be useful if you need to upload a query's exact content to a server that doesn't support automatic persisted queries.
+
+```groovy
+apollo {
+  generateOperationOutput = true
+}
+```


### PR DESCRIPTION
The `apollo-tooling`(https://github.com/apollographql/apollo-tooling) API provides a way to generate a json file such as using `operationIdsPath`.
```json
{
  "$operation_id" : {
    "name"   : "$name",
    "source" : "$transformedQuery"
  }
}
```
Real example:
```json
{
  "8fe6f24988733e5c84d90cfcdcdc9590987654321b651d3ce35889bf5b5b477a": {
    "name": "CurrentLocation",
    "source": "query CurrentLocation {\n  currentLocation {\n    __typename\n    coordinates {\n      __typename\n      latitude\n      longitude\n    }\n    zipCode\n  }\n}"
  },
  "d11117159ca53b57bbee9c1b3cd64a3fe24a72d584f04aa1fa68eb098863edcd": {
    "name": "CurrentUser",
    "source": "query CurrentUser {\n  currentUser {\n    __typename\n    id\n    fullName\n    avatarImage {\n      __typename\n      url\n    }\n  }\n}"
  }
}
```


Currently, there is no way to access such information in a format outside of `.kt` or `.java` classes for this plugin.

TODO:
- [x] add a test