### PR TITLE
[Gradle Plugin] Remove after evaluate

### DIFF
--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilationUnit.kt
@@ -23,6 +23,11 @@ interface CompilationUnit: CompilerParams {
    */
   val variantName: String
   /**
+   * Whether this compilation Unit is for Kotlin or Java
+   */
+  val kotlin: Boolean
+
+  /**
    * If on Android, this will contain the Android Variant. It is safe to cast it to [com.android.build.gradle.api.BaseVariant]
    */
   val androidVariant: Any?

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 object AndroidTaskConfigurator {
   private fun apolloVariant(baseVariant: BaseVariant): ApolloVariant {
-    return ApolloVariant(
+    return AndroidApolloVariant(
         name = baseVariant.name,
         sourceSetNames = baseVariant.sourceSets.map { it.name }.distinct(),
         androidVariant = baseVariant
@@ -51,16 +51,17 @@ object AndroidTaskConfigurator {
     }
     return container
   }
+}
 
+class AndroidApolloVariant(name: String, sourceSetNames: List<String>, androidVariant: Any): ApolloVariant(name, sourceSetNames, androidVariant) {
   // TODO: make this lazy (https://github.com/apollographql/apollo-android/issues/1454)
-  fun registerGeneratedDirectory(
+  override fun registerGeneratedDirectory(
       project: Project,
-      androidExtension: Any,
-      compilationUnit: DefaultCompilationUnit,
+      forKotlin: Boolean,
       codegenProvider: TaskProvider<ApolloGenerateSourcesTask>
   ) {
-    val variant = compilationUnit.androidVariant as BaseVariant
-    if (compilationUnit.generateKotlinModels()) {
+    val variant = this.androidVariant as BaseVariant
+    if (forKotlin) {
       // This is apparently needed for intelliJ to find the generated files
       variant.addJavaSourceFoldersToModel(codegenProvider.get().outputDir.get().asFile)
       // Tell the kotlin compiler to compile our files

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -53,7 +53,7 @@ object AndroidTaskConfigurator {
   }
 }
 
-class AndroidApolloVariant(name: String, sourceSetNames: List<String>, androidVariant: Any): ApolloVariant(name, sourceSetNames, androidVariant) {
+class AndroidApolloVariant(name: String, sourceSetNames: List<String>, androidVariant: Any) : ApolloVariant(name, sourceSetNames, androidVariant) {
   // TODO: make this lazy (https://github.com/apollographql/apollo-android/issues/1454)
   override fun registerGeneratedDirectory(
       project: Project,
@@ -61,30 +61,20 @@ class AndroidApolloVariant(name: String, sourceSetNames: List<String>, androidVa
       codegenProvider: TaskProvider<ApolloGenerateSourcesTask>
   ) {
     val variant = this.androidVariant as BaseVariant
-    if (forKotlin) {
-      // This is apparently needed for intelliJ to find the generated files
-      variant.addJavaSourceFoldersToModel(codegenProvider.get().outputDir.get().asFile)
-      // Tell the kotlin compiler to compile our files
-      project.tasks.named("compile${variant.name.capitalize()}Kotlin").configure {
-        it.dependsOn(codegenProvider)
-        (it as KotlinCompile).source(codegenProvider.get().outputDir.asFile.get())
-      }
-    } else {
-      variant.registerJavaGeneratingTask(codegenProvider.get(), codegenProvider.get().outputDir.get().asFile)
+    variant.registerJavaGeneratingTask(codegenProvider.get(), codegenProvider.get().outputDir.get().asFile)
 
-      /**
-       * By the time we come here, the KotlinCompile task has been configured by the kotlin plugin already.
-       *
-       * Right now this is done in [org.jetbrains.kotlin.gradle.plugin.AbstractAndroidProjectHandler.configureSources].
-       *
-       * To workaround this, we're adding the java generated models folder here
-       */
-      project.tasks.matching {
-        it.name == "compile${variant.name.capitalize()}Kotlin"
-      }.configureEach{
-        it.dependsOn(codegenProvider)
-        (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
-      }
+    /**
+     * By the time we come here, the KotlinCompile task has been configured by the kotlin plugin already.
+     *
+     * Right now this is done in [org.jetbrains.kotlin.gradle.plugin.AbstractAndroidProjectHandler.configureSources].
+     *
+     * To workaround this, we're adding the java generated models folder here
+     */
+    project.tasks.matching {
+      it.name == "compile${variant.name.capitalize()}Kotlin"
+    }.configureEach {
+      it.dependsOn(codegenProvider)
+      (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -95,15 +95,12 @@ open class ApolloPlugin : Plugin<Project> {
          * services or set generateKotlinModels. Here we disable the ones that do not make sense once we
          * know the actual user configuration.
          */
-        var enabled = true
-        if (generateKotlinModels != compilationUnit.kotlin) {
-          enabled = false
-        }
-        if (!compilationUnit.service.isUserDefined && hasUserDefinedServices()) {
-          enabled = false
-        }
 
-        it.enabled = enabled
+        it.enabled = when {
+          generateKotlinModels != compilationUnit.kotlin -> false
+          !compilationUnit.service.isUserDefined && hasUserDefinedServices() -> false
+          else -> true
+        }
 
         compilationUnit.setSourcesIfNeeded(compilerParams.graphqlSourceDirectorySet, compilerParams.schemaFile)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -90,6 +90,11 @@ open class ApolloPlugin : Plugin<Project> {
 
         val generateKotlinModels = compilerParams.generateKotlinModels.getOrElse(false)
 
+        /**
+         * To avoid project.afterEvaluate, all tasks are registered before we know if the user configured
+         * services or set generateKotlinModels. Here we disable the ones that do not make sense once we
+         * know the actual user configuration.
+         */
         var enabled = true
         if (generateKotlinModels != compilationUnit.kotlin) {
           enabled = false

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.util.GradleVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
@@ -246,12 +247,13 @@ open class ApolloPlugin : Plugin<Project> {
       it.isUserDefined = false
     })
 
-    project.plugins.withType(JavaPlugin::class.java) {
-      onLanguage(project, apolloExtension, Language.Java)
-
-      JvmTaskConfigurator.getVariants(project).all { variant ->
-        onVariant(project, apolloExtension, variant)
+    project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets.all {
+      if (!languages.contains(Language.Java)) {
+        onLanguage(project, apolloExtension, Language.Java)
       }
+
+      val apolloVariant = JvmApolloVariant(it.name)
+      onVariant(project, apolloExtension, apolloVariant)
     }
 
     project.plugins.all {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -278,8 +278,6 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   private fun onService(project: Project, apolloExtension: DefaultApolloExtension, service: DefaultService) {
-    println("onService: ${service.name} - isUserDefined=${service.isUserDefined}")
-
     registerDownloadSchemaTask(project, service)
 
     if (service.isUserDefined) {
@@ -295,7 +293,6 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   private fun onVariant(project: Project, apolloExtension: DefaultApolloExtension, variant: ApolloVariant) {
-    println("onVariant: ${variant.name} - ${variant.androidVariant}")
     val taskProvider = project.tasks.register("generate${variant.name.capitalize()}ApolloSources") {
       it.group = TASK_GROUP
     }
@@ -310,8 +307,6 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   private fun onLanguage(project: Project, apolloExtension: DefaultApolloExtension, language: Language) {
-    println("onLanguage: ${language.name}")
-
     services.forEach { service ->
       variants.forEach { variant ->
         registerCodeGenTask(project, apolloExtension, variant, service, language)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloVariant.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloVariant.kt
@@ -1,6 +1,9 @@
 package com.apollographql.apollo.gradle.internal
 
-class ApolloVariant(
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+abstract class ApolloVariant(
     /**
      * The full name of the variant
      *
@@ -29,4 +32,6 @@ class ApolloVariant(
      * to BaseVariant.
      */
     val androidVariant: Any?
-)
+) {
+    abstract fun registerGeneratedDirectory(project: Project, forKotlin: Boolean, codegenProvider: TaskProvider<ApolloGenerateSourcesTask>)
+}

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -27,7 +27,12 @@ open class DefaultApolloExtension(val project: Project)
   override fun service(name: String, action: Action<DefaultService>) {
     val service = project.objects.newInstance(DefaultService::class.java, project.objects, name)
     action.execute(service)
-    services.add(service)
+    if (!services.add(service)) {
+      if (name == "service") {
+        throw IllegalArgumentException("\"service\" is a reserved service name, please use something else.")
+      }
+      throw IllegalArgumentException("a service with name \"$name\" was already registered, please use something else")
+    }
   }
 
   override val outputPackageName = project.objects.property(String::class.java)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -12,7 +12,7 @@ open class DefaultApolloExtension(val project: Project)
   /**
    * This is the input to the apollo plugin. Users will populate the services from their gradle files
    */
-  val services = mutableListOf<DefaultService>()
+  val services = project.objects.domainObjectContainer(DefaultService::class.java)
 
   /**
    * compilationUnits is meant to be consumed by other gradle plugin.

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -15,7 +15,7 @@ open class DefaultApolloExtension(val project: Project)
   val services = project.objects.domainObjectContainer(DefaultService::class.java)
 
   /**
-   * compilationUnits is meant to be consumed by other gradle plugin.
+   * compilationUnits is meant to be consumed by other gradle plugins.
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
   internal val compilationUnits = project.container(CompilationUnit::class.java)

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -11,14 +11,15 @@ abstract class DefaultCompilationUnit @Inject constructor(
     val project: Project,
     val apolloExtension: DefaultApolloExtension,
     val apolloVariant: ApolloVariant,
-    val service: DefaultService
+    val service: DefaultService,
+    override val kotlin: Boolean
 ) : CompilationUnit, CompilerParams by project.objects.newInstance(DefaultCompilerParams::class.java) {
 
   final override val androidVariant = apolloVariant.androidVariant
   final override val variantName = apolloVariant.name
   final override val serviceName = service.name
 
-  override val name = "${variantName}${serviceName.capitalize()}"
+  override val name = "${variantName}${serviceName.capitalize()}${if (kotlin) "Kotlin" else "Java"}"
 
   abstract override val outputDir: DirectoryProperty
   abstract override val transformedQueriesDir: DirectoryProperty
@@ -90,34 +91,23 @@ abstract class DefaultCompilationUnit @Inject constructor(
     }
   }
 
-  fun generateKotlinModels(): Boolean {
-    return generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(false)
-  }
-
   companion object {
     fun createDefaultCompilationUnit(
         project: Project,
         apolloExtension: DefaultApolloExtension,
         apolloVariant: ApolloVariant,
-        service: DefaultService
+        service: DefaultService,
+        kotlin: Boolean
     ): DefaultCompilationUnit {
       return project.objects.newInstance(DefaultCompilationUnit::class.java,
           project,
           apolloExtension,
           apolloVariant,
-          service
+          service,
+          kotlin
       ).apply {
         graphqlSourceDirectorySet.include("**/*.graphql", "**/*.gql")
       }
-    }
-
-    fun fromService(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant, service: DefaultService): DefaultCompilationUnit {
-      return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
-    }
-
-    fun fromFiles(project: Project, apolloExtension: DefaultApolloExtension, apolloVariant: ApolloVariant): DefaultCompilationUnit{
-      val service = project.objects.newInstance(DefaultService::class.java, project.objects, "service")
-      return createDefaultCompilationUnit(project, apolloExtension, apolloVariant, service)
     }
 
     private fun multipleSchemaError(schemaList: List<File>): String {

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -18,6 +18,8 @@ open class DefaultService @Inject constructor(val objects: ObjectFactory, val na
 
   var introspection: DefaultIntrospection? = null
 
+  var isUserDefined = true
+
   override fun introspection(configure: Action<in Introspection>) {
     val introspection = objects.newInstance(DefaultIntrospection::class.java, objects)
 

--- a/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin-incubating/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -16,8 +16,7 @@ object JvmTaskConfigurator {
 
     sourceSets.map { it.name }.forEach { name ->
       val apolloVariant = JvmApolloVariant(
-          name = name,
-          sourceSetNames = listOf(name)
+          name = name
       )
       container.add(apolloVariant)
     }
@@ -26,7 +25,7 @@ object JvmTaskConfigurator {
   }
 }
 
-class JvmApolloVariant(name: String, sourceSetNames: List<String>) : ApolloVariant(name, sourceSetNames, null) {
+class JvmApolloVariant(name: String) : ApolloVariant(name, listOf(name), null) {
   override fun registerGeneratedDirectory(project: Project, forKotlin: Boolean, codegenProvider: TaskProvider<ApolloGenerateSourcesTask>) {
     val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
     val sourceSets = javaPlugin.sourceSets

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/CacheTests.kt
@@ -25,17 +25,17 @@ class CacheTests {
       """.trimIndent())
 
       System.out.println("build the project")
-      var result = TestUtils.executeTask("generateMainServiceApolloSources", dir, "--build-cache")
+      var result = TestUtils.executeTask("generateMainServiceJavaApolloSources", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceJavaApolloSources")!!.outcome)
 
       System.out.println("delete build folder")
       dir.child("build").deleteRecursively()
 
       System.out.println("build from cache")
-      result = TestUtils.executeTask("generateMainServiceApolloSources", dir, "--build-cache")
+      result = TestUtils.executeTask("generateMainServiceJavaApolloSources", dir, "--build-cache")
 
-      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMainServiceApolloSources")!!.outcome)
+      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":generateMainServiceJavaApolloSources")!!.outcome)
     }
   }
 }

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -398,9 +398,9 @@ class ConfigurationTests {
         }
       }
     """.trimIndent()) { dir ->
-      val result = TestUtils.executeTask("customTaskMainservice", dir)
+      val result = TestUtils.executeTask("customTaskMainServiceJava", dir)
 
-      assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceJavaApolloSources")!!.outcome)
     }
   }
 

--- a/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin-incubating/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -295,15 +295,15 @@ class ConfigurationTests {
     withSimpleProject("""
       apollo {
         rootPackageName = "com.something.else"
-        service("service") {
+        service("starwars") {
           rootPackageName = "com.starwars"
         }
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/DroidDetailsQuery.java").isFile)
-      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/type/CustomType.java").isFile)
-      assertTrue(dir.generatedChild("main/service/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/DroidDetailsQuery.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/type/CustomType.java").isFile)
+      assertTrue(dir.generatedChild("main/starwars/com/starwars/com/example/fragment/SpeciesInformation.java").isFile)
     }
   }
 


### PR DESCRIPTION
Attempt at removing `project.afterEvaluate` from the plugin following a discussion with the Gradle team. The idea is to:

* register all possible tasks: `generate${apolloVariant}${service}${language}ApolloSources` regardless of what the user configured in the extension:
  * generateMainStarwarsJavaApolloSources
  * generateMainStarwarsKotlinApolloSources
  * generateDebugStarwarsJavaApolloSources
  * generateDebugServiceJavaApolloSources
  * etc...
* enable/disable the tasks during task configuration, once the `apolloExtension` has been configured and `generateKotlinModels` is known.

This is in theory harmless in terms of performance since the extra tasks are simply "registered" and  registration is very fast but the Angroid Gradle Plugin configure them all eagerly for `registerJavaGeneratingTask` so maybe it adds a bit of configuration time, not sure.