### PR TITLE
Apollo coroutines are now on jcenter

### DIFF
--- a/apollo-coroutines-support/README.md
+++ b/apollo-coroutines-support/README.md
@@ -1,14 +1,6 @@
 # Implementation
 
-To add the `apollo-coroutines-support` module to your project, first add the following maven repository to your gradle file:
-
-```groovy
-maven { 
-    url "https://dl.bintray.com/apollographql/android" 
-}
-```
-
-Then add the dependency with the latest Apollo version:
+To add the `apollo-coroutines-support` module to your project, first add the following dependency to your gradle file
 
 ```groovy
 implementation "com.apollographql.apollo:apollo-coroutines-support:$apollo_version"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ subprojects {
     val version = "1.2.1"
     val jar = "$artifact-$version.jar"
 
-    url.set("https://jcenter.bintray.com/apollographql/android/${group.replace(".", "/")}/$artifact/$version/$jar")
+    url.set("https://jcenter.bintray.com/${group.replace(".", "/")}/$artifact/$version/$jar")
     output.set(File(buildDir, "japicmp/cache/$jar"))
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ subprojects {
     val version = "1.2.1"
     val jar = "$artifact-$version.jar"
 
-    url.set("https://dl.bintray.com/apollographql/android/${group.replace(".", "/")}/$artifact/$version/$jar")
+    url.set("https://jcenter.bintray.com/apollographql/android/${group.replace(".", "/")}/$artifact/$version/$jar")
     output.set(File(buildDir, "japicmp/cache/$jar"))
   }
 

--- a/docs/source/advanced/coroutines.md
+++ b/docs/source/advanced/coroutines.md
@@ -18,13 +18,5 @@ Add the following `dependency`:
 
 [ ![apollo-coroutines-support](https://img.shields.io/bintray/v/apollographql/android/apollo-coroutines-support.svg?label=apollo-coroutines-coroutines) ](https://bintray.com/apollographql/android/apollo-coroutines-support/_latestVersion)
 ```gradle
-repositories {
-    maven {
-        // The coroutines artifact is not deployed on jcenter yet
-        // See https://github.com/apollographql/apollo-android/issues/1325
-        url = uri("http://dl.bintray.com/apollographql/android")
-    }
-}
-
 implementation 'com.apollographql.apollo:apollo-coroutines-support:x.y.z'
 ```


### PR DESCRIPTION
Remove previous references to `dl.bintray.com`