### PR TITLE
Fix a small issue with the javadoc of Input class

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/Input.java
@@ -18,7 +18,7 @@ public final class Input<V> {
   public final V value;
   public final boolean defined;
 
-  private Input(V value, boolean defined) {
+  private Input(@Nullable V value, boolean defined) {
     this.value = value;
     this.defined = defined;
   }
@@ -51,7 +51,6 @@ public final class Input<V> {
   /**
    * Creates a new {@link Input} instance that is always undefined.
    *
-   * @param value to be wrapped
    * @return a new {@link Input} instance
    */
   public static <V> Input<V> absent() {


### PR DESCRIPTION
Fix a small issue with the javadoc of Input class. It was a copy paste error. `value` is never defined in this particular function.