### PR TITLE
Generate default value for optional variables

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -149,10 +149,13 @@ private val OperationType.primaryConstructorSpec: FunSpec
         .constructorBuilder()
         .addParameters(variables.fields.map { variable ->
           val typeName = variable.type.asTypeName()
-          ParameterSpec.builder(
-              name = variable.name,
-              type = if (variable.isOptional) Input::class.asClassName().parameterizedBy(typeName) else typeName
-          ).build()
+          ParameterSpec
+              .builder(
+                  name = variable.name,
+                  type = if (variable.isOptional) Input::class.asClassName().parameterizedBy(typeName) else typeName
+              )
+              .applyIf(variable.isOptional) { defaultValue("%T.absent()", Input::class.asClassName()) }
+              .build()
         })
         .build()
   }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -35,7 +35,7 @@ import okio.BufferedSource
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 data class TestQuery(
-  val episode: Input<Episode>,
+  val episode: Input<Episode> = Input.absent(),
   val stars: Int,
   val greenValue: Double
 ) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -37,7 +37,7 @@ import okio.BufferedSource
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 data class TestQuery(
-  val episode: Input<Episode>,
+  val episode: Input<Episode> = Input.absent(),
   val includeName: Boolean,
   val friendsCount: Int,
   val listOfListOfStringArgs: List<List<String?>>

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -35,7 +35,7 @@ import okio.BufferedSource
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 data class TestQuery(
-  val episode: Input<Episode>
+  val episode: Input<Episode> = Input.absent()
 ) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -35,7 +35,7 @@ import okio.BufferedSource
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 data class TestQuery(
-  val episode: Input<Episode>
+  val episode: Input<Episode> = Input.absent()
 ) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {


### PR DESCRIPTION
In case of optional GraphQL operation variables generate default value `Input.absent()` for them.

Closes https://github.com/apollographql/apollo-android/issues/1839