### PR TITLE
Fix docs sidebar issue

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -18,7 +18,8 @@ module.exports = {
           Essentials: [
             'essentials/get-started',
             'essentials/queries',
-            'essentials/mutations'
+            'essentials/mutations',
+            'essentials/caching',
           ],
           'Gradle Plugin': [
             'gradle/incubating-plugin',
@@ -26,7 +27,6 @@ module.exports = {
           ],
           Advanced: [
             'advanced/android',
-            'advanced/caching',
             'advanced/coroutines',
             'advanced/file-upload',
             'advanced/no-runtime',

--- a/docs/source/advanced/no-runtime.md
+++ b/docs/source/advanced/no-runtime.md
@@ -2,7 +2,7 @@
 title: Using apollo without `apollo-runtime` 
 ---
 
-`apollo-runtime` and `ApolloClient` provides support for doing the network requests and interacting with the cache but you can use the generated queries withouth the runtime if you want.
+`apollo-runtime` and `ApolloClient` provides support for doing the network requests and interacting with the cache but you can use the generated queries without the runtime if you want.
 
 For this, remove the `com.apollographql.apollo:apollo-runtime`dependency and replace it with:
 


### PR DESCRIPTION
Caching doc is under essentials.

In fact in the website, it was missing under `Advanced`. That is probably because of the broken link. Normally, CI blocks the PR if there are broken links. It looks like that is only for the actual content