### PR TITLE
More clear project name for composite build

### DIFF
--- a/composite/settings.gradle.kts
+++ b/composite/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "composite"
+rootProject.name = "apollo-composite"
 
 include(":java-sample")
 project(":java-sample").projectDir = file("../samples/java-sample")


### PR DESCRIPTION
Prefix composite project name with apollo

This name appears in IntelliJ / AS dashboard. Composite is too generic. This will make it look like `apollo-composite`