### PR TITLE
Singularization fixes

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Inflector.kt
@@ -5,7 +5,7 @@ import java.util.regex.Pattern
 /**
  * Various string transformation utilities. Transforms singular words to plural and folder paths to packages
  *
- * The singularization methods were heavily based off rogueweb <link> https://code.google.com/archive/p/rogueweb/source</link>
+ * The singularization methods were heavily based off ruby on rails <link>https://github.com/rails/rails/blob/master/activesupport/lib/active_support/inflections.rb</link>
  */
 
 fun String.singularize(): String {
@@ -14,63 +14,68 @@ fun String.singularize(): String {
   if (exclude.contains(this.toLowerCase())) return this
 
   val capitalized = first().isUpperCase()
-  val irregular = irregular().firstOrNull { this.toLowerCase() == it.component2() }
+  val irregular = irregular.firstOrNull { this.toLowerCase() == it.component2() }
   if (irregular != null) return irregular.component1().let {
     if (capitalized) it.capitalize() else it
   }
 
-  if (singularizationRules().find { match(it.component1(), this) } == null) return this
+  val rule = singularizationRules.lastOrNull { it.component1().matcher(this).find() }
+  if (rule != null) {
+    return rule.component1().matcher(this).replaceAll(rule.component2())
+  }
 
-  val rule = singularizationRules().last { match(it.component1(), this) }
-  return Pattern.compile(rule.component1(), Pattern.CASE_INSENSITIVE).matcher(this).replaceAll(rule.component2())
+  return this
 }
 
-private fun singularizationRules(): List<Pair<String, String>> {
-  return listOf(
-      "s$" to "",
-      "(s|si|u)s$" to "$1s",
-      "(n)ews$" to "$1ews",
-      "([ti])a$" to "$1um",
-      "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$" to "$1$2sis",
-      "(^analy)ses$" to "$1sis",
-      "(^analy)sis$" to "$1sis",
-      "([^f])ves$" to "$1fe",
-      "(hive)s$" to "$1",
-      "(tive)s$" to "$1",
-      "([lr])ves$" to "$1f",
-      "([^aeiouy]|qu)ies$" to "$1y",
-      "(s)eries$" to "$1eries",
-      "(m)ovies$" to "$1ovie",
-      "(x|ch|ss|sh)es$" to "$1",
-      "([m|l])ice$" to "$1ouse",
-      "(bus)es$" to "$1",
-      "(o)es$" to "$1",
-      "(shoe)s$" to "$1",
-      "(cris|ax|test)is$" to "$1is",
-      "(cris|ax|test)es$" to "$1is",
-      "(octop|vir)i$" to "$1us",
-      "(octop|vir)us$" to "$1us",
-      "(alias|status)es$" to "$1",
-      "(alias|status)$" to "$1",
-      "^(ox)en" to "$1",
-      "(vert|ind)ices$" to "$1ex",
-      "(matr)ices$" to "$1ix",
-      "(quiz)zes$" to "$1")
-}
+private val singularizationRules = listOf(
+    "s$" to "",
+    "(ss)$" to "$1",
+    "([ti])a$" to "$1um",
+    "(^analy)(sis|ses)$" to "$1sis",
+    "([^f])ves$" to "$1fe",
+    "(hive)s$" to "$1",
+    "(tive)s$" to "$1",
+    "([lr])ves$" to "$1f",
+    "([^aeiouy]|qu)ies$" to "$1y",
+    "(s)eries$" to "$1eries",
+    "(m)ovies$" to "$1ovie",
+    "(x|ch|ss|sh)es$" to "$1",
+    "^(m|l)ice$" to "$1ouse",
+    "(bus)(es)?$" to "$1",
+    "(o)es$" to "$1",
+    "(shoe)s$" to "$1",
+    "(cris|test)(is|es)$" to "$1is",
+    "^(a)x[ie]s$" to "$1xis",
+    "(octop|vir)(us|i)$" to "$1us",
+    "(alias|status)(es)?$" to "$1",
+    "^(ox)en/$" to "$1",
+    "(vert|ind)ices$" to "$1ex",
+    "(matr)ices$" to "$1ix",
+    "(quiz)zes$" to "$1",
+    "(database)s$" to "$1"
+).map { Pattern.compile(it.first, Pattern.CASE_INSENSITIVE) to it.second }
 
-private fun irregular(): List<Pair<String, String>> {
-  return listOf(
-      "person" to "people",
-      "man" to "men",
-      "goose" to "geese",
-      "child" to "children",
-      "sex" to "sexes",
-      "move" to "moves")
-}
+private val irregular = listOf(
+    "person" to "people",
+    "man" to "men",
+    "child" to "children",
+    "sex" to "sexes",
+    "move" to "moves",
+    "zombie" to "zombies",
+    "goose" to "geese"
+)
 
-private val uncountable = listOf("equipment", "information", "rice", "money", "species", "series", "fish", "sheep")
+private val uncountable = listOf(
+    "equipment",
+    "information",
+    "rice",
+    "money",
+    "species",
+    "series",
+    "fish",
+    "sheep",
+    "jeans",
+    "police"
+)
+
 private val exclude = listOf("data")
-
-private fun match(pattern: String, word: String): Boolean {
-  return Pattern.compile(pattern, Pattern.CASE_INSENSITIVE).matcher(word).find()
-}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
@@ -84,6 +84,7 @@ private fun Field.`object`(context: Context): ObjectType.Field {
       fragmentSpreads = fragmentSpreads,
       inlineFragments = inlineFragments,
       fields = fields,
+      singularize = false,
       kind = ObjectType.Kind.Object
   )
   return ObjectType.Field(

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -117,7 +117,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     }
   }
 
-  data class AllStarship(
+  data class AllStarships1(
     val __typename: String,
     /**
      * A list of edges.
@@ -139,7 +139,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AllStarship {
+      operator fun invoke(reader: ResponseReader): AllStarships1 {
         val __typename = reader.readString(RESPONSE_FIELDS[0])
         val edges = reader.readList<Edge>(RESPONSE_FIELDS[1]) {
           it.readObject<Edge> { reader ->
@@ -147,7 +147,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           }
 
         }
-        return AllStarship(
+        return AllStarships1(
           __typename = __typename,
           edges = edges
         )
@@ -156,7 +156,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
   }
 
   data class Data(
-    val allStarships: AllStarship?
+    val allStarships: AllStarships1?
   ) : Operation.Data {
     override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
       it.writeObject(RESPONSE_FIELDS[0], allStarships?.marshaller())
@@ -169,8 +169,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
 
       operator fun invoke(reader: ResponseReader): Data {
-        val allStarships = reader.readObject<AllStarship>(RESPONSE_FIELDS[0]) { reader ->
-          AllStarship(reader)
+        val allStarships = reader.readObject<AllStarships1>(RESPONSE_FIELDS[0]) { reader ->
+          AllStarships1(reader)
         }
 
         return Data(


### PR DESCRIPTION
Picking up where #1880 left off…

Since updating to the kotlin codegen, we've run into lots of issues with bizarre singularization in our project. Examples include Pies -> Py, Ctas -> Ctum, and Slice -> Slouses. Another user opened an issue to report this problem a while back: #1686.

This PR addresses this issue in 2 ways, neither of which are guaranteed to work for all cases. For our project, all 3 instances of bad singularization have been fixed by this PR. Two were fixed by disabling singularization on non-arrays and one was fixed by updating the singularization rules.

1) Singularization was disabled for everything that is not an element of an array. It seems like it was a bug that these classes were ever singularized in the first place.
2) Singularization rules were synced from ruby on rails's inflector, which seems to be where the rules in this project came from in the first place (via rogueweb).

Note: While I was working on Inflector.kt, I also did some minor optimizations. Now arrays will only be created once and each regex will only be compiled once.
