### PR TITLE
Allow nested classes to have the same name as their parents in kotlin

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.compiler.ast.builder
 
-import com.apollographql.apollo.compiler.applyIf
 import com.apollographql.apollo.compiler.ast.CustomTypes
 import com.apollographql.apollo.compiler.ast.EnumType
 import com.apollographql.apollo.compiler.ast.ObjectType
@@ -12,7 +11,6 @@ import com.apollographql.apollo.compiler.ir.InlineFragment
 import com.apollographql.apollo.compiler.singularize
 
 internal class Context(
-    reservedObjectTypeRef: TypeRef?,
     val customTypeMap: CustomTypes,
     val enums: List<EnumType>,
     val typesPackageName: String,
@@ -21,9 +19,7 @@ internal class Context(
     private val objectTypeContainer: MutableMap<TypeRef, ObjectType> = LinkedHashMap()
 ) : Map<TypeRef, ObjectType> by objectTypeContainer {
 
-  private val reservedObjectTypeRefs = HashSet<TypeRef>().applyIf(reservedObjectTypeRef != null) {
-    add(reservedObjectTypeRef!!)
-  }
+  private val reservedObjectTypeRefs = HashSet<TypeRef>()
 
   fun registerObjectType(
       name: String,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
@@ -26,7 +26,6 @@ internal fun CodeGenerationIR.ast(
   val fragments = fragments.map {
     it.ast(
         Context(
-            reservedObjectTypeRef = null,
             customTypeMap = customTypeMap,
             enums = enums,
             typesPackageName = typesPackageName,
@@ -39,8 +38,6 @@ internal fun CodeGenerationIR.ast(
     operation.ast(
         operationClassName = operation.normalizedOperationName(useSemanticNaming).capitalize(),
         context = Context(
-            reservedObjectTypeRef = TypeRef(
-                name = operation.normalizedOperationName(useSemanticNaming).capitalize()),
             customTypeMap = customTypeMap,
             enums = enums,
             typesPackageName = typesPackageName,

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -117,7 +117,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     }
   }
 
-  data class AllStarships1(
+  data class AllStarships(
     val __typename: String,
     /**
      * A list of edges.
@@ -139,7 +139,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AllStarships1 {
+      operator fun invoke(reader: ResponseReader): AllStarships {
         val __typename = reader.readString(RESPONSE_FIELDS[0])
         val edges = reader.readList<Edge>(RESPONSE_FIELDS[1]) {
           it.readObject<Edge> { reader ->
@@ -147,7 +147,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           }
 
         }
-        return AllStarships1(
+        return AllStarships(
           __typename = __typename,
           edges = edges
         )
@@ -156,7 +156,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
   }
 
   data class Data(
-    val allStarships: AllStarships1?
+    val allStarships: AllStarships?
   ) : Operation.Data {
     override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
       it.writeObject(RESPONSE_FIELDS[0], allStarships?.marshaller())
@@ -169,8 +169,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
 
       operator fun invoke(reader: ResponseReader): Data {
-        val allStarships = reader.readObject<AllStarships1>(RESPONSE_FIELDS[0]) { reader ->
-          AllStarships1(reader)
+        val allStarships = reader.readObject<AllStarships>(RESPONSE_FIELDS[0]) { reader ->
+          AllStarships(reader)
         }
 
         return Data(

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -236,7 +236,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
-  data class HeroDetailQuery1(
+  data class HeroDetailQuery(
     val __typename: String,
     /**
      * The name of the character
@@ -269,7 +269,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forInlineFragment("__typename", "__typename", listOf("Human"))
           )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailQuery1 {
+      operator fun invoke(reader: ResponseReader): HeroDetailQuery {
         val __typename = reader.readString(RESPONSE_FIELDS[0])
         val name = reader.readString(RESPONSE_FIELDS[1])
         val friends = reader.readList<Friend2>(RESPONSE_FIELDS[2]) {
@@ -285,7 +285,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           }
         }
 
-        return HeroDetailQuery1(
+        return HeroDetailQuery(
           __typename = __typename,
           name = name,
           friends = friends,
@@ -296,7 +296,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
   }
 
   data class Data(
-    val heroDetailQuery: HeroDetailQuery1?
+    val heroDetailQuery: HeroDetailQuery?
   ) : Operation.Data {
     override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
       it.writeObject(RESPONSE_FIELDS[0], heroDetailQuery?.marshaller())
@@ -308,8 +308,8 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
 
       operator fun invoke(reader: ResponseReader): Data {
-        val heroDetailQuery = reader.readObject<HeroDetailQuery1>(RESPONSE_FIELDS[0]) { reader ->
-          HeroDetailQuery1(reader)
+        val heroDetailQuery = reader.readObject<HeroDetailQuery>(RESPONSE_FIELDS[0]) { reader ->
+          HeroDetailQuery(reader)
         }
 
         return Data(


### PR DESCRIPTION
As discussed in #1888, it makes sense to allow nested class with the same name as their parent class in Kotlin. This makes generated classes slightly nicer and should be merged in for 1.3.0 (see checklist in #1889).

Note: This PR does not alter how Java code is generated, as nested classes can not have the same name as their parents in Java.