### PR TITLE
Bump version to 1.3.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=1.2.3-SNAPSHOT
+VERSION_NAME=1.3.0-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     androidPlugin         : '3.4.2',
-    apollo                : '1.2.3-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
+    apollo                : '1.3.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     bintray               : '1.8.4',
     cache                 : '2.0.2',


### PR DESCRIPTION
Bump master to 1.3.0-SNAPSHOT, See https://github.com/apollographql/apollo-android/issues/1889

To keep 1.2.x alive, there's a release branch for hotfixes: https://github.com/apollographql/apollo-android/tree/hotfix/1.2.3

