### PR TITLE
Use the correct OperationIdGenerator for OperationOutput

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -54,7 +54,7 @@ class GraphQLCompiler {
       val dir = operationOutputFile.parentFile
       dir.mkdirs()
 
-      val operationOutput = OperationOutputWriter(args.packageNameProvider)
+      val operationOutput = OperationOutputWriter(args.operationIdGenerator)
       operationOutput.apply { visit(ir) }.writeTo(operationOutputFile)
     }
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationIdGenerator.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationIdGenerator.kt
@@ -30,7 +30,7 @@ interface OperationIdGenerator {
       return operationDocument.sha256()
     }
 
-    override val version = "1.0"
+    override val version = "sha256-1.0"
 
     private fun String.sha256(): String {
       val bytes = toByteArray(charset = StandardCharsets.UTF_8)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationIdGenerator.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationIdGenerator.kt
@@ -1,5 +1,8 @@
 package com.apollographql.apollo.compiler
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
 interface OperationIdGenerator {
   fun apply(
       /**
@@ -22,11 +25,18 @@ interface OperationIdGenerator {
    */
   val version: String
 
-  class Sha256: OperationIdGenerator {
+  class Sha256 : OperationIdGenerator {
     override fun apply(operationDocument: String, operationFilepath: String): String {
       return operationDocument.sha256()
     }
 
     override val version = "1.0"
+
+    private fun String.sha256(): String {
+      val bytes = toByteArray(charset = StandardCharsets.UTF_8)
+      val md = MessageDigest.getInstance("SHA-256")
+      val digest = md.digest(bytes)
+      return digest.fold("") { str, it -> str + "%02x".format(it) }
+    }
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Util.kt
@@ -507,13 +507,6 @@ fun Number.castTo(type: TypeName): Number {
   }
 }
 
-fun String.sha256(): String {
-  val bytes = toByteArray(charset = StandardCharsets.UTF_8)
-  val md = MessageDigest.getInstance("SHA-256")
-  val digest = md.digest(bytes)
-  return digest.fold("") { str, it -> str + "%02x".format(it) }
-}
-
 internal inline fun <T> T.applyIf(condition: Boolean, block: T.() -> Unit): T = if (condition) apply(block) else this
 
 object Util {


### PR DESCRIPTION
Use the correct OperationIdGenerator for OperationOutput

Since only used in single place, move sha256 implementation and make it private