### PR TITLE
Do not take into account sources set on ApolloExtension or Service for Test variants

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -99,10 +99,14 @@ interface CompilerParams {
   /**
    * The graphql files containing the queries.
    *
-   * This SourceDirectorySet includes .graphql and .gql files by default.
+   * By default, the plugin will use [Service.sourceFolder] to populate the graphqlSourceDirectorySet.
    *
-   * By default, it will use [Service.sourceFolder] to populate the SourceDirectorySet.
-   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   * You can override the default behaviour in either [ApolloExtension], [Service] or [CompilationUnit] by adding directories to graphqlSourceDirectorySet.
+   * If you override the default behaviour, you're responsible of setting the includes and excludes accordingly. Typically, you would
+   * set graphqlSourceDirectorySet.include("**&#47;*.graphql")
+   *
+   * Directories set on [ApolloExtension.graphqlSourceDirectorySet] or [Service.graphqlSourceDirectorySet] will not be used for test
+   * variants as that would produce duplicate classes since the exact same files would be compiled for the main variants.
    */
   val graphqlSourceDirectorySet: SourceDirectorySet
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidTaskConfigurator.kt
@@ -10,11 +10,12 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 object AndroidTaskConfigurator {
-  private fun apolloVariant(baseVariant: BaseVariant): ApolloVariant {
+  private fun apolloVariant(baseVariant: BaseVariant, isTest: Boolean): ApolloVariant {
     return ApolloVariant(
         name = baseVariant.name,
         sourceSetNames = baseVariant.sourceSets.map { it.name }.distinct(),
-        androidVariant = baseVariant
+        androidVariant = baseVariant,
+        isTest = isTest
     )
   }
 
@@ -24,24 +25,24 @@ object AndroidTaskConfigurator {
     when (androidExtension) {
       is LibraryExtension -> {
         androidExtension.libraryVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, false))
         }
         androidExtension.testVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, true))
         }
         androidExtension.unitTestVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, true))
         }
       }
       is AppExtension -> {
         androidExtension.applicationVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, false))
         }
         androidExtension.testVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, true))
         }
         androidExtension.unitTestVariants.all { variant ->
-          container.add(apolloVariant(variant))
+          container.add(apolloVariant(variant, true))
         }
       }
       else -> {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -166,9 +166,9 @@ open class ApolloPlugin : Plugin<Project> {
         }
         compilationUnit.setSourcesIfNeeded(graphqlSourceDirectorySet, compilerParams.schemaFile)
 
-        it.graphqlFiles.setFrom(compilerParams.graphqlSourceDirectorySet)
+        it.graphqlFiles.setFrom(graphqlSourceDirectorySet)
         // I'm not sure if gradle is sensitive to the order of the rootFolders. Sort them just in case.
-        it.rootFolders.set(project.provider { compilerParams.graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.sorted() })
+        it.rootFolders.set(project.provider { graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.sorted() })
         it.schemaFile.set(compilerParams.schemaFile)
 
         it.nullableValueType.set(compilerParams.nullableValueType)

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -159,7 +159,12 @@ open class ApolloPlugin : Plugin<Project> {
             .withFallback(project.objects, compilationUnit.service)
             .withFallback(project.objects, compilationUnit.apolloExtension)
 
-        compilationUnit.setSourcesIfNeeded(compilerParams.graphqlSourceDirectorySet, compilerParams.schemaFile)
+        val graphqlSourceDirectorySet = if (compilationUnit.apolloVariant.isTest) {
+          compilationUnit.graphqlSourceDirectorySet
+        } else {
+          compilerParams.graphqlSourceDirectorySet
+        }
+        compilationUnit.setSourcesIfNeeded(graphqlSourceDirectorySet, compilerParams.schemaFile)
 
         it.graphqlFiles.setFrom(compilerParams.graphqlSourceDirectorySet)
         // I'm not sure if gradle is sensitive to the order of the rootFolders. Sort them just in case.

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloVariant.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloVariant.kt
@@ -28,5 +28,10 @@ class ApolloVariant(
      * This is Any so that it does not pull a dependency on the gradle plugin but can be safely cast
      * to BaseVariant.
      */
-    val androidVariant: Any?
+    val androidVariant: Any?,
+
+    /**
+     * True if this variant is a test variant.
+     */
+    val isTest: Boolean
 )

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -14,11 +14,12 @@ object JvmTaskConfigurator {
     val javaPlugin = project.convention.getPlugin(JavaPluginConvention::class.java)
     val sourceSets = javaPlugin.sourceSets
 
-    sourceSets.map { it.name }.forEach {name ->
+    sourceSets.map { it.name }.forEach { name ->
       val apolloVariant = ApolloVariant(
           name = name,
           sourceSetNames = listOf(name),
-          androidVariant = null
+          androidVariant = null,
+          isTest = name == "test"
       )
 
       container.add(apolloVariant)
@@ -60,7 +61,7 @@ object JvmTaskConfigurator {
        */
       project.tasks.matching {
         it.name == "compileKotlin"
-      }.configureEach{
+      }.configureEach {
         (it as KotlinCompile).source(codegenProvider.get().outputDir.get().asFile)
       }
     }


### PR DESCRIPTION
closes #1906

I was not able to reproduce the specific issue as it seems linked to kapt (and maybe java-kotlin interop) but in all cases, I think it's safe to take this as test variants should have the main classes in its classpath so it's no use compiling the exact same classes twice.