### PR TITLE
toJson kotlin extension

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/InputExtensions.kt
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/InputExtensions.kt
@@ -1,5 +1,6 @@
 @file:Suppress("NOTHING_TO_INLINE")
 @file:JvmName("KotlinExtensions")
+@file:JvmMultifileClass
 
 package com.apollographql.apollo.api
 

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/OperationDataExtensions.kt
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/OperationDataExtensions.kt
@@ -1,0 +1,11 @@
+@file:Suppress("NOTHING_TO_INLINE")
+@file:JvmMultifileClass
+@file:JvmName("KotlinExtensions")
+
+package com.apollographql.apollo.api
+
+import com.apollographql.apollo.response.ScalarTypeAdapters
+
+@JvmSynthetic
+inline fun toJson(data: Operation.Data, indent: String, scalarTypeAdapters: ScalarTypeAdapters = ScalarTypeAdapters.DEFAULT): String =
+    OperationDataJsonSerializer.serialize(data, indent, scalarTypeAdapters)

--- a/apollo-api/src/main/java/com/apollographql/apollo/api/OperationDataExtensions.kt
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/OperationDataExtensions.kt
@@ -6,6 +6,31 @@ package com.apollographql.apollo.api
 
 import com.apollographql.apollo.response.ScalarTypeAdapters
 
+/**
+ * Serializes GraphQL operation response data into its equivalent Json representation.
+ * For example:
+ * <pre>{@code
+ *    {
+ *      "data": {
+ *        "allPlanets": {
+ *          "__typename": "PlanetsConnection",
+ *          "planets": [
+ *            {
+ *              "__typename": "Planet",
+ *              "name": "Tatooine",
+ *              "surfaceWater": 1.0
+ *            }
+ *          ]
+ *        }
+ *      }
+ *    }
+ * }</pre>
+ *
+ * @param indent the indentation string to be repeated for each level of indentation in the encoded document. Must be a string
+ * containing only whitespace. If [indent] is an empty String the encoded document will be compact. Otherwise the encoded
+ * document will be more human-readable.
+ * @param scalarTypeAdapters configured instance of custom GraphQL scalar type adapters.
+ */
 @JvmSynthetic
-inline fun toJson(data: Operation.Data, indent: String, scalarTypeAdapters: ScalarTypeAdapters = ScalarTypeAdapters.DEFAULT): String =
-    OperationDataJsonSerializer.serialize(data, indent, scalarTypeAdapters)
+inline fun Operation.Data.toJson(indent: String = "", scalarTypeAdapters: ScalarTypeAdapters = ScalarTypeAdapters.DEFAULT): String =
+    OperationDataJsonSerializer.serialize(this, indent, scalarTypeAdapters)

--- a/docs/source/advanced/no-runtime.md
+++ b/docs/source/advanced/no-runtime.md
@@ -10,13 +10,15 @@ For this, remove the `com.apollographql.apollo:apollo-runtime`dependency and rep
   implementation("com.apollographql.apollo:apollo-api:x.y.z")
 ```
 
+## Parsing HTTP body
+
 All `Operation` instances provide an API to parse `Response` from raw `okio.BufferedSource` source that represents http response body returned by the GraphQL server.
 If for some reason you want to use your own network layer and don't want to use fully featured `ApolloClient` provided by `apollo-runtime` you can use this API:
 
 ```java
     okhttp3.Response httpResponse = ...;
 
-    Response<Query.Data> response = new Query().parse(httpResponse.body().source());
+    Response<Operation.Data> response = new Query().parse(httpResponse.body().source());
 ```
 
 If you do have custom GraphQL scalar types, pass properly configured instance of `com.apollographql.apollo.response.ScalarTypeAdapters`:
@@ -26,8 +28,30 @@ If you do have custom GraphQL scalar types, pass properly configured instance of
 
     ScalarTypeAdapters scalarTypeAdapters = new ScalarTypeAdapters(<provide your custom scalar type adapters>);
 
-    Response<Query.Data> response = new Query().parse(httpResponse.body().source(), scalarTypeAdapters);
+    Response<Operation.Data> response = new Query().parse(httpResponse.body().source(), scalarTypeAdapters);
 ```
+
+## Converting Query.Data back to JSON
+
+In case you have an instance of `Operation.Data` and want to convert it back to JSON representation, you can use `OperationDataJsonSerializer.serialize` static method.
+
+```java
+    Operation.Data data = ...;
+
+    String json = OperationDataJsonSerializer.serialize(data, "  ");
+```
+
+Just like above, you can provide instance of custom `ScalarTypeAdapters` as last argument.
+
+Simpler extension function is available for `Kotlin` users:
+```kotlin
+   val json = data.toJson()
+
+   // or
+   val json = data.toJson(indent = "  ")
+```
+
+## Creating request payload for POST request
 
 To compose a GraphQL POST request along with operation variables to be sent to the server, you can use `Operation.Variables#marshal()` API: 
 


### PR DESCRIPTION
Add `toJson` Kotlin extension for Kotlin users. I didn't go for `serialize` since as an extension, that is not super clear. `data.toJson` looks nicer.

Doc updates:
- Add documentation about the new `OperationDataJsonSerializer`.
- Split `no-runtime` doc into multiple sections.
- Also add new Kotlin extension in 
there