### PR TITLE
Update the "getting started" now that the incubating plugin is the default plugin

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -9,9 +9,9 @@ Apollo Android has been [launched](https://blog.apollographql.com/launching-apol
 
 To get started, start with [Get Started Guide](https://www.apollographql.com/docs/android/essentials/get-started/).
 
-Apollo Android has a Gradle Plugin to integrate into projects easily. Use Gradle docs for more details on the plugin APIs.
-- [Gradle Plugin (soon to be deprecated)](https://www.apollographql.com/docs/android/gradle/plugin-configuration/)
-- [Incubating Gradle Plugin](https://www.apollographql.com/docs/android/gradle/incubating-plugin/)
+Apollo Android has a Gradle Plugin to integrate into projects easily. Use Gradle docs for more details on the plugin APIs:
+- [Gradle Plugin](https://www.apollographql.com/docs/android/gradle/plugin-configuration/)
+- [Deprecated Gradle Plugin](https://github.com/apollographql/apollo-android/blob/v1.2.3/doc/plugin-configuration.md)
 
 Once you started, you can dive into advanced topics by going into Advanced section from the left pane.
 


### PR DESCRIPTION
closes https://github.com/apollographql/apollo-android/issues/1929