### PR TITLE
Remove bintray plugin and upload marker to bintray

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -34,9 +34,9 @@ tasks.withType<Test> {
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
   setForkEvery(8L)
-  dependsOn(":apollo-api:publishMavenPublicationToPluginTestRepository")
-  dependsOn(":apollo-compiler:publishMavenPublicationToPluginTestRepository")
-  dependsOn("publishMavenPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishDefaultPublicationToPluginTestRepository")
+  dependsOn(":apollo-compiler:publishDefaultPublicationToPluginTestRepository")
+  dependsOn("publishDefaultPublicationToPluginTestRepository")
 
   inputs.dir("src/test/files")
 }

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
@@ -15,11 +15,11 @@ buildscript {
   }
 
   repositories {
-    google()
-    mavenCentral()
     maven {
       url = uri("../../../build/localMaven")
     }
+    google()
+    mavenCentral()
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE
@@ -42,12 +42,12 @@ fun kotlinDep(artifact: String): Any {
 // apply plugin: 'com.apollographql.apollo'
 
 repositories {
-  google() // for aapt2
-  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
-  jcenter() // for org.jetbrains.trove4j, depended on by lint
   maven {
     url = uri("../../../build/localMaven")
   }
+  google() // for aapt2
+  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
+  jcenter() // for org.jetbrains.trove4j, depended on by lint
 }
 
 dependencies {

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
@@ -2,11 +2,11 @@ buildscript {
   apply from: "../../../gradle/dependencies.gradle"
 
   repositories {
-    google()
-    mavenCentral()
     maven {
       url = uri("../../../build/localMaven")
     }
+    google()
+    mavenCentral()
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE
@@ -20,12 +20,12 @@ buildscript {
 // apply plugin: 'com.apollographql.apollo'
 
 repositories {
-  google() // for aapt2
-  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
-  jcenter() // for org.jetbrains.trove4j, depended on by lint
   maven {
     url = uri("../../../build/localMaven")
   }
+  google() // for aapt2
+  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
+  jcenter() // for org.jetbrains.trove4j, depended on by lint
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,8 @@ buildscript {
     classpath(groovy.util.Eval.x(project, "x.dep.gradleErrorpronePlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.bintrayGradlePlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
   }
-}
-plugins {
-  id("com.jfrog.bintray").version("1.8.4").apply(false)
 }
 
 val rootJapiCmp = tasks.register("japicmp")
@@ -60,7 +56,6 @@ subprojects {
       google()
     }
   }
-  this.apply(plugin = "com.jfrog.bintray")
   this.apply(plugin = "maven-publish")
 
   repositories {
@@ -143,7 +138,7 @@ subprojects {
 }
 
 fun Project.configurePublishing() {
-  val publicationName = "maven"
+  val publicationName = "default"
   val android = extensions.findByType(com.android.build.gradle.BaseExtension::class.java)
 
   /**
@@ -248,6 +243,16 @@ fun Project.configurePublishing() {
         name = "pluginTest"
         url = uri("file://${rootProject.buildDir}/localMaven")
       }
+
+      maven {
+        name = "bintray"
+        url = uri("https://api.bintray.com/maven/apollographql/android/${project.property("POM_ARTIFACT_ID")}/;publish=1;override=1")
+        credentials {
+          username = findProperty("bintray.user") as String?
+          password = findProperty("bintray.apikey") as String?
+        }
+      }
+
       maven {
         name = "oss"
         url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
@@ -255,28 +260,6 @@ fun Project.configurePublishing() {
           username = findProperty("SONATYPE_NEXUS_USERNAME") as String?
           password = findProperty("SONATYPE_NEXUS_PASSWORD") as String?
         }
-      }
-    }
-  }
-
-  configure<com.jfrog.bintray.gradle.BintrayExtension> {
-    user = findProperty("bintray.user") as String?
-    key = findProperty("bintray.apikey") as String?
-
-    setPublications(publicationName)
-
-    pkg.run {
-      userOrg = findProperty("POM_DEVELOPER_ID") as String?
-      repo = findProperty("BINTRAY_POM_REPO") as String?
-      name = findProperty("POM_ARTIFACT_ID") as String?
-      desc = findProperty("POM_DESCRIPTION") as String?
-      websiteUrl = findProperty("POM_URL") as String?
-      vcsUrl = findProperty("POM_SCM_URL") as String?
-      setLicenses(findProperty("POM_LICENCE_NAME") as String?)
-      publish = true
-      publicDownloadNumbers = true
-      version.run {
-        desc = findProperty("POM_DESCRIPTION") as String?
       }
     }
   }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,6 @@ def versions = [
     androidPlugin         : '3.4.2',
     apollo                : '1.3.1-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
-    bintray               : '1.8.4',
     cache                 : '2.0.2',
     compiletesting        : '0.15',
     espressoIdlingResource: '3.2.0',
@@ -47,7 +46,6 @@ ext.dep = [
         httpCache       : "com.apollographql.apollo:apollo-http-cache:$versions.apollo",
         api             : "com.apollographql.apollo:apollo-api:$versions.apollo",
     ],
-    bintrayGradlePlugin   : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintray",
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     errorProneCore        : "com.google.errorprone:error_prone_core:2.1.1",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,5 +37,9 @@ else
   echo "Deploy to Gradle portal..."
   ./gradlew :apollo-gradle-plugin:publishPlugin -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
   echo "Deployed to Gradle portal!"
+  echo "Deploy Gradle plugin marker to bintray..."
+  # We override the artifact_id for the marker else it is uploaded at the same coordinates as apollo-gradle-plugin
+  ./gradlew publishApolloGradlePluginPluginMarkerMavenPublicationToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}" -PPOM_ARTIFACT_ID=com.apollographql.apollo.gradle.plugin
+  echo "Deployed Gradle plugin marker to bintray!"
 fi
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ elif [ "$TRAVIS_BRANCH" != "$SNAPSHOT_BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$SNAPSHOT_BRANCH' but was '$TRAVIS_BRANCH'."
 else
   echo "Deploying snapshot..."
-  ./gradlew publishMavenPublicationToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
+  ./gradlew publishDefaultPublicationToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
   echo "Snapshot deployed!"
 fi
 
@@ -32,7 +32,7 @@ if [ "$TRAVIS_TAG" == "" ]; then
   echo "Skipping release deployment: not a tag"
 else
   echo "Deploy to bintray..."
-  ./gradlew bintrayUpload -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
+  ./gradlew publishDefaultPublicationToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
   echo "Deployed to bintray!"
   echo "Deploy to Gradle portal..."
   ./gradlew :apollo-gradle-plugin:publishPlugin -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET


### PR DESCRIPTION
It turns out that the `maven-publish` plugin is very capable of uploading to bintray. Use that and remove a dependency.

I also took the opportunity to upload the [Gradle plugin marker](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) to ~jcenter~ bintray. I made it manually for 1.3.0. It should be done by the CI for next versions.
Promotion to jcenter is not possible at the moment because "there's no binary file, aar, jar, ... in the package". I emailed bintray support about it.

