### PR TITLE
Fix POM url & licenses

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -229,8 +229,10 @@ fun Project.configurePublishing() {
           }
 
           licenses {
-            name.set(findProperty("POM_LICENCE_NAME") as String?)
-            url.set(findProperty("POM_LICENCE_URL") as String?)
+            license {
+              name.set(findProperty("POM_LICENCE_NAME") as String?)
+              url.set(findProperty("POM_LICENCE_URL") as String?)
+            }
           }
 
           developers {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/apollographql/apollo-android.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/apollographql/apollo-android.git
 
 POM_LICENCE_NAME=MIT License
-POM_LICENCE_URL=http://www.opensource.org/licenses/mit-license.phpandroid/master/LICENSE
+POM_LICENCE_URL=https://raw.githubusercontent.com/apollographql/apollo-android/master/LICENSE
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=apollographql


### PR DESCRIPTION
The license url was overwriting the main url.
Also fix the link to the license