### PR TITLE
Add support for auto persisted subscriptions

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -450,8 +450,8 @@ public final class RealSubscriptionManager implements SubscriptionManager {
     final boolean resendSubscriptionWithDocument;
     if (autoPersistSubscription) {
       Error error = OperationResponseParser.parseError(message.payload);
-      resendSubscriptionWithDocument = PROTOCOL_NEGOTIATION_ERROR_NOT_FOUND.equalsIgnoreCase(error.message()) ||
-          PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED.equalsIgnoreCase(error.message());
+      resendSubscriptionWithDocument = PROTOCOL_NEGOTIATION_ERROR_NOT_FOUND.equalsIgnoreCase(error.message())
+          || PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED.equalsIgnoreCase(error.message());
     } else {
       resendSubscriptionWithDocument = false;
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -177,8 +177,7 @@ public final class RealSubscriptionManager implements SubscriptionManager {
           transport.connect();
         } else if (state == SubscriptionManagerState.ACTIVE) {
           transport.send(
-              new OperationClientMessage.Start(subscriptionId.toString(), subscription, scalarTypeAdapters, autoPersistSubscription,
-                  false)
+              new OperationClientMessage.Start(subscriptionId.toString(), subscription, scalarTypeAdapters, autoPersistSubscription, false)
           );
         }
       }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -63,7 +63,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
       if (errorPayloads != null) {
         errors = new ArrayList<>();
         for (Map<String, Object> errorPayload : errorPayloads) {
-          errors.add(readError(errorPayload));
+          errors.add(parseError(errorPayload));
         }
       }
     }
@@ -130,7 +130,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
       @Override public Error read(ResponseJsonStreamReader reader) throws IOException {
         return reader.nextObject(true, new ResponseJsonStreamReader.ObjectReader<Error>() {
           @Override public Error read(ResponseJsonStreamReader reader) throws IOException {
-            return readError(reader.toMap());
+            return parseError(reader.toMap());
           }
         });
       }
@@ -138,7 +138,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
   }
 
   @SuppressWarnings("unchecked")
-  private Error readError(Map<String, Object> payload) {
+  public static Error parseError(Map<String, Object> payload) {
     String message = null;
     final List<Error.Location> locations = new ArrayList<>();
     final Map<String, Object> customAttributes = new HashMap<>();
@@ -150,7 +150,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
         List<Map<String, Object>> locationItems = (List<Map<String, Object>>) entry.getValue();
         if (locationItems != null) {
           for (Map<String, Object> item : locationItems) {
-            locations.add(readErrorLocation(item));
+            locations.add(parseErrorLocation(item));
           }
         }
       } else {
@@ -163,7 +163,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
   }
 
   @SuppressWarnings("ConstantConditions")
-  private Error.Location readErrorLocation(Map<String, Object> data) {
+  private static Error.Location parseErrorLocation(Map<String, Object> data) {
     long line = -1;
     long column = -1;
     if (data != null) {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
@@ -1,0 +1,249 @@
+package com.apollographql.apollo.internal.subscription;
+
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.OperationName;
+import com.apollographql.apollo.api.Response;
+import com.apollographql.apollo.api.ResponseFieldMapper;
+import com.apollographql.apollo.api.ResponseFieldMarshaller;
+import com.apollographql.apollo.api.ResponseReader;
+import com.apollographql.apollo.api.ScalarType;
+import com.apollographql.apollo.api.Subscription;
+import com.apollographql.apollo.api.internal.Supplier;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
+import com.apollographql.apollo.cache.normalized.ApolloStore;
+import com.apollographql.apollo.internal.cache.normalized.ResponseNormalizer;
+import com.apollographql.apollo.response.CustomTypeAdapter;
+import com.apollographql.apollo.response.ScalarTypeAdapters;
+import com.apollographql.apollo.subscription.OperationClientMessage;
+import com.apollographql.apollo.subscription.OperationServerMessage;
+import com.apollographql.apollo.subscription.SubscriptionConnectionParams;
+import com.apollographql.apollo.subscription.SubscriptionConnectionParamsProvider;
+import com.apollographql.apollo.subscription.SubscriptionManagerState;
+import com.apollographql.apollo.subscription.SubscriptionTransport;
+import okio.BufferedSource;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class SubscriptionAutoPersistTest {
+  private MockSubscriptionTransportFactory subscriptionTransportFactory;
+  private RealSubscriptionManager subscriptionManager;
+  private MockSubscription subscription = new MockSubscription("MockSubscription");
+  private SubscriptionManagerCallbackAdapter<Operation.Data> callbackAdapter;
+
+  @Before public void setUp() {
+    subscriptionTransportFactory = new MockSubscriptionTransportFactory();
+    subscriptionManager = new RealSubscriptionManager(new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()),
+        subscriptionTransportFactory, new SubscriptionConnectionParamsProvider.Const(new SubscriptionConnectionParams()),
+        new MockExecutor(), -1, new Supplier<ResponseNormalizer<Map<String, Object>>>() {
+      @Override public ResponseNormalizer<Map<String, Object>> get() {
+        return ApolloStore.NO_APOLLO_STORE.networkResponseNormalizer();
+      }
+    }, true);
+    assertThat(subscriptionTransportFactory.subscriptionTransport).isNotNull();
+    assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.DISCONNECTED);
+
+    callbackAdapter = new SubscriptionManagerCallbackAdapter<>();
+    subscriptionManager.subscribe(subscription, callbackAdapter);
+    subscriptionTransportFactory.callback.onConnected();
+    subscriptionTransportFactory.callback.onMessage(new OperationServerMessage.ConnectionAcknowledge());
+    assertStartMessage(false);
+  }
+
+  @Test public void success() {
+    final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
+    subscriptionTransportFactory.callback.onMessage(
+        new OperationServerMessage.Data(subscriptionId.toString(), Collections.<String, Object>emptyMap())
+    );
+    assertThat(callbackAdapter.response).isNotNull();
+  }
+
+  @Test public void protocolNegotiationErrorNotFound() {
+    final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
+    subscriptionTransportFactory.callback.onMessage(
+        new OperationServerMessage.Error(
+            subscriptionId.toString(),
+            new UnmodifiableMapBuilder<String, Object>()
+                .put("message", RealSubscriptionManager.PROTOCOL_NEGOTIATION_ERROR_NOT_FOUND)
+                .build()
+        )
+    );
+    assertStartMessage(true);
+  }
+
+  @Test public void protocolNegotiationErrorNotSupported() {
+    final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
+    subscriptionTransportFactory.callback.onMessage(
+        new OperationServerMessage.Error(
+            subscriptionId.toString(),
+            new UnmodifiableMapBuilder<String, Object>()
+                .put("message", RealSubscriptionManager.PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED)
+                .build()
+        )
+    );
+    assertStartMessage(true);
+  }
+
+  @Test public void unknownError() {
+    final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
+    subscriptionTransportFactory.callback.onMessage(
+        new OperationServerMessage.Error(
+            subscriptionId.toString(),
+            new UnmodifiableMapBuilder<String, Object>()
+                .put("meh", "¯\\_(ツ)_/¯")
+                .build()
+        )
+    );
+    assertThat(callbackAdapter.error).isInstanceOf(ApolloSubscriptionServerException.class);
+    assertThat(((ApolloSubscriptionServerException) callbackAdapter.error).errorPayload).containsEntry("meh", "¯\\_(ツ)_/¯");
+  }
+
+  private void assertStartMessage(boolean isWriteDocument) {
+    final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
+    if (isWriteDocument) {
+      assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage.toJsonString()).isEqualTo(
+          "" +
+              "{\"id\":\"" + subscriptionId.toString() + "\"," +
+              "\"type\":\"start\"," +
+              "\"payload\":{" +
+              "\"variables\":{}," +
+              "\"operationName\":\"SomeSubscription\"," +
+              "\"query\":\"subscription{\\ncommentAdded(repoFullName:\\\"repo\\\"){\\n__typename\\nid\\ncontent\\n}\\n}\"," +
+              "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
+      );
+    } else {
+      assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage.toJsonString()).isEqualTo(
+          "" +
+              "{\"id\":\"" + subscriptionId.toString() + "\"," +
+              "\"type\":\"start\"," +
+              "\"payload\":{" +
+              "\"variables\":{}," +
+              "\"operationName\":\"SomeSubscription\"," +
+              "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
+      );
+    }
+  }
+
+  private static final class MockSubscriptionTransportFactory implements SubscriptionTransport.Factory {
+    MockSubscriptionTransport subscriptionTransport;
+    SubscriptionTransport.Callback callback;
+
+    @Override public SubscriptionTransport create(@NotNull SubscriptionTransport.Callback callback) {
+      this.callback = callback;
+      return subscriptionTransport = new MockSubscriptionTransport();
+    }
+  }
+
+  private static final class MockSubscriptionTransport implements SubscriptionTransport {
+    volatile OperationClientMessage lastSentMessage;
+
+    @Override public void connect() {
+    }
+
+    @Override public void disconnect(OperationClientMessage message) {
+    }
+
+    @Override public void send(OperationClientMessage message) {
+      lastSentMessage = message;
+    }
+  }
+
+  private static final class MockExecutor implements Executor {
+    @Override public void execute(@NotNull Runnable command) {
+      command.run();
+    }
+  }
+
+  private static final class MockSubscription implements Subscription<Operation.Data, Operation.Data, Operation.Variables> {
+    final String operationId;
+
+    MockSubscription(String operationId) {
+      this.operationId = operationId;
+    }
+
+    @Override public String queryDocument() {
+      return "subscription{\ncommentAdded(repoFullName:\"repo\"){\n__typename\nid\ncontent\n}\n}";
+    }
+
+    @Override public Variables variables() {
+      return EMPTY_VARIABLES;
+    }
+
+    @Override public ResponseFieldMapper<Data> responseFieldMapper() {
+      return new ResponseFieldMapper<Data>() {
+        @Override public Data map(ResponseReader responseReader) {
+          return new Data() {
+            @Override public ResponseFieldMarshaller marshaller() {
+              throw new UnsupportedOperationException();
+            }
+          };
+        }
+      };
+    }
+
+    @Override public Data wrapData(Data data) {
+      return data;
+    }
+
+    @NotNull @Override public OperationName name() {
+      return new OperationName() {
+        @Override public String name() {
+          return "SomeSubscription";
+        }
+      };
+    }
+
+    @NotNull @Override public String operationId() {
+      return operationId;
+    }
+
+    @NotNull @Override public Response<Data> parse(@NotNull BufferedSource source) {
+      throw new UnsupportedOperationException();
+    }
+
+    @NotNull @Override public Response<Data> parse(@NotNull BufferedSource source, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class SubscriptionManagerCallbackAdapter<T> implements SubscriptionManager.Callback<T> {
+    volatile SubscriptionResponse<T> response;
+    volatile ApolloSubscriptionException error;
+    volatile Throwable networkError;
+    volatile boolean completed;
+    volatile boolean terminated;
+    volatile boolean connected;
+
+    @Override public void onResponse(@NotNull SubscriptionResponse<T> response) {
+      this.response = response;
+    }
+
+    @Override public void onError(@NotNull ApolloSubscriptionException error) {
+      this.error = error;
+    }
+
+    @Override public void onNetworkError(@NotNull Throwable t) {
+      networkError = t;
+    }
+
+    @Override public void onCompleted() {
+      completed = true;
+    }
+
+    @Override public void onTerminated() {
+      terminated = true;
+    }
+
+    @Override public void onConnected() {
+      connected = true;
+    }
+  }
+}

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
@@ -52,7 +52,7 @@ public class SubscriptionManagerTest {
       @Override public ResponseNormalizer<Map<String, Object>> get() {
         return ApolloStore.NO_APOLLO_STORE.networkResponseNormalizer();
       }
-    });
+    }, false);
     subscriptionManager.addOnStateChangeListener(onStateChangeListener);
     assertThat(subscriptionTransportFactory.subscriptionTransport).isNotNull();
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.DISCONNECTED);

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -58,11 +58,35 @@ public class WebSocketSubscriptionTransportMessageTest {
     assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo("{\"type\":\"connection_init\",\"payload\":{\"param1\":true,\"param2\":\"value\"}}");
   }
 
-  @Test public void startSubscription() {
+  @Test public void startSubscriptionAutoPersistSubscriptionDisabled() {
     subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
-        new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap())));
-    assertThat(webSocketFactory.webSocket.lastSentMessage)
-        .isEqualTo("{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"query\":\"subscription{commentAdded{id  name}\",\"variables\":{},\"operationName\":\"SomeSubscription\"}}");
+        new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()), false, false));
+
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
+        "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\"}}";
+
+    assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
+  }
+
+  @Test public void startSubscriptionAutoPersistSubscriptionEnabledSendDocumentEnabled() {
+    subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
+        new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()), true, true));
+
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
+        "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\"," +
+        "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
+
+    assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
+  }
+
+    @Test public void startSubscriptionAutoPersistSubscriptionEnabledSendDocumentDisabled() {
+    subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
+        new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap()), true, false));
+
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
+        "\"operationName\":\"SomeSubscription\",\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
+
+    assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
   }
 
   @Test public void stopSubscription() {


### PR DESCRIPTION
- Introduce new configuration flag to enable subscription auto persistence feature (it was intentionally introduced as a separate flag to avoid messing with regular subscriptions, though I'm not really confident if need it, we might use the same flag as for regular queries `enableAutoPersistedQueries`)
- Update `Start` protocol message to support auto persistence
- Handle subscription `protocol negotiation errors` and resend `Start` message with subscription document
- Tests.

Closes https://github.com/apollographql/apollo-android/issues/1850