### PR TITLE
Rename all singular CompilationUnit references to singular

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ sourceSets {
 
 // With:
 apollo {
-  onCompilationUnits {
+  onCompilationUnit {
      graphqlSourceDirectorySet.srcDirs += "/path/to/your/graphql/queries/dir"
   }
 }
@@ -303,7 +303,7 @@ apollo {
 
 // With:
 apollo {
-  onCompilationUnits {
+  onCompilationUnit {
      schemaFile = "/path/to/your/schema.json"
      graphqlSourceDirectorySet.exclude("**/*.gql")
      rootPackageName = "com.example"

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -33,11 +33,11 @@ interface ApolloExtension: CompilerParams {
 
   /**
    * [CompilationUnit] are created by the plugin based on the registered [Service]s and variants.
-   * [onCompilationUnits] allows to retrieve and configure them.
+   * [onCompilationUnit] allows to retrieve and configure them.
    *
    * @param action: the configure action for the [CompilationUnit]
    */
-  fun onCompilationUnits(action: Action<CompilationUnit>)
+  fun onCompilationUnit(action: Action<CompilationUnit>)
 
   /**
    * @Deprecated

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -42,6 +42,14 @@ interface ApolloExtension: CompilerParams {
   /**
    * @Deprecated
    *
+   * Please see [onCompilationUnit]
+   */
+  @Deprecated("There is a typo. Please use onCompilationUnit instead", replaceWith = ReplaceWith("onCompilationUnit"))
+  fun onCompilationUnits(action: Action<CompilationUnit>)
+
+  /**
+   * @Deprecated
+   *
    * Used for backward compatibility reasons with the old groovy plugin
    */
   @Deprecated("please use services instead")

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -144,7 +144,7 @@ interface CompilerParams {
    * The schema file
    *
    * By default, it will use [Service.schemaPath] to set schemaFile.
-   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   * You can override it from [ApolloExtension.onCompilationUnit] for more advanced use cases
    */
   val schemaFile: RegularFileProperty
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -108,7 +108,7 @@ open class ApolloPlugin : Plugin<Project> {
           compilationUnit.outputDir.set(codegenProvider.flatMap { it.outputDir })
           compilationUnit.operationOutputFile.set(codegenProvider.flatMap { it.operationOutputFile })
 
-          apolloExtension.compilationUnits.add(compilationUnit)
+          apolloExtension.compilationUnit.add(compilationUnit)
         }
 
         rootProvider.configure {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -108,7 +108,7 @@ open class ApolloPlugin : Plugin<Project> {
           compilationUnit.outputDir.set(codegenProvider.flatMap { it.outputDir })
           compilationUnit.operationOutputFile.set(codegenProvider.flatMap { it.operationOutputFile })
 
-          apolloExtension.compilationUnit.add(compilationUnit)
+          apolloExtension.compilationUnits.add(compilationUnit)
         }
 
         rootProvider.configure {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -15,13 +15,13 @@ open class DefaultApolloExtension(val project: Project)
   val services = mutableListOf<DefaultService>()
 
   /**
-   * compilationUnits is meant to be consumed by other gradle plugin.
+   * compilationUnit is meant to be consumed by other gradle plugin.
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
-  internal val compilationUnits = project.container(CompilationUnit::class.java)
+  internal val compilationUnit = project.container(CompilationUnit::class.java)
 
-  override fun onCompilationUnits(action: Action<CompilationUnit>) {
-    compilationUnits.all(action)
+  override fun onCompilationUnit(action: Action<CompilationUnit>) {
+    compilationUnit.all(action)
   }
 
   override fun service(name: String, action: Action<DefaultService>) {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -15,13 +15,17 @@ open class DefaultApolloExtension(val project: Project)
   val services = mutableListOf<DefaultService>()
 
   /**
-   * compilationUnit is meant to be consumed by other gradle plugin.
+   * compilationUnits is meant to be consumed by other gradle plugin.
    * The apollo plugin will add the {@link CompilationUnit} as it creates them
    */
-  internal val compilationUnit = project.container(CompilationUnit::class.java)
+  internal val compilationUnits = project.container(CompilationUnit::class.java)
 
   override fun onCompilationUnit(action: Action<CompilationUnit>) {
-    compilationUnit.all(action)
+    compilationUnits.all(action)
+  }
+
+  override fun onCompilationUnits(action: Action<CompilationUnit>) {
+    throw Exception("please use 'onCompilationUnit'(singular) instead")
   }
 
   override fun service(name: String, action: Action<DefaultService>) {

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -310,14 +310,14 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `rootPackageName can be overridden in compilationUnits`() {
+  fun `rootPackageName can be overridden in compilationUnit`() {
     withSimpleProject("""
       apollo {
         rootPackageName = "com.default"
         service("starwars") {
           rootPackageName = "com.starwars"
         }
-        onCompilationUnits {
+        onCompilationUnit {
           rootPackageName = "com.overrides"
         }
       }
@@ -330,7 +330,7 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `sources with a service can be overridden in compilationUnits`() {
+  fun `sources with a service can be overridden in compilationUnit`() {
     withSimpleProject("""
       apollo {
         service("starwars") {
@@ -338,7 +338,7 @@ class ConfigurationTests {
           sourceFolder = "com/some/other"
         }
         
-        onCompilationUnits {
+        onCompilationUnit {
           schemaFile = file("src/main/graphql/com/example/schema.json")
           graphqlSourceDirectorySet.srcDir(file("src/main/graphql/"))
           graphqlSourceDirectorySet.include("**/*.graphql")
@@ -353,12 +353,12 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `sources can be overridden in compilationUnits`() {
+  fun `sources can be overridden in compilationUnit`() {
     withSimpleProject("""
       apollo {
         schemaFile = file("com/some/other/schema.json")
 
-        onCompilationUnits {
+        onCompilationUnit {
           schemaFile = file("src/main/graphql/com/example/schema.json")
           graphqlSourceDirectorySet.srcDir(file("src/main/graphql/"))
           graphqlSourceDirectorySet.include("**/*.graphql")
@@ -371,10 +371,10 @@ class ConfigurationTests {
   }
 
   @Test
-  fun `onCompilationUnits can configure sources alone`() {
+  fun `onCompilationUnit can configure sources alone`() {
     withSimpleProject("""
       apollo {
-        onCompilationUnits {
+        onCompilationUnit {
           schemaFile = file("src/main/graphql/com/example/schema.json")
           graphqlSourceDirectorySet.srcDir(file("src/main/graphql/"))
           graphqlSourceDirectorySet.include("**/*.graphql")
@@ -390,7 +390,7 @@ class ConfigurationTests {
   fun `onCompilationUnits for main sourceSet should not generate for test`() {
     withSimpleProject("""
       apollo {
-        onCompilationUnits {
+        onCompilationUnit {
           if (variantName == "main") {
             schemaFile = file("src/main/graphql/com/example/schema.json")
             graphqlSourceDirectorySet.srcDir(file("src/main/graphql/"))
@@ -478,7 +478,7 @@ class ConfigurationTests {
       apollo {
         generateOperationOutput = true
         
-        onCompilationUnits { compilationUnit ->
+        onCompilationUnit { compilationUnit ->
           tasks.register("customTask" + compilationUnit.name.capitalize()) {
             inputs.file(compilationUnit.operationOutputFile)
           }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/LazyTests.kt
@@ -46,7 +46,7 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
 }
 
 configure<ApolloExtension> {
-  onCompilationUnits {
+  onCompilationUnit {
     graphqlSourceDirectorySet.srcDir(installTask.flatMap { it.outputDir })
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/OperationIdGeneratorTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/OperationIdGeneratorTests.kt
@@ -42,7 +42,7 @@ class CustomIdGeneratorTests {
   }
 
   @Test
-  fun `operationIdGenerator can be set from onCompilationUnits`() {
+  fun `operationIdGenerator can be set from onCompilationUnit`() {
     val apolloConfiguration = """
       class MyIdGenerator implements OperationIdGenerator {
           String apply(String queryString, String queryFilepath) {
@@ -52,7 +52,7 @@ class CustomIdGeneratorTests {
       }
       
       apollo {
-        onCompilationUnits {
+        onCompilationUnit {
           operationIdGenerator = new MyIdGenerator()
         }
       }

--- a/docs/source/essentials/plugin-configuration.md
+++ b/docs/source/essentials/plugin-configuration.md
@@ -4,7 +4,7 @@ title: Gradle Configuration
 
 Apollo Android comes with logical defaults that will work for the majority of use cases. If you're getting started, please read the main [README.md](https://github.com/apollographql/apollo-android/blob/master/README.md) for an overview of the most common options. This page describes the different options individually.
  
-## ApolloExtension, Services and CompilationUnits
+## ApolloExtension, Services and CompilationUnit
 
 The Gradle DSL exposes three types of objects:
 
@@ -36,7 +36,7 @@ apollo {
     rootPackageName = "com.starwars"
   }
 
-  onCompilationUnits {
+  onCompilationUnit {
     // Overwrite some options here for single CompilationUnit if needed
   }
 }
@@ -163,7 +163,7 @@ The up-to-date list of options can be found in [CompilerParams](https://github.c
    * This SourceDirectorySet includes .graphql and .gql files by default.
    *
    * By default, it will use [Service.sourceFolder] to populate the SourceDirectorySet.
-   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   * You can override it from [ApolloExtension.onCompilationUnit] for more advanced use cases
    */
   val graphqlSourceDirectorySet: SourceDirectorySet
 
@@ -171,7 +171,7 @@ The up-to-date list of options can be found in [CompilerParams](https://github.c
    * The schema file
    *
    * By default, it will use [Service.schemaPath] to set schemaFile.
-   * You can override it from [ApolloExtension.onCompilationUnits] for more advanced use cases
+   * You can override it from [ApolloExtension.onCompilationUnit] for more advanced use cases
    */
   val schemaFile: RegularFileProperty
 


### PR DESCRIPTION
From #1947: rename almost all references of `CompilationUnit` to singular.