### PR TITLE
Avoid field names clash

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/InputType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/InputType.kt
@@ -61,121 +61,200 @@ private val InputType.marshallerFunSpec: FunSpec
         .builder("marshaller")
         .returns(InputFieldMarshaller::class)
         .addModifiers(KModifier.OVERRIDE)
-        .addCode(
-            CodeBlock.builder()
-                .add("return %T { _writer ->\n", InputFieldMarshaller::class)
-                .indent()
-                .apply { fields.forEach { field -> add(field.writeCodeBlock) } }
-                .unindent()
-                .add("}\n")
-                .build()
+        .addCode(CodeBlock
+            .builder()
+            .beginControlFlow("return %T { writer ->", InputFieldMarshaller::class)
+            .apply { fields.forEach { field -> add(field.writeCodeBlock(name)) } }
+            .endControlFlow()
+            .build()
         ).build()
   }
 
-internal val InputType.Field.writeCodeBlock: CodeBlock
-  get() {
-    return when (type) {
-      is FieldType.Scalar -> when (type) {
-        is FieldType.Scalar.String -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeString(%S, %L.value)\n", name, schemaName, name)
-          } else {
-            CodeBlock.of("_writer.writeString(%S, %L)\n", schemaName, name)
-          }
-        }
-        is FieldType.Scalar.Int -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeInt(%S, %L.value)\n", schemaName, name, name)
-          } else {
-            CodeBlock.of("_writer.writeInt(%S, %L)\n", schemaName, name)
-          }
-        }
-        is FieldType.Scalar.Boolean -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeBoolean(%S, %L.value)\n", name, schemaName, name)
-          } else {
-            CodeBlock.of("_writer.writeBoolean(%S, %L)\n", schemaName, name)
-          }
-        }
-        is FieldType.Scalar.Float -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeDouble(%S, %L.value)\n", name, schemaName, name)
-          } else {
-            CodeBlock.of("_writer.writeDouble(%S, %L)\n", schemaName, name)
-          }
-        }
-        is FieldType.Scalar.Enum -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeString(%S, %L.value?.rawValue)\n", name, schemaName, name)
-          } else {
-            CodeBlock.of("_writer.writeString(%S, %L.rawValue)\n", schemaName, name)
-          }
-        }
-        is FieldType.Scalar.Custom -> {
-          if (isOptional) {
-            CodeBlock.of("if (%L.defined) _writer.writeCustom(%S, %T.%L, %L.value)\n", name, schemaName,
-                type.customEnumType.asTypeName(),
-                type.customEnumConst, name)
-          } else {
-            CodeBlock.of("_writer.writeCustom(%S, %T.%L, %L)\n", schemaName, type.customEnumType.asTypeName(), type.customEnumConst, name)
-          }
-        }
-      }
-      is FieldType.Object -> {
+internal fun InputType.Field.writeCodeBlock(thisRef: String): CodeBlock {
+  return when (type) {
+    is FieldType.Scalar -> when (type) {
+      is FieldType.Scalar.String -> {
         if (isOptional) {
-          CodeBlock.of("if (%L.defined) _writer.writeObject(%S, %L.value?.marshaller())\n", name, schemaName, name)
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeString(%S, this@%L.%L.value)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              name,
+              schemaName,
+              thisRef,
+              name
+          )
         } else {
-          CodeBlock.of("_writer.writeObject(%S, %L.marshaller())\n", schemaName, name)
+          CodeBlock.of("writer.writeString(%S, this@%L.%L)\n", schemaName, thisRef, name)
         }
       }
-      is FieldType.Array -> {
-        val codeBlockBuilder: CodeBlock.Builder = CodeBlock.Builder()
+      is FieldType.Scalar.Int -> {
         if (isOptional) {
-          codeBlockBuilder
-              .beginControlFlow("if (%L.defined)", name)
-              .add("_writer.writeList(%S, %L.value?.let { _value ->\n", schemaName, name)
-              .indent()
-              .beginControlFlow("%T { _listItemWriter ->", InputFieldWriter.ListWriter::class)
-              .beginControlFlow("_value.forEach { _value ->")
-              .add(type.rawType.writeListItem(type.isOptional))
-              .endControlFlow()
-              .endControlFlow()
-              .unindent()
-              .add("})\n")
-              .endControlFlow()
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeInt(%S, this@%L.%L.value)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              schemaName,
+              name,
+              thisRef,
+              name
+          )
         } else {
-          codeBlockBuilder
-              .beginControlFlow("_writer.writeList(%S) { _listItemWriter ->", schemaName)
-              .applyIf(isOptional) { beginControlFlow("%L?.forEach { _value ->", name) }
-              .applyIf(!isOptional) { beginControlFlow("%L.forEach { _value ->", name) }
-              .add(type.rawType.writeListItem(type.isOptional))
-              .endControlFlow()
-              .endControlFlow()
+          CodeBlock.of("writer.writeInt(%S, this@%L.%L)\n", schemaName, thisRef, name)
         }
-
-        codeBlockBuilder.build()
       }
-      else -> throw IllegalArgumentException("Unsupported input object field type: $type")
+      is FieldType.Scalar.Boolean -> {
+        if (isOptional) {
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeBoolean(%S, this@%L.%L.value)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              name,
+              schemaName,
+              thisRef,
+              name
+          )
+        } else {
+          CodeBlock.of("writer.writeBoolean(%S, this@%L.%L)\n", schemaName, thisRef, name)
+        }
+      }
+      is FieldType.Scalar.Float -> {
+        if (isOptional) {
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeDouble(%S, this@%L.%L.value)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              name,
+              schemaName,
+              thisRef,
+              name
+          )
+        } else {
+          CodeBlock.of("writer.writeDouble(%S, this@%L.%L)\n", schemaName, thisRef, name)
+        }
+      }
+      is FieldType.Scalar.Enum -> {
+        if (isOptional) {
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeString(%S, this@%L.%L.value?.rawValue)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              name,
+              schemaName,
+              thisRef,
+              name
+          )
+        } else {
+          CodeBlock.of("writer.writeString(%S, this@%L.%L.rawValue)\n", schemaName, thisRef, name)
+        }
+      }
+      is FieldType.Scalar.Custom -> {
+        if (isOptional) {
+          CodeBlock.of(
+              """
+                if (this@%L.%L.defined) {
+                  writer.writeCustom(%S, %T.%L, this@%L.%L.value)
+                }
+                
+                """.trimIndent(),
+              thisRef,
+              name,
+              schemaName,
+              type.customEnumType.asTypeName(),
+              type.customEnumConst,
+              thisRef,
+              name
+          )
+        } else {
+          CodeBlock.of("writer.writeCustom(%S, %T.%L, this@%L.%L)\n", schemaName, type.customEnumType.asTypeName(), type.customEnumConst,
+              thisRef, name)
+        }
+      }
     }
+    is FieldType.Object -> {
+      if (isOptional) {
+        CodeBlock.of(
+            """
+              if (this@%L.%L.defined) {
+                writer.writeObject(%S, this@%L.%L.value?.marshaller())
+              }
+              
+              """.trimIndent(),
+            thisRef,
+            name,
+            schemaName,
+            thisRef,
+            name
+        )
+      } else {
+        CodeBlock.of("writer.writeObject(%S, this@%L.%L.marshaller())\n", schemaName, thisRef, name)
+      }
+    }
+    is FieldType.Array -> {
+      val codeBlockBuilder: CodeBlock.Builder = CodeBlock.Builder()
+      if (isOptional) {
+        codeBlockBuilder
+            .beginControlFlow("if (this@%L.%L.defined)", thisRef, name)
+            .add("writer.writeList(%S, this@%L.%L.value?.let { value ->\n", schemaName, thisRef, name)
+            .indent()
+            .beginControlFlow("%T { listItemWriter ->", InputFieldWriter.ListWriter::class)
+            .beginControlFlow("value.forEach { value ->")
+            .add(type.rawType.writeListItem(type.isOptional))
+            .endControlFlow()
+            .endControlFlow()
+            .unindent()
+            .add("})\n")
+            .endControlFlow()
+      } else {
+        codeBlockBuilder
+            .beginControlFlow("writer.writeList(%S) { listItemWriter ->", schemaName)
+            .beginControlFlow("this@%L.%L.forEach { value ->", thisRef, name)
+            .add(type.rawType.writeListItem(type.isOptional))
+            .endControlFlow()
+            .endControlFlow()
+      }
+      codeBlockBuilder.build()
+    }
+    else -> throw IllegalArgumentException("Unsupported input object field type: $type")
   }
+}
 
 private fun FieldType.writeListItem(isOptional: Boolean): CodeBlock {
   return when (this) {
     is FieldType.Scalar -> when (this) {
-      is FieldType.Scalar.String -> CodeBlock.of("_listItemWriter.writeString(_value)\n")
-      is FieldType.Scalar.Int -> CodeBlock.of("_listItemWriter.writeInt(_value)\n")
-      is FieldType.Scalar.Boolean -> CodeBlock.of("_listItemWriter.writeBoolean(_value)\n")
-      is FieldType.Scalar.Float -> CodeBlock.of("_listItemWriter.writeDouble(_value)\n")
-      is FieldType.Scalar.Enum -> CodeBlock.of("_listItemWriter.writeString(_value%L.rawValue)\n", if (isOptional) "?" else "")
-      is FieldType.Scalar.Custom -> CodeBlock.of("_listItemWriter.writeCustom(%T.%L, _value)\n", customEnumType.asTypeName(),
-          customEnumConst)
+      is FieldType.Scalar.String -> CodeBlock.of("listItemWriter.writeString(value)\n")
+      is FieldType.Scalar.Int -> CodeBlock.of("listItemWriter.writeInt(value)\n")
+      is FieldType.Scalar.Boolean -> CodeBlock.of("listItemWriter.writeBoolean(value)\n")
+      is FieldType.Scalar.Float -> CodeBlock.of("listItemWriter.writeDouble(value)\n")
+      is FieldType.Scalar.Enum -> CodeBlock.of("listItemWriter.writeString(value%L.rawValue)\n", if (isOptional) "?" else "")
+      is FieldType.Scalar.Custom -> CodeBlock.of("listItemWriter.writeCustom(%T.%L, value)\n", customEnumType.asTypeName(), customEnumConst)
     }
     is FieldType.Object -> {
-      CodeBlock.of("_listItemWriter.writeObject(_value%L.marshaller())\n", if (isOptional) "?" else "")
+      CodeBlock.of("listItemWriter.writeObject(value%L.marshaller())\n", if (isOptional) "?" else "")
     }
     is FieldType.Array -> CodeBlock.builder()
-        .beginControlFlow("_listItemWriter.writeList { _listItemWriter ->")
-        .beginControlFlow("_value%L.forEach { _value ->", if (isOptional) "?" else "")
+        .beginControlFlow("listItemWriter.writeList { listItemWriter ->")
+        .beginControlFlow("value%L.forEach { value ->", if (isOptional) "?" else "")
         .add(rawType.writeListItem(this.isOptional))
         .endControlFlow()
         .endControlFlow()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
@@ -25,7 +25,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
           .addFunction(fields.toMapperFun(ClassName(packageName = "", simpleName = name)))
           .build())
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
-      .addFunction(marshallerFunSpec(fields))
+      .addFunction(marshallerFunSpec(fields = fields, thisRef = name))
       .addTypes(nestedObjects.map { (_, type) -> type.typeSpec() })
       .build()
 
@@ -49,7 +49,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
           .addProperty(responseFieldsPropertySpec(fields))
           .addFunction(fields.toMapperFun(ClassName.bestGuess(name)))
           .build())
-      .addFunction(marshallerFunSpec(fields = fields, override = true))
+      .addFunction(marshallerFunSpec(fields = fields, override = true, thisRef = name))
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
       .addTypes(nestedObjects.map { (_, type) -> type.typeSpec() })
       .build()
@@ -72,7 +72,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
           .addFunction(fields.toMapperFun(ClassName.bestGuess(name)))
           .build())
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
-      .addFunction(marshallerFunSpec(fields, true))
+      .addFunction(marshallerFunSpec(fields = fields, override = true, thisRef = name))
       .addTypes(nestedObjects.map { (_, type) -> type.typeSpec() })
       .build()
 
@@ -89,7 +89,7 @@ private fun ObjectType.fragmentsTypeSpec(generateAsInternal: Boolean = false): T
           .addProperty(responseFieldsPropertySpec(fields))
           .addFunction(fields.toMapperFun(ClassName(packageName = "", simpleName = name)))
           .build())
-      .addFunction(marshallerFunSpec(fields))
+      .addFunction(marshallerFunSpec(fields = fields, thisRef = name))
       .addTypes(nestedObjects.map { (_, type) -> type.typeSpec() })
       .build()
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -47,10 +47,12 @@ data class TestQuery(
       this["greenValue"] = this@TestQuery.greenValue
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
-      _writer.writeInt("stars", stars)
-      _writer.writeDouble("greenValue", greenValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      if (this@TestQuery.episode.defined) {
+        writer.writeString("episode", this@TestQuery.episode.value?.rawValue)
+      }
+      writer.writeInt("stars", this@TestQuery.stars)
+      writer.writeDouble("greenValue", this@TestQuery.greenValue)
     }
   }
 
@@ -81,10 +83,10 @@ data class TestQuery(
      */
     val height: Double?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeDouble(RESPONSE_FIELDS[2], height)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@HeroWithReview.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@HeroWithReview.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@HeroWithReview.height)
     }
 
     companion object {
@@ -95,11 +97,11 @@ data class TestQuery(
             "unit" to "FOOT"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): HeroWithReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        return HeroWithReview(
+      operator fun invoke(reader: ResponseReader): HeroWithReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        HeroWithReview(
           __typename = __typename,
           name = name,
           height = height
@@ -111,8 +113,8 @@ data class TestQuery(
   data class Data(
     val heroWithReview: HeroWithReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], heroWithReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.heroWithReview?.marshaller())
     }
 
     companion object {
@@ -137,12 +139,11 @@ data class TestQuery(
               null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val heroWithReview = reader.readObject<HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
           HeroWithReview(reader)
         }
-
-        return Data(
+        Data(
           heroWithReview = heroWithReview
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -42,15 +42,15 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = episode.value
-      this["stars"] = stars
-      this["greenValue"] = greenValue
+      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      this["stars"] = this@TestQuery.stars
+      this["greenValue"] = this@TestQuery.greenValue
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      if (episode.defined) writer.writeString("episode", episode.value?.rawValue)
-      writer.writeInt("stars", stars)
-      writer.writeDouble("greenValue", greenValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
+      _writer.writeInt("stars", stars)
+      _writer.writeDouble("greenValue", greenValue)
     }
   }
 
@@ -81,10 +81,10 @@ data class TestQuery(
      */
     val height: Double?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeDouble(RESPONSE_FIELDS[2], height)
     }
 
     companion object {
@@ -111,8 +111,8 @@ data class TestQuery(
   data class Data(
     val heroWithReview: HeroWithReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], heroWithReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], heroWithReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -56,10 +56,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], stars)
-      _writer.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Review.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@Review.stars)
+      writer.writeString(RESPONSE_FIELDS[2], this@Review.commentary)
     }
 
     companion object {
@@ -69,11 +69,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("commentary", "commentary", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Review {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val stars = reader.readInt(RESPONSE_FIELDS[1])
-        val commentary = reader.readString(RESPONSE_FIELDS[2])
-        return Review(
+      operator fun invoke(reader: ResponseReader): Review = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val stars = readInt(RESPONSE_FIELDS[1])
+        val commentary = readString(RESPONSE_FIELDS[2])
+        Review(
           __typename = __typename,
           stars = stars,
           commentary = commentary
@@ -85,11 +85,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val reviews: List<Review?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeList(RESPONSE_FIELDS[0], reviews) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeList(RESPONSE_FIELDS[0], this@Data.reviews) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -101,14 +100,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "starsFloat" to "9.9"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val reviews = reader.readList<Review>(RESPONSE_FIELDS[0]) {
-          it.readObject<Review> { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val reviews = readList<Review>(RESPONSE_FIELDS[0]) { reader ->
+          reader.readObject<Review> { reader ->
             Review(reader)
           }
-
         }
-        return Data(
+        Data(
           reviews = reviews
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -56,10 +56,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], stars)
-      it.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], stars)
+      _writer.writeString(RESPONSE_FIELDS[2], commentary)
     }
 
     companion object {
@@ -85,10 +85,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val reviews: List<Review?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeList(RESPONSE_FIELDS[0], reviews) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeList(RESPONSE_FIELDS[0], reviews) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -45,21 +45,21 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = episode.value
-      this["IncludeName"] = includeName
-      this["friendsCount"] = friendsCount
-      this["listOfListOfStringArgs"] = listOfListOfStringArgs
+      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      this["IncludeName"] = this@TestQuery.includeName
+      this["friendsCount"] = this@TestQuery.friendsCount
+      this["listOfListOfStringArgs"] = this@TestQuery.listOfListOfStringArgs
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      if (episode.defined) writer.writeString("episode", episode.value?.rawValue)
-      writer.writeBoolean("IncludeName", includeName)
-      writer.writeInt("friendsCount", friendsCount)
-      writer.writeList("listOfListOfStringArgs") { listItemWriter ->
-        listOfListOfStringArgs.forEach { value ->
-          listItemWriter.writeList { listItemWriter ->
-            value.forEach { value ->
-              listItemWriter.writeString(value)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
+      _writer.writeBoolean("IncludeName", includeName)
+      _writer.writeInt("friendsCount", friendsCount)
+      _writer.writeList("listOfListOfStringArgs") { _listItemWriter ->
+        listOfListOfStringArgs.forEach { _value ->
+          _listItemWriter.writeList { _listItemWriter ->
+            _value.forEach { _value ->
+              _listItemWriter.writeString(_value)
             }
           }
         }
@@ -91,10 +91,10 @@ data class TestQuery(
     val name: String?,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -120,8 +120,8 @@ data class TestQuery(
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
       }
 
       companion object {
@@ -150,9 +150,9 @@ data class TestQuery(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -176,9 +176,9 @@ data class TestQuery(
     val hero: Hero?,
     val heroWithReview: HeroWithReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], heroWithReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], heroWithReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -51,15 +51,17 @@ data class TestQuery(
       this["listOfListOfStringArgs"] = this@TestQuery.listOfListOfStringArgs
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
-      _writer.writeBoolean("IncludeName", includeName)
-      _writer.writeInt("friendsCount", friendsCount)
-      _writer.writeList("listOfListOfStringArgs") { _listItemWriter ->
-        listOfListOfStringArgs.forEach { _value ->
-          _listItemWriter.writeList { _listItemWriter ->
-            _value.forEach { _value ->
-              _listItemWriter.writeString(_value)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      if (this@TestQuery.episode.defined) {
+        writer.writeString("episode", this@TestQuery.episode.value?.rawValue)
+      }
+      writer.writeBoolean("IncludeName", this@TestQuery.includeName)
+      writer.writeInt("friendsCount", this@TestQuery.friendsCount)
+      writer.writeList("listOfListOfStringArgs") { listItemWriter ->
+        this@TestQuery.listOfListOfStringArgs.forEach { value ->
+          listItemWriter.writeList { listItemWriter ->
+            value.forEach { value ->
+              listItemWriter.writeString(value)
             }
           }
         }
@@ -91,10 +93,10 @@ data class TestQuery(
     val name: String?,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -105,11 +107,11 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           fragments = fragments
@@ -120,8 +122,8 @@ data class TestQuery(
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
       }
 
       companion object {
@@ -131,11 +133,11 @@ data class TestQuery(
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails
           )
         }
@@ -150,9 +152,9 @@ data class TestQuery(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@HeroWithReview.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@HeroWithReview.name)
     }
 
     companion object {
@@ -161,10 +163,10 @@ data class TestQuery(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): HeroWithReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return HeroWithReview(
+      operator fun invoke(reader: ResponseReader): HeroWithReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        HeroWithReview(
           __typename = __typename,
           name = name
         )
@@ -176,9 +178,9 @@ data class TestQuery(
     val hero: Hero?,
     val heroWithReview: HeroWithReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], heroWithReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.heroWithReview?.marshaller())
     }
 
     companion object {
@@ -197,16 +199,14 @@ data class TestQuery(
             "review" to emptyMap<String, Any>()), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        val heroWithReview = reader.readObject<HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
+        val heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
           HeroWithReview(reader)
         }
-
-        return Data(
+        Data(
           hero = hero,
           heroWithReview = heroWithReview
         )

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -24,9 +24,9 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeObject(RESPONSE_FIELDS[1], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeObject(RESPONSE_FIELDS[1], this@HeroDetails.friendsConnection.marshaller())
   }
 
   companion object {
@@ -55,13 +55,12 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
         FriendsConnection(reader)
       }
-
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         friendsConnection = friendsConnection
       )
@@ -75,9 +74,9 @@ data class HeroDetails(
      */
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -88,10 +87,10 @@ data class HeroDetails(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -106,9 +105,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -117,13 +116,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -142,13 +140,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -159,16 +156,15 @@ data class HeroDetails(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -24,9 +24,9 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeObject(RESPONSE_FIELDS[1], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeObject(RESPONSE_FIELDS[1], friendsConnection.marshaller())
   }
 
   companion object {
@@ -75,9 +75,9 @@ data class HeroDetails(
      */
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -106,9 +106,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -142,12 +142,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -74,22 +74,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val links: List<java.lang.String>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
-      _writer.writeList(RESPONSE_FIELDS[3], appearanceDates) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeCustom(CustomType.DATE, _value)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, this@Hero.birthDate)
+      writer.writeList(RESPONSE_FIELDS[3], this@Hero.appearanceDates) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeCustom(CustomType.DATE, value)}
       }
-      _writer.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomTypeField,
-          fieldWithUnsupportedType)
-      _writer.writeCustom(RESPONSE_FIELDS[5] as ResponseField.CustomTypeField, profileLink)
-      _writer.writeList(RESPONSE_FIELDS[6], links) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeCustom(CustomType.URL, _value)
-        }
+      writer.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomTypeField,
+          this@Hero.fieldWithUnsupportedType)
+      writer.writeCustom(RESPONSE_FIELDS[5] as ResponseField.CustomTypeField, this@Hero.profileLink)
+      writer.writeList(RESPONSE_FIELDS[6], this@Hero.links) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeCustom(CustomType.URL, value)}
       }
     }
 
@@ -106,22 +104,19 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("links", "links", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val birthDate = reader.readCustomType<Date>(RESPONSE_FIELDS[2] as
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val birthDate = readCustomType<Date>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+        val appearanceDates = readList<Date>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readCustomType<Date>(CustomType.DATE)}
+        val fieldWithUnsupportedType = readCustomType<Any>(RESPONSE_FIELDS[4] as
             ResponseField.CustomTypeField)
-        val appearanceDates = reader.readList<Date>(RESPONSE_FIELDS[3]) {
-          it.readCustomType<Date>(CustomType.DATE)
-        }
-        val fieldWithUnsupportedType = reader.readCustomType<Any>(RESPONSE_FIELDS[4] as
+        val profileLink = readCustomType<java.lang.String>(RESPONSE_FIELDS[5] as
             ResponseField.CustomTypeField)
-        val profileLink = reader.readCustomType<java.lang.String>(RESPONSE_FIELDS[5] as
-            ResponseField.CustomTypeField)
-        val links = reader.readList<java.lang.String>(RESPONSE_FIELDS[6]) {
-          it.readCustomType<java.lang.String>(CustomType.URL)
-        }
-        return Hero(
+        val links = readList<java.lang.String>(RESPONSE_FIELDS[6]) { reader ->
+          reader.readCustomType<java.lang.String>(CustomType.URL)}
+        Hero(
           __typename = __typename,
           name = name,
           birthDate = birthDate,
@@ -137,8 +132,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -146,12 +141,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -74,20 +74,21 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val links: List<java.lang.String>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
-      it.writeList(RESPONSE_FIELDS[3], appearanceDates) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeCustom(CustomType.DATE, value)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
+      _writer.writeList(RESPONSE_FIELDS[3], appearanceDates) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeCustom(CustomType.DATE, _value)
         }
       }
-      it.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomTypeField, fieldWithUnsupportedType)
-      it.writeCustom(RESPONSE_FIELDS[5] as ResponseField.CustomTypeField, profileLink)
-      it.writeList(RESPONSE_FIELDS[6], links) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeCustom(CustomType.URL, value)
+      _writer.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomTypeField,
+          fieldWithUnsupportedType)
+      _writer.writeCustom(RESPONSE_FIELDS[5] as ResponseField.CustomTypeField, profileLink)
+      _writer.writeList(RESPONSE_FIELDS[6], links) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeCustom(CustomType.URL, _value)
         }
       }
     }
@@ -136,8 +137,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -53,11 +53,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val links: List<Any>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeList(RESPONSE_FIELDS[1], links) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeCustom(CustomType.URL, value)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeList(RESPONSE_FIELDS[1], links) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeCustom(CustomType.URL, _value)
         }
       }
     }
@@ -84,8 +84,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -53,12 +53,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val links: List<Any>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeList(RESPONSE_FIELDS[1], links) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeCustom(CustomType.URL, _value)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeList(RESPONSE_FIELDS[1], this@Hero.links) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeCustom(CustomType.URL, value)}
       }
     }
 
@@ -68,12 +67,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("links", "links", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val links = reader.readList<Any>(RESPONSE_FIELDS[1]) {
-          it.readCustomType<Any>(CustomType.URL)
-        }
-        return Hero(
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val links = readList<Any>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readCustomType<Any>(CustomType.URL)}
+        Hero(
           __typename = __typename,
           links = links
         )
@@ -84,8 +82,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -93,12 +91,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -43,8 +43,10 @@ data class TestQuery(
       if (episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      if (this@TestQuery.episode.defined) {
+        writer.writeString("episode", this@TestQuery.episode.value?.rawValue)
+      }
     }
   }
 
@@ -81,11 +83,11 @@ data class TestQuery(
     @Deprecated(message = "For test purpose only")
     val deprecatedBool: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeString(RESPONSE_FIELDS[2], deprecated)
-      _writer.writeBoolean(RESPONSE_FIELDS[3], deprecatedBool)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeString(RESPONSE_FIELDS[2], this@Hero.deprecated)
+      writer.writeBoolean(RESPONSE_FIELDS[3], this@Hero.deprecatedBool)
     }
 
     companion object {
@@ -96,12 +98,12 @@ data class TestQuery(
           ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val deprecated = reader.readString(RESPONSE_FIELDS[2])
-        val deprecatedBool = reader.readBoolean(RESPONSE_FIELDS[3])
-        return Hero(
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val deprecated = readString(RESPONSE_FIELDS[2])
+        val deprecatedBool = readBoolean(RESPONSE_FIELDS[3])
+        Hero(
           __typename = __typename,
           name = name,
           deprecated = deprecated,
@@ -114,8 +116,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -126,12 +128,11 @@ data class TestQuery(
               "variableName" to "episode")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -40,11 +40,11 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = episode.value
+      if (episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      if (episode.defined) writer.writeString("episode", episode.value?.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
     }
   }
 
@@ -81,11 +81,11 @@ data class TestQuery(
     @Deprecated(message = "For test purpose only")
     val deprecatedBool: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeString(RESPONSE_FIELDS[2], deprecated)
-      it.writeBoolean(RESPONSE_FIELDS[3], deprecatedBool)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeString(RESPONSE_FIELDS[2], deprecated)
+      _writer.writeBoolean(RESPONSE_FIELDS[3], deprecatedBool)
     }
 
     companion object {
@@ -114,8 +114,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -41,13 +41,13 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["withDetails"] = withDetails
-      this["skipHumanDetails"] = skipHumanDetails
+      this["withDetails"] = this@TestQuery.withDetails
+      this["skipHumanDetails"] = this@TestQuery.skipHumanDetails
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeBoolean("withDetails", withDetails)
-      writer.writeBoolean("skipHumanDetails", skipHumanDetails)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeBoolean("withDetails", withDetails)
+      _writer.writeBoolean("skipHumanDetails", skipHumanDetails)
     }
   }
 
@@ -75,10 +75,10 @@ data class TestQuery(
     val id: String,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -103,9 +103,9 @@ data class TestQuery(
       val heroDetails: HeroDetails?,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails?.marshaller())
-        it.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails?.marshaller())
+        _writer.writeFragment(humanDetails?.marshaller())
       }
 
       companion object {
@@ -140,8 +140,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -45,9 +45,9 @@ data class TestQuery(
       this["skipHumanDetails"] = this@TestQuery.skipHumanDetails
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeBoolean("withDetails", withDetails)
-      _writer.writeBoolean("skipHumanDetails", skipHumanDetails)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeBoolean("withDetails", this@TestQuery.withDetails)
+      writer.writeBoolean("skipHumanDetails", this@TestQuery.skipHumanDetails)
     }
   }
 
@@ -75,10 +75,10 @@ data class TestQuery(
     val id: String,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Hero.id)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -87,11 +87,11 @@ data class TestQuery(
           ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           id = id,
           fragments = fragments
@@ -103,9 +103,9 @@ data class TestQuery(
       val heroDetails: HeroDetails?,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails?.marshaller())
-        _writer.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails?.marshaller())
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
       }
 
       companion object {
@@ -121,14 +121,14 @@ data class TestQuery(
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
             HumanDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails,
             humanDetails = humanDetails
           )
@@ -140,8 +140,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -149,12 +149,11 @@ data class TestQuery(
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -22,9 +22,9 @@ data class HeroDetails(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
   }
 
   companion object {
@@ -40,10 +40,10 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      return HeroDetails(
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      HeroDetails(
         __typename = __typename,
         name = name
       )

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -22,9 +22,9 @@ data class HeroDetails(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -22,9 +22,9 @@ data class HumanDetails(
    */
   val homePlanet: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], homePlanet)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], homePlanet)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -22,9 +22,9 @@ data class HumanDetails(
    */
   val homePlanet: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], homePlanet)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HumanDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HumanDetails.homePlanet)
   }
 
   companion object {
@@ -40,10 +40,10 @@ data class HumanDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val homePlanet = reader.readString(RESPONSE_FIELDS[1])
-      return HumanDetails(
+    operator fun invoke(reader: ResponseReader): HumanDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val homePlanet = readString(RESPONSE_FIELDS[1])
+      HumanDetails(
         __typename = __typename,
         homePlanet = homePlanet
       )

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -39,13 +39,13 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["withDetails"] = withDetails
-      this["skipHumanDetails"] = skipHumanDetails
+      this["withDetails"] = this@TestQuery.withDetails
+      this["skipHumanDetails"] = this@TestQuery.skipHumanDetails
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeBoolean("withDetails", withDetails)
-      writer.writeBoolean("skipHumanDetails", skipHumanDetails)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeBoolean("withDetails", withDetails)
+      _writer.writeBoolean("skipHumanDetails", skipHumanDetails)
     }
   }
 
@@ -84,11 +84,11 @@ data class TestQuery(
      */
     val homePlanet: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
-      it.writeString(RESPONSE_FIELDS[3], homePlanet)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
+      _writer.writeString(RESPONSE_FIELDS[3], homePlanet)
     }
 
     companion object {
@@ -129,11 +129,11 @@ data class TestQuery(
      */
     val primaryFunction: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
-      it.writeString(RESPONSE_FIELDS[3], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
+      _writer.writeString(RESPONSE_FIELDS[3], primaryFunction)
     }
 
     companion object {
@@ -168,11 +168,11 @@ data class TestQuery(
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeFragment(asHuman?.marshaller())
-      it.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asDroid?.marshaller())
     }
 
     companion object {
@@ -212,8 +212,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -43,9 +43,9 @@ data class TestQuery(
       this["skipHumanDetails"] = this@TestQuery.skipHumanDetails
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeBoolean("withDetails", withDetails)
-      _writer.writeBoolean("skipHumanDetails", skipHumanDetails)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeBoolean("withDetails", this@TestQuery.withDetails)
+      writer.writeBoolean("skipHumanDetails", this@TestQuery.skipHumanDetails)
     }
   }
 
@@ -84,11 +84,11 @@ data class TestQuery(
      */
     val homePlanet: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
-      _writer.writeString(RESPONSE_FIELDS[3], homePlanet)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@AsHuman.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@AsHuman.name)
+      writer.writeString(RESPONSE_FIELDS[3], this@AsHuman.homePlanet)
     }
 
     companion object {
@@ -99,12 +99,12 @@ data class TestQuery(
           ResponseField.forString("homePlanet", "homePlanet", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        val homePlanet = reader.readString(RESPONSE_FIELDS[3])
-        return AsHuman(
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        val homePlanet = readString(RESPONSE_FIELDS[3])
+        AsHuman(
           __typename = __typename,
           id = id,
           name = name,
@@ -129,11 +129,11 @@ data class TestQuery(
      */
     val primaryFunction: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
-      _writer.writeString(RESPONSE_FIELDS[3], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@AsDroid.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@AsDroid.name)
+      writer.writeString(RESPONSE_FIELDS[3], this@AsDroid.primaryFunction)
     }
 
     companion object {
@@ -144,12 +144,12 @@ data class TestQuery(
           ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        val primaryFunction = reader.readString(RESPONSE_FIELDS[3])
-        return AsDroid(
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        val primaryFunction = readString(RESPONSE_FIELDS[3])
+        AsDroid(
           __typename = __typename,
           id = id,
           name = name,
@@ -168,11 +168,11 @@ data class TestQuery(
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeFragment(asHuman?.marshaller())
-      _writer.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Hero.id)
+      writer.writeFragment(this@Hero.asHuman?.marshaller())
+      writer.writeFragment(this@Hero.asDroid?.marshaller())
     }
 
     companion object {
@@ -190,16 +190,16 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+        val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
           AsDroid(reader)
         }
-        return Hero(
+        Hero(
           __typename = __typename,
           id = id,
           asHuman = asHuman,
@@ -212,8 +212,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -221,12 +221,11 @@ data class TestQuery(
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -43,9 +43,9 @@ data class TestQuery(
       this["skipFriends"] = this@TestQuery.skipFriends
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeBoolean("includeName", includeName)
-      _writer.writeBoolean("skipFriends", skipFriends)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeBoolean("includeName", this@TestQuery.includeName)
+      writer.writeBoolean("skipFriends", this@TestQuery.skipFriends)
     }
   }
 
@@ -72,9 +72,9 @@ data class TestQuery(
      */
     val totalCount: Int?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
     }
 
     companion object {
@@ -83,10 +83,10 @@ data class TestQuery(
           ResponseField.forInt("totalCount", "totalCount", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        return FriendsConnection(
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount
         )
@@ -105,10 +105,10 @@ data class TestQuery(
      */
     val friendsConnection: FriendsConnection?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection?.marshaller())
     }
 
     companion object {
@@ -122,14 +122,13 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -141,8 +140,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -150,12 +149,11 @@ data class TestQuery(
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -39,13 +39,13 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["includeName"] = includeName
-      this["skipFriends"] = skipFriends
+      this["includeName"] = this@TestQuery.includeName
+      this["skipFriends"] = this@TestQuery.skipFriends
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeBoolean("includeName", includeName)
-      writer.writeBoolean("skipFriends", skipFriends)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeBoolean("includeName", includeName)
+      _writer.writeBoolean("skipFriends", skipFriends)
     }
   }
 
@@ -72,9 +72,9 @@ data class TestQuery(
      */
     val totalCount: Int?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
     }
 
     companion object {
@@ -105,10 +105,10 @@ data class TestQuery(
      */
     val friendsConnection: FriendsConnection?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection?.marshaller())
     }
 
     companion object {
@@ -141,8 +141,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -60,15 +60,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val firstAppearsIn: Episode
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeString(_value?.rawValue)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@Hero.appearsIn) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeString(value?.rawValue)}
       }
-      _writer.writeString(RESPONSE_FIELDS[3], firstAppearsIn.rawValue)
+      writer.writeString(RESPONSE_FIELDS[3], this@Hero.firstAppearsIn.rawValue)
     }
 
     companion object {
@@ -79,14 +78,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val appearsIn = reader.readList<Episode>(RESPONSE_FIELDS[2]) {
-          it.readString()?.let{ Episode.safeValueOf(it) }
-        }
-        val firstAppearsIn = Episode.safeValueOf(reader.readString(RESPONSE_FIELDS[3]))
-        return Hero(
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readString()?.let{ Episode.safeValueOf(it) }}
+        val firstAppearsIn = Episode.safeValueOf(readString(RESPONSE_FIELDS[3]))
+        Hero(
           __typename = __typename,
           name = name,
           appearsIn = appearsIn,
@@ -99,8 +97,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -108,12 +106,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -60,15 +60,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val firstAppearsIn: Episode
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], appearsIn) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeString(value?.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeString(_value?.rawValue)
         }
       }
-      it.writeString(RESPONSE_FIELDS[3], firstAppearsIn.rawValue)
+      _writer.writeString(RESPONSE_FIELDS[3], firstAppearsIn.rawValue)
     }
 
     companion object {
@@ -99,8 +99,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -48,9 +48,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -71,8 +71,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
       }
 
       companion object {
@@ -97,8 +97,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -48,9 +48,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -58,10 +58,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           fragments = fragments
         )
@@ -71,8 +71,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
       }
 
       companion object {
@@ -82,11 +82,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails
           )
         }
@@ -97,8 +97,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -106,12 +106,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -28,10 +28,10 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
   }
 
   companion object {
@@ -81,9 +81,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -110,9 +110,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -146,12 +146,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -28,10 +28,10 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    writer.writeObject(RESPONSE_FIELDS[2], this@HeroDetails.friendsConnection.marshaller())
   }
 
   companion object {
@@ -59,14 +59,13 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
         FriendsConnection(reader)
       }
-
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         friendsConnection = friendsConnection
@@ -81,9 +80,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -92,10 +91,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -110,9 +109,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -121,13 +120,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -146,13 +144,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -163,16 +160,15 @@ data class HeroDetails(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -49,9 +49,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     val __typename: String = "Starship",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      this@Node.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -59,10 +59,10 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Node(
+        Node(
           __typename = __typename,
           fragments = fragments
         )
@@ -72,8 +72,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     data class Fragments(
       val starshipFragment: StarshipFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(starshipFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.starshipFragment.marshaller())
       }
 
       companion object {
@@ -83,12 +83,11 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val starshipFragment = reader.readFragment<StarshipFragment>(RESPONSE_FIELDS[0]) {
-              reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val starshipFragment = readFragment<StarshipFragment>(RESPONSE_FIELDS[0]) { reader ->
             StarshipFragment(reader)
           }
-          return Fragments(
+          Fragments(
             starshipFragment = starshipFragment
           )
         }
@@ -103,9 +102,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -114,13 +113,12 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -135,12 +133,11 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AllStarships.__typename)
+      writer.writeList(RESPONSE_FIELDS[1], this@AllStarships.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -150,15 +147,14 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AllStarships {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[1]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): AllStarships = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return AllStarships(
+        AllStarships(
           __typename = __typename,
           edges = edges
         )
@@ -169,8 +165,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
   data class Data(
     val allStarships: AllStarships?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], allStarships?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.allStarships?.marshaller())
     }
 
     companion object {
@@ -179,12 +175,11 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
             "first" to "7"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val allStarships = reader.readObject<AllStarships>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val allStarships = readObject<AllStarships>(RESPONSE_FIELDS[0]) { reader ->
           AllStarships(reader)
         }
-
-        return Data(
+        Data(
           allStarships = allStarships
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -49,9 +49,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     val __typename: String = "Starship",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -72,8 +72,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     data class Fragments(
       val starshipFragment: StarshipFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(starshipFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(starshipFragment.marshaller())
       }
 
       companion object {
@@ -103,9 +103,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -135,11 +135,11 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeList(RESPONSE_FIELDS[1], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -169,8 +169,8 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
   data class Data(
     val allStarships: AllStarships?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], allStarships?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], allStarships?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -26,10 +26,10 @@ data class PilotFragment(
    */
   val homeworld: Homeworld?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeObject(RESPONSE_FIELDS[2], homeworld?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeObject(RESPONSE_FIELDS[2], homeworld?.marshaller())
   }
 
   companion object {
@@ -69,9 +69,9 @@ data class PilotFragment(
     val __typename: String = "Planet",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -92,8 +92,8 @@ data class PilotFragment(
     data class Fragments(
       val planetFragment: PlanetFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(planetFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(planetFragment.marshaller())
       }
 
       companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -26,10 +26,10 @@ data class PilotFragment(
    */
   val homeworld: Homeworld?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeObject(RESPONSE_FIELDS[2], homeworld?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@PilotFragment.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@PilotFragment.name)
+    writer.writeObject(RESPONSE_FIELDS[2], this@PilotFragment.homeworld?.marshaller())
   }
 
   companion object {
@@ -50,14 +50,13 @@ data class PilotFragment(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): PilotFragment {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val homeworld = reader.readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+    operator fun invoke(reader: ResponseReader): PilotFragment = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val homeworld = readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
         Homeworld(reader)
       }
-
-      return PilotFragment(
+      PilotFragment(
         __typename = __typename,
         name = name,
         homeworld = homeworld
@@ -69,9 +68,9 @@ data class PilotFragment(
     val __typename: String = "Planet",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Homeworld.__typename)
+      this@Homeworld.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -79,10 +78,10 @@ data class PilotFragment(
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Homeworld {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Homeworld = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Homeworld(
+        Homeworld(
           __typename = __typename,
           fragments = fragments
         )
@@ -92,8 +91,8 @@ data class PilotFragment(
     data class Fragments(
       val planetFragment: PlanetFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(planetFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.planetFragment.marshaller())
       }
 
       companion object {
@@ -103,11 +102,11 @@ data class PilotFragment(
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val planetFragment = reader.readFragment<PlanetFragment>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val planetFragment = readFragment<PlanetFragment>(RESPONSE_FIELDS[0]) { reader ->
             PlanetFragment(reader)
           }
-          return Fragments(
+          Fragments(
             planetFragment = planetFragment
           )
         }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -22,9 +22,9 @@ data class PlanetFragment(
    */
   val name: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@PlanetFragment.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@PlanetFragment.name)
   }
 
   companion object {
@@ -40,10 +40,10 @@ data class PlanetFragment(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): PlanetFragment {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      return PlanetFragment(
+    operator fun invoke(reader: ResponseReader): PlanetFragment = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      PlanetFragment(
         __typename = __typename,
         name = name
       )

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -22,9 +22,9 @@ data class PlanetFragment(
    */
   val name: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -29,11 +29,12 @@ data class StarshipFragment(
   val name: String?,
   val pilotConnection: PilotConnection?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-    _writer.writeString(RESPONSE_FIELDS[2], name)
-    _writer.writeObject(RESPONSE_FIELDS[3], pilotConnection?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@StarshipFragment.__typename)
+    writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField,
+        this@StarshipFragment.id)
+    writer.writeString(RESPONSE_FIELDS[2], this@StarshipFragment.name)
+    writer.writeObject(RESPONSE_FIELDS[3], this@StarshipFragment.pilotConnection?.marshaller())
   }
 
   companion object {
@@ -62,15 +63,14 @@ data class StarshipFragment(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): StarshipFragment {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-      val name = reader.readString(RESPONSE_FIELDS[2])
-      val pilotConnection = reader.readObject<PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
+    operator fun invoke(reader: ResponseReader): StarshipFragment = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+      val name = readString(RESPONSE_FIELDS[2])
+      val pilotConnection = readObject<PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
         PilotConnection(reader)
       }
-
-      return StarshipFragment(
+      StarshipFragment(
         __typename = __typename,
         id = id,
         name = name,
@@ -83,9 +83,9 @@ data class StarshipFragment(
     val __typename: String = "Person",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      this@Node.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -93,10 +93,10 @@ data class StarshipFragment(
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Node(
+        Node(
           __typename = __typename,
           fragments = fragments
         )
@@ -106,8 +106,8 @@ data class StarshipFragment(
     data class Fragments(
       val pilotFragment: PilotFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(pilotFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.pilotFragment.marshaller())
       }
 
       companion object {
@@ -117,11 +117,11 @@ data class StarshipFragment(
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val pilotFragment = reader.readFragment<PilotFragment>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val pilotFragment = readFragment<PilotFragment>(RESPONSE_FIELDS[0]) { reader ->
             PilotFragment(reader)
           }
-          return Fragments(
+          Fragments(
             pilotFragment = pilotFragment
           )
         }
@@ -136,9 +136,9 @@ data class StarshipFragment(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -147,13 +147,12 @@ data class StarshipFragment(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -168,12 +167,11 @@ data class StarshipFragment(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@PilotConnection.__typename)
+      writer.writeList(RESPONSE_FIELDS[1], this@PilotConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -183,15 +181,14 @@ data class StarshipFragment(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): PilotConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[1]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): PilotConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return PilotConnection(
+        PilotConnection(
           __typename = __typename,
           edges = edges
         )

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -29,11 +29,11 @@ data class StarshipFragment(
   val name: String?,
   val pilotConnection: PilotConnection?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-    it.writeString(RESPONSE_FIELDS[2], name)
-    it.writeObject(RESPONSE_FIELDS[3], pilotConnection?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+    _writer.writeString(RESPONSE_FIELDS[2], name)
+    _writer.writeObject(RESPONSE_FIELDS[3], pilotConnection?.marshaller())
   }
 
   companion object {
@@ -83,9 +83,9 @@ data class StarshipFragment(
     val __typename: String = "Person",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -106,8 +106,8 @@ data class StarshipFragment(
     data class Fragments(
       val pilotFragment: PilotFragment
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(pilotFragment.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(pilotFragment.marshaller())
       }
 
       companion object {
@@ -136,9 +136,9 @@ data class StarshipFragment(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -168,11 +168,11 @@ data class StarshipFragment(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeList(RESPONSE_FIELDS[1], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           fragments = fragments
         )
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val heroDetails: HeroDetails,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
-        _writer.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
       }
 
       companion object {
@@ -88,14 +88,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
             HumanDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails,
             humanDetails = humanDetails
           )
@@ -107,8 +107,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -116,12 +116,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val heroDetails: HeroDetails,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
-        it.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
+        _writer.writeFragment(humanDetails?.marshaller())
       }
 
       companion object {
@@ -107,8 +107,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -28,10 +28,10 @@ data class CharacterDetails(
    */
   val birthDate: Any
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -28,10 +28,11 @@ data class CharacterDetails(
    */
   val birthDate: Any
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, birthDate)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@CharacterDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@CharacterDetails.name)
+    writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField,
+        this@CharacterDetails.birthDate)
   }
 
   companion object {
@@ -49,12 +50,11 @@ data class CharacterDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): CharacterDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val birthDate = reader.readCustomType<Any>(RESPONSE_FIELDS[2] as
-          ResponseField.CustomTypeField)
-      return CharacterDetails(
+    operator fun invoke(reader: ResponseReader): CharacterDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+      CharacterDetails(
         __typename = __typename,
         name = name,
         birthDate = birthDate

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -23,10 +23,10 @@ data class HeroDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(_writer)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    this@HeroDetails.fragments.marshaller().marshal(writer)
   }
 
   companion object {
@@ -43,11 +43,11 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
       val fragments = Fragments(reader)
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         fragments = fragments
@@ -58,8 +58,8 @@ data class HeroDetails(
   data class Fragments(
     val characterDetails: CharacterDetails
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeFragment(characterDetails.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeFragment(this@Fragments.characterDetails.marshaller())
     }
 
     companion object {
@@ -69,11 +69,11 @@ data class HeroDetails(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Fragments {
-        val characterDetails = reader.readFragment<CharacterDetails>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+        val characterDetails = readFragment<CharacterDetails>(RESPONSE_FIELDS[0]) { reader ->
           CharacterDetails(reader)
         }
-        return Fragments(
+        Fragments(
           characterDetails = characterDetails
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -23,10 +23,10 @@ data class HeroDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(it)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    fragments.marshaller().marshal(_writer)
   }
 
   companion object {
@@ -58,8 +58,8 @@ data class HeroDetails(
   data class Fragments(
     val characterDetails: CharacterDetails
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeFragment(characterDetails.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeFragment(characterDetails.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -23,10 +23,10 @@ data class HumanDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(_writer)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HumanDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HumanDetails.name)
+    this@HumanDetails.fragments.marshaller().marshal(writer)
   }
 
   companion object {
@@ -43,11 +43,11 @@ data class HumanDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
+    operator fun invoke(reader: ResponseReader): HumanDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
       val fragments = Fragments(reader)
-      return HumanDetails(
+      HumanDetails(
         __typename = __typename,
         name = name,
         fragments = fragments
@@ -58,8 +58,8 @@ data class HumanDetails(
   data class Fragments(
     val characterDetails: CharacterDetails?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeFragment(characterDetails?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeFragment(this@Fragments.characterDetails?.marshaller())
     }
 
     companion object {
@@ -69,11 +69,11 @@ data class HumanDetails(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Fragments {
-        val characterDetails = reader.readFragment<CharacterDetails>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+        val characterDetails = readFragment<CharacterDetails>(RESPONSE_FIELDS[0]) { reader ->
           CharacterDetails(reader)
         }
-        return Fragments(
+        Fragments(
           characterDetails = characterDetails
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -23,10 +23,10 @@ data class HumanDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(it)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    fragments.marshaller().marshal(_writer)
   }
 
   companion object {
@@ -58,8 +58,8 @@ data class HumanDetails(
   data class Fragments(
     val characterDetails: CharacterDetails?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeFragment(characterDetails?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeFragment(characterDetails?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -58,15 +58,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val appearsIn: List<Episode?>,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], appearsIn) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeString(value?.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeString(_value?.rawValue)
         }
       }
-      fragments.marshaller().marshal(it)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -95,8 +95,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
       }
 
       companion object {
@@ -121,8 +121,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -58,15 +58,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val appearsIn: List<Episode?>,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeString(_value?.rawValue)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@Hero.appearsIn) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeString(value?.rawValue)}
       }
-      fragments.marshaller().marshal(_writer)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -76,14 +75,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("appearsIn", "appearsIn", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val appearsIn = reader.readList<Episode>(RESPONSE_FIELDS[2]) {
-          it.readString()?.let{ Episode.safeValueOf(it) }
-        }
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readString()?.let{ Episode.safeValueOf(it) }}
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           appearsIn = appearsIn,
@@ -95,8 +93,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
       }
 
       companion object {
@@ -106,11 +104,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails
           )
         }
@@ -121,8 +119,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -130,12 +128,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@DroidDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@DroidDetails.name)
+    writer.writeString(RESPONSE_FIELDS[2], this@DroidDetails.primaryFunction)
   }
 
   companion object {
@@ -47,11 +47,11 @@ data class DroidDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val primaryFunction = reader.readString(RESPONSE_FIELDS[2])
-      return DroidDetails(
+    operator fun invoke(reader: ResponseReader): DroidDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val primaryFunction = readString(RESPONSE_FIELDS[2])
+      DroidDetails(
         __typename = __typename,
         name = name,
         primaryFunction = primaryFunction

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -29,11 +29,11 @@ data class HeroDetails(
   val friendsConnection: FriendsConnection,
   val asDroid: AsDroid?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-    _writer.writeFragment(asDroid?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    writer.writeObject(RESPONSE_FIELDS[2], this@HeroDetails.friendsConnection.marshaller())
+    writer.writeFragment(this@HeroDetails.asDroid?.marshaller())
   }
 
   companion object {
@@ -67,17 +67,16 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
         FriendsConnection(reader)
       }
-
-      val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+      val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
         AsDroid(reader)
       }
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         friendsConnection = friendsConnection,
@@ -93,9 +92,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -104,10 +103,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -122,9 +121,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -133,13 +132,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -158,13 +156,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -175,16 +172,15 @@ data class HeroDetails(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -204,9 +200,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node1.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node1.name)
     }
 
     companion object {
@@ -215,10 +211,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node1(
+      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node1(
           __typename = __typename,
           name = name
         )
@@ -233,9 +229,9 @@ data class HeroDetails(
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge1.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge1.node?.marshaller())
     }
 
     companion object {
@@ -244,13 +240,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
           Node1(reader)
         }
-
-        return Edge1(
+        Edge1(
           __typename = __typename,
           node = node
         )
@@ -269,13 +264,12 @@ data class HeroDetails(
      */
     val edges: List<Edge1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection1.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection1.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection1.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -286,16 +280,15 @@ data class HeroDetails(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge1>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge1> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge1> { reader ->
             Edge1(reader)
           }
-
         }
-        return FriendsConnection1(
+        FriendsConnection1(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -316,11 +309,11 @@ data class HeroDetails(
     val friendsConnection: FriendsConnection1,
     val fragments: Fragments
   ) : HeroDetailCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      fragments.marshaller().marshal(_writer)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@AsDroid.friendsConnection.marshaller())
+      this@AsDroid.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -330,16 +323,14 @@ data class HeroDetails(
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) {
-            reader ->
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection1(reader)
         }
-
         val fragments = Fragments(reader)
-        return AsDroid(
+        AsDroid(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection,
@@ -351,8 +342,8 @@ data class HeroDetails(
     data class Fragments(
       val droidDetails: DroidDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(droidDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.droidDetails.marshaller())
       }
 
       companion object {
@@ -362,11 +353,11 @@ data class HeroDetails(
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val droidDetails = reader.readFragment<DroidDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val droidDetails = readFragment<DroidDetails>(RESPONSE_FIELDS[0]) { reader ->
             DroidDetails(reader)
           }
-          return Fragments(
+          Fragments(
             droidDetails = droidDetails
           )
         }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -29,11 +29,11 @@ data class HeroDetails(
   val friendsConnection: FriendsConnection,
   val asDroid: AsDroid?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-    it.writeFragment(asDroid?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    _writer.writeFragment(asDroid?.marshaller())
   }
 
   companion object {
@@ -93,9 +93,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -122,9 +122,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -158,12 +158,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -204,9 +204,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -233,9 +233,9 @@ data class HeroDetails(
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -269,12 +269,12 @@ data class HeroDetails(
      */
     val edges: List<Edge1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -316,11 +316,11 @@ data class HeroDetails(
     val friendsConnection: FriendsConnection1,
     val fragments: Fragments
   ) : HeroDetailCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      fragments.marshaller().marshal(it)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -351,8 +351,8 @@ data class HeroDetails(
     data class Fragments(
       val droidDetails: DroidDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(droidDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(droidDetails.marshaller())
       }
 
       companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@R2.__typename)
+      this@R2.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): R2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return R2(
+        R2(
           __typename = __typename,
           fragments = fragments
         )
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(humanDetails?.marshaller())
-        _writer.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
+        writer.writeFragment(this@Fragments.droidDetails?.marshaller())
       }
 
       companion object {
@@ -88,14 +88,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
             HumanDetails(reader)
           }
-          val droidDetails = reader.readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val droidDetails = readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
             DroidDetails(reader)
           }
-          return Fragments(
+          Fragments(
             humanDetails = humanDetails,
             droidDetails = droidDetails
           )
@@ -108,9 +108,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Luke.__typename)
+      this@Luke.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -118,10 +118,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Luke = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Luke(
+        Luke(
           __typename = __typename,
           fragments = fragments
         )
@@ -132,9 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(humanDetails?.marshaller())
-        _writer.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
+        writer.writeFragment(this@Fragments.droidDetails?.marshaller())
       }
 
       companion object {
@@ -147,14 +147,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
             HumanDetails(reader)
           }
-          val droidDetails = reader.readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val droidDetails = readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
             DroidDetails(reader)
           }
-          return Fragments(
+          Fragments(
             humanDetails = humanDetails,
             droidDetails = droidDetails
           )
@@ -167,9 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.r2?.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.luke?.marshaller())
     }
 
     companion object {
@@ -178,16 +178,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("luke", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val r2 = reader.readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
           R2(reader)
         }
-
-        val luke = reader.readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
           Luke(reader)
         }
-
-        return Data(
+        Data(
           r2 = r2,
           luke = luke
         )

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(humanDetails?.marshaller())
-        it.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(humanDetails?.marshaller())
+        _writer.writeFragment(droidDetails?.marshaller())
       }
 
       companion object {
@@ -108,9 +108,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -132,9 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(humanDetails?.marshaller())
-        it.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(humanDetails?.marshaller())
+        _writer.writeFragment(droidDetails?.marshaller())
       }
 
       companion object {
@@ -167,9 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@DroidDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@DroidDetails.name)
+    writer.writeString(RESPONSE_FIELDS[2], this@DroidDetails.primaryFunction)
   }
 
   companion object {
@@ -47,11 +47,11 @@ data class DroidDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val primaryFunction = reader.readString(RESPONSE_FIELDS[2])
-      return DroidDetails(
+    operator fun invoke(reader: ResponseReader): DroidDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val primaryFunction = readString(RESPONSE_FIELDS[2])
+      DroidDetails(
         __typename = __typename,
         name = name,
         primaryFunction = primaryFunction

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -27,10 +27,10 @@ data class HumanDetails(
    */
   val height: Double?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeDouble(RESPONSE_FIELDS[2], height)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HumanDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HumanDetails.name)
+    writer.writeDouble(RESPONSE_FIELDS[2], this@HumanDetails.height)
   }
 
   companion object {
@@ -48,11 +48,11 @@ data class HumanDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val height = reader.readDouble(RESPONSE_FIELDS[2])
-      return HumanDetails(
+    operator fun invoke(reader: ResponseReader): HumanDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val height = readDouble(RESPONSE_FIELDS[2])
+      HumanDetails(
         __typename = __typename,
         name = name,
         height = height

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -27,10 +27,10 @@ data class HumanDetails(
    */
   val height: Double?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeDouble(RESPONSE_FIELDS[2], height)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeDouble(RESPONSE_FIELDS[2], height)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@R2.__typename)
+      this@R2.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): R2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return R2(
+        R2(
           __typename = __typename,
           fragments = fragments
         )
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(humanDetails?.marshaller())
-        _writer.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
+        writer.writeFragment(this@Fragments.droidDetails?.marshaller())
       }
 
       companion object {
@@ -88,14 +88,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
             HumanDetails(reader)
           }
-          val droidDetails = reader.readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val droidDetails = readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
             DroidDetails(reader)
           }
-          return Fragments(
+          Fragments(
             humanDetails = humanDetails,
             droidDetails = droidDetails
           )
@@ -108,9 +108,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Luke.__typename)
+      this@Luke.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -118,10 +118,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Luke = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Luke(
+        Luke(
           __typename = __typename,
           fragments = fragments
         )
@@ -132,9 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(humanDetails?.marshaller())
-        _writer.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
+        writer.writeFragment(this@Fragments.droidDetails?.marshaller())
       }
 
       companion object {
@@ -147,14 +147,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
             HumanDetails(reader)
           }
-          val droidDetails = reader.readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val droidDetails = readFragment<DroidDetails>(RESPONSE_FIELDS[1]) { reader ->
             DroidDetails(reader)
           }
-          return Fragments(
+          Fragments(
             humanDetails = humanDetails,
             droidDetails = droidDetails
           )
@@ -167,9 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.r2?.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.luke?.marshaller())
     }
 
     companion object {
@@ -178,16 +178,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("luke", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val r2 = reader.readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
           R2(reader)
         }
-
-        val luke = reader.readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
           Luke(reader)
         }
-
-        return Data(
+        Data(
           r2 = r2,
           luke = luke
         )

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -49,9 +49,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -73,9 +73,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(humanDetails?.marshaller())
-        it.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(humanDetails?.marshaller())
+        _writer.writeFragment(droidDetails?.marshaller())
       }
 
       companion object {
@@ -108,9 +108,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -132,9 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val humanDetails: HumanDetails?,
       val droidDetails: DroidDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(humanDetails?.marshaller())
-        it.writeFragment(droidDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(humanDetails?.marshaller())
+        _writer.writeFragment(droidDetails?.marshaller())
       }
 
       companion object {
@@ -167,9 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -26,10 +26,10 @@ data class DroidDetails(
    */
   val primaryFunction: String?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@DroidDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@DroidDetails.name)
+    writer.writeString(RESPONSE_FIELDS[2], this@DroidDetails.primaryFunction)
   }
 
   companion object {
@@ -47,11 +47,11 @@ data class DroidDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val primaryFunction = reader.readString(RESPONSE_FIELDS[2])
-      return DroidDetails(
+    operator fun invoke(reader: ResponseReader): DroidDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val primaryFunction = readString(RESPONSE_FIELDS[2])
+      DroidDetails(
         __typename = __typename,
         name = name,
         primaryFunction = primaryFunction

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -27,10 +27,10 @@ data class HumanDetails(
    */
   val height: Double?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeDouble(RESPONSE_FIELDS[2], height)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HumanDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HumanDetails.name)
+    writer.writeDouble(RESPONSE_FIELDS[2], this@HumanDetails.height)
   }
 
   companion object {
@@ -48,11 +48,11 @@ data class HumanDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val height = reader.readDouble(RESPONSE_FIELDS[2])
-      return HumanDetails(
+    operator fun invoke(reader: ResponseReader): HumanDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val height = readDouble(RESPONSE_FIELDS[2])
+      HumanDetails(
         __typename = __typename,
         name = name,
         height = height

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -27,10 +27,10 @@ data class HumanDetails(
    */
   val height: Double?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeDouble(RESPONSE_FIELDS[2], height)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeDouble(RESPONSE_FIELDS[2], height)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -52,9 +52,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -81,9 +81,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -117,12 +117,12 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -163,10 +163,10 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -195,8 +195,8 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -52,9 +52,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -63,10 +63,10 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -81,9 +81,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -92,13 +92,12 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -117,13 +116,12 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -134,16 +132,15 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -163,10 +160,10 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
     }
 
     companion object {
@@ -176,14 +173,13 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -195,8 +191,8 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -204,12 +200,11 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -117,12 +117,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -163,10 +163,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -195,8 +195,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -63,10 +63,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -92,13 +92,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -117,13 +116,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -134,16 +132,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -163,10 +160,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
     }
 
     companion object {
@@ -176,14 +173,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -195,8 +191,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -204,12 +200,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -117,12 +117,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -163,10 +163,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -195,8 +195,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -63,10 +63,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -92,13 +92,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -117,13 +116,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -134,16 +132,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -163,10 +160,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
     }
 
     companion object {
@@ -176,14 +173,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -195,8 +191,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -204,12 +200,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -117,12 +117,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -163,10 +163,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -195,8 +195,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -52,9 +52,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -63,10 +63,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -81,9 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -92,13 +92,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -117,13 +116,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -134,16 +132,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -163,10 +160,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
     }
 
     companion object {
@@ -176,14 +173,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -195,8 +191,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -204,12 +200,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -52,9 +52,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -81,9 +81,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -117,12 +117,12 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -163,10 +163,10 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -195,8 +195,8 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -52,9 +52,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -63,10 +63,10 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -81,9 +81,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -92,13 +92,12 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -117,13 +116,12 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -134,16 +132,15 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -163,10 +160,10 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
     }
 
     companion object {
@@ -176,14 +173,13 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -195,8 +191,8 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -204,12 +200,11 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -55,10 +55,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, this@Hero.id)
     }
 
     companion object {
@@ -68,11 +68,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
-        return Hero(
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+        Hero(
           __typename = __typename,
           name = name,
           id = id
@@ -84,8 +84,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -93,12 +93,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -55,10 +55,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
     }
 
     companion object {
@@ -84,8 +84,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -38,11 +38,11 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["ep"] = ep
+      this["ep"] = this@TestQuery.ep
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeString("ep", ep.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeString("ep", ep.rawValue)
     }
   }
 
@@ -73,10 +73,10 @@ data class TestQuery(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], stars)
-      it.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], stars)
+      _writer.writeString(RESPONSE_FIELDS[2], commentary)
     }
 
     companion object {
@@ -102,8 +102,8 @@ data class TestQuery(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -41,8 +41,8 @@ data class TestQuery(
       this["ep"] = this@TestQuery.ep
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeString("ep", ep.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeString("ep", this@TestQuery.ep.rawValue)
     }
   }
 
@@ -73,10 +73,10 @@ data class TestQuery(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], stars)
-      _writer.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@CreateReview.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@CreateReview.stars)
+      writer.writeString(RESPONSE_FIELDS[2], this@CreateReview.commentary)
     }
 
     companion object {
@@ -86,11 +86,11 @@ data class TestQuery(
           ResponseField.forString("commentary", "commentary", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): CreateReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val stars = reader.readInt(RESPONSE_FIELDS[1])
-        val commentary = reader.readString(RESPONSE_FIELDS[2])
-        return CreateReview(
+      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val stars = readInt(RESPONSE_FIELDS[1])
+        val commentary = readString(RESPONSE_FIELDS[2])
+        CreateReview(
           __typename = __typename,
           stars = stars,
           commentary = commentary
@@ -102,8 +102,8 @@ data class TestQuery(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.createReview?.marshaller())
     }
 
     companion object {
@@ -121,12 +121,11 @@ data class TestQuery(
                 "blue" to "1.0"))), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val createReview = reader.readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
           CreateReview(reader)
         }
-
-        return Data(
+        Data(
           createReview = createReview
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val height: Double?
   ) : NonOptionalHeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman.height)
     }
 
     companion object {
@@ -72,11 +72,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forDouble("height", "height", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        return AsHuman(
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        AsHuman(
           __typename = __typename,
           name = name,
           height = height
@@ -93,10 +93,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val name: String,
     val asHuman: AsHuman?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@NonOptionalHero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@NonOptionalHero.name)
+      writer.writeFragment(this@NonOptionalHero.asHuman?.marshaller())
     }
 
     companion object {
@@ -108,13 +108,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): NonOptionalHero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): NonOptionalHero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        return NonOptionalHero(
+        NonOptionalHero(
           __typename = __typename,
           name = name,
           asHuman = asHuman
@@ -126,8 +126,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val nonOptionalHero: NonOptionalHero
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], nonOptionalHero.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.nonOptionalHero.marshaller())
     }
 
     companion object {
@@ -136,12 +136,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "episode" to "EMPIRE"), false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val nonOptionalHero = reader.readObject<NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val nonOptionalHero = readObject<NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
           NonOptionalHero(reader)
         }
-
-        return Data(
+        Data(
           nonOptionalHero = nonOptionalHero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -53,9 +53,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -64,10 +64,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -82,9 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -93,13 +93,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -114,12 +113,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeList(RESPONSE_FIELDS[1], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -129,15 +127,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[1]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           edges = edges
         )
@@ -160,11 +157,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val profileLink: Any
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      _writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField, profileLink)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
+      writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField, this@Hero.profileLink)
     }
 
     companion object {
@@ -176,16 +173,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
               null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        val profileLink = reader.readCustomType<Any>(RESPONSE_FIELDS[3] as
-            ResponseField.CustomTypeField)
-        return Hero(
+        val profileLink = readCustomType<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField)
+        Hero(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection,
@@ -198,8 +193,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -207,12 +202,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -53,9 +53,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -82,9 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -114,11 +114,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeList(RESPONSE_FIELDS[1], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeList(RESPONSE_FIELDS[1], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -160,11 +160,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val profileLink: Any
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      it.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField, profileLink)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+      _writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField, profileLink)
     }
 
     companion object {
@@ -198,8 +198,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -58,12 +58,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val appearsIn: List<Episode?>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeList(RESPONSE_FIELDS[1], appearsIn) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeString(_value?.rawValue)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend.__typename)
+      writer.writeList(RESPONSE_FIELDS[1], this@Friend.appearsIn) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeString(value?.rawValue)}
       }
     }
 
@@ -73,12 +72,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("appearsIn", "appearsIn", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val appearsIn = reader.readList<Episode>(RESPONSE_FIELDS[1]) {
-          it.readString()?.let{ Episode.safeValueOf(it) }
-        }
-        return Friend(
+      operator fun invoke(reader: ResponseReader): Friend = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readString()?.let{ Episode.safeValueOf(it) }}
+        Friend(
           __typename = __typename,
           appearsIn = appearsIn
         )
@@ -101,14 +99,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeDouble(RESPONSE_FIELDS[2], height)
-      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman.height)
+      writer.writeList(RESPONSE_FIELDS[3], this@AsHuman.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -120,17 +117,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        val friends = reader.readList<Friend>(RESPONSE_FIELDS[3]) {
-          it.readObject<Friend> { reader ->
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        val friends = readList<Friend>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readObject<Friend> { reader ->
             Friend(reader)
           }
-
         }
-        return AsHuman(
+        AsHuman(
           __typename = __typename,
           name = name,
           height = height,
@@ -147,9 +143,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend1.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Friend1.id)
     }
 
     companion object {
@@ -158,10 +154,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        return Friend1(
+      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        Friend1(
           __typename = __typename,
           id = id
         )
@@ -184,14 +180,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend1?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
-      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.name)
+      writer.writeString(RESPONSE_FIELDS[2], this@AsDroid.primaryFunction)
+      writer.writeList(RESPONSE_FIELDS[3], this@AsDroid.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -203,17 +198,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val primaryFunction = reader.readString(RESPONSE_FIELDS[2])
-        val friends = reader.readList<Friend1>(RESPONSE_FIELDS[3]) {
-          it.readObject<Friend1> { reader ->
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val primaryFunction = readString(RESPONSE_FIELDS[2])
+        val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readObject<Friend1> { reader ->
             Friend1(reader)
           }
-
         }
-        return AsDroid(
+        AsDroid(
           __typename = __typename,
           name = name,
           primaryFunction = primaryFunction,
@@ -232,11 +226,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman?.marshaller())
-      _writer.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeFragment(this@Hero.asHuman?.marshaller())
+      writer.writeFragment(this@Hero.asDroid?.marshaller())
     }
 
     companion object {
@@ -251,16 +245,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+        val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
           AsDroid(reader)
         }
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           asHuman = asHuman,
@@ -273,8 +267,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -282,12 +276,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -58,11 +58,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val appearsIn: List<Episode?>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeList(RESPONSE_FIELDS[1], appearsIn) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeString(value?.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeList(RESPONSE_FIELDS[1], appearsIn) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeString(_value?.rawValue)
         }
       }
     }
@@ -101,13 +101,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
-      it.writeList(RESPONSE_FIELDS[3], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeDouble(RESPONSE_FIELDS[2], height)
+      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -147,9 +147,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
     }
 
     companion object {
@@ -184,13 +184,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend1?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeString(RESPONSE_FIELDS[2], primaryFunction)
-      it.writeList(RESPONSE_FIELDS[3], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
+      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -232,11 +232,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman?.marshaller())
-      it.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asDroid?.marshaller())
     }
 
     companion object {
@@ -273,8 +273,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -44,9 +44,9 @@ data class TestQuery(
       this["review"] = this@TestQuery.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeString("ep", ep.rawValue)
-      _writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeString("ep", this@TestQuery.ep.rawValue)
+      writer.writeObject("review", this@TestQuery.review.marshaller())
     }
   }
 
@@ -77,10 +77,10 @@ data class TestQuery(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], stars)
-      _writer.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@CreateReview.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@CreateReview.stars)
+      writer.writeString(RESPONSE_FIELDS[2], this@CreateReview.commentary)
     }
 
     companion object {
@@ -90,11 +90,11 @@ data class TestQuery(
           ResponseField.forString("commentary", "commentary", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): CreateReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val stars = reader.readInt(RESPONSE_FIELDS[1])
-        val commentary = reader.readString(RESPONSE_FIELDS[2])
-        return CreateReview(
+      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val stars = readInt(RESPONSE_FIELDS[1])
+        val commentary = readString(RESPONSE_FIELDS[2])
+        CreateReview(
           __typename = __typename,
           stars = stars,
           commentary = commentary
@@ -106,8 +106,8 @@ data class TestQuery(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.createReview?.marshaller())
     }
 
     companion object {
@@ -121,12 +121,11 @@ data class TestQuery(
               "variableName" to "review")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val createReview = reader.readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
           CreateReview(reader)
         }
-
-        return Data(
+        Data(
           createReview = createReview
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -40,13 +40,13 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["ep"] = ep
-      this["review"] = review
+      this["ep"] = this@TestQuery.ep
+      this["review"] = this@TestQuery.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeString("ep", ep.rawValue)
-      writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeString("ep", ep.rawValue)
+      _writer.writeObject("review", review.marshaller())
     }
   }
 
@@ -77,10 +77,10 @@ data class TestQuery(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], stars)
-      it.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], stars)
+      _writer.writeString(RESPONSE_FIELDS[2], commentary)
     }
 
     companion object {
@@ -106,8 +106,8 @@ data class TestQuery(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.kt
@@ -39,13 +39,18 @@ data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("red", red)
-    if (green.defined) _writer.writeDouble("green", green.value)
-    _writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
-        reviewRefInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("red", this@ColorInput.red)
+    if (this@ColorInput.green.defined) {
+      writer.writeDouble("green", this@ColorInput.green.value)
+    }
+    writer.writeDouble("blue", this@ColorInput.blue)
+    if (this@ColorInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ColorInput.enumWithDefaultValue.value?.rawValue)
+    }
+    if (this@ColorInput.reviewRefInput.defined) {
+      writer.writeObject("reviewRefInput", this@ColorInput.reviewRefInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ColorInput.kt
@@ -39,13 +39,13 @@ data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("red", red)
-    if (green.defined) writer.writeDouble("green", green.value)
-    writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("red", red)
+    if (green.defined) _writer.writeDouble("green", green.value)
+    _writer.writeDouble("blue", blue)
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) writer.writeObject("reviewRefInput",
+    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
         reviewRefInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.kt
@@ -104,122 +104,139 @@ data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("stars", stars)
-    if (nullableIntFieldWithDefaultValue.defined)
-        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) _writer.writeString("commentary", commentary.value)
-    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
-    if (listOfCustomScalar.defined) {
-      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeCustom(CustomType.DATE, _value)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("stars", this@ReviewInput.stars)
+    if (this@ReviewInput.nullableIntFieldWithDefaultValue.defined) {
+      writer.writeInt("nullableIntFieldWithDefaultValue",
+        this@ReviewInput.nullableIntFieldWithDefaultValue.value)
+    }
+    if (this@ReviewInput.commentary.defined) {
+      writer.writeString("commentary", this@ReviewInput.commentary.value)
+    }
+    writer.writeObject("favoriteColor", this@ReviewInput.favoriteColor.marshaller())
+    if (this@ReviewInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ReviewInput.enumWithDefaultValue.value?.rawValue)
+    }
+    writer.writeString("nonNullableEnumWithDefaultValue",
+        this@ReviewInput.nonNullableEnumWithDefaultValue.rawValue)
+    if (this@ReviewInput.nullableEnum.defined) {
+      writer.writeString("nullableEnum", this@ReviewInput.nullableEnum.value?.rawValue)
+    }
+    if (this@ReviewInput.listOfCustomScalar.defined) {
+      writer.writeList("listOfCustomScalar", this@ReviewInput.listOfCustomScalar.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeCustom(CustomType.DATE, value)
           }
         }
       })
     }
-    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
-        customScalar.value)
-    if (listOfEnums.defined) {
-      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value?.rawValue)
+    if (this@ReviewInput.customScalar.defined) {
+      writer.writeCustom("customScalar", CustomType.DATE, this@ReviewInput.customScalar.value)
+    }
+    if (this@ReviewInput.listOfEnums.defined) {
+      writer.writeList("listOfEnums", this@ReviewInput.listOfEnums.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value?.rawValue)
           }
         }
       })
     }
-    if (listOfInt.defined) {
-      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeInt(_value)
+    if (this@ReviewInput.listOfInt.defined) {
+      writer.writeList("listOfInt", this@ReviewInput.listOfInt.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeInt(value)
           }
         }
       })
     }
-    if (listOfString.defined) {
-      _writer.writeList("listOfString", listOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value)
+    if (this@ReviewInput.listOfString.defined) {
+      writer.writeList("listOfString", this@ReviewInput.listOfString.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value)
           }
         }
       })
     }
-    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
-      listOfStringNonOptional.forEach { _value ->
-        _listItemWriter.writeString(_value)
+    writer.writeList("listOfStringNonOptional") { listItemWriter ->
+      this@ReviewInput.listOfStringNonOptional.forEach { value ->
+        listItemWriter.writeString(value)
       }
     }
-    if (listOfInputTypes.defined) {
-      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeObject(_value?.marshaller())
+    if (this@ReviewInput.listOfInputTypes.defined) {
+      writer.writeList("listOfInputTypes", this@ReviewInput.listOfInputTypes.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeObject(value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
-        booleanWithDefaultValue.value)
-    if (listOfListOfString.defined) {
-      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value)
+    if (this@ReviewInput.booleanWithDefaultValue.defined) {
+      writer.writeBoolean("booleanWithDefaultValue", this@ReviewInput.booleanWithDefaultValue.value)
+    }
+    if (this@ReviewInput.listOfListOfString.defined) {
+      writer.writeList("listOfListOfString", this@ReviewInput.listOfListOfString.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfEnum.defined) {
-      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value.rawValue)
+    if (this@ReviewInput.listOfListOfEnum.defined) {
+      writer.writeList("listOfListOfEnum", this@ReviewInput.listOfListOfEnum.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value.rawValue)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfCustom.defined) {
-      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeCustom(CustomType.DATE, _value)
+    if (this@ReviewInput.listOfListOfCustom.defined) {
+      writer.writeList("listOfListOfCustom", this@ReviewInput.listOfListOfCustom.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeCustom(CustomType.DATE, value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfObject.defined) {
-      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeObject(_value.marshaller())
+    if (this@ReviewInput.listOfListOfObject.defined) {
+      writer.writeList("listOfListOfObject", this@ReviewInput.listOfListOfObject.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeObject(value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
+    if (this@ReviewInput.capitalizedField.defined) {
+      writer.writeString("CapitalizedField", this@ReviewInput.capitalizedField.value)
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewInput.kt
@@ -104,77 +104,77 @@ data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("stars", stars)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("stars", stars)
     if (nullableIntFieldWithDefaultValue.defined)
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) writer.writeString("commentary", commentary.value)
-    writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
+    if (commentary.defined) _writer.writeString("commentary", commentary.value)
+    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
+    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
+    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
     if (listOfCustomScalar.defined) {
-      writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeCustom(CustomType.DATE, _value)
           }
         }
       })
     }
-    if (customScalar.defined) writer.writeCustom("customScalar", CustomType.DATE,
+    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
         customScalar.value)
     if (listOfEnums.defined) {
-      writer.writeList("listOfEnums", listOfEnums.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value?.rawValue)
+      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value?.rawValue)
           }
         }
       })
     }
     if (listOfInt.defined) {
-      writer.writeList("listOfInt", listOfInt.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeInt(value)
+      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeInt(_value)
           }
         }
       })
     }
     if (listOfString.defined) {
-      writer.writeList("listOfString", listOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value)
+      _writer.writeList("listOfString", listOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value)
           }
         }
       })
     }
-    writer.writeList("listOfStringNonOptional") { listItemWriter ->
-      listOfStringNonOptional.forEach { value ->
-        listItemWriter.writeString(value)
+    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
+      listOfStringNonOptional.forEach { _value ->
+        _listItemWriter.writeString(_value)
       }
     }
     if (listOfInputTypes.defined) {
-      writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeObject(value?.marshaller())
+      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeObject(_value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) writer.writeBoolean("booleanWithDefaultValue",
+    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
         booleanWithDefaultValue.value)
     if (listOfListOfString.defined) {
-      writer.writeList("listOfListOfString", listOfListOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value)
+      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value)
               }
             }
           }
@@ -182,12 +182,12 @@ data class ReviewInput(
       })
     }
     if (listOfListOfEnum.defined) {
-      writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value.rawValue)
+      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value.rawValue)
               }
             }
           }
@@ -195,12 +195,12 @@ data class ReviewInput(
       })
     }
     if (listOfListOfCustom.defined) {
-      writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeCustom(CustomType.DATE, _value)
               }
             }
           }
@@ -208,18 +208,18 @@ data class ReviewInput(
       })
     }
     if (listOfListOfObject.defined) {
-      writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeObject(value.marshaller())
+      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeObject(_value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) writer.writeString("CapitalizedField", capitalizedField.value)
+    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewRefInput.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    if (reviewInput.defined) writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/ReviewRefInput.kt
@@ -18,7 +18,9 @@ import kotlin.Suppress
 data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    if (this@ReviewRefInput.reviewInput.defined) {
+      writer.writeObject("reviewInput", this@ReviewRefInput.reviewInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -48,9 +48,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@QueryType.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@QueryType.name)
     }
 
     companion object {
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): QueryType {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return QueryType(
+      operator fun invoke(reader: ResponseReader): QueryType = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        QueryType(
           __typename = __typename,
           name = name
         )
@@ -74,9 +74,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Type.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Type.name)
     }
 
     companion object {
@@ -85,10 +85,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Type {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Type(
+      operator fun invoke(reader: ResponseReader): Type = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Type(
           __typename = __typename,
           name = name
         )
@@ -107,13 +107,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val types: List<Type>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], queryType.marshaller())
-      _writer.writeList(RESPONSE_FIELDS[2], types) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@__Schema.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@__Schema.queryType.marshaller())
+      writer.writeList(RESPONSE_FIELDS[2], this@__Schema.types) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -124,19 +123,17 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("types", "types", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): __Schema {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val queryType = reader.readObject<QueryType>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): __Schema = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val queryType = readObject<QueryType>(RESPONSE_FIELDS[1]) { reader ->
           QueryType(reader)
         }
-
-        val types = reader.readList<Type>(RESPONSE_FIELDS[2]) {
-          it.readObject<Type> { reader ->
+        val types = readList<Type>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Type> { reader ->
             Type(reader)
           }
-
         }
-        return __Schema(
+        __Schema(
           __typename = __typename,
           queryType = queryType,
           types = types
@@ -149,9 +146,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@__Type.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@__Type.name)
     }
 
     companion object {
@@ -160,10 +157,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): __Type {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return __Type(
+      operator fun invoke(reader: ResponseReader): __Type = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        __Type(
           __typename = __typename,
           name = name
         )
@@ -175,9 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __schema: __Schema,
     val __type: __Type?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], __schema.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], __type?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.__schema.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.__type?.marshaller())
     }
 
     companion object {
@@ -187,16 +184,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "name" to "Vehicle"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val __schema = reader.readObject<__Schema>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val __schema = readObject<__Schema>(RESPONSE_FIELDS[0]) { reader ->
           __Schema(reader)
         }
-
-        val __type = reader.readObject<__Type>(RESPONSE_FIELDS[1]) { reader ->
+        val __type = readObject<__Type>(RESPONSE_FIELDS[1]) { reader ->
           __Type(reader)
         }
-
-        return Data(
+        Data(
           __schema = __schema,
           __type = __type
         )

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -48,9 +48,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -74,9 +74,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -107,12 +107,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val types: List<Type>
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], queryType.marshaller())
-      it.writeList(RESPONSE_FIELDS[2], types) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], queryType.marshaller())
+      _writer.writeList(RESPONSE_FIELDS[2], types) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -149,9 +149,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "__Type",
     val name: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -175,9 +175,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __schema: __Schema,
     val __type: __Type?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], __schema.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], __type?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], __schema.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], __type?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -58,15 +58,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val appearsIn: List<Episode?>,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], appearsIn) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeString(value?.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeString(_value?.rawValue)
         }
       }
-      fragments.marshaller().marshal(it)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -95,8 +95,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
       }
 
       companion object {
@@ -121,8 +121,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -58,15 +58,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val appearsIn: List<Episode?>,
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeString(_value?.rawValue)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@Hero.appearsIn) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeString(value?.rawValue)}
       }
-      fragments.marshaller().marshal(_writer)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -76,14 +75,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("appearsIn", "appearsIn", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val appearsIn = reader.readList<Episode>(RESPONSE_FIELDS[2]) {
-          it.readString()?.let{ Episode.safeValueOf(it) }
-        }
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readString()?.let{ Episode.safeValueOf(it) }}
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           appearsIn = appearsIn,
@@ -95,8 +93,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
       }
 
       companion object {
@@ -106,11 +104,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails
           )
         }
@@ -121,8 +119,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -130,12 +128,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
@@ -30,11 +30,11 @@ data class HeroDetails(
   val friendsConnection: FriendsConnection,
   val asDroid: AsDroid?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-    _writer.writeFragment(asDroid?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    writer.writeObject(RESPONSE_FIELDS[2], this@HeroDetails.friendsConnection.marshaller())
+    writer.writeFragment(this@HeroDetails.asDroid?.marshaller())
   }
 
   companion object {
@@ -74,17 +74,16 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
         FriendsConnection(reader)
       }
-
-      val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+      val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
         AsDroid(reader)
       }
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         friendsConnection = friendsConnection,
@@ -100,9 +99,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -111,10 +110,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -129,9 +128,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -140,13 +139,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -158,9 +156,9 @@ data class HeroDetails(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@PageInfo.__typename)
+      writer.writeBoolean(RESPONSE_FIELDS[1], this@PageInfo.hasNextPage)
     }
 
     companion object {
@@ -169,10 +167,10 @@ data class HeroDetails(
           ResponseField.forBoolean("hasNextPage", "hasNextPage", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): PageInfo {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val hasNextPage = reader.readBoolean(RESPONSE_FIELDS[1])
-        return PageInfo(
+      operator fun invoke(reader: ResponseReader): PageInfo = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val hasNextPage = readBoolean(RESPONSE_FIELDS[1])
+        PageInfo(
           __typename = __typename,
           hasNextPage = hasNextPage
         )
@@ -199,16 +197,15 @@ data class HeroDetails(
      */
     val isEmpty: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
-      _writer.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
+      writer.writeObject(RESPONSE_FIELDS[3], this@FriendsConnection.pageInfo.marshaller())
+      writer.writeBoolean(RESPONSE_FIELDS[4], this@FriendsConnection.isEmpty)
     }
 
     companion object {
@@ -220,21 +217,19 @@ data class HeroDetails(
           ResponseField.forBoolean("isEmpty", "isEmpty", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        val pageInfo = reader.readObject<PageInfo>(RESPONSE_FIELDS[3]) { reader ->
+        val pageInfo = readObject<PageInfo>(RESPONSE_FIELDS[3]) { reader ->
           PageInfo(reader)
         }
-
-        val isEmpty = reader.readBoolean(RESPONSE_FIELDS[4])
-        return FriendsConnection(
+        val isEmpty = readBoolean(RESPONSE_FIELDS[4])
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges,
@@ -256,9 +251,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node1.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node1.name)
     }
 
     companion object {
@@ -267,10 +262,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node1(
+      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node1(
           __typename = __typename,
           name = name
         )
@@ -285,9 +280,9 @@ data class HeroDetails(
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge1.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge1.node?.marshaller())
     }
 
     companion object {
@@ -296,13 +291,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
           Node1(reader)
         }
-
-        return Edge1(
+        Edge1(
           __typename = __typename,
           node = node
         )
@@ -314,9 +308,9 @@ data class HeroDetails(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@PageInfo1.__typename)
+      writer.writeBoolean(RESPONSE_FIELDS[1], this@PageInfo1.hasNextPage)
     }
 
     companion object {
@@ -325,10 +319,10 @@ data class HeroDetails(
           ResponseField.forBoolean("hasNextPage", "hasNextPage", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): PageInfo1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val hasNextPage = reader.readBoolean(RESPONSE_FIELDS[1])
-        return PageInfo1(
+      operator fun invoke(reader: ResponseReader): PageInfo1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val hasNextPage = readBoolean(RESPONSE_FIELDS[1])
+        PageInfo1(
           __typename = __typename,
           hasNextPage = hasNextPage
         )
@@ -355,16 +349,15 @@ data class HeroDetails(
      */
     val isEmpty: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection1.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection1.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection1.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
-      _writer.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
+      writer.writeObject(RESPONSE_FIELDS[3], this@FriendsConnection1.pageInfo.marshaller())
+      writer.writeBoolean(RESPONSE_FIELDS[4], this@FriendsConnection1.isEmpty)
     }
 
     companion object {
@@ -376,21 +369,19 @@ data class HeroDetails(
           ResponseField.forBoolean("isEmpty", "isEmpty", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge1>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge1> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge1> { reader ->
             Edge1(reader)
           }
-
         }
-        val pageInfo = reader.readObject<PageInfo1>(RESPONSE_FIELDS[3]) { reader ->
+        val pageInfo = readObject<PageInfo1>(RESPONSE_FIELDS[3]) { reader ->
           PageInfo1(reader)
         }
-
-        val isEmpty = reader.readBoolean(RESPONSE_FIELDS[4])
-        return FriendsConnection1(
+        val isEmpty = readBoolean(RESPONSE_FIELDS[4])
+        FriendsConnection1(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges,
@@ -416,11 +407,11 @@ data class HeroDetails(
      */
     val primaryFunction: String?
   ) : HeroDetailCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      _writer.writeString(RESPONSE_FIELDS[3], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@AsDroid.friendsConnection.marshaller())
+      writer.writeString(RESPONSE_FIELDS[3], this@AsDroid.primaryFunction)
     }
 
     companion object {
@@ -431,16 +422,14 @@ data class HeroDetails(
           ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) {
-            reader ->
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection1(reader)
         }
-
-        val primaryFunction = reader.readString(RESPONSE_FIELDS[3])
-        return AsDroid(
+        val primaryFunction = readString(RESPONSE_FIELDS[3])
+        AsDroid(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection,

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
@@ -30,11 +30,11 @@ data class HeroDetails(
   val friendsConnection: FriendsConnection,
   val asDroid: AsDroid?
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-    it.writeFragment(asDroid?.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    _writer.writeFragment(asDroid?.marshaller())
   }
 
   companion object {
@@ -100,9 +100,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -129,9 +129,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -158,9 +158,9 @@ data class HeroDetails(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
     }
 
     companion object {
@@ -199,16 +199,16 @@ data class HeroDetails(
      */
     val isEmpty: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
-      it.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
+      _writer.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
+      _writer.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
     }
 
     companion object {
@@ -256,9 +256,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -285,9 +285,9 @@ data class HeroDetails(
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -314,9 +314,9 @@ data class HeroDetails(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeBoolean(RESPONSE_FIELDS[1], hasNextPage)
     }
 
     companion object {
@@ -355,16 +355,16 @@ data class HeroDetails(
      */
     val isEmpty: Boolean
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
-      it.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
+      _writer.writeObject(RESPONSE_FIELDS[3], pageInfo.marshaller())
+      _writer.writeBoolean(RESPONSE_FIELDS[4], isEmpty)
     }
 
     companion object {
@@ -416,11 +416,11 @@ data class HeroDetails(
      */
     val primaryFunction: String?
   ) : HeroDetailCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
-      it.writeString(RESPONSE_FIELDS[3], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+      _writer.writeString(RESPONSE_FIELDS[3], primaryFunction)
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -47,9 +47,9 @@ internal data class CreateReviewForEpisode(
       this["review"] = this@CreateReviewForEpisode.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeString("ep", ep.rawValue)
-      _writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeString("ep", this@CreateReviewForEpisode.ep.rawValue)
+      writer.writeObject("review", this@CreateReviewForEpisode.review.marshaller())
     }
   }
 
@@ -76,9 +76,9 @@ internal data class CreateReviewForEpisode(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@ListOfListOfObject.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@ListOfListOfObject.name)
     }
 
     companion object {
@@ -87,10 +87,10 @@ internal data class CreateReviewForEpisode(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): ListOfListOfObject {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return ListOfListOfObject(
+      operator fun invoke(reader: ResponseReader): ListOfListOfObject = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        ListOfListOfObject(
           __typename = __typename,
           name = name
         )
@@ -125,43 +125,43 @@ internal data class CreateReviewForEpisode(
      */
     val listOfListOfObject: List<List<ListOfListOfObject>>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], stars)
-      _writer.writeString(RESPONSE_FIELDS[2], commentary)
-      _writer.writeList(RESPONSE_FIELDS[3], listOfListOfString) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
-            _value?.forEach { _value ->
-              _listItemWriter.writeString(_value)
-            }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@CreateReview.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@CreateReview.stars)
+      writer.writeString(RESPONSE_FIELDS[2], this@CreateReview.commentary)
+      writer.writeList(RESPONSE_FIELDS[3], this@CreateReview.listOfListOfString) { value,
+          listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeList(value) { value, listItemWriter ->
+            value?.forEach { value ->
+              listItemWriter.writeString(value)}
           }
         }
       }
-      _writer.writeList(RESPONSE_FIELDS[4], listOfListOfEnum) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
-            _value?.forEach { _value ->
-              _listItemWriter.writeString(_value?.rawValue)
-            }
+      writer.writeList(RESPONSE_FIELDS[4], this@CreateReview.listOfListOfEnum) { value,
+          listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeList(value) { value, listItemWriter ->
+            value?.forEach { value ->
+              listItemWriter.writeString(value?.rawValue)}
           }
         }
       }
-      _writer.writeList(RESPONSE_FIELDS[5], listOfListOfCustom) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
-            _value?.forEach { _value ->
-              _listItemWriter.writeCustom(CustomType.DATE, _value)
-            }
+      writer.writeList(RESPONSE_FIELDS[5], this@CreateReview.listOfListOfCustom) { value,
+          listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeList(value) { value, listItemWriter ->
+            value?.forEach { value ->
+              listItemWriter.writeCustom(CustomType.DATE, value)}
           }
         }
       }
-      _writer.writeList(RESPONSE_FIELDS[6], listOfListOfObject) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
-            _value?.forEach { _value ->
-              _listItemWriter.writeObject(_value?.marshaller())
-            }
+      writer.writeList(RESPONSE_FIELDS[6], this@CreateReview.listOfListOfObject) { value,
+          listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeList(value) { value, listItemWriter ->
+            value?.forEach { value ->
+              listItemWriter.writeObject(value?.marshaller())}
           }
         }
       }
@@ -178,34 +178,30 @@ internal data class CreateReviewForEpisode(
           ResponseField.forList("listOfListOfObject", "listOfListOfObject", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): CreateReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val stars = reader.readInt(RESPONSE_FIELDS[1])
-        val commentary = reader.readString(RESPONSE_FIELDS[2])
-        val listOfListOfString = reader.readList<List<String>>(RESPONSE_FIELDS[3]) {
-          it.readList<String> {
-            it.readString()
-          }
+      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val stars = readInt(RESPONSE_FIELDS[1])
+        val commentary = readString(RESPONSE_FIELDS[2])
+        val listOfListOfString = readList<List<String>>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readList<String> { reader ->
+            reader.readString()}
         }
-        val listOfListOfEnum = reader.readList<List<Episode>>(RESPONSE_FIELDS[4]) {
-          it.readList<Episode> {
-            Episode.safeValueOf(it.readString())
-          }
+        val listOfListOfEnum = readList<List<Episode>>(RESPONSE_FIELDS[4]) { reader ->
+          reader.readList<Episode> { reader ->
+            Episode.safeValueOf(reader.readString())}
         }
-        val listOfListOfCustom = reader.readList<List<Date>>(RESPONSE_FIELDS[5]) {
-          it.readList<Date> {
-            it.readCustomType<Date>(CustomType.DATE)
-          }
+        val listOfListOfCustom = readList<List<Date>>(RESPONSE_FIELDS[5]) { reader ->
+          reader.readList<Date> { reader ->
+            reader.readCustomType<Date>(CustomType.DATE)}
         }
-        val listOfListOfObject = reader.readList<List<ListOfListOfObject>>(RESPONSE_FIELDS[6]) {
-          it.readList<ListOfListOfObject> {
-            it.readObject<ListOfListOfObject> { reader ->
+        val listOfListOfObject = readList<List<ListOfListOfObject>>(RESPONSE_FIELDS[6]) { reader ->
+          reader.readList<ListOfListOfObject> { reader ->
+            reader.readObject<ListOfListOfObject> { reader ->
               ListOfListOfObject(reader)
             }
-
           }
         }
-        return CreateReview(
+        CreateReview(
           __typename = __typename,
           stars = stars,
           commentary = commentary,
@@ -221,8 +217,8 @@ internal data class CreateReviewForEpisode(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.createReview?.marshaller())
     }
 
     companion object {
@@ -236,12 +232,11 @@ internal data class CreateReviewForEpisode(
               "variableName" to "review")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val createReview = reader.readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
           CreateReview(reader)
         }
-
-        return Data(
+        Data(
           createReview = createReview
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -43,13 +43,13 @@ internal data class CreateReviewForEpisode(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["ep"] = ep
-      this["review"] = review
+      this["ep"] = this@CreateReviewForEpisode.ep
+      this["review"] = this@CreateReviewForEpisode.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeString("ep", ep.rawValue)
-      writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeString("ep", ep.rawValue)
+      _writer.writeObject("review", review.marshaller())
     }
   }
 
@@ -76,9 +76,9 @@ internal data class CreateReviewForEpisode(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -125,42 +125,42 @@ internal data class CreateReviewForEpisode(
      */
     val listOfListOfObject: List<List<ListOfListOfObject>>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], stars)
-      it.writeString(RESPONSE_FIELDS[2], commentary)
-      it.writeList(RESPONSE_FIELDS[3], listOfListOfString) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            value?.forEach { value ->
-              listItemWriter.writeString(value)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], stars)
+      _writer.writeString(RESPONSE_FIELDS[2], commentary)
+      _writer.writeList(RESPONSE_FIELDS[3], listOfListOfString) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
+            _value?.forEach { _value ->
+              _listItemWriter.writeString(_value)
             }
           }
         }
       }
-      it.writeList(RESPONSE_FIELDS[4], listOfListOfEnum) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            value?.forEach { value ->
-              listItemWriter.writeString(value?.rawValue)
+      _writer.writeList(RESPONSE_FIELDS[4], listOfListOfEnum) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
+            _value?.forEach { _value ->
+              _listItemWriter.writeString(_value?.rawValue)
             }
           }
         }
       }
-      it.writeList(RESPONSE_FIELDS[5], listOfListOfCustom) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            value?.forEach { value ->
-              listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList(RESPONSE_FIELDS[5], listOfListOfCustom) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
+            _value?.forEach { _value ->
+              _listItemWriter.writeCustom(CustomType.DATE, _value)
             }
           }
         }
       }
-      it.writeList(RESPONSE_FIELDS[6], listOfListOfObject) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            value?.forEach { value ->
-              listItemWriter.writeObject(value?.marshaller())
+      _writer.writeList(RESPONSE_FIELDS[6], listOfListOfObject) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
+            _value?.forEach { _value ->
+              _listItemWriter.writeObject(_value?.marshaller())
             }
           }
         }
@@ -221,8 +221,8 @@ internal data class CreateReviewForEpisode(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.kt
@@ -39,13 +39,18 @@ internal data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("red", red)
-    if (green.defined) _writer.writeDouble("green", green.value)
-    _writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
-        reviewRefInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("red", this@ColorInput.red)
+    if (this@ColorInput.green.defined) {
+      writer.writeDouble("green", this@ColorInput.green.value)
+    }
+    writer.writeDouble("blue", this@ColorInput.blue)
+    if (this@ColorInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ColorInput.enumWithDefaultValue.value?.rawValue)
+    }
+    if (this@ColorInput.reviewRefInput.defined) {
+      writer.writeObject("reviewRefInput", this@ColorInput.reviewRefInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ColorInput.kt
@@ -39,13 +39,13 @@ internal data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("red", red)
-    if (green.defined) writer.writeDouble("green", green.value)
-    writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("red", red)
+    if (green.defined) _writer.writeDouble("green", green.value)
+    _writer.writeDouble("blue", blue)
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) writer.writeObject("reviewRefInput",
+    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
         reviewRefInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.kt
@@ -104,77 +104,77 @@ internal data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("stars", stars)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("stars", stars)
     if (nullableIntFieldWithDefaultValue.defined)
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) writer.writeString("commentary", commentary.value)
-    writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
+    if (commentary.defined) _writer.writeString("commentary", commentary.value)
+    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
+    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
+    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
     if (listOfCustomScalar.defined) {
-      writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeCustom(CustomType.DATE, _value)
           }
         }
       })
     }
-    if (customScalar.defined) writer.writeCustom("customScalar", CustomType.DATE,
+    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
         customScalar.value)
     if (listOfEnums.defined) {
-      writer.writeList("listOfEnums", listOfEnums.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value?.rawValue)
+      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value?.rawValue)
           }
         }
       })
     }
     if (listOfInt.defined) {
-      writer.writeList("listOfInt", listOfInt.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeInt(value)
+      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeInt(_value)
           }
         }
       })
     }
     if (listOfString.defined) {
-      writer.writeList("listOfString", listOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value)
+      _writer.writeList("listOfString", listOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value)
           }
         }
       })
     }
-    writer.writeList("listOfStringNonOptional") { listItemWriter ->
-      listOfStringNonOptional.forEach { value ->
-        listItemWriter.writeString(value)
+    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
+      listOfStringNonOptional.forEach { _value ->
+        _listItemWriter.writeString(_value)
       }
     }
     if (listOfInputTypes.defined) {
-      writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeObject(value?.marshaller())
+      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeObject(_value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) writer.writeBoolean("booleanWithDefaultValue",
+    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
         booleanWithDefaultValue.value)
     if (listOfListOfString.defined) {
-      writer.writeList("listOfListOfString", listOfListOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value)
+      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value)
               }
             }
           }
@@ -182,12 +182,12 @@ internal data class ReviewInput(
       })
     }
     if (listOfListOfEnum.defined) {
-      writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value.rawValue)
+      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value.rawValue)
               }
             }
           }
@@ -195,12 +195,12 @@ internal data class ReviewInput(
       })
     }
     if (listOfListOfCustom.defined) {
-      writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeCustom(CustomType.DATE, _value)
               }
             }
           }
@@ -208,18 +208,18 @@ internal data class ReviewInput(
       })
     }
     if (listOfListOfObject.defined) {
-      writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeObject(value.marshaller())
+      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeObject(_value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) writer.writeString("CapitalizedField", capitalizedField.value)
+    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewInput.kt
@@ -104,122 +104,139 @@ internal data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("stars", stars)
-    if (nullableIntFieldWithDefaultValue.defined)
-        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) _writer.writeString("commentary", commentary.value)
-    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
-    if (listOfCustomScalar.defined) {
-      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeCustom(CustomType.DATE, _value)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("stars", this@ReviewInput.stars)
+    if (this@ReviewInput.nullableIntFieldWithDefaultValue.defined) {
+      writer.writeInt("nullableIntFieldWithDefaultValue",
+        this@ReviewInput.nullableIntFieldWithDefaultValue.value)
+    }
+    if (this@ReviewInput.commentary.defined) {
+      writer.writeString("commentary", this@ReviewInput.commentary.value)
+    }
+    writer.writeObject("favoriteColor", this@ReviewInput.favoriteColor.marshaller())
+    if (this@ReviewInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ReviewInput.enumWithDefaultValue.value?.rawValue)
+    }
+    writer.writeString("nonNullableEnumWithDefaultValue",
+        this@ReviewInput.nonNullableEnumWithDefaultValue.rawValue)
+    if (this@ReviewInput.nullableEnum.defined) {
+      writer.writeString("nullableEnum", this@ReviewInput.nullableEnum.value?.rawValue)
+    }
+    if (this@ReviewInput.listOfCustomScalar.defined) {
+      writer.writeList("listOfCustomScalar", this@ReviewInput.listOfCustomScalar.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeCustom(CustomType.DATE, value)
           }
         }
       })
     }
-    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
-        customScalar.value)
-    if (listOfEnums.defined) {
-      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value?.rawValue)
+    if (this@ReviewInput.customScalar.defined) {
+      writer.writeCustom("customScalar", CustomType.DATE, this@ReviewInput.customScalar.value)
+    }
+    if (this@ReviewInput.listOfEnums.defined) {
+      writer.writeList("listOfEnums", this@ReviewInput.listOfEnums.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value?.rawValue)
           }
         }
       })
     }
-    if (listOfInt.defined) {
-      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeInt(_value)
+    if (this@ReviewInput.listOfInt.defined) {
+      writer.writeList("listOfInt", this@ReviewInput.listOfInt.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeInt(value)
           }
         }
       })
     }
-    if (listOfString.defined) {
-      _writer.writeList("listOfString", listOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value)
+    if (this@ReviewInput.listOfString.defined) {
+      writer.writeList("listOfString", this@ReviewInput.listOfString.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value)
           }
         }
       })
     }
-    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
-      listOfStringNonOptional.forEach { _value ->
-        _listItemWriter.writeString(_value)
+    writer.writeList("listOfStringNonOptional") { listItemWriter ->
+      this@ReviewInput.listOfStringNonOptional.forEach { value ->
+        listItemWriter.writeString(value)
       }
     }
-    if (listOfInputTypes.defined) {
-      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeObject(_value?.marshaller())
+    if (this@ReviewInput.listOfInputTypes.defined) {
+      writer.writeList("listOfInputTypes", this@ReviewInput.listOfInputTypes.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeObject(value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
-        booleanWithDefaultValue.value)
-    if (listOfListOfString.defined) {
-      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value)
+    if (this@ReviewInput.booleanWithDefaultValue.defined) {
+      writer.writeBoolean("booleanWithDefaultValue", this@ReviewInput.booleanWithDefaultValue.value)
+    }
+    if (this@ReviewInput.listOfListOfString.defined) {
+      writer.writeList("listOfListOfString", this@ReviewInput.listOfListOfString.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfEnum.defined) {
-      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value.rawValue)
+    if (this@ReviewInput.listOfListOfEnum.defined) {
+      writer.writeList("listOfListOfEnum", this@ReviewInput.listOfListOfEnum.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value.rawValue)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfCustom.defined) {
-      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeCustom(CustomType.DATE, _value)
+    if (this@ReviewInput.listOfListOfCustom.defined) {
+      writer.writeList("listOfListOfCustom", this@ReviewInput.listOfListOfCustom.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeCustom(CustomType.DATE, value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfObject.defined) {
-      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeObject(_value.marshaller())
+    if (this@ReviewInput.listOfListOfObject.defined) {
+      writer.writeList("listOfListOfObject", this@ReviewInput.listOfListOfObject.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeObject(value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
+    if (this@ReviewInput.capitalizedField.defined) {
+      writer.writeString("CapitalizedField", this@ReviewInput.capitalizedField.value)
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewRefInput.kt
@@ -18,7 +18,9 @@ import kotlin.Suppress
 internal data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    if (this@ReviewRefInput.reviewInput.defined) {
+      writer.writeObject("reviewInput", this@ReviewRefInput.reviewInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/ReviewRefInput.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 internal data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    if (reviewInput.defined) writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -45,9 +45,9 @@ data class CreateReviewForEpisodeMutation(
       this["review"] = this@CreateReviewForEpisodeMutation.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeString("ep", ep.rawValue)
-      _writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeString("ep", this@CreateReviewForEpisodeMutation.ep.rawValue)
+      writer.writeObject("review", this@CreateReviewForEpisodeMutation.review.marshaller())
     }
   }
 
@@ -78,10 +78,10 @@ data class CreateReviewForEpisodeMutation(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], stars)
-      _writer.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@CreateReview.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@CreateReview.stars)
+      writer.writeString(RESPONSE_FIELDS[2], this@CreateReview.commentary)
     }
 
     companion object {
@@ -91,11 +91,11 @@ data class CreateReviewForEpisodeMutation(
           ResponseField.forString("commentary", "commentary", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): CreateReview {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val stars = reader.readInt(RESPONSE_FIELDS[1])
-        val commentary = reader.readString(RESPONSE_FIELDS[2])
-        return CreateReview(
+      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val stars = readInt(RESPONSE_FIELDS[1])
+        val commentary = readString(RESPONSE_FIELDS[2])
+        CreateReview(
           __typename = __typename,
           stars = stars,
           commentary = commentary
@@ -107,8 +107,8 @@ data class CreateReviewForEpisodeMutation(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.createReview?.marshaller())
     }
 
     companion object {
@@ -122,12 +122,11 @@ data class CreateReviewForEpisodeMutation(
               "variableName" to "review")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val createReview = reader.readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
           CreateReview(reader)
         }
-
-        return Data(
+        Data(
           createReview = createReview
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -41,13 +41,13 @@ data class CreateReviewForEpisodeMutation(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["ep"] = ep
-      this["review"] = review
+      this["ep"] = this@CreateReviewForEpisodeMutation.ep
+      this["review"] = this@CreateReviewForEpisodeMutation.review
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeString("ep", ep.rawValue)
-      writer.writeObject("review", review.marshaller())
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeString("ep", ep.rawValue)
+      _writer.writeObject("review", review.marshaller())
     }
   }
 
@@ -78,10 +78,10 @@ data class CreateReviewForEpisodeMutation(
      */
     val commentary: String?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], stars)
-      it.writeString(RESPONSE_FIELDS[2], commentary)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], stars)
+      _writer.writeString(RESPONSE_FIELDS[2], commentary)
     }
 
     companion object {
@@ -107,8 +107,8 @@ data class CreateReviewForEpisodeMutation(
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], createReview?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.kt
@@ -39,13 +39,18 @@ data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("red", red)
-    if (green.defined) _writer.writeDouble("green", green.value)
-    _writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
-        reviewRefInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("red", this@ColorInput.red)
+    if (this@ColorInput.green.defined) {
+      writer.writeDouble("green", this@ColorInput.green.value)
+    }
+    writer.writeDouble("blue", this@ColorInput.blue)
+    if (this@ColorInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ColorInput.enumWithDefaultValue.value?.rawValue)
+    }
+    if (this@ColorInput.reviewRefInput.defined) {
+      writer.writeObject("reviewRefInput", this@ColorInput.reviewRefInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ColorInput.kt
@@ -39,13 +39,13 @@ data class ColorInput(
    */
   val reviewRefInput: Input<ReviewRefInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("red", red)
-    if (green.defined) writer.writeDouble("green", green.value)
-    writer.writeDouble("blue", blue)
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("red", red)
+    if (green.defined) _writer.writeDouble("green", green.value)
+    _writer.writeDouble("blue", blue)
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    if (reviewRefInput.defined) writer.writeObject("reviewRefInput",
+    if (reviewRefInput.defined) _writer.writeObject("reviewRefInput",
         reviewRefInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.kt
@@ -104,122 +104,139 @@ data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    _writer.writeInt("stars", stars)
-    if (nullableIntFieldWithDefaultValue.defined)
-        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) _writer.writeString("commentary", commentary.value)
-    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
-        enumWithDefaultValue.value?.rawValue)
-    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
-    if (listOfCustomScalar.defined) {
-      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeCustom(CustomType.DATE, _value)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    writer.writeInt("stars", this@ReviewInput.stars)
+    if (this@ReviewInput.nullableIntFieldWithDefaultValue.defined) {
+      writer.writeInt("nullableIntFieldWithDefaultValue",
+        this@ReviewInput.nullableIntFieldWithDefaultValue.value)
+    }
+    if (this@ReviewInput.commentary.defined) {
+      writer.writeString("commentary", this@ReviewInput.commentary.value)
+    }
+    writer.writeObject("favoriteColor", this@ReviewInput.favoriteColor.marshaller())
+    if (this@ReviewInput.enumWithDefaultValue.defined) {
+      writer.writeString("enumWithDefaultValue",
+        this@ReviewInput.enumWithDefaultValue.value?.rawValue)
+    }
+    writer.writeString("nonNullableEnumWithDefaultValue",
+        this@ReviewInput.nonNullableEnumWithDefaultValue.rawValue)
+    if (this@ReviewInput.nullableEnum.defined) {
+      writer.writeString("nullableEnum", this@ReviewInput.nullableEnum.value?.rawValue)
+    }
+    if (this@ReviewInput.listOfCustomScalar.defined) {
+      writer.writeList("listOfCustomScalar", this@ReviewInput.listOfCustomScalar.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeCustom(CustomType.DATE, value)
           }
         }
       })
     }
-    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
-        customScalar.value)
-    if (listOfEnums.defined) {
-      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value?.rawValue)
+    if (this@ReviewInput.customScalar.defined) {
+      writer.writeCustom("customScalar", CustomType.DATE, this@ReviewInput.customScalar.value)
+    }
+    if (this@ReviewInput.listOfEnums.defined) {
+      writer.writeList("listOfEnums", this@ReviewInput.listOfEnums.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value?.rawValue)
           }
         }
       })
     }
-    if (listOfInt.defined) {
-      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeInt(_value)
+    if (this@ReviewInput.listOfInt.defined) {
+      writer.writeList("listOfInt", this@ReviewInput.listOfInt.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeInt(value)
           }
         }
       })
     }
-    if (listOfString.defined) {
-      _writer.writeList("listOfString", listOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeString(_value)
+    if (this@ReviewInput.listOfString.defined) {
+      writer.writeList("listOfString", this@ReviewInput.listOfString.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeString(value)
           }
         }
       })
     }
-    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
-      listOfStringNonOptional.forEach { _value ->
-        _listItemWriter.writeString(_value)
+    writer.writeList("listOfStringNonOptional") { listItemWriter ->
+      this@ReviewInput.listOfStringNonOptional.forEach { value ->
+        listItemWriter.writeString(value)
       }
     }
-    if (listOfInputTypes.defined) {
-      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeObject(_value?.marshaller())
+    if (this@ReviewInput.listOfInputTypes.defined) {
+      writer.writeList("listOfInputTypes", this@ReviewInput.listOfInputTypes.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeObject(value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
-        booleanWithDefaultValue.value)
-    if (listOfListOfString.defined) {
-      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value)
+    if (this@ReviewInput.booleanWithDefaultValue.defined) {
+      writer.writeBoolean("booleanWithDefaultValue", this@ReviewInput.booleanWithDefaultValue.value)
+    }
+    if (this@ReviewInput.listOfListOfString.defined) {
+      writer.writeList("listOfListOfString", this@ReviewInput.listOfListOfString.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfEnum.defined) {
-      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeString(_value.rawValue)
+    if (this@ReviewInput.listOfListOfEnum.defined) {
+      writer.writeList("listOfListOfEnum", this@ReviewInput.listOfListOfEnum.value?.let { value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeString(value.rawValue)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfCustom.defined) {
-      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeCustom(CustomType.DATE, _value)
+    if (this@ReviewInput.listOfListOfCustom.defined) {
+      writer.writeList("listOfListOfCustom", this@ReviewInput.listOfListOfCustom.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeCustom(CustomType.DATE, value)
               }
             }
           }
         }
       })
     }
-    if (listOfListOfObject.defined) {
-      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
-        InputFieldWriter.ListWriter { _listItemWriter ->
-          _value.forEach { _value ->
-            _listItemWriter.writeList { _listItemWriter ->
-              _value.forEach { _value ->
-                _listItemWriter.writeObject(_value.marshaller())
+    if (this@ReviewInput.listOfListOfObject.defined) {
+      writer.writeList("listOfListOfObject", this@ReviewInput.listOfListOfObject.value?.let {
+          value ->
+        InputFieldWriter.ListWriter { listItemWriter ->
+          value.forEach { value ->
+            listItemWriter.writeList { listItemWriter ->
+              value.forEach { value ->
+                listItemWriter.writeObject(value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
+    if (this@ReviewInput.capitalizedField.defined) {
+      writer.writeString("CapitalizedField", this@ReviewInput.capitalizedField.value)
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewInput.kt
@@ -104,77 +104,77 @@ data class ReviewInput(
    */
   val capitalizedField: Input<String> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    writer.writeInt("stars", stars)
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    _writer.writeInt("stars", stars)
     if (nullableIntFieldWithDefaultValue.defined)
-        writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
-    if (commentary.defined) writer.writeString("commentary", commentary.value)
-    writer.writeObject("favoriteColor", favoriteColor.marshaller())
-    if (enumWithDefaultValue.defined) writer.writeString("enumWithDefaultValue",
+        _writer.writeInt("nullableIntFieldWithDefaultValue", nullableIntFieldWithDefaultValue.value)
+    if (commentary.defined) _writer.writeString("commentary", commentary.value)
+    _writer.writeObject("favoriteColor", favoriteColor.marshaller())
+    if (enumWithDefaultValue.defined) _writer.writeString("enumWithDefaultValue",
         enumWithDefaultValue.value?.rawValue)
-    writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
-    if (nullableEnum.defined) writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
+    _writer.writeString("nonNullableEnumWithDefaultValue", nonNullableEnumWithDefaultValue.rawValue)
+    if (nullableEnum.defined) _writer.writeString("nullableEnum", nullableEnum.value?.rawValue)
     if (listOfCustomScalar.defined) {
-      writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfCustomScalar", listOfCustomScalar.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeCustom(CustomType.DATE, _value)
           }
         }
       })
     }
-    if (customScalar.defined) writer.writeCustom("customScalar", CustomType.DATE,
+    if (customScalar.defined) _writer.writeCustom("customScalar", CustomType.DATE,
         customScalar.value)
     if (listOfEnums.defined) {
-      writer.writeList("listOfEnums", listOfEnums.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value?.rawValue)
+      _writer.writeList("listOfEnums", listOfEnums.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value?.rawValue)
           }
         }
       })
     }
     if (listOfInt.defined) {
-      writer.writeList("listOfInt", listOfInt.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeInt(value)
+      _writer.writeList("listOfInt", listOfInt.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeInt(_value)
           }
         }
       })
     }
     if (listOfString.defined) {
-      writer.writeList("listOfString", listOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeString(value)
+      _writer.writeList("listOfString", listOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeString(_value)
           }
         }
       })
     }
-    writer.writeList("listOfStringNonOptional") { listItemWriter ->
-      listOfStringNonOptional.forEach { value ->
-        listItemWriter.writeString(value)
+    _writer.writeList("listOfStringNonOptional") { _listItemWriter ->
+      listOfStringNonOptional.forEach { _value ->
+        _listItemWriter.writeString(_value)
       }
     }
     if (listOfInputTypes.defined) {
-      writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeObject(value?.marshaller())
+      _writer.writeList("listOfInputTypes", listOfInputTypes.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeObject(_value?.marshaller())
           }
         }
       })
     }
-    if (booleanWithDefaultValue.defined) writer.writeBoolean("booleanWithDefaultValue",
+    if (booleanWithDefaultValue.defined) _writer.writeBoolean("booleanWithDefaultValue",
         booleanWithDefaultValue.value)
     if (listOfListOfString.defined) {
-      writer.writeList("listOfListOfString", listOfListOfString.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value)
+      _writer.writeList("listOfListOfString", listOfListOfString.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value)
               }
             }
           }
@@ -182,12 +182,12 @@ data class ReviewInput(
       })
     }
     if (listOfListOfEnum.defined) {
-      writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeString(value.rawValue)
+      _writer.writeList("listOfListOfEnum", listOfListOfEnum.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeString(_value.rawValue)
               }
             }
           }
@@ -195,12 +195,12 @@ data class ReviewInput(
       })
     }
     if (listOfListOfCustom.defined) {
-      writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeCustom(CustomType.DATE, value)
+      _writer.writeList("listOfListOfCustom", listOfListOfCustom.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeCustom(CustomType.DATE, _value)
               }
             }
           }
@@ -208,18 +208,18 @@ data class ReviewInput(
       })
     }
     if (listOfListOfObject.defined) {
-      writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { value ->
-        InputFieldWriter.ListWriter { listItemWriter ->
-          value.forEach { value ->
-            listItemWriter.writeList { listItemWriter ->
-              value.forEach { value ->
-                listItemWriter.writeObject(value.marshaller())
+      _writer.writeList("listOfListOfObject", listOfListOfObject.value?.let { _value ->
+        InputFieldWriter.ListWriter { _listItemWriter ->
+          _value.forEach { _value ->
+            _listItemWriter.writeList { _listItemWriter ->
+              _value.forEach { _value ->
+                _listItemWriter.writeObject(_value.marshaller())
               }
             }
           }
         }
       })
     }
-    if (capitalizedField.defined) writer.writeString("CapitalizedField", capitalizedField.value)
+    if (capitalizedField.defined) _writer.writeString("CapitalizedField", capitalizedField.value)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewRefInput.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-    if (reviewInput.defined) writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewRefInput.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/ReviewRefInput.kt
@@ -18,7 +18,9 @@ import kotlin.Suppress
 data class ReviewRefInput(
   val reviewInput: Input<ReviewInput> = Input.absent()
 ) : InputType {
-  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-    if (reviewInput.defined) _writer.writeObject("reviewInput", reviewInput.value?.marshaller())
+  override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+    if (this@ReviewRefInput.reviewInput.defined) {
+      writer.writeObject("reviewInput", this@ReviewRefInput.reviewInput.value?.marshaller())
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -40,11 +40,11 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = episode.value
+      if (episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      if (episode.defined) writer.writeString("episode", episode.value?.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
     }
   }
 
@@ -83,10 +83,10 @@ data class TestQuery(
      */
     val height: Double?
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeDouble(RESPONSE_FIELDS[2], height)
     }
 
     companion object {
@@ -118,10 +118,10 @@ data class TestQuery(
     val name: String,
     val asHuman1: AsHuman1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman1?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman1?.marshaller())
     }
 
     companion object {
@@ -159,12 +159,12 @@ data class TestQuery(
      */
     val friends: List<Friend?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -209,10 +209,10 @@ data class TestQuery(
      */
     val height: Double?
   ) : FriendCharacter1 {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeDouble(RESPONSE_FIELDS[2], height)
     }
 
     companion object {
@@ -244,10 +244,10 @@ data class TestQuery(
     val name: String,
     val asHuman2: AsHuman2?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman2?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman2?.marshaller())
     }
 
     companion object {
@@ -285,12 +285,12 @@ data class TestQuery(
      */
     val friends: List<Friend1?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -329,11 +329,11 @@ data class TestQuery(
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman?.marshaller())
-      it.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asDroid?.marshaller())
     }
 
     companion object {
@@ -370,8 +370,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -43,8 +43,10 @@ data class TestQuery(
       if (episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      if (episode.defined) _writer.writeString("episode", episode.value?.rawValue)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      if (this@TestQuery.episode.defined) {
+        writer.writeString("episode", this@TestQuery.episode.value?.rawValue)
+      }
     }
   }
 
@@ -83,10 +85,10 @@ data class TestQuery(
      */
     val height: Double?
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman1.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman1.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman1.height)
     }
 
     companion object {
@@ -97,11 +99,11 @@ data class TestQuery(
             "unit" to "FOOT"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        return AsHuman1(
+      operator fun invoke(reader: ResponseReader): AsHuman1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        AsHuman1(
           __typename = __typename,
           name = name,
           height = height
@@ -118,10 +120,10 @@ data class TestQuery(
     val name: String,
     val asHuman1: AsHuman1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman1?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend.name)
+      writer.writeFragment(this@Friend.asHuman1?.marshaller())
     }
 
     companion object {
@@ -133,13 +135,13 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman1 = reader.readFragment<AsHuman1>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Friend = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman1 = readFragment<AsHuman1>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman1(reader)
         }
-        return Friend(
+        Friend(
           __typename = __typename,
           name = name,
           asHuman1 = asHuman1
@@ -159,13 +161,12 @@ data class TestQuery(
      */
     val friends: List<Friend?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@AsHuman.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -176,16 +177,15 @@ data class TestQuery(
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend> { reader ->
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend> { reader ->
             Friend(reader)
           }
-
         }
-        return AsHuman(
+        AsHuman(
           __typename = __typename,
           name = name,
           friends = friends
@@ -209,10 +209,10 @@ data class TestQuery(
      */
     val height: Double?
   ) : FriendCharacter1 {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman2.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman2.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman2.height)
     }
 
     companion object {
@@ -223,11 +223,11 @@ data class TestQuery(
             "unit" to "METER"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        return AsHuman2(
+      operator fun invoke(reader: ResponseReader): AsHuman2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        AsHuman2(
           __typename = __typename,
           name = name,
           height = height
@@ -244,10 +244,10 @@ data class TestQuery(
     val name: String,
     val asHuman2: AsHuman2?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman2?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend1.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend1.name)
+      writer.writeFragment(this@Friend1.asHuman2?.marshaller())
     }
 
     companion object {
@@ -259,13 +259,13 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Friend1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman2 = reader.readFragment<AsHuman2>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman2 = readFragment<AsHuman2>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman2(reader)
         }
-        return Friend1(
+        Friend1(
           __typename = __typename,
           name = name,
           asHuman2 = asHuman2
@@ -285,13 +285,12 @@ data class TestQuery(
      */
     val friends: List<Friend1?>?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@AsDroid.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -302,16 +301,15 @@ data class TestQuery(
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend1>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend1> { reader ->
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend1> { reader ->
             Friend1(reader)
           }
-
         }
-        return AsDroid(
+        AsDroid(
           __typename = __typename,
           name = name,
           friends = friends
@@ -329,11 +327,11 @@ data class TestQuery(
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman?.marshaller())
-      _writer.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeFragment(this@Hero.asHuman?.marshaller())
+      writer.writeFragment(this@Hero.asDroid?.marshaller())
     }
 
     companion object {
@@ -348,16 +346,16 @@ data class TestQuery(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+        val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
           AsDroid(reader)
         }
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           asHuman = asHuman,
@@ -370,8 +368,8 @@ data class TestQuery(
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -382,12 +380,11 @@ data class TestQuery(
               "variableName" to "episode")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -55,10 +55,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, this@Hero.id)
     }
 
     companion object {
@@ -68,11 +68,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
-        return Hero(
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+        Hero(
           __typename = __typename,
           name = name,
           id = id
@@ -84,8 +84,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -93,12 +93,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -55,10 +55,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val id: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, id)
     }
 
     companion object {
@@ -84,8 +84,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -49,9 +49,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -73,9 +73,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
       val heroDetails: HeroDetails,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
-        it.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
+        _writer.writeFragment(humanDetails?.marshaller())
       }
 
       companion object {
@@ -107,8 +107,8 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -49,9 +49,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      this@Hero.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -59,10 +59,10 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Hero(
+        Hero(
           __typename = __typename,
           fragments = fragments
         )
@@ -73,9 +73,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
       val heroDetails: HeroDetails,
       val humanDetails: HumanDetails?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
-        _writer.writeFragment(humanDetails?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
+        writer.writeFragment(this@Fragments.humanDetails?.marshaller())
       }
 
       companion object {
@@ -88,14 +88,14 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
+          val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[1]) { reader ->
             HumanDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails,
             humanDetails = humanDetails
           )
@@ -107,8 +107,8 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -116,12 +116,11 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -23,10 +23,10 @@ internal data class HeroDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(_writer)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    this@HeroDetails.fragments.marshaller().marshal(writer)
   }
 
   companion object {
@@ -43,11 +43,11 @@ internal data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
       val fragments = Fragments(reader)
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         fragments = fragments
@@ -58,8 +58,8 @@ internal data class HeroDetails(
   internal data class Fragments(
     val humanDetails: HumanDetails?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeFragment(humanDetails?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeFragment(this@Fragments.humanDetails?.marshaller())
     }
 
     companion object {
@@ -69,11 +69,11 @@ internal data class HeroDetails(
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Fragments {
-        val humanDetails = reader.readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+        val humanDetails = readFragment<HumanDetails>(RESPONSE_FIELDS[0]) { reader ->
           HumanDetails(reader)
         }
-        return Fragments(
+        Fragments(
           humanDetails = humanDetails
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -23,10 +23,10 @@ internal data class HeroDetails(
   val name: String,
   val fragments: Fragments
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    fragments.marshaller().marshal(it)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    fragments.marshaller().marshal(_writer)
   }
 
   companion object {
@@ -58,8 +58,8 @@ internal data class HeroDetails(
   internal data class Fragments(
     val humanDetails: HumanDetails?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeFragment(humanDetails?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeFragment(humanDetails?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -22,9 +22,9 @@ internal data class HumanDetails(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HumanDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HumanDetails.name)
   }
 
   companion object {
@@ -40,10 +40,10 @@ internal data class HumanDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      return HumanDetails(
+    operator fun invoke(reader: ResponseReader): HumanDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      HumanDetails(
         __typename = __typename,
         name = name
       )

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -22,9 +22,9 @@ internal data class HumanDetails(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val height: Double?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeDouble(RESPONSE_FIELDS[2], height)
     }
 
     companion object {
@@ -96,10 +96,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val primaryFunction: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeString(RESPONSE_FIELDS[2], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
     }
 
     companion object {
@@ -131,11 +131,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman?.marshaller())
-      it.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asDroid?.marshaller())
     }
 
     companion object {
@@ -172,8 +172,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -59,10 +59,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val height: Double?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeDouble(RESPONSE_FIELDS[2], height)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman.height)
     }
 
     companion object {
@@ -72,11 +72,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forDouble("height", "height", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val height = reader.readDouble(RESPONSE_FIELDS[2])
-        return AsHuman(
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val height = readDouble(RESPONSE_FIELDS[2])
+        AsHuman(
           __typename = __typename,
           name = name,
           height = height
@@ -96,10 +96,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val primaryFunction: String?
   ) : HeroCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeString(RESPONSE_FIELDS[2], primaryFunction)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.name)
+      writer.writeString(RESPONSE_FIELDS[2], this@AsDroid.primaryFunction)
     }
 
     companion object {
@@ -109,11 +109,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val primaryFunction = reader.readString(RESPONSE_FIELDS[2])
-        return AsDroid(
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val primaryFunction = readString(RESPONSE_FIELDS[2])
+        AsDroid(
           __typename = __typename,
           name = name,
           primaryFunction = primaryFunction
@@ -131,11 +131,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman?.marshaller())
-      _writer.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeFragment(this@Hero.asHuman?.marshaller())
+      writer.writeFragment(this@Hero.asDroid?.marshaller())
     }
 
     companion object {
@@ -150,16 +150,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Hero = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+        val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
           AsDroid(reader)
         }
-        return Hero(
+        Hero(
           __typename = __typename,
           name = name,
           asHuman = asHuman,
@@ -172,8 +172,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val hero: Hero?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], hero?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.hero?.marshaller())
     }
 
     companion object {
@@ -181,12 +181,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("hero", "hero", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val hero = reader.readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
           Hero(reader)
         }
-
-        return Data(
+        Data(
           hero = hero
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -42,8 +42,8 @@ data class TestQuery(
       this["id"] = this@TestQuery.id
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeCustom("id", CustomType.ID, id)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeCustom("id", CustomType.ID, this@TestQuery.id)
     }
   }
 
@@ -75,16 +75,15 @@ data class TestQuery(
     val name: String,
     val coordinates: List<List<Double>>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
-      _writer.writeList(RESPONSE_FIELDS[3], coordinates) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
-            _value?.forEach { _value ->
-              _listItemWriter.writeDouble(_value)
-            }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Starship.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Starship.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@Starship.name)
+      writer.writeList(RESPONSE_FIELDS[3], this@Starship.coordinates) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeList(value) { value, listItemWriter ->
+            value?.forEach { value ->
+              listItemWriter.writeDouble(value)}
           }
         }
       }
@@ -98,16 +97,15 @@ data class TestQuery(
           ResponseField.forList("coordinates", "coordinates", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Starship {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        val coordinates = reader.readList<List<Double>>(RESPONSE_FIELDS[3]) {
-          it.readList<Double> {
-            it.readDouble()
-          }
+      operator fun invoke(reader: ResponseReader): Starship = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        val coordinates = readList<List<Double>>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readList<Double> { reader ->
+            reader.readDouble()}
         }
-        return Starship(
+        Starship(
           __typename = __typename,
           id = id,
           name = name,
@@ -120,8 +118,8 @@ data class TestQuery(
   data class Data(
     val starship: Starship?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], starship?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.starship?.marshaller())
     }
 
     companion object {
@@ -132,12 +130,11 @@ data class TestQuery(
               "variableName" to "id")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val starship = reader.readObject<Starship>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val starship = readObject<Starship>(RESPONSE_FIELDS[0]) { reader ->
           Starship(reader)
         }
-
-        return Data(
+        Data(
           starship = starship
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -39,11 +39,11 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["id"] = id
+      this["id"] = this@TestQuery.id
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeCustom("id", CustomType.ID, id)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeCustom("id", CustomType.ID, id)
     }
   }
 
@@ -75,15 +75,15 @@ data class TestQuery(
     val name: String,
     val coordinates: List<List<Double>>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
-      it.writeList(RESPONSE_FIELDS[3], coordinates) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            value?.forEach { value ->
-              listItemWriter.writeDouble(value)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
+      _writer.writeList(RESPONSE_FIELDS[3], coordinates) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeList(_value) { _value, _listItemWriter ->
+            _value?.forEach { _value ->
+              _listItemWriter.writeDouble(_value)
             }
           }
         }
@@ -120,8 +120,8 @@ data class TestQuery(
   data class Data(
     val starship: Starship?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], starship?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], starship?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -37,11 +37,11 @@ data class TestSubscription(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      this["repo"] = repo
+      this["repo"] = this@TestSubscription.repo
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
-      writer.writeString("repo", repo)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
+      _writer.writeString("repo", repo)
     }
   }
 
@@ -72,10 +72,10 @@ data class TestSubscription(
      */
     val content: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], id)
-      it.writeString(RESPONSE_FIELDS[2], content)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], id)
+      _writer.writeString(RESPONSE_FIELDS[2], content)
     }
 
     companion object {
@@ -104,8 +104,8 @@ data class TestSubscription(
      */
     val commentAdded: CommentAdded?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], commentAdded?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], commentAdded?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -40,8 +40,8 @@ data class TestSubscription(
       this["repo"] = this@TestSubscription.repo
     }
 
-    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { _writer ->
-      _writer.writeString("repo", repo)
+    override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller { writer ->
+      writer.writeString("repo", this@TestSubscription.repo)
     }
   }
 
@@ -72,10 +72,10 @@ data class TestSubscription(
      */
     val content: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], id)
-      _writer.writeString(RESPONSE_FIELDS[2], content)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@CommentAdded.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@CommentAdded.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@CommentAdded.content)
     }
 
     companion object {
@@ -85,11 +85,11 @@ data class TestSubscription(
           ResponseField.forString("content", "content", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): CommentAdded {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readInt(RESPONSE_FIELDS[1])
-        val content = reader.readString(RESPONSE_FIELDS[2])
-        return CommentAdded(
+      operator fun invoke(reader: ResponseReader): CommentAdded = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readInt(RESPONSE_FIELDS[1])
+        val content = readString(RESPONSE_FIELDS[2])
+        CommentAdded(
           __typename = __typename,
           id = id,
           content = content
@@ -104,8 +104,8 @@ data class TestSubscription(
      */
     val commentAdded: CommentAdded?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], commentAdded?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.commentAdded?.marshaller())
     }
 
     companion object {
@@ -116,12 +116,11 @@ data class TestSubscription(
               "variableName" to "repo")), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val commentAdded = reader.readObject<CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val commentAdded = readObject<CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
           CommentAdded(reader)
         }
-
-        return Data(
+        Data(
           commentAdded = commentAdded
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -51,9 +51,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@R2.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@R2.name)
     }
 
     companion object {
@@ -62,10 +62,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return R2(
+      operator fun invoke(reader: ResponseReader): R2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        R2(
           __typename = __typename,
           name = name
         )
@@ -84,10 +84,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Luke.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Luke.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@Luke.name)
     }
 
     companion object {
@@ -97,11 +97,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        return Luke(
+      operator fun invoke(reader: ResponseReader): Luke = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        Luke(
           __typename = __typename,
           id = id,
           name = name
@@ -114,9 +114,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.r2?.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.luke?.marshaller())
     }
 
     companion object {
@@ -126,16 +126,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "episode" to "EMPIRE"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val r2 = reader.readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
           R2(reader)
         }
-
-        val luke = reader.readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
           Luke(reader)
         }
-
-        return Data(
+        Data(
           r2 = r2,
           luke = luke
         )

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -51,9 +51,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -84,10 +84,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
     }
 
     companion object {
@@ -114,9 +114,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -53,9 +53,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -82,9 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -118,12 +118,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -164,10 +164,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
     }
 
     companion object {
@@ -200,9 +200,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -229,9 +229,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -265,12 +265,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -315,11 +315,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection1
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
-      it.writeObject(RESPONSE_FIELDS[3], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
+      _writer.writeObject(RESPONSE_FIELDS[3], friendsConnection.marshaller())
     }
 
     companion object {
@@ -353,9 +353,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      it.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
+      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -53,9 +53,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -64,10 +64,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -82,9 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -93,13 +93,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -118,13 +117,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -135,16 +133,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -164,10 +161,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@R2.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@R2.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@R2.friendsConnection.marshaller())
     }
 
     companion object {
@@ -177,14 +174,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): R2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
           FriendsConnection(reader)
         }
-
-        return R2(
+        R2(
           __typename = __typename,
           name = name,
           friendsConnection = friendsConnection
@@ -200,9 +196,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node1.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node1.name)
     }
 
     companion object {
@@ -211,10 +207,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node1(
+      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node1(
           __typename = __typename,
           name = name
         )
@@ -229,9 +225,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val node: Node1?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge1.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge1.node?.marshaller())
     }
 
     companion object {
@@ -240,13 +236,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
           Node1(reader)
         }
-
-        return Edge1(
+        Edge1(
           __typename = __typename,
           node = node
         )
@@ -265,13 +260,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val edges: List<Edge1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection1.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection1.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection1.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -282,16 +276,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge1>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge1> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge1> { reader ->
             Edge1(reader)
           }
-
         }
-        return FriendsConnection1(
+        FriendsConnection1(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges
@@ -315,11 +308,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friendsConnection: FriendsConnection1
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
-      _writer.writeObject(RESPONSE_FIELDS[3], friendsConnection.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Luke.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Luke.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@Luke.name)
+      writer.writeObject(RESPONSE_FIELDS[3], this@Luke.friendsConnection.marshaller())
     }
 
     companion object {
@@ -330,16 +323,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        val friendsConnection = reader.readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) {
-            reader ->
+      operator fun invoke(reader: ResponseReader): Luke = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) { reader ->
           FriendsConnection1(reader)
         }
-
-        return Luke(
+        Luke(
           __typename = __typename,
           id = id,
           name = name,
@@ -353,9 +344,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val r2: R2?,
     val luke: Luke?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], r2?.marshaller())
-      _writer.writeObject(RESPONSE_FIELDS[1], luke?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.r2?.marshaller())
+      writer.writeObject(RESPONSE_FIELDS[1], this@Data.luke?.marshaller())
     }
 
     companion object {
@@ -365,16 +356,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "episode" to "EMPIRE"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val r2 = reader.readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
           R2(reader)
         }
-
-        val luke = reader.readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
           Luke(reader)
         }
-
-        return Data(
+        Data(
           r2 = r2,
           luke = luke
         )

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -50,9 +50,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "SearchResult",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -74,9 +74,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val character: Character?,
       val starship: Starship?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(character?.marshaller())
-        it.writeFragment(starship?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(character?.marshaller())
+        _writer.writeFragment(starship?.marshaller())
       }
 
       companion object {
@@ -108,10 +108,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeList(RESPONSE_FIELDS[0], search) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeList(RESPONSE_FIELDS[0], search) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -50,9 +50,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val __typename: String = "SearchResult",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Search.__typename)
+      this@Search.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -60,10 +60,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Search {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Search = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Search(
+        Search(
           __typename = __typename,
           fragments = fragments
         )
@@ -74,9 +74,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       val character: Character?,
       val starship: Starship?
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(character?.marshaller())
-        _writer.writeFragment(starship?.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.character?.marshaller())
+        writer.writeFragment(this@Fragments.starship?.marshaller())
       }
 
       companion object {
@@ -89,14 +89,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val character = reader.readFragment<Character>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val character = readFragment<Character>(RESPONSE_FIELDS[0]) { reader ->
             Character(reader)
           }
-          val starship = reader.readFragment<Starship>(RESPONSE_FIELDS[1]) { reader ->
+          val starship = readFragment<Starship>(RESPONSE_FIELDS[1]) { reader ->
             Starship(reader)
           }
-          return Fragments(
+          Fragments(
             character = character,
             starship = starship
           )
@@ -108,11 +108,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeList(RESPONSE_FIELDS[0], search) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeList(RESPONSE_FIELDS[0], this@Data.search) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -122,14 +121,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "text" to "test"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val search = reader.readList<Search>(RESPONSE_FIELDS[0]) {
-          it.readObject<Search> { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
+          reader.readObject<Search> { reader ->
             Search(reader)
           }
-
         }
-        return Data(
+        Data(
           search = search
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -27,10 +27,10 @@ data class Character(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-    it.writeString(RESPONSE_FIELDS[2], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+    _writer.writeString(RESPONSE_FIELDS[2], name)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -27,10 +27,10 @@ data class Character(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-    _writer.writeString(RESPONSE_FIELDS[2], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@Character.__typename)
+    writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Character.id)
+    writer.writeString(RESPONSE_FIELDS[2], this@Character.name)
   }
 
   companion object {
@@ -48,11 +48,11 @@ data class Character(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): Character {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-      val name = reader.readString(RESPONSE_FIELDS[2])
-      return Character(
+    operator fun invoke(reader: ResponseReader): Character = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+      val name = readString(RESPONSE_FIELDS[2])
+      Character(
         __typename = __typename,
         id = id,
         name = name

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -22,9 +22,9 @@ data class Starship(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
   }
 
   companion object {

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -22,9 +22,9 @@ data class Starship(
    */
   val name: String
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@Starship.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@Starship.name)
   }
 
   companion object {
@@ -40,10 +40,10 @@ data class Starship(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): Starship {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      return Starship(
+    operator fun invoke(reader: ResponseReader): Starship = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      Starship(
         __typename = __typename,
         name = name
       )

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -62,9 +62,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val firstAppearsIn: Episode
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], firstAppearsIn.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend.firstAppearsIn.rawValue)
     }
 
     companion object {
@@ -73,10 +73,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val firstAppearsIn = Episode.safeValueOf(reader.readString(RESPONSE_FIELDS[1]))
-        return Friend(
+      operator fun invoke(reader: ResponseReader): Friend = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val firstAppearsIn = Episode.safeValueOf(readString(RESPONSE_FIELDS[1]))
+        Friend(
           __typename = __typename,
           firstAppearsIn = firstAppearsIn
         )
@@ -99,15 +99,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], homePlanet)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.homePlanet)
+      writer.writeList(RESPONSE_FIELDS[2], this@AsHuman.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeString(RESPONSE_FIELDS[3], name)
+      writer.writeString(RESPONSE_FIELDS[3], this@AsHuman.name)
     }
 
     companion object {
@@ -118,17 +117,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val homePlanet = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend> { reader ->
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val homePlanet = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend> { reader ->
             Friend(reader)
           }
-
         }
-        val name = reader.readString(RESPONSE_FIELDS[3])
-        return AsHuman(
+        val name = readString(RESPONSE_FIELDS[3])
+        AsHuman(
           __typename = __typename,
           homePlanet = homePlanet,
           friends = friends,
@@ -150,10 +148,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     @Deprecated(message = "For test purpose only")
     val deprecated: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], deprecated)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend1.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Friend1.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@Friend1.deprecated)
     }
 
     companion object {
@@ -163,11 +161,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("deprecated", "deprecated", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val deprecated = reader.readString(RESPONSE_FIELDS[2])
-        return Friend1(
+      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val deprecated = readString(RESPONSE_FIELDS[2])
+        Friend1(
           __typename = __typename,
           id = id,
           deprecated = deprecated
@@ -191,15 +189,14 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], primaryFunction)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsDroid.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsDroid.primaryFunction)
+      writer.writeList(RESPONSE_FIELDS[2], this@AsDroid.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeString(RESPONSE_FIELDS[3], name)
+      writer.writeString(RESPONSE_FIELDS[3], this@AsDroid.name)
     }
 
     companion object {
@@ -210,17 +207,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsDroid {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val primaryFunction = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend1>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend1> { reader ->
+      operator fun invoke(reader: ResponseReader): AsDroid = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val primaryFunction = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend1> { reader ->
             Friend1(reader)
           }
-
         }
-        val name = reader.readString(RESPONSE_FIELDS[3])
-        return AsDroid(
+        val name = readString(RESPONSE_FIELDS[3])
+        AsDroid(
           __typename = __typename,
           primaryFunction = primaryFunction,
           friends = friends,
@@ -239,11 +235,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeFragment(asHuman?.marshaller())
-      _writer.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend2.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend2.name)
+      writer.writeFragment(this@Friend2.asHuman?.marshaller())
+      writer.writeFragment(this@Friend2.asDroid?.marshaller())
     }
 
     companion object {
@@ -258,16 +254,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Friend2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+      operator fun invoke(reader: ResponseReader): Friend2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
           AsHuman(reader)
         }
-        val asDroid = reader.readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
+        val asDroid = readFragment<AsDroid>(RESPONSE_FIELDS[3]) { reader ->
           AsDroid(reader)
         }
-        return Friend2(
+        Friend2(
           __typename = __typename,
           name = name,
           asHuman = asHuman,
@@ -292,14 +288,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend2?>?
   ) : SearchSearchResult {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      _writer.writeString(RESPONSE_FIELDS[2], name)
-      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsCharacter.__typename)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@AsCharacter.id)
+      writer.writeString(RESPONSE_FIELDS[2], this@AsCharacter.name)
+      writer.writeList(RESPONSE_FIELDS[3], this@AsCharacter.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -311,17 +306,16 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsCharacter {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val id = reader.readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
-        val name = reader.readString(RESPONSE_FIELDS[2])
-        val friends = reader.readList<Friend2>(RESPONSE_FIELDS[3]) {
-          it.readObject<Friend2> { reader ->
+      operator fun invoke(reader: ResponseReader): AsCharacter = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+        val name = readString(RESPONSE_FIELDS[2])
+        val friends = readList<Friend2>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readObject<Friend2> { reader ->
             Friend2(reader)
           }
-
         }
-        return AsCharacter(
+        AsCharacter(
           __typename = __typename,
           id = id,
           name = name,
@@ -338,9 +332,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : SearchSearchResult {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsStarship.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsStarship.name)
     }
 
     companion object {
@@ -349,10 +343,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsStarship {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return AsStarship(
+      operator fun invoke(reader: ResponseReader): AsStarship = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        AsStarship(
           __typename = __typename,
           name = name
         )
@@ -365,10 +359,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asCharacter: AsCharacter?,
     val asStarship: AsStarship?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeFragment(asCharacter?.marshaller())
-      _writer.writeFragment(asStarship?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Search.__typename)
+      writer.writeFragment(this@Search.asCharacter?.marshaller())
+      writer.writeFragment(this@Search.asStarship?.marshaller())
     }
 
     companion object {
@@ -382,15 +376,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): Search {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val asCharacter = reader.readFragment<AsCharacter>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Search = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val asCharacter = readFragment<AsCharacter>(RESPONSE_FIELDS[1]) { reader ->
           AsCharacter(reader)
         }
-        val asStarship = reader.readFragment<AsStarship>(RESPONSE_FIELDS[2]) { reader ->
+        val asStarship = readFragment<AsStarship>(RESPONSE_FIELDS[2]) { reader ->
           AsStarship(reader)
         }
-        return Search(
+        Search(
           __typename = __typename,
           asCharacter = asCharacter,
           asStarship = asStarship
@@ -402,11 +396,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeList(RESPONSE_FIELDS[0], search) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeList(RESPONSE_FIELDS[0], this@Data.search) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -416,14 +409,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             "text" to "test"), true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val search = reader.readList<Search>(RESPONSE_FIELDS[0]) {
-          it.readObject<Search> { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
+          reader.readObject<Search> { reader ->
             Search(reader)
           }
-
         }
-        return Data(
+        Data(
           search = search
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -62,9 +62,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val firstAppearsIn: Episode
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], firstAppearsIn.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], firstAppearsIn.rawValue)
     }
 
     companion object {
@@ -99,15 +99,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], homePlanet)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], homePlanet)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeString(RESPONSE_FIELDS[3], name)
+      _writer.writeString(RESPONSE_FIELDS[3], name)
     }
 
     companion object {
@@ -150,10 +150,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     @Deprecated(message = "For test purpose only")
     val deprecated: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], deprecated)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], deprecated)
     }
 
     companion object {
@@ -191,15 +191,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : FriendCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], primaryFunction)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], primaryFunction)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeString(RESPONSE_FIELDS[3], name)
+      _writer.writeString(RESPONSE_FIELDS[3], name)
     }
 
     companion object {
@@ -239,11 +239,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asHuman: AsHuman?,
     val asDroid: AsDroid?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeFragment(asHuman?.marshaller())
-      it.writeFragment(asDroid?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asDroid?.marshaller())
     }
 
     companion object {
@@ -292,13 +292,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend2?>?
   ) : SearchSearchResult {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
-      it.writeString(RESPONSE_FIELDS[2], name)
-      it.writeList(RESPONSE_FIELDS[3], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, id)
+      _writer.writeString(RESPONSE_FIELDS[2], name)
+      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -338,9 +338,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
      */
     val name: String
   ) : SearchSearchResult {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -365,10 +365,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val asCharacter: AsCharacter?,
     val asStarship: AsStarship?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeFragment(asCharacter?.marshaller())
-      it.writeFragment(asStarship?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeFragment(asCharacter?.marshaller())
+      _writer.writeFragment(asStarship?.marshaller())
     }
 
     companion object {
@@ -402,10 +402,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeList(RESPONSE_FIELDS[0], search) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeList(RESPONSE_FIELDS[0], search) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -55,9 +55,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(it)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      fragments.marshaller().marshal(_writer)
     }
 
     companion object {
@@ -78,8 +78,8 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-        it.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+        _writer.writeFragment(heroDetails.marshaller())
       }
 
       companion object {
@@ -116,17 +116,17 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val friends: List<Friend1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], appearsIn) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeString(value?.rawValue)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeString(_value?.rawValue)
         }
       }
-      it.writeList(RESPONSE_FIELDS[3], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }
@@ -176,15 +176,15 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val height: Double?
   ) : HeroDetailQueryCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeDouble(RESPONSE_FIELDS[3], height)
+      _writer.writeDouble(RESPONSE_FIELDS[3], height)
     }
 
     companion object {
@@ -222,9 +222,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -256,15 +256,15 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     val friends: List<Friend2?>?,
     val asHuman: AsHuman?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
-      it.writeList(RESPONSE_FIELDS[2], friends) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
+      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
-      it.writeFragment(asHuman?.marshaller())
+      _writer.writeFragment(asHuman?.marshaller())
     }
 
     companion object {
@@ -302,8 +302,8 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
   data class Data(
     val heroDetailQuery: HeroDetailQuery?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeObject(RESPONSE_FIELDS[0], heroDetailQuery?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeObject(RESPONSE_FIELDS[0], heroDetailQuery?.marshaller())
     }
 
     companion object {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -55,9 +55,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     val __typename: String = "Character",
     val fragments: Fragments
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      fragments.marshaller().marshal(_writer)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend1.__typename)
+      this@Friend1.fragments.marshaller().marshal(writer)
     }
 
     companion object {
@@ -65,10 +65,10 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend1 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
         val fragments = Fragments(reader)
-        return Friend1(
+        Friend1(
           __typename = __typename,
           fragments = fragments
         )
@@ -78,8 +78,8 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     data class Fragments(
       val heroDetails: HeroDetails
     ) {
-      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-        _writer.writeFragment(heroDetails.marshaller())
+      fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+        writer.writeFragment(this@Fragments.heroDetails.marshaller())
       }
 
       companion object {
@@ -89,11 +89,11 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
             ))
             )
 
-        operator fun invoke(reader: ResponseReader): Fragments {
-          val heroDetails = reader.readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
+        operator fun invoke(reader: ResponseReader): Fragments = reader.run {
+          val heroDetails = readFragment<HeroDetails>(RESPONSE_FIELDS[0]) { reader ->
             HeroDetails(reader)
           }
-          return Fragments(
+          Fragments(
             heroDetails = heroDetails
           )
         }
@@ -116,18 +116,16 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val friends: List<Friend1?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], appearsIn) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeString(_value?.rawValue)
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@Friend.appearsIn) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeString(value?.rawValue)}
       }
-      _writer.writeList(RESPONSE_FIELDS[3], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+      writer.writeList(RESPONSE_FIELDS[3], this@Friend.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -139,19 +137,17 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forList("friends", "friends", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val appearsIn = reader.readList<Episode>(RESPONSE_FIELDS[2]) {
-          it.readString()?.let{ Episode.safeValueOf(it) }
-        }
-        val friends = reader.readList<Friend1>(RESPONSE_FIELDS[3]) {
-          it.readObject<Friend1> { reader ->
+      operator fun invoke(reader: ResponseReader): Friend = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readString()?.let{ Episode.safeValueOf(it) }}
+        val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
+          reader.readObject<Friend1> { reader ->
             Friend1(reader)
           }
-
         }
-        return Friend(
+        Friend(
           __typename = __typename,
           name = name,
           appearsIn = appearsIn,
@@ -176,15 +172,14 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val height: Double?
   ) : HeroDetailQueryCharacter {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@AsHuman.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeDouble(RESPONSE_FIELDS[3], height)
+      writer.writeDouble(RESPONSE_FIELDS[3], this@AsHuman.height)
     }
 
     companion object {
@@ -195,17 +190,16 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forDouble("height", "height", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): AsHuman {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend> { reader ->
+      operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend> { reader ->
             Friend(reader)
           }
-
         }
-        val height = reader.readDouble(RESPONSE_FIELDS[3])
-        return AsHuman(
+        val height = readDouble(RESPONSE_FIELDS[3])
+        AsHuman(
           __typename = __typename,
           name = name,
           friends = friends,
@@ -222,9 +216,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Friend2.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Friend2.name)
     }
 
     companion object {
@@ -233,10 +227,10 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Friend2 {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Friend2(
+      operator fun invoke(reader: ResponseReader): Friend2 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Friend2(
           __typename = __typename,
           name = name
         )
@@ -256,15 +250,14 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     val friends: List<Friend2?>?,
     val asHuman: AsHuman?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
-      _writer.writeList(RESPONSE_FIELDS[2], friends) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@HeroDetailQuery.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@HeroDetailQuery.name)
+      writer.writeList(RESPONSE_FIELDS[2], this@HeroDetailQuery.friends) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
-      _writer.writeFragment(asHuman?.marshaller())
+      writer.writeFragment(this@HeroDetailQuery.asHuman?.marshaller())
     }
 
     companion object {
@@ -277,19 +270,18 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ))
           )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailQuery {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        val friends = reader.readList<Friend2>(RESPONSE_FIELDS[2]) {
-          it.readObject<Friend2> { reader ->
+      operator fun invoke(reader: ResponseReader): HeroDetailQuery = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        val friends = readList<Friend2>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Friend2> { reader ->
             Friend2(reader)
           }
-
         }
-        val asHuman = reader.readFragment<AsHuman>(RESPONSE_FIELDS[3]) { reader ->
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[3]) { reader ->
           AsHuman(reader)
         }
-        return HeroDetailQuery(
+        HeroDetailQuery(
           __typename = __typename,
           name = name,
           friends = friends,
@@ -302,8 +294,8 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
   data class Data(
     val heroDetailQuery: HeroDetailQuery?
   ) : Operation.Data {
-    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeObject(RESPONSE_FIELDS[0], heroDetailQuery?.marshaller())
+    override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeObject(RESPONSE_FIELDS[0], this@Data.heroDetailQuery?.marshaller())
     }
 
     companion object {
@@ -311,12 +303,11 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Data {
-        val heroDetailQuery = reader.readObject<HeroDetailQuery>(RESPONSE_FIELDS[0]) { reader ->
+      operator fun invoke(reader: ResponseReader): Data = reader.run {
+        val heroDetailQuery = readObject<HeroDetailQuery>(RESPONSE_FIELDS[0]) { reader ->
           HeroDetailQuery(reader)
         }
-
-        return Data(
+        Data(
           heroDetailQuery = heroDetailQuery
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -28,10 +28,10 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-    it.writeString(RESPONSE_FIELDS[0], __typename)
-    it.writeString(RESPONSE_FIELDS[1], name)
-    it.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+    _writer.writeString(RESPONSE_FIELDS[0], __typename)
+    _writer.writeString(RESPONSE_FIELDS[1], name)
+    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
   }
 
   companion object {
@@ -81,9 +81,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeString(RESPONSE_FIELDS[1], name)
     }
 
     companion object {
@@ -110,9 +110,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
     }
 
     companion object {
@@ -146,12 +146,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller {
-      it.writeString(RESPONSE_FIELDS[0], __typename)
-      it.writeInt(RESPONSE_FIELDS[1], totalCount)
-      it.writeList(RESPONSE_FIELDS[2], edges) { value, listItemWriter ->
-        value?.forEach { value ->
-          listItemWriter.writeObject(value?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
+      _writer.writeString(RESPONSE_FIELDS[0], __typename)
+      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
+      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
+        _value?.forEach { _value ->
+          _listItemWriter.writeObject(_value?.marshaller())
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -28,10 +28,10 @@ data class HeroDetails(
    */
   val friendsConnection: FriendsConnection
 ) : GraphqlFragment {
-  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-    _writer.writeString(RESPONSE_FIELDS[0], __typename)
-    _writer.writeString(RESPONSE_FIELDS[1], name)
-    _writer.writeObject(RESPONSE_FIELDS[2], friendsConnection.marshaller())
+  override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+    writer.writeString(RESPONSE_FIELDS[0], this@HeroDetails.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], this@HeroDetails.name)
+    writer.writeObject(RESPONSE_FIELDS[2], this@HeroDetails.friendsConnection.marshaller())
   }
 
   companion object {
@@ -59,14 +59,13 @@ data class HeroDetails(
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails {
-      val __typename = reader.readString(RESPONSE_FIELDS[0])
-      val name = reader.readString(RESPONSE_FIELDS[1])
-      val friendsConnection = reader.readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+    operator fun invoke(reader: ResponseReader): HeroDetails = reader.run {
+      val __typename = readString(RESPONSE_FIELDS[0])
+      val name = readString(RESPONSE_FIELDS[1])
+      val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
         FriendsConnection(reader)
       }
-
-      return HeroDetails(
+      HeroDetails(
         __typename = __typename,
         name = name,
         friendsConnection = friendsConnection
@@ -81,9 +80,9 @@ data class HeroDetails(
      */
     val name: String
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeString(RESPONSE_FIELDS[1], name)
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Node.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], this@Node.name)
     }
 
     companion object {
@@ -92,10 +91,10 @@ data class HeroDetails(
           ResponseField.forString("name", "name", null, false, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Node {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val name = reader.readString(RESPONSE_FIELDS[1])
-        return Node(
+      operator fun invoke(reader: ResponseReader): Node = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val name = readString(RESPONSE_FIELDS[1])
+        Node(
           __typename = __typename,
           name = name
         )
@@ -110,9 +109,9 @@ data class HeroDetails(
      */
     val node: Node?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeObject(RESPONSE_FIELDS[1], node?.marshaller())
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@Edge.__typename)
+      writer.writeObject(RESPONSE_FIELDS[1], this@Edge.node?.marshaller())
     }
 
     companion object {
@@ -121,13 +120,12 @@ data class HeroDetails(
           ResponseField.forObject("node", "node", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): Edge {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val node = reader.readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+      operator fun invoke(reader: ResponseReader): Edge = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
           Node(reader)
         }
-
-        return Edge(
+        Edge(
           __typename = __typename,
           node = node
         )
@@ -146,13 +144,12 @@ data class HeroDetails(
      */
     val edges: List<Edge?>?
   ) {
-    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { _writer ->
-      _writer.writeString(RESPONSE_FIELDS[0], __typename)
-      _writer.writeInt(RESPONSE_FIELDS[1], totalCount)
-      _writer.writeList(RESPONSE_FIELDS[2], edges) { _value, _listItemWriter ->
-        _value?.forEach { _value ->
-          _listItemWriter.writeObject(_value?.marshaller())
-        }
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+      writer.writeList(RESPONSE_FIELDS[2], this@FriendsConnection.edges) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeObject(value?.marshaller())}
       }
     }
 
@@ -163,16 +160,15 @@ data class HeroDetails(
           ResponseField.forList("edges", "edges", null, true, null)
           )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection {
-        val __typename = reader.readString(RESPONSE_FIELDS[0])
-        val totalCount = reader.readInt(RESPONSE_FIELDS[1])
-        val edges = reader.readList<Edge>(RESPONSE_FIELDS[2]) {
-          it.readObject<Edge> { reader ->
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+          reader.readObject<Edge> { reader ->
             Edge(reader)
           }
-
         }
-        return FriendsConnection(
+        FriendsConnection(
           __typename = __typename,
           totalCount = totalCount,
           edges = edges


### PR DESCRIPTION
- Fix issue query argument with name `size` clashing with `Map.size`
- Fix potential field names clash with lambda arguments such as `writer`, 'listItemWriter', 'value' by prefixing last ones with `_`

Closes #1953