### PR TITLE
Field with inline fragment forced to be optional

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </value>
+    </option>
     <option name="RIGHT_MARGIN" value="140" />
     <JavaCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
@@ -93,7 +93,7 @@ private fun Field.`object`(context: Context): ObjectType.Field {
       schemaName = fieldName,
       type = FieldType.Object(typeRef),
       description = description,
-      isOptional = !type.endsWith("!") || isConditional || inlineFragments.isNotEmpty(),
+      isOptional = !type.endsWith("!") || isConditional,
       isDeprecated = isDeprecated,
       deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -106,7 +106,7 @@ data class Field(
     "_".repeat(originalClassName.length - className.length) + className.capitalize()
   }
 
-  fun isOptional(): Boolean = isConditional || !methodResponseType().endsWith("!") || inlineFragments.isNotEmpty()
+  fun isOptional(): Boolean = isConditional || !methodResponseType().endsWith("!")
 
   fun isNonScalar() = hasFragments() || fields.any()
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestOperation.graphql
@@ -1,5 +1,6 @@
 query TestQuery {
-  hero {
+  nonOptionalHero(episode: EMPIRE) {
+    name
     ... on Human {
       height
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -16,6 +16,7 @@ import com.apollographql.apollo.api.ResponseReader;
 import com.apollographql.apollo.api.ResponseWriter;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.SimpleOperationResponseParser;
+import com.apollographql.apollo.api.internal.UnmodifiableMapBuilder;
 import com.apollographql.apollo.api.internal.Utils;
 import com.apollographql.apollo.internal.QueryDocumentMinifier;
 import com.apollographql.apollo.response.ScalarTypeAdapters;
@@ -32,12 +33,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_ID = "5438a5b2731bc2f21c90dcc4bff5628dd91f65534a3f5cab0dbbbfdd3b4bf19b";
+  public static final String OPERATION_ID = "e33ec8a463abf6b32191d1f07aa6c7e4d038a493cace83a45a64632eb65b1ced";
 
   public static final String QUERY_DOCUMENT = QueryDocumentMinifier.minify(
     "query TestQuery {\n"
-        + "  hero {\n"
+        + "  nonOptionalHero(episode: EMPIRE) {\n"
         + "    __typename\n"
+        + "    name\n"
         + "    ... on Human {\n"
         + "      height\n"
         + "    }\n"
@@ -117,10 +119,12 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
-      ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forObject("nonOptionalHero", "nonOptionalHero", new UnmodifiableMapBuilder<String, Object>(1)
+      .put("episode", "EMPIRE")
+      .build(), false, Collections.<ResponseField.Condition>emptyList())
     };
 
-    final Optional<Hero> hero;
+    final @NotNull NonOptionalHero nonOptionalHero;
 
     private transient volatile String $toString;
 
@@ -128,12 +132,12 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private transient volatile boolean $hashCodeMemoized;
 
-    public Data(@Nullable Hero hero) {
-      this.hero = Optional.fromNullable(hero);
+    public Data(@NotNull NonOptionalHero nonOptionalHero) {
+      this.nonOptionalHero = Utils.checkNotNull(nonOptionalHero, "nonOptionalHero == null");
     }
 
-    public Optional<Hero> hero() {
-      return this.hero;
+    public @NotNull NonOptionalHero nonOptionalHero() {
+      return this.nonOptionalHero;
     }
 
     @SuppressWarnings("unchecked")
@@ -141,7 +145,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return new ResponseFieldMarshaller() {
         @Override
         public void marshal(ResponseWriter writer) {
-          writer.writeObject($responseFields[0], hero.isPresent() ? hero.get().marshaller() : null);
+          writer.writeObject($responseFields[0], nonOptionalHero.marshaller());
         }
       };
     }
@@ -150,7 +154,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public String toString() {
       if ($toString == null) {
         $toString = "Data{"
-          + "hero=" + hero
+          + "nonOptionalHero=" + nonOptionalHero
           + "}";
       }
       return $toString;
@@ -163,7 +167,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
       if (o instanceof Data) {
         Data that = (Data) o;
-        return this.hero.equals(that.hero);
+        return this.nonOptionalHero.equals(that.nonOptionalHero);
       }
       return false;
     }
@@ -173,7 +177,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (!$hashCodeMemoized) {
         int h = 1;
         h *= 1000003;
-        h ^= hero.hashCode();
+        h ^= nonOptionalHero.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -181,23 +185,28 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     public static final class Mapper implements ResponseFieldMapper<Data> {
-      final Hero.Mapper heroFieldMapper = new Hero.Mapper();
+      final NonOptionalHero.Mapper nonOptionalHeroFieldMapper = new NonOptionalHero.Mapper();
 
       @Override
       public Data map(ResponseReader reader) {
-        final Hero hero = reader.readObject($responseFields[0], new ResponseReader.ObjectReader<Hero>() {
+        final NonOptionalHero nonOptionalHero = reader.readObject($responseFields[0], new ResponseReader.ObjectReader<NonOptionalHero>() {
           @Override
-          public Hero read(ResponseReader reader) {
-            return heroFieldMapper.map(reader);
+          public NonOptionalHero read(ResponseReader reader) {
+            return nonOptionalHeroFieldMapper.map(reader);
           }
         });
-        return new Data(hero);
+        return new Data(nonOptionalHero);
       }
     }
   }
 
-  public interface Hero {
+  public interface NonOptionalHero {
     @NotNull String __typename();
+
+    /**
+     * The name of the character
+     */
+    @NotNull String name();
 
     ResponseFieldMarshaller marshaller();
 
@@ -210,7 +219,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return visitor.visitDefault(this);
     }
 
-    final class Mapper implements ResponseFieldMapper<Hero> {
+    final class Mapper implements ResponseFieldMapper<NonOptionalHero> {
       static final ResponseField[] $responseFields = {
         ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
           ResponseField.Condition.typeCondition(new String[] {"Human"})
@@ -222,7 +231,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       final AsCharacter.Mapper asCharacterFieldMapper = new AsCharacter.Mapper();
 
       @Override
-      public Hero map(ResponseReader reader) {
+      public NonOptionalHero map(ResponseReader reader) {
         final AsHuman asHuman = reader.readFragment($responseFields[0], new ResponseReader.ObjectReader<AsHuman>() {
           @Override
           public AsHuman read(ResponseReader reader) {
@@ -237,7 +246,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
 
     interface Visitor<T> {
-      T visitDefault(@NotNull Hero hero);
+      T visitDefault(@NotNull NonOptionalHero nonOptionalHero);
 
       T visit(@NotNull AsHuman asHuman);
 
@@ -245,13 +254,16 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
-  public static class AsHuman implements Hero {
+  public static class AsHuman implements NonOptionalHero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
       ResponseField.forDouble("height", "height", null, true, Collections.<ResponseField.Condition>emptyList())
     };
 
     final @NotNull String __typename;
+
+    final @NotNull String name;
 
     final Optional<Double> height;
 
@@ -261,13 +273,21 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private transient volatile boolean $hashCodeMemoized;
 
-    public AsHuman(@NotNull String __typename, @Nullable Double height) {
+    public AsHuman(@NotNull String __typename, @NotNull String name, @Nullable Double height) {
       this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
       this.height = Optional.fromNullable(height);
     }
 
     public @NotNull String __typename() {
       return this.__typename;
+    }
+
+    /**
+     * What this human calls themselves
+     */
+    public @NotNull String name() {
+      return this.name;
     }
 
     /**
@@ -283,7 +303,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
-          writer.writeDouble($responseFields[1], height.isPresent() ? height.get() : null);
+          writer.writeString($responseFields[1], name);
+          writer.writeDouble($responseFields[2], height.isPresent() ? height.get() : null);
         }
       };
     }
@@ -293,6 +314,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if ($toString == null) {
         $toString = "AsHuman{"
           + "__typename=" + __typename + ", "
+          + "name=" + name + ", "
           + "height=" + height
           + "}";
       }
@@ -307,6 +329,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (o instanceof AsHuman) {
         AsHuman that = (AsHuman) o;
         return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name)
          && this.height.equals(that.height);
       }
       return false;
@@ -319,6 +342,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         h *= 1000003;
         h ^= __typename.hashCode();
         h *= 1000003;
+        h ^= name.hashCode();
+        h *= 1000003;
         h ^= height.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
@@ -330,18 +355,22 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public AsHuman map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
-        final Double height = reader.readDouble($responseFields[1]);
-        return new AsHuman(__typename, height);
+        final String name = reader.readString($responseFields[1]);
+        final Double height = reader.readDouble($responseFields[2]);
+        return new AsHuman(__typename, name, height);
       }
     }
   }
 
-  public static class AsCharacter implements Hero {
+  public static class AsCharacter implements NonOptionalHero {
     static final ResponseField[] $responseFields = {
-      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList())
     };
 
     final @NotNull String __typename;
+
+    final @NotNull String name;
 
     private transient volatile String $toString;
 
@@ -349,12 +378,20 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private transient volatile boolean $hashCodeMemoized;
 
-    public AsCharacter(@NotNull String __typename) {
+    public AsCharacter(@NotNull String __typename, @NotNull String name) {
       this.__typename = Utils.checkNotNull(__typename, "__typename == null");
+      this.name = Utils.checkNotNull(name, "name == null");
     }
 
     public @NotNull String __typename() {
       return this.__typename;
+    }
+
+    /**
+     * The name of the character
+     */
+    public @NotNull String name() {
+      return this.name;
     }
 
     @SuppressWarnings("unchecked")
@@ -363,6 +400,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
+          writer.writeString($responseFields[1], name);
         }
       };
     }
@@ -371,7 +409,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     public String toString() {
       if ($toString == null) {
         $toString = "AsCharacter{"
-          + "__typename=" + __typename
+          + "__typename=" + __typename + ", "
+          + "name=" + name
           + "}";
       }
       return $toString;
@@ -384,7 +423,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       }
       if (o instanceof AsCharacter) {
         AsCharacter that = (AsCharacter) o;
-        return this.__typename.equals(that.__typename);
+        return this.__typename.equals(that.__typename)
+         && this.name.equals(that.name);
       }
       return false;
     }
@@ -395,6 +435,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         int h = 1;
         h *= 1000003;
         h ^= __typename.hashCode();
+        h *= 1000003;
+        h ^= name.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -405,7 +447,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       @Override
       public AsCharacter map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
-        return new AsCharacter(__typename);
+        final String name = reader.readString($responseFields[1]);
+        return new AsCharacter(__typename, name);
       }
     }
   }


### PR DESCRIPTION
¯\_(ツ)_/¯ who knows why this condition was in place, maybe it became irrelevant after couple iterations.

Fix `inline_fragment_for_non_optional_field` fixture as it wasn't right before, this fixture was supposed to test this particular case.

Closes https://github.com/apollographql/apollo-android/issues/1955