### PR TITLE
use kotlin-compile-testing

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -10,9 +10,6 @@ plugins {
 java {
   targetCompatibility = JavaVersion.VERSION_1_7
   sourceCompatibility = JavaVersion.VERSION_1_7
-
-  // As temporary solution enable this to verify if generated kotlin test fixtures compiles
-  sourceSets["test"].java.srcDir("src/test/graphql").exclude("**/*.java")
 }
 
 dependencies {
@@ -29,6 +26,7 @@ dependencies {
 
 
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.compiletesting"))
+  add("testImplementation", groovy.util.Eval.x(project, "x.dep.kotlinCompileTesting"))
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.junit"))
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.truth"))
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -47,6 +47,7 @@ ext.dep = [
         api             : "com.apollographql.apollo:apollo-api:$versions.apollo",
     ],
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
+    kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.5",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     errorProneCore        : "com.google.errorprone:error_prone_core:2.1.1",
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/1799

This compiles generated Kotlin files as part of the compiler tests themselves (instead of compiling them at the same time as the apollo-compiler sources). This way, the tests will actually fail fast instead of having to wait for next build if something goes wrong.

Most of the credit goes to the moshi team for doing it there: https://github.com/square/moshi/pull/928

