### PR TITLE
[Plugin] Fix compile task naming

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/GUtil.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/GUtil.kt
@@ -22,9 +22,6 @@ import java.util.regex.Pattern
 object GUtil {
   private val WORD_SEPARATOR: Pattern = Pattern.compile("\\W+")
 
-  fun String.uncapitalize(): String {
-    return if (isNotEmpty() && this[0].isUpperCase()) substring(0, 1).toLowerCase() + substring(1) else this
-  }
   fun toCamelCase(string: CharSequence?, lower: Boolean): String? {
     if (string == null) {
       return null
@@ -40,7 +37,7 @@ object GUtil {
         continue
       }
       if (lower && first) {
-        chunk = chunk.uncapitalize()
+        chunk = chunk.decapitalize()
         first = false
       } else {
         chunk = chunk.capitalize()
@@ -49,7 +46,7 @@ object GUtil {
     }
     var rest = string.subSequence(pos, string.length).toString()
     rest = if (lower && first) {
-      rest.uncapitalize()
+      rest.decapitalize()
     } else {
       rest.capitalize()
     }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/GUtil.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/GUtil.kt
@@ -1,0 +1,59 @@
+package com.apollographql.apollo.gradle.internal
+
+import java.util.regex.Pattern
+
+/*
+ * Adapted from Gradle GUtil.java so that we can match the task names
+ *
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+object GUtil {
+  private val WORD_SEPARATOR: Pattern = Pattern.compile("\\W+")
+
+  fun String.uncapitalize(): String {
+    return if (isNotEmpty() && this[0].isUpperCase()) substring(0, 1).toLowerCase() + substring(1) else this
+  }
+  fun toCamelCase(string: CharSequence?, lower: Boolean): String? {
+    if (string == null) {
+      return null
+    }
+    val builder = StringBuilder()
+    val matcher = WORD_SEPARATOR.matcher(string)
+    var pos = 0
+    var first = true
+    while (matcher.find()) {
+      var chunk = string.subSequence(pos, matcher.start()).toString()
+      pos = matcher.end()
+      if (chunk.isEmpty()) {
+        continue
+      }
+      if (lower && first) {
+        chunk = chunk.uncapitalize()
+        first = false
+      } else {
+        chunk = chunk.capitalize()
+      }
+      builder.append(chunk)
+    }
+    var rest = string.subSequence(pos, string.length).toString()
+    rest = if (lower && first) {
+      rest.uncapitalize()
+    } else {
+      rest.capitalize()
+    }
+    builder.append(rest)
+    return builder.toString()
+  }
+}

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/JvmTaskConfigurator.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo.gradle.internal
 
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
-import org.gradle.api.internal.jvm.ClassDirectoryBinaryNamingScheme
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
@@ -40,12 +39,16 @@ object JvmTaskConfigurator {
     }
 
     val language = if (compilationUnit.generateKotlinModels()) "kotlin" else "java"
+    val baseName = if (sourceSetName == "main") {
+      ""
+    } else {
+      sourceSetName
+    }
 
     // This is taken from the Java plugin to try and match their naming.
     // Hopefully the Kotlin plugin uses similar code.
-    // ClassDirectoryBinaryNamingScheme will replace "main" with ""
     // See https://github.com/gradle/gradle/blob/v6.1.1/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSet.java#L136
-    val compileTaskName = ClassDirectoryBinaryNamingScheme(sourceSetName).getTaskName("compile", language)
+    val compileTaskName = GUtil.toCamelCase("compile $baseName $language", true)
 
     if (!compilationUnit.generateKotlinModels()) {
       /**

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -211,6 +211,23 @@ class SourceDirectorySetTests {
   }
 
   @Test
+  fun `custom sourceSets with dash does not make configuration fail`() {
+    val apolloConfiguration = """
+      sourceSets {
+        'native-test' {
+        }
+      }
+    """.trimIndent()
+    TestUtils.withProject(apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.apolloPlugin),
+        usesKotlinDsl = false) { dir ->
+
+      val result = TestUtils.executeTask("compileNativeTestJava", dir)
+      Assert.assertEquals(TaskOutcome.NO_SOURCE, result.task(":compileNativeTestJava")!!.outcome)
+    }
+  }
+
+  @Test
   fun `android can add queries to the test variant`() {
     val apolloConfiguration = """
       apollo {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/1981

The java plugin removes the dash when generating the task name, do the same in the apollo plugin.