### PR TITLE
Make flow extensions be retryable

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -52,7 +52,7 @@ fun <T> ApolloCall<T>.toFlow(capacity: Int = Channel.UNLIMITED) = flow {
     checkCapacity(capacity)
     val channel = Channel<Response<T>>(capacity)
 
-    enqueue(ChannelCallback(channel = channel))
+    clone().enqueue(ChannelCallback(channel = channel))
     try {
         for (item in channel) {
             emit(item)
@@ -76,7 +76,7 @@ fun <T> ApolloQueryWatcher<T>.toFlow(capacity: Int = Channel.UNLIMITED) = flow {
     checkCapacity(capacity)
     val channel = Channel<Response<T>>(capacity)
 
-    enqueueAndWatch(ChannelCallback(channel = channel))
+    clone().enqueueAndWatch(ChannelCallback(channel = channel))
     try {
         for (item in channel) {
             emit(item)

--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -108,6 +108,7 @@ fun <T> ApolloQueryWatcher<T>.toFlow() = callbackFlow {
  * @return a channel which emits [Responses<T>]
  */
 @ExperimentalCoroutinesApi
+@Deprecated(message = "Use toFlow instead", replaceWith = ReplaceWith("toFlow()"))
 fun <T> ApolloCall<T>.toChannel(capacity: Int = Channel.UNLIMITED): Channel<Response<T>> {
   checkCapacity(capacity)
   val channel = Channel<Response<T>>(capacity)
@@ -161,6 +162,7 @@ fun <T> ApolloCall<T>.toDeferred(): Deferred<Response<T>> {
  * @return a channel which emits [Responses<T>]
  */
 @ExperimentalCoroutinesApi
+@Deprecated(message = "Use toFlow instead", replaceWith = ReplaceWith("toFlow()"))
 fun <T> ApolloQueryWatcher<T>.toChannel(capacity: Int = Channel.UNLIMITED): Channel<Response<T>> {
   checkCapacity(capacity)
   val channel = Channel<Response<T>>(capacity)
@@ -182,6 +184,7 @@ fun <T> ApolloQueryWatcher<T>.toChannel(capacity: Int = Channel.UNLIMITED): Chan
  * @return a channel which emits [Responses<T>]
  */
 @ExperimentalCoroutinesApi
+@Deprecated(message = "Use toFlow instead", replaceWith = ReplaceWith("toFlow()"))
 fun <T> ApolloSubscriptionCall<T>.toChannel(capacity: Int = Channel.UNLIMITED): Channel<Response<T>> {
   checkCapacity(capacity)
   val channel = Channel<Response<T>>(capacity)

--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -137,11 +137,15 @@ fun <T> ApolloCall<T>.toDeferred(): Deferred<Response<T>> {
   }
   enqueue(object : ApolloCall.Callback<T>() {
     override fun onResponse(response: Response<T>) {
-      deferred.complete(response)
+      if (deferred.isActive) {
+        deferred.complete(response)
+      }
     }
 
     override fun onFailure(e: ApolloException) {
-      deferred.completeExceptionally(e)
+      if (deferred.isActive) {
+        deferred.completeExceptionally(e)
+      }
     }
   })
 
@@ -258,11 +262,15 @@ fun ApolloPrefetch.toJob(): Job {
 
   enqueue(object : ApolloPrefetch.Callback() {
     override fun onSuccess() {
-      deferred.complete(Unit)
+      if (deferred.isActive) {
+        deferred.complete(Unit)
+      }
     }
 
     override fun onFailure(e: ApolloException) {
-      deferred.completeExceptionally(e)
+      if (deferred.isActive) {
+        deferred.completeExceptionally(e)
+      }
     }
   })
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CoroutinesApolloTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CoroutinesApolloTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
@@ -30,7 +31,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-
 
 class CoroutinesApolloTest {
   private lateinit var apolloClient: ApolloClient
@@ -239,7 +239,7 @@ class CoroutinesApolloTest {
           .query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE)))
           .toFlow()
           .retry(retries = 1)
-          .first()
+          .single()
     }
 
     assertThat(response.data()!!.hero()!!.name()).isEqualTo("R2-D2")

--- a/apollo-integration/src/test/java/com/apollographql/apollo/CoroutinesApolloTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CoroutinesApolloTest.kt
@@ -18,12 +18,11 @@ import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo.integration.normalizer.type.Episode
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -197,37 +196,72 @@ class CoroutinesApolloTest {
     assertThat(channel.isClosedForReceive).isEqualTo(true)
   }
 
-    @Test
-    fun flowCanBeRead() {
-        server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
+  @Test
+  fun flowCanBeRead() {
+    server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
 
-        val flow = apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))).toFlow()
+    val flow = apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))).toFlow()
 
-        runBlocking {
-            val result = mutableListOf<Response<EpisodeHeroNameQuery.Data>>()
-            flow.toList(result)
-            assertThat(result.size).isEqualTo(1)
-            assertThat(result[0].data()?.hero()?.name()).isEqualTo("R2-D2")
-        }
+    runBlocking {
+      val result = mutableListOf<Response<EpisodeHeroNameQuery.Data>>()
+      flow.toList(result)
+      assertThat(result.size).isEqualTo(1)
+      assertThat(result[0].data()?.hero()?.name()).isEqualTo("R2-D2")
+    }
+  }
+
+  @Test
+  fun flowError() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("nonsense"))
+
+    val flow = apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))).toFlow()
+
+    runBlocking {
+      val result = mutableListOf<Response<EpisodeHeroNameQuery.Data>>()
+      try {
+        flow.toList(result)
+      } catch (e: ApolloException) {
+        return@runBlocking
+      }
+
+      throw Exception("exception has not been thrown")
+    }
+  }
+
+  @Test
+  @ExperimentalCoroutinesApi
+  fun callFlowRetry() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("nonsense"))
+    server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
+
+    val response = runBlocking {
+      apolloClient
+          .query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE)))
+          .toFlow()
+          .retry(retries = 1)
+          .first()
     }
 
-    @Test
-    fun flowError() {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("nonsense"))
+    assertThat(response.data()!!.hero()!!.name()).isEqualTo("R2-D2")
+  }
 
-        val flow = apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))).toFlow()
+  @Test
+  @ExperimentalCoroutinesApi
+  fun watcherFlowRetry() {
+    server.enqueue(MockResponse().setResponseCode(200).setBody("nonsense"))
+    server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
 
-        runBlocking {
-            val result = mutableListOf<Response<EpisodeHeroNameQuery.Data>>()
-            try {
-                flow.toList(result)
-            } catch (e: ApolloException) {
-                return@runBlocking
-            }
-
-            throw Exception("exception has not been thrown")
-        }
+    val response = runBlocking {
+      apolloClient
+          .query(EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE)))
+          .watcher()
+          .toFlow()
+          .retry(retries = 1)
+          .first()
     }
+
+    assertThat(response.data()!!.hero()!!.name()).isEqualTo("R2-D2")
+  }
 
   companion object {
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
@@ -13,7 +13,7 @@ public interface ApolloQueryWatcher<T> extends Cancelable {
 
   /**
    * @param fetcher The {@link ResponseFetcher} to use when the call is refetched due to a field changing in the
-   *                     cache.
+   * cache.
    */
   @NotNull ApolloQueryWatcher<T> refetchResponseFetcher(@NotNull ResponseFetcher fetcher);
 
@@ -36,4 +36,10 @@ public interface ApolloQueryWatcher<T> extends Cancelable {
    */
   @Override void cancel();
 
+  /**
+   * Creates a new, identical call to this one which can be enqueued or executed even if this call has already been.
+   *
+   * @return The cloned ApolloQueryWatcher object.
+   */
+  @NotNull ApolloQueryWatcher<T> clone();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -126,7 +126,10 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
         throw new IllegalStateException("Unknown state");
 
     }
+  }
 
+  @NotNull @Override public ApolloQueryWatcher<T> clone() {
+    return new RealApolloQueryWatcher<>(activeCall.clone(), apolloStore, logger, tracker);
   }
 
   private ApolloCall.Callback<T> callbackProxy() {


### PR DESCRIPTION
Refactor how apollo calls converted into flow by using `callbackFlow`.

Closes https://github.com/apollographql/apollo-android/issues/1986
Closes https://github.com/apollographql/apollo-android/issues/1585
Closes https://github.com/apollographql/apollo-android/issues/1808