### PR TITLE
Add a <scm> tag to the pom file for inclusion on jcenter

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -57,3 +57,22 @@ gradlePlugin {
     }
   }
 }
+
+/**
+ * This is so that the plugin marker pom contains a <scm> tag
+ * It was recommended by the Gradle support team.
+ */
+configure<PublishingExtension> {
+  publications.configureEach {
+    if (name == "apolloGradlePluginPluginMarkerMaven") {
+      this as MavenPublication
+      pom {
+        scm {
+          url.set(findProperty("POM_SCM_URL") as String?)
+          connection.set(findProperty("POM_SCM_CONNECTION") as String?)
+          developerConnection.set(findProperty("POM_SCM_DEV_CONNECTION") as String?)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
With a `<scm>` tag, jcenter now accepts the plugin marker. So now we have:

* OSS Sonatype: snapshots
* Gradle Plugin Portal: gradle plugin and marker
* Jcenter: all libraries + gradle plugin and marker



