### PR TITLE
Coroutines: make sure we do not crash when calling `offer`

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -13,9 +13,8 @@ import kotlinx.coroutines.flow.*
 
 private class ChannelCallback<T>(val channel: Channel<Response<T>>) : ApolloCall.Callback<T>() {
 
-  @ExperimentalCoroutinesApi
   override fun onResponse(response: Response<T>) {
-    if (!channel.isClosedForSend) {
+    runCatching {
       channel.offer(response)
     }
   }
@@ -196,7 +195,9 @@ fun <T> ApolloSubscriptionCall<T>.toChannel(capacity: Int = Channel.UNLIMITED): 
     }
 
     override fun onResponse(response: Response<T>) {
-      channel.offer(response)
+      runCatching {
+        channel.offer(response)
+      }
     }
 
     override fun onFailure(e: ApolloException) {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-android/issues/2005

See https://github.com/Kotlin/kotlinx.coroutines/issues/974
See https://github.com/apollographql/apollo-android/issues/1585