### PR TITLE
Make apollo-compiler an api dependency

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   compileOnly(dep("kotlin").dot("plugin"))
   compileOnly(dep("android").dot("plugin"))
 
-  implementation(project(":apollo-compiler"))
+  api(project(":apollo-compiler"))
   implementation(dep("kotlin").dot("stdLib"))
   implementation(dep("okHttp").dot("okHttp"))
   implementation(dep("moshi").dot("moshi"))


### PR DESCRIPTION
OperationIdGenerator is used in the plugin API and therefore should be an api dependency.

Closes https://github.com/apollographql/apollo-android/issues/2008