### PR TITLE
config okHttp timeout

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
 
 abstract class ApolloDownloadSchemaTask : DefaultTask() {
   @get:Input
@@ -66,7 +67,11 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
         .url(urlBuilder.build())
         .build()
 
-    val response = OkHttpClient().newCall(requestBuilder.build()).execute()
+    val response = OkHttpClient.Builder()
+        .connectTimeout(System.getProperty("okHttp.connectTimeout","10").toLong(), TimeUnit.SECONDS)
+        .readTimeout(System.getProperty("okHttp.readTimeout","10").toLong(), TimeUnit.SECONDS)
+        .build()
+        .newCall(requestBuilder.build()).execute()
 
     if (!response.isSuccessful) {
       throw Exception("cannot get schema: ${response.code()}:\n${response.body()?.string()}")

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -68,8 +68,8 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
         .build()
 
     val response = OkHttpClient.Builder()
-        .connectTimeout(System.getProperty("okHttp.connectTimeout","10").toLong(), TimeUnit.SECONDS)
-        .readTimeout(System.getProperty("okHttp.readTimeout","10").toLong(), TimeUnit.SECONDS)
+        .connectTimeout(System.getProperty("okHttp.connectTimeout", "60").toLong(), TimeUnit.SECONDS)
+        .readTimeout(System.getProperty("okHttp.readTimeout", "60").toLong(), TimeUnit.SECONDS)
         .build()
         .newCall(requestBuilder.build()).execute()
 


### PR DESCRIPTION
when schema.json too large or network slow，may generate socket exception！set properties in jvmargs:
```
org.gradle.jvmargs=-DokHttp.connectTimeout=60 -DokHttp.readTimeout=60
```

