### PR TITLE
Fix issue when JSON object map to raw String it loses quotes

### DIFF
--- a/apollo-api/src/main/java/com/apollographql/apollo/api/internal/UnmodifiableMapBuilder.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/api/internal/UnmodifiableMapBuilder.java
@@ -1,18 +1,18 @@
 package com.apollographql.apollo.api.internal;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class UnmodifiableMapBuilder<K, V> {
   private final Map<K, V> map;
 
   public UnmodifiableMapBuilder(int initialCapacity) {
-    this.map = new HashMap<>(initialCapacity);
+    this.map = new LinkedHashMap<>(initialCapacity);
   }
 
   public UnmodifiableMapBuilder() {
-    this.map = new HashMap<>();
+    this.map = new LinkedHashMap<>();
   }
 
   public UnmodifiableMapBuilder<K, V> put(K key, V value) {

--- a/apollo-api/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
+++ b/apollo-api/src/main/java/com/apollographql/apollo/response/ScalarTypeAdapters.java
@@ -49,8 +49,8 @@ public final class ScalarTypeAdapters {
     Map<Class, CustomTypeAdapter> adapters = new LinkedHashMap<>();
     adapters.put(String.class, new DefaultCustomTypeAdapter<String>() {
       @NotNull @Override public String decode(@NotNull CustomTypeValue value) {
-        if (value instanceof CustomTypeValue.GraphQLJsonList ||
-            value instanceof CustomTypeValue.GraphQLJsonObject) {
+        if (value instanceof CustomTypeValue.GraphQLJsonList
+            || value instanceof CustomTypeValue.GraphQLJsonObject) {
           final Buffer buffer = new Buffer();
           final JsonWriter writer = JsonWriter.of(buffer);
           try {

--- a/apollo-api/src/test/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.java
+++ b/apollo-api/src/test/java/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.java
@@ -176,7 +176,7 @@ public class InputFieldJsonWriterTest {
 
     inputFieldJsonWriter.writeCustom("someField", new MockCustomScalarType(Map.class), value);
     inputFieldJsonWriter.writeCustom("someNullField", new MockCustomScalarType(Map.class), null);
-    assertThat(jsonBuffer.readUtf8()).isEqualTo("{\"someField\":{\"objectField\":{\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3],\"stringField\":\"string\"},\"numberField\":100,\"booleanField\":true,\"listField\":[\"string\",true,100,{\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3],\"stringField\":\"string\"}],\"stringField\":\"string\"},\"someNullField\":null");
+    assertThat(jsonBuffer.readUtf8()).isEqualTo("{\"someField\":{\"stringField\":\"string\",\"booleanField\":true,\"numberField\":100,\"listField\":[\"string\",true,100,{\"stringField\":\"string\",\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3]}],\"objectField\":{\"stringField\":\"string\",\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3]}},\"someNullField\":null");
   }
 
   @Test
@@ -195,7 +195,7 @@ public class InputFieldJsonWriterTest {
 
     inputFieldJsonWriter.writeCustom("someField", new MockCustomScalarType(List.class), value);
     inputFieldJsonWriter.writeCustom("someNullField", new MockCustomScalarType(List.class), null);
-    assertThat(jsonBuffer.readUtf8()).isEqualTo("{\"someField\":[\"string\",true,100,{\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3],\"stringField\":\"string\"}],\"someNullField\":null");
+    assertThat(jsonBuffer.readUtf8()).isEqualTo("{\"someField\":[\"string\",true,100,{\"stringField\":\"string\",\"numberField\":100,\"booleanField\":true,\"listField\":[1,2,3]}],\"someNullField\":null");
   }
 
   @Test

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/response/ScalarTypeAdaptersTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/response/ScalarTypeAdaptersTest.java
@@ -133,6 +133,24 @@ public class ScalarTypeAdaptersTest {
     assertThat(adapter.encode(value).value).isEqualTo(value);
   }
 
+  @Test
+  public void defaultJsonString() {
+    final CustomTypeValue.GraphQLJsonObject actualObject = new CustomTypeValue.GraphQLJsonObject(
+        new UnmodifiableMapBuilder<String, Object>()
+            .put("key", "scalar")
+            .put("object", new UnmodifiableMapBuilder<String, Object>()
+                .put("nestedKey", "nestedScalar")
+                .build()
+            )
+            .put("list", Arrays.asList("1", "2", "3"))
+            .build()
+    );
+    final String expectedJsonString = "{\"key\":\"scalar\",\"object\":{\"nestedKey\":\"nestedScalar\"},\"list\":[\"1\",\"2\",\"3\"]}";
+
+    final CustomTypeAdapter<String> adapter = defaultAdapter(String.class);
+    assertThat(adapter.decode(actualObject)).isEqualTo(expectedJsonString);
+  }
+
   private <T> CustomTypeAdapter<T> defaultAdapter(final Class<T> clazz) {
     return new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter>emptyMap())
         .adapterFor(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=1.3.2
+VERSION_NAME=1.3.3
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=1.3.3
+VERSION_NAME=1.3.2
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/


### PR DESCRIPTION
In case when JSON object / array is mapped to plain `String` call proper JSON serialization instead of `value.toString()`.

Also it appears that `UnmodifiableMapBuilder` doesn't preserve order that seem really odd.

Closes https://github.com/apollographql/apollo-android/issues/2012