### PR TITLE
Remove redundant moshi-kotlin dependency

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
   add("antlr", groovy.util.Eval.x(project, "x.dep.antlr.antlr"))
   add("implementation", groovy.util.Eval.x(project, "x.dep.kotlin.stdLib"))
   add("implementation", groovy.util.Eval.x(project, "x.dep.moshi.adapters"))
-  add("implementation", groovy.util.Eval.x(project, "x.dep.moshi.kotlin"))
   add("implementation", groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
   add("implementation", groovy.util.Eval.x(project, "x.dep.poet.java"))
   add("implementation", groovy.util.Eval.x(project, "x.dep.poet.kotlin"))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/Schema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/Schema.kt
@@ -4,7 +4,6 @@ import com.squareup.moshi.JsonClass
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okio.ByteString
 import okio.Okio
 import java.io.File
@@ -132,7 +131,6 @@ class Schema(
                   .withSubtype(Type.Enum::class.java, Kind.ENUM.name)
                   .withSubtype(Type.InputObject::class.java, Kind.INPUT_OBJECT.name)
           )
-          .add(KotlinJsonAdapterFactory())
           .build()
 
       val source = try {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -65,7 +65,6 @@ ext.dep = [
     mockito               : "org.mockito:mockito-all:$versions.mockito",
     moshi                 : [
         adapters     : "com.squareup.moshi:moshi-adapters:$versions.moshi",
-        kotlin       : "com.squareup.moshi:moshi-kotlin:$versions.moshi",
         kotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi",
         moshi        : "com.squareup.moshi:moshi:$versions.moshi",
     ],


### PR DESCRIPTION
I realized we are using both reflection based and code generation based Moshi parsing. I removed the reflection one since it is redundant

This was bringing kotlin-reflect dependency which was causing a warning in the build. That seems to be gone too.