### PR TITLE
Fix publish task to cover Kotlin MPP

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -34,8 +34,8 @@ tasks.withType<Test> {
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
   setForkEvery(8L)
-  dependsOn(":apollo-api:publishAllPublicationToPluginTestRepository")
-  dependsOn(":apollo-compiler:publishAllPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishDefaultPublicationToPluginTestRepository")
 
   inputs.dir("src/test/files")

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -34,9 +34,8 @@ tasks.withType<Test> {
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
   setForkEvery(8L)
-  dependsOn(":apollo-api:publishJvmPublicationToPluginTestRepository")
-  dependsOn(":apollo-api:publishKotlinMultiplatformPublicationToPluginTestRepository")
-  dependsOn(":apollo-compiler:publishDefaultPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishAllPublicationToPluginTestRepository")
+  dependsOn(":apollo-compiler:publishAllPublicationToPluginTestRepository")
   dependsOn("publishDefaultPublicationToPluginTestRepository")
 
   inputs.dir("src/test/files")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ elif [ "$TRAVIS_BRANCH" != "$SNAPSHOT_BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$SNAPSHOT_BRANCH' but was '$TRAVIS_BRANCH'."
 else
   echo "Deploying snapshot..."
-  ./gradlew publishAllPublicationToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
+  ./gradlew publishAllPublicationsToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
   echo "Snapshot deployed!"
 fi
 
@@ -32,7 +32,7 @@ if [ "$TRAVIS_TAG" == "" ]; then
   echo "Skipping release deployment: not a tag"
 else
   echo "Deploy to bintray..."
-  ./gradlew publishAllPublicationToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
+  ./gradlew publishAllPublicationsToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
   echo "Deployed to bintray!"
   echo "Deploy to Gradle portal..."
   ./gradlew :apollo-gradle-plugin:publishPlugin -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -21,7 +21,7 @@ elif [ "$TRAVIS_BRANCH" != "$SNAPSHOT_BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$SNAPSHOT_BRANCH' but was '$TRAVIS_BRANCH'."
 else
   echo "Deploying snapshot..."
-  ./gradlew publishDefaultPublicationToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
+  ./gradlew publishAllPublicationToOssRepository -PSONATYPE_NEXUS_USERNAME="${SONATYPE_NEXUS_USERNAME}" -PSONATYPE_NEXUS_PASSWORD="${SONATYPE_NEXUS_PASSWORD}"
   echo "Snapshot deployed!"
 fi
 
@@ -32,7 +32,7 @@ if [ "$TRAVIS_TAG" == "" ]; then
   echo "Skipping release deployment: not a tag"
 else
   echo "Deploy to bintray..."
-  ./gradlew publishDefaultPublicationToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
+  ./gradlew publishAllPublicationToBintrayRepository -Pbintray.user="${BINTRAY_USER}" -Pbintray.apikey="${BINTRAY_API_KEY}"
   echo "Deployed to bintray!"
   echo "Deploy to Gradle portal..."
   ./gradlew :apollo-gradle-plugin:publishPlugin -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET


### PR DESCRIPTION
The default task is not enough for Kotlin MPP. Instead use `publishAll` lifecycle-task which runs all necessary publish tasks.