### PR TITLE
Some Kotlin MPP publication fixes

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<Test> {
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
   setForkEvery(8L)
-  dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-api:publishJvmPublicationToPluginTestRepository")
   dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishDefaultPublicationToPluginTestRepository")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -192,7 +192,13 @@ fun Project.configurePublishing() {
 
   configure<PublishingExtension> {
     publications {
-      if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+      if (plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+        withType<MavenPublication>().getByName("jvm") {
+          if (javadocJarTaskProvider != null) {
+            artifact(javadocJarTaskProvider.get())
+          }
+        }
+      } else {
         create<MavenPublication>(publicationName) {
           val javaComponent = components.findByName("java")
           if (javaComponent != null) {


### PR DESCRIPTION
I realized one problem with `Default` vs `Jvm` configuration for Multiplatform projects. The `if` conditional I put was not really the correct way.

Plus, the `pom` configuration like (scm, developers, license) were removed.

## Approach w/ this PR

Create Default publication explicitly only for non-KMP (regular) modules
Keep pom configuration for all MavenPublications

With this change, calling `publishAllPublicationsToBintrayRepository` will call `Default` one for all modules except for the KMP one (apollo-api). In KMP modules, it will run all other publish tasks (no Default). Here is the dry-run output

### For apollo-compiler

```
:apollo-compiler:jar SKIPPED
:apollo-compiler:generateMetadataFileForDefaultPublication SKIPPED
:apollo-compiler:generatePomFileForDefaultPublication SKIPPED
:apollo-compiler:javadoc SKIPPED
:apollo-compiler:javadocJar SKIPPED
:apollo-compiler:sourcesJar SKIPPED
:apollo-compiler:publishDefaultPublicationToBintrayRepository SKIPPED
:apollo-compiler:publishAllPublicationsToBintrayRepository SKIPPED
```

### For apollo-api (notice no `Default` anymore)

```
:apollo-api:compileKotlinIos SKIPPED
:apollo-api:generateMetadataFileForIosPublication SKIPPED
:apollo-api:generatePomFileForIosPublication SKIPPED
:apollo-api:iosSourcesJar SKIPPED
:apollo-api:publishIosPublicationToBintrayRepository SKIPPED
:apollo-api:compileKotlinIosSim SKIPPED
:apollo-api:generateMetadataFileForIosSimPublication SKIPPED
:apollo-api:generatePomFileForIosSimPublication SKIPPED
:apollo-api:iosSimSourcesJar SKIPPED
:apollo-api:publishIosSimPublicationToBintrayRepository SKIPPED
:apollo-api:compileKotlinJvm SKIPPED
:apollo-api:compileJava SKIPPED
:apollo-api:jvmProcessResources SKIPPED
:apollo-api:jvmMainClasses SKIPPED
:apollo-api:jvmJar SKIPPED
:apollo-api:generateMetadataFileForJvmPublication SKIPPED
:apollo-api:generatePomFileForJvmPublication SKIPPED
:apollo-api:processResources SKIPPED
:apollo-api:classes SKIPPED
:apollo-api:javadoc SKIPPED
:apollo-api:javadocJar SKIPPED
:apollo-api:jvmSourcesJar SKIPPED
:apollo-api:publishJvmPublicationToBintrayRepository SKIPPED
:apollo-api:generateMetadataFileForKotlinMultiplatformPublication SKIPPED
:apollo-api:generatePomFileForKotlinMultiplatformPublication SKIPPED
:apollo-api:publishKotlinMultiplatformPublicationToBintrayRepository SKIPPED
:apollo-api:compileKotlinMetadata SKIPPED
:apollo-api:metadataMainClasses SKIPPED
:apollo-api:metadataJar SKIPPED
:apollo-api:generateMetadataFileForMetadataPublication SKIPPED
:apollo-api:generatePomFileForMetadataPublication SKIPPED
:apollo-api:metadataSourcesJar SKIPPED
:apollo-api:publishMetadataPublicationToBintrayRepository SKIPPED
:apollo-api:publishAllPublicationsToBintrayRepository SKIPPED
```