### PR TITLE
stick with kotlin 1.3.61

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,7 +9,7 @@ def versions = [
     javaPoet              : '1.9.0',
     jetbrainsAnnotations  : '13.0',
     junit                 : '4.12',
-    kotlin                : '1.3.70',
+    kotlin                : '1.3.61',
     kotlinCoroutines      : '1.3.1',
     kotlinPoet            : '1.5.0',
     mockito               : '1.9.5',


### PR DESCRIPTION
We need a new okio version until we can migrate to 1.3.70.
See https://github.com/square/okio/pull/707#issuecomment-601449587

Test only pass on CI because they run on a linux machine and therefore skip the iOS/macOS targets