### PR TITLE
Update agp to 3.6

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ fun Any.dot(key: String): Any {
 dependencies {
   compileOnly(gradleApi())
   compileOnly(dep("kotlin").dot("plugin"))
-  compileOnly(dep("android").dot("plugin"))
+  compileOnly(dep("android").dot("minPlugin"))
 
   api(project(":apollo-compiler"))
   implementation(dep("kotlin").dot("stdLib"))

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
@@ -20,6 +20,7 @@ buildscript {
     }
     google()
     mavenCentral()
+    jcenter()
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
@@ -7,6 +7,7 @@ buildscript {
     }
     google()
     mavenCentral()
+    jcenter()
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SourceDirectorySetTests.kt
@@ -94,7 +94,7 @@ class SourceDirectorySetTests {
 
       TestUtils.executeTask("assembleDebug", dir)
 
-      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/classes/com/example/DroidDetailsQuery.class").isFile)
       Assert.assertTrue(File(dir, "build/tmp/kotlin-classes/debug/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
       Assert.assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
@@ -117,8 +117,8 @@ class SourceDirectorySetTests {
 
       TestUtils.executeTask("assembleDebug", dir)
 
-      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/DroidDetailsQuery.class").isFile)
-      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/compileDebugJavaWithJavac/classes/com/example/Main.class").isFile)
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/classes/com/example/DroidDetailsQuery.class").isFile)
+      Assert.assertTrue(File(dir, "build/intermediates/javac/debug/classes/com/example/Main.class").isFile)
       Assert.assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
       Assert.assertTrue(dir.generatedChild("debug/service/com/example/DroidDetailsQuery.java").isFile)
     }

--- a/apollo-gradle-plugin/testProjects/compilationUnitAndroid/build.gradle
+++ b/apollo-gradle-plugin/testProjects/compilationUnitAndroid/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     google()
     mavenCentral()
+    jcenter()
   }
   dependencies {
     classpath(dep.android.plugin)

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@ POM_DEVELOPER_ID=apollographql
 POM_DEVELOPER_NAME=Apollo
 
 BINTRAY_POM_REPO=android
+
+android.useAndroidX=true

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     minAndroidPlugin      : '3.4.2',
-    androidPlugin         : '3.6.0',
+    androidPlugin         : '3.6.1',
     apollo                : '1.4.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,5 +1,6 @@
 def versions = [
-    androidPlugin         : '3.4.2',
+    minAndroidPlugin      : '3.4.2',
+    androidPlugin         : '3.6.0',
     apollo                : '1.4.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',
@@ -29,6 +30,7 @@ ext.isCi = "true" == System.getenv('CI')
 ext.dep = [
     android               : [
         plugin                : "com.android.tools.build:gradle:$versions.androidPlugin",
+        minPlugin             : "com.android.tools.build:gradle:$versions.minAndroidPlugin",
         recyclerView          : "com.android.support:recyclerview-v7:$versions.supportLib",
         appcompat             : "com.android.support:appcompat-v7:$versions.supportLib",
         testRunner            : "com.android.support.test:runner:$versions.testRunner",


### PR DESCRIPTION
Update Android Gradle Plugin version.
AGP 3.6 is especially nice because it publishes  softwareComponents ready to be consumed by `maven-publish`. See https://issuetracker.google.com/issues/37055147