### PR TITLE
Expose per repo publishing tasks

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -75,7 +75,7 @@ fun <T> ApolloQueryWatcher<T>.toFlow() = callbackFlow {
 
 /**
  * Converts an [ApolloCall] to an [Deferred]. This is a convenience method that will only return the first value emitted.
- * If the more than one response is required, for an example to retrieve cached and network response, use [toChannel] instead.
+ * If the more than one response is required, for an example to retrieve cached and network response, use [toFlow] instead.
  *
  * @param <T>  the value type.
  * @return the deferred

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,6 @@ POM_DEVELOPER_NAME=Apollo
 BINTRAY_POM_REPO=android
 
 android.useAndroidX=true
+
+# https://github.com/gradle/gradle/issues/11412
+systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
This is useful for testing:

```
export BINTRAY_USER=[...]
export BINTRAY_API_KEY=[...]

./gradlew publishToOjo
./gradlew publishToBintray

export SONATYPE_NEXUS_USERNAME=[...]
export SONATYPE_NEXUS_PASSWORD=[...]

./gradlew publishToOss
```

Snapshots are not working at the moment, I asked Sonatype for access and I'll set the secrets in Github Actions.
This also fixes an exception when calling `publishIfNeeded`