### PR TITLE
Update release scripts

### DIFF
--- a/Releasing.md
+++ b/Releasing.md
@@ -5,10 +5,10 @@ Run `./gradlew japicmp` and check what API may have changed. We ideally want 100
 
 # Releasing
 
-0. Make sure that you have `kscript` installed - https://github.com/holgerbrandl/kscript#installation
-1. Run `./scripts/release.kts` from your local dev machine.
-2. The script removes the `-SNAPSHOT` suffix, commits and tags version `v1.x.y`
-3. The script bumps version to the next patch version and commits
-4. Push (this could be automated in a future PR but I prefer to keep a manual step for the time being)
-5. CI will build tag `v1.x.y` and `scripts/deploy.sh` will see it's from a tag and deploy to bintray with the encrypted credentials
+0. Make sure that you have `kotlin 1.3.70+` installed.
+1. Run `./scripts/release.main.kts` from your local dev machine.
+2. The script removes the `-SNAPSHOT` suffix, commits and tags version `v1.x.y`.
+3. The script bumps version to the next patch version and commits.
+4. Verify that everything is OK and push.
+5. The CI will build tag `v1.x.y` and deploy the artifact.
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinDSLTests.kt
@@ -43,7 +43,6 @@ class KotlinDSLTests {
     }
   }
 
-
   @Test
   fun `parameters do not throw`() {
     val apolloConfiguration = """

--- a/scripts/release.main.kts
+++ b/scripts/release.main.kts
@@ -1,12 +1,10 @@
-#!/usr/bin/env kscript
+#!/usr/bin/env kotlin
 import java.io.File
 
 /**
  * A script to run locally in order to make a release.
  *
- * You need kscript installed on your machine: https://github.com/holgerbrandl/kscript
- *
- * To edit, run `kscript --idea misc/release.kts`
+ * You need kotlin 1.3.70+ installed on your machine
  */
 
 fun runCommand(vararg args: String): String {


### PR DESCRIPTION
Kotlin 1.3.70 has some nice scripting improvements and we don't need kscript anymore.
Also tweak slightly the release documentation.