### PR TITLE
Fix query watcher not calling status events

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -12,6 +12,13 @@
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
       <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="50" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="50" />
+    </JetCodeStyleSettings>
     <XML>
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </XML>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
   </state>
 </component>

--- a/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/ApolloWatcherTest.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,10 +31,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
+import static com.apollographql.apollo.ApolloCall.StatusEvent.COMPLETED;
+import static com.apollographql.apollo.ApolloCall.StatusEvent.FETCH_CACHE;
+import static com.apollographql.apollo.ApolloCall.StatusEvent.FETCH_NETWORK;
+import static com.apollographql.apollo.ApolloCall.StatusEvent.SCHEDULED;
 import static com.apollographql.apollo.fetcher.ApolloResponseFetchers.CACHE_ONLY;
 import static com.apollographql.apollo.fetcher.ApolloResponseFetchers.NETWORK_ONLY;
 import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.fail;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 public class ApolloWatcherTest {
   private ApolloClient apolloClient;
@@ -365,5 +372,22 @@ public class ApolloWatcherTest {
 
     assertThat(watchedHeroes).hasSize(1);
     assertThat(watchedHeroes.get(0).name()).isEqualTo("R2-D2");
+  }
+
+  @SuppressWarnings("unchecked") @Test
+  public void queryWatcher_onStatusEvent_properlyCalled() throws Exception {
+    EpisodeHeroNameQuery query = EpisodeHeroNameQuery.builder().episode(Episode.EMPIRE).build();
+    server.enqueue(Utils.INSTANCE.mockResponse("EpisodeHeroNameResponseWithId.json"));
+
+    ApolloQueryWatcher<EpisodeHeroNameQuery.Data> watcher = apolloClient.query(query).watcher();
+
+    ApolloCall.Callback<EpisodeHeroNameQuery.Data> callback = mock(ApolloCall.Callback.class);
+    watcher.enqueueAndWatch(callback);
+
+    InOrder inOrder = inOrder(callback);
+    inOrder.verify(callback).onStatusEvent(SCHEDULED);
+    inOrder.verify(callback).onStatusEvent(FETCH_CACHE);
+    inOrder.verify(callback).onStatusEvent(FETCH_NETWORK);
+    inOrder.verify(callback).onStatusEvent(COMPLETED);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloQueryWatcher.java
@@ -160,6 +160,15 @@ final class RealApolloQueryWatcher<T> implements ApolloQueryWatcher<T> {
           callback.get().onFailure(e);
         }
       }
+
+      @Override public void onStatusEvent(@NotNull ApolloCall.StatusEvent event) {
+        ApolloCall.Callback<T> callback = originalCallback.get();
+        if (callback == null) {
+          logger.d("onStatusEvent for operation: %s. No callback present.", operation().name().name());
+          return;
+        }
+        callback.onStatusEvent(event);
+      }
     };
   }
 

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo.kotlinsample.data.ApolloCallbackService
 import com.apollographql.apollo.kotlinsample.data.ApolloCoroutinesService
 import com.apollographql.apollo.kotlinsample.data.ApolloRxService
+import com.apollographql.apollo.kotlinsample.data.ApolloWatcherService
 import com.apollographql.apollo.kotlinsample.data.GitHubDataSource
 import okhttp3.OkHttpClient
 
@@ -63,12 +64,14 @@ class KotlinSampleApp : Application() {
       ServiceTypes.CALLBACK -> ApolloCallbackService(apolloClient)
       ServiceTypes.RX_JAVA -> ApolloRxService(apolloClient)
       ServiceTypes.COROUTINES -> ApolloCoroutinesService(apolloClient)
+      ServiceTypes.WATCHER -> ApolloWatcherService(apolloClient)
     }
   }
 
   enum class ServiceTypes {
     CALLBACK,
     RX_JAVA,
-    COROUTINES
+    COROUTINES,
+    WATCHER
   }
 }

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloWatcherService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloWatcherService.kt
@@ -1,0 +1,90 @@
+package com.apollographql.apollo.kotlinsample.data
+
+import android.util.Log
+import com.apollographql.apollo.ApolloCall
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers
+import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
+import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
+import com.apollographql.apollo.kotlinsample.type.OrderDirection
+import com.apollographql.apollo.kotlinsample.type.PullRequestState
+import com.apollographql.apollo.kotlinsample.type.RepositoryOrderField
+
+/**
+ * An implementation of a [GitHubDataSource] that shows how to fetch data using callbacks.
+ */
+class ApolloWatcherService(apolloClient: ApolloClient) : GitHubDataSource(apolloClient) {
+  override fun fetchRepositories() {
+    val repositoriesQuery = GithubRepositoriesQuery.builder()
+        .repositoriesCount(50)
+        .orderBy(RepositoryOrderField.UPDATED_AT)
+        .orderDirection(OrderDirection.DESC)
+        .build()
+
+    val callback = createCallback<GithubRepositoriesQuery.Data> {
+      repositoriesSubject.onNext(mapRepositoriesResponseToRepositories(it))
+    }
+
+    apolloClient
+        .query(repositoriesQuery)
+        .responseFetcher(ApolloResponseFetchers.CACHE_AND_NETWORK)
+        .watcher()
+        .enqueueAndWatch(callback)
+  }
+
+  override fun fetchRepositoryDetail(repositoryName: String) {
+    val repositoryDetailQuery = GithubRepositoryDetailQuery.builder()
+        .name(repositoryName)
+        .pullRequestStates(listOf(PullRequestState.OPEN))
+        .build()
+
+    val callback = createCallback<GithubRepositoryDetailQuery.Data> {
+      repositoryDetailSubject.onNext(it)
+    }
+
+    apolloClient
+        .query(repositoryDetailQuery)
+        .responseFetcher(ApolloResponseFetchers.CACHE_AND_NETWORK)
+        .watcher()
+        .enqueueAndWatch(callback)
+  }
+
+  override fun fetchCommits(repositoryName: String) {
+    val commitsQuery = GithubRepositoryCommitsQuery.builder()
+        .name(repositoryName)
+        .build()
+
+    val callback = createCallback<GithubRepositoryCommitsQuery.Data> { response ->
+      val headCommit = response.data?.viewer()?.repository()?.ref()?.target() as? GithubRepositoryCommitsQuery.AsCommit
+      val commits = headCommit?.history()?.edges().orEmpty()
+      commitsSubject.onNext(commits)
+    }
+
+    apolloClient
+        .query(commitsQuery)
+        .responseFetcher(ApolloResponseFetchers.CACHE_AND_NETWORK)
+        .watcher()
+        .enqueueAndWatch(callback)
+  }
+
+  private fun <T : Operation.Data> createCallback(onResponse: (response: Response<T>) -> Unit) =
+      object : ApolloCall.Callback<T>() {
+        override fun onResponse(response: Response<T>) = onResponse(response)
+
+        override fun onFailure(e: ApolloException) {
+          exceptionSubject.onNext(e)
+        }
+
+        override fun onStatusEvent(event: ApolloCall.StatusEvent) {
+          Log.d("ApolloWatcherService", "Apollo Status Event: $event")
+        }
+      }
+
+  override fun cancelFetching() {
+    //TODO: Determine how to cancel this when there's callbacks
+  }
+}


### PR DESCRIPTION
Fixes #2096 

- Fix an issue where the callback wrapper was not properly calling the original callback

- Added ApolloWatcherService into the sample.