### PR TITLE
Fix issue with HttpCache causes HttpParseException

### DIFF
--- a/apollo-http-cache-api/src/main/kotlin/com/apollographql/apollo/api/cache/http/HttpCache.kt
+++ b/apollo-http-cache-api/src/main/kotlin/com/apollographql/apollo/api/cache/http/HttpCache.kt
@@ -76,5 +76,10 @@ interface HttpCache {
      * Do not store the http response
      */
     const val CACHE_DO_NOT_STORE = "X-APOLLO-CACHE-DO-NOT-STORE"
+
+    /**
+     * Signals that HTTP response comes from the local cache
+     */
+    const val FROM_CACHE = "X-APOLLO-FROM-CACHE"
   }
 }

--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/ApolloHttpCache.java
@@ -83,6 +83,7 @@ public final class ApolloHttpCache implements HttpCache {
       String contentType = response.header("Content-Type");
       String contentLength = response.header("Content-Length");
       return response.newBuilder()
+          .addHeader(FROM_CACHE, "true")
           .body(new CacheResponseBody(cacheResponseSource, contentType, contentLength))
           .build();
     } catch (Exception e) {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -71,6 +71,7 @@ ext.dep = [
     okHttp                : [
         mockWebServer: "com.squareup.okhttp3:mockwebserver:$versions.okHttp",
         okHttp       : "com.squareup.okhttp3:okhttp:$versions.okHttp",
+        logging      : "com.squareup.okhttp3:logging-interceptor:$versions.okHttp",
     ],
     okio                  : [
         okio             : "com.squareup.okio:okio:$versions.okio",

--- a/samples/kotlin-sample/build.gradle.kts
+++ b/samples/kotlin-sample/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     add("implementation", "com.apollographql.apollo:apollo-rx2-support")
     add("implementation", "com.apollographql.apollo:apollo-coroutines-support")
     add("implementation", "com.apollographql.apollo:apollo-runtime")
+    add("implementation", "com.apollographql.apollo:apollo-http-cache")
+    add("implementation", groovy.util.Eval.x(project, "x.dep.okHttp.logging"))
     add("implementation", groovy.util.Eval.x(project, "x.dep.android.appcompat"))
     add("implementation", groovy.util.Eval.x(project, "x.dep.android.recyclerView"))
     add("implementation", groovy.util.Eval.x(project, "x.dep.kotlin.coroutines.android"))

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
@@ -1,9 +1,13 @@
 package com.apollographql.apollo.kotlinsample
 
 import android.app.Application
+import android.util.Log
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy
+import com.apollographql.apollo.cache.http.ApolloHttpCache
+import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore
 import com.apollographql.apollo.cache.normalized.CacheKey
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver
 import com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper
@@ -13,11 +17,21 @@ import com.apollographql.apollo.kotlinsample.data.ApolloCoroutinesService
 import com.apollographql.apollo.kotlinsample.data.ApolloRxService
 import com.apollographql.apollo.kotlinsample.data.GitHubDataSource
 import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import java.io.File
 
 @Suppress("unused")
 class KotlinSampleApp : Application() {
   private val baseUrl = "https://api.github.com/graphql"
   private val apolloClient: ApolloClient by lazy {
+    val logInterceptor = HttpLoggingInterceptor(
+        object : HttpLoggingInterceptor.Logger {
+          override fun log(message: String) {
+            Log.d("OkHttp", message)
+          }
+        }
+    ).apply { level = HttpLoggingInterceptor.Level.BODY }
+
     val okHttpClient = OkHttpClient.Builder()
         .addNetworkInterceptor { chain ->
           val request = chain.request().newBuilder()
@@ -26,6 +40,7 @@ class KotlinSampleApp : Application() {
 
           chain.proceed(request)
         }
+        .addInterceptor(logInterceptor)
         .build()
 
     val apolloSqlHelper = ApolloSqlHelper.create(this, "github_cache")
@@ -44,9 +59,14 @@ class KotlinSampleApp : Application() {
       }
     }
 
+    // Create the http response cache store
+    val cacheStore = DiskLruHttpCacheStore(File(cacheDir, "apolloCache"), 1024 * 1024)
+
     ApolloClient.builder()
         .serverUrl(baseUrl)
         .normalizedCache(sqlNormalizedCacheFactory, cacheKeyResolver)
+        .httpCache(ApolloHttpCache(cacheStore))
+        .defaultHttpCachePolicy(HttpCachePolicy.CACHE_FIRST)
         .okHttpClient(okHttpClient)
         .build()
   }


### PR DESCRIPTION
> When app is freshly installed (or when there is no cached response)
> When HttpLoggingInterceptor is added to OkHttp
> Log level is set to BODY
> The issues is that HttpLoggingInterceptor when logging response body requests whole response https://github.com/square/okhttp/blob/master/okhttp-logging-interceptor/src/main/java/okhttp3/logging/HttpLoggingInterceptor.kt#L244-L246
> that causes ApolloParseInterceptor to fail as there was a bug in our http cache: we didn't properly buffer original response, so instead of giving buffered response to ApolloParseInterceptor we give it non-buffered, that obviously will fail as response already was read from the source.

Closes https://github.com/apollographql/apollo-android/issues/1786