### PR TITLE
Silence sdkmanager in CI builds

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,7 +7,7 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 
 which emulator
 
-sdkmanager --install 'system-images;android-28;default;x86_64' 'emulator'
+sdkmanager --install 'system-images;android-28;default;x86_64' 'emulator' >/dev/null
 echo "no" |avdmanager create avd --force -n test -k 'system-images;android-28;default;x86_64'
 
 "$ANDROID_HOME"/emulator/emulator -avd test -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim &


### PR DESCRIPTION
Send sdkmanager stdout to >/dev/null because otherwise CI output becomes unmanageably big.