### PR TITLE
Skip CI checks if the changes are only for documentations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
 
 jobs:
   build:


### PR DESCRIPTION
Skip CI checks if the changes are only for documentations

Taken from https://github.com/cashapp/sqldelight/blob/2173c25ff72b24eda1de68ba2671c447157698a5/.github/workflows/PR.yml#L3-L7