### PR TITLE
Scope fields in operation variables

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -197,7 +197,7 @@ private fun InputType.variablesValueMapSpec(operationType: OperationType): FunSp
       .addCode(
           fields.map { field ->
             if (field.isOptional) {
-              CodeBlock.of("if (%L.defined) this[%S] = this@%L.%L.value", field.name, field.schemaName, operationType.name, field.name)
+              CodeBlock.of("if (this@%L.%L.defined) this[%S] = this@%L.%L.value", operationType.name, field.name, field.schemaName, operationType.name, field.name)
             } else {
               CodeBlock.of("this[%S] = this@%L.%L", field.schemaName, operationType.name, field.name)
             }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -42,7 +42,7 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      if (this@TestQuery.episode.defined) this["episode"] = this@TestQuery.episode.value
       this["stars"] = this@TestQuery.stars
       this["greenValue"] = this@TestQuery.greenValue
     }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -45,7 +45,7 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      if (this@TestQuery.episode.defined) this["episode"] = this@TestQuery.episode.value
       this["IncludeName"] = this@TestQuery.includeName
       this["friendsCount"] = this@TestQuery.friendsCount
       this["listOfListOfStringArgs"] = this@TestQuery.listOfListOfStringArgs

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -40,7 +40,7 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      if (this@TestQuery.episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
     override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller.invoke { writer ->

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -40,7 +40,7 @@ data class TestQuery(
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
-      if (episode.defined) this["episode"] = this@TestQuery.episode.value
+      if (this@TestQuery.episode.defined) this["episode"] = this@TestQuery.episode.value
     }
 
     override fun marshaller(): InputFieldMarshaller = InputFieldMarshaller.invoke { writer ->


### PR DESCRIPTION
Prepend `this@OperationName` in variables as well to avoid name clashes like in https://github.com/apollographql/apollo-android/commit/309f8699b3ddf4ad9a9fd63daac9d59831fdb565

Closes https://github.com/apollographql/apollo-android/issues/2035

@sav007 can you check ? 