### PR TITLE
Publishing: fix tag detection for bintray upload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -379,7 +379,7 @@ tasks.register("publishIfNeeded") {
     dependsOn(publishToOss)
   }
 
-  if (ref?.startsWith("ref/tags/") == true) {
+  if (ref?.startsWith("refs/tags/") == true) {
     project.logger.log(LogLevel.LIFECYCLE, "Deploying release to Bintray...")
     dependsOn(publishToBintray)
 


### PR DESCRIPTION
Just a typo in the way we detect tags with github Actions.