### PR TITLE
Fix issue with fragment field type conditions

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
@@ -113,8 +113,11 @@ class SimpleResponseReader private constructor(
 
     return value?.let { typename ->
       field.conditions
-          .firstOrNull { condition -> condition is ResponseField.TypeNameCondition && condition.typeNames.contains(typename) }
-          ?.let { objectReader.read(this) }
+          .mapNotNull { condition -> condition as? ResponseField.TypeNameCondition }
+          .all { condition -> condition.typeNames.contains(typename) }
+          .let { matchAllTypeConditions ->
+            if (matchAllTypeConditions) objectReader.read(this) else null
+          }
     }
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ResponseFieldSpec.kt
@@ -86,19 +86,23 @@ class ResponseFieldSpec(
             .build()
       }
     }
-    val conditions = (booleanConditions + typeCondition).foldIndexed(CodeBlock.builder()) { index, builder, code ->
-      builder.applyIf(index > 0) { add(",\n") }.add(code)
-    }.build().let { code ->
-      if (code.isEmpty) {
-        CodeBlock.of("\$T.<\$T>emptyList()", Collections::class.java, ResponseField.Condition::class.java)
-      } else {
-        CodeBlock.builder()
-            .add("\$T.<\$T>asList(\n", Arrays::class.java, ResponseField.Condition::class.java)
-            .indent().add(code).unindent()
-            .add("\n)")
-            .build()
-      }
-    }
+    val conditions = (booleanConditions + typeCondition)
+        .filter { code -> !code.isEmpty }
+        .foldIndexed(CodeBlock.builder()) { index, builder, code ->
+          builder.applyIf(index > 0) { add(",\n") }.add(code)
+        }
+        .build()
+        .let { code ->
+          if (code.isEmpty) {
+            CodeBlock.of("\$T.<\$T>emptyList()", Collections::class.java, ResponseField.Condition::class.java)
+          } else {
+            CodeBlock.builder()
+                .add("\$T.<\$T>asList(\n", Arrays::class.java, ResponseField.Condition::class.java)
+                .indent().add(code).unindent()
+                .add("\n)")
+                .build()
+          }
+        }
     return CodeBlock.of("\$T.\$L(\$S, \$S, \$L)", ResponseField::class.java, factoryMethod, irField.responseName, irField.fieldName,
         conditions)
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -184,6 +184,7 @@ class SchemaTypeSpecBuilder(
           .mapNotNull { fragmentRef -> context.ir.fragments.find { it.fragmentName == fragmentRef.name }?.let { fragmentRef to it } }
           .map { (fragmentRef, fragment) ->
             val optional = fragmentRef.isOptional()
+            val possibleTypes = fragment.takeIf { fragment.typeCondition != normalizeGraphQlType(schemaType) }?.possibleTypes ?: emptyList()
             val fieldSpec = FieldSpec.builder(
                 JavaTypeResolver(context = context, packageName = context.packageNameProvider.fragmentsPackageName)
                     .resolve(typeName = fragment.fragmentName.capitalize(), isOptional = optional), fragment.fragmentName.decapitalize())
@@ -196,7 +197,7 @@ class SchemaTypeSpecBuilder(
                 normalizedFieldSpec = normalizedFieldSpec,
                 responseFieldType = ResponseField.Type.FRAGMENT,
                 context = context,
-                typeConditions = fragment.possibleTypes
+                typeConditions = possibleTypes
             )
           }
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
@@ -50,7 +50,7 @@ internal class Context(
         }
         .astFragmentsObjectFieldType(
             fragmentsPackage = fragmentsPackage,
-            isOptional = { typeCondition != schemaTypeName }
+            parentFieldSchemaTypeName = schemaTypeName
         )
 
     val normalizedClassName = name.escapeKotlinReservedWord().let { originalClassName ->

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -530,9 +530,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -129,9 +129,7 @@ data class TestQuery(
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.java
@@ -439,8 +439,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         static final ResponseField[] $responseFields = {
           ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
             ResponseField.Condition.booleanCondition("withDetails", false),
-            ResponseField.Condition.booleanCondition("skipHumanDetails", true),
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
+            ResponseField.Condition.booleanCondition("skipHumanDetails", true)
           )),
           ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
             ResponseField.Condition.booleanCondition("withDetails", false),

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -113,8 +113,7 @@ data class TestQuery(
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
             ResponseField.forFragment("__typename", "__typename", listOf(
               ResponseField.Condition.booleanCondition("withDetails", false),
-              ResponseField.Condition.booleanCondition("skipHumanDetails", true),
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
+              ResponseField.Condition.booleanCondition("skipHumanDetails", true)
             )),
             ResponseField.forFragment("__typename", "__typename", listOf(
               ResponseField.Condition.booleanCondition("withDetails", false),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -25,7 +25,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import okio.BufferedSource;
 import org.jetbrains.annotations.NotNull;
@@ -349,9 +348,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -78,9 +78,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -26,7 +26,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okio.BufferedSource;
@@ -579,9 +578,7 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Starship"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final StarshipFragment.Mapper starshipFragmentFieldMapper = new StarshipFragment.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -79,9 +79,7 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Starship"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -17,7 +17,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -286,9 +285,7 @@ public class PilotFragment implements GraphqlFragment {
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Planet"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final PlanetFragment.Mapper planetFragmentFieldMapper = new PlanetFragment.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -98,9 +98,7 @@ data class PilotFragment(
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Planet"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -18,7 +18,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
@@ -517,9 +516,7 @@ public class StarshipFragment implements GraphqlFragment {
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Person"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final PilotFragment.Mapper pilotFragmentFieldMapper = new PilotFragment.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -113,9 +113,7 @@ data class StarshipFragment(
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Person"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
@@ -366,9 +366,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          )),
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList()),
           ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
             ResponseField.Condition.typeCondition(new String[] {"Human"})
           ))

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -81,9 +81,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            )),
+            ResponseField.forFragment("__typename", "__typename", null),
             ResponseField.forFragment("__typename", "__typename", listOf(
               ResponseField.Condition.typeCondition(arrayOf("Human"))
             ))

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.java
@@ -16,7 +16,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 
@@ -183,9 +182,7 @@ public class HeroDetails implements GraphqlFragment {
 
     public static final class Mapper implements ResponseFieldMapper<Fragments> {
       static final ResponseField[] $responseFields = {
-        ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-          ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-        ))
+        ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
       };
 
       final CharacterDetails.Mapper characterDetailsFieldMapper = new CharacterDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -65,9 +65,7 @@ data class HeroDetails(
 
     companion object {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forFragment("__typename", "__typename", listOf(
-            ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-          ))
+          ResponseField.forFragment("__typename", "__typename", null)
           )
 
       operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -27,7 +27,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okio.BufferedSource;
@@ -464,9 +463,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -101,9 +101,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -380,9 +380,7 @@ data class HeroDetails(
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -26,7 +26,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.SuppressWarnings;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okio.BufferedSource;
@@ -402,9 +401,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -101,9 +101,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -360,9 +360,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          )),
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList()),
           ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
             ResponseField.Condition.typeCondition(new String[] {"Human"})
           ))

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -81,9 +81,7 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            )),
+            ResponseField.forFragment("__typename", "__typename", null),
             ResponseField.forFragment("__typename", "__typename", listOf(
               ResponseField.Condition.typeCondition(arrayOf("Human"))
             ))

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -739,9 +739,7 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
 
       public static final class Mapper implements ResponseFieldMapper<Fragments> {
         static final ResponseField[] $responseFields = {
-          ResponseField.forFragment("__typename", "__typename", Arrays.<ResponseField.Condition>asList(
-            ResponseField.Condition.typeCondition(new String[] {"Human", "Droid"})
-          ))
+          ResponseField.forFragment("__typename", "__typename", Collections.<ResponseField.Condition>emptyList())
         };
 
         final HeroDetails.Mapper heroDetailsFieldMapper = new HeroDetails.Mapper();

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -85,9 +85,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
 
       companion object {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forFragment("__typename", "__typename", listOf(
-              ResponseField.Condition.typeCondition(arrayOf("Human", "Droid"))
-            ))
+            ResponseField.forFragment("__typename", "__typename", null)
             )
 
         operator fun invoke(reader: ResponseReader): Fragments = reader.run {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.java
@@ -199,7 +199,7 @@ public final class RealResponseReader<R> implements ResponseReader {
       resolveDelegate.didResolveNull();
       result = null;
     } else {
-      CustomTypeAdapter<T> typeAdapter = scalarTypeAdapters.adapterFor(field.getScalarType());
+      CustomTypeAdapter<T> typeAdapter = scalarTypeAdapters.adapterFor(field.scalarType());
       result = typeAdapter.decode(CustomTypeValue.fromRawValue(value));
       checkValue(field, result);
       resolveDelegate.didResolveScalar(value);
@@ -228,7 +228,7 @@ public final class RealResponseReader<R> implements ResponseReader {
       if (field.getType() == ResponseField.Type.FRAGMENT) {
         for (ResponseField.Condition condition : field.getConditions()) {
           if (condition instanceof ResponseField.TypeNameCondition) {
-            if (!((ResponseField.TypeNameCondition) condition).getTypeNames().contains(value)) {
+            if (!((ResponseField.TypeNameCondition) condition).typeNames().contains(value)) {
               return null;
             }
           }
@@ -241,11 +241,11 @@ public final class RealResponseReader<R> implements ResponseReader {
   }
 
   private boolean shouldSkip(ResponseField field) {
-    for (ResponseField.Condition condition : field.getConditions()) {
+    for (ResponseField.Condition condition : field.conditions()) {
       if (condition instanceof ResponseField.BooleanCondition) {
         ResponseField.BooleanCondition booleanCondition = (ResponseField.BooleanCondition) condition;
-        Boolean conditionValue = (Boolean) variableValues.get(booleanCondition.getVariableName());
-        if (booleanCondition.getInverted()) {
+        Boolean conditionValue = (Boolean) variableValues.get(booleanCondition.variableName());
+        if (booleanCondition.inverted()) {
           // means it's a skip directive
           if (Boolean.TRUE.equals(conditionValue)) {
             return true;
@@ -270,8 +270,8 @@ public final class RealResponseReader<R> implements ResponseReader {
   }
 
   private void checkValue(ResponseField field, Object value) {
-    if (!field.getOptional() && value == null) {
-      throw new NullPointerException("corrupted response reader, expected non null value for " + field.getFieldName());
+    if (!field.optional() && value == null) {
+      throw new NullPointerException("corrupted response reader, expected non null value for " + field.fieldName());
     }
   }
 


### PR DESCRIPTION
When fragment defined on the same type as parent field, don't generate fragment field type conditions otherwise it breaks parsing response for any new type.

See original issue for more details. 

Now for cases when fragment is defined on type of parent field we don't generate type conditions:
```
query TestQuery {
  hero { # hero here has type Character
    ...HeroDetails
  }  
}

fragment HeroDetails on Character {
   ...
}
```

https://github.com/apollographql/apollo-android/pull/2125/files#diff-988687da010965f3832fb8c9216ff862


Closes https://github.com/apollographql/apollo-android/issues/2097