### PR TITLE
Generate Mapper function for Kotlin models

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.compiler.codegen.kotlin
 
 import com.apollographql.apollo.api.Input
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.apollographql.apollo.compiler.applyIf
@@ -157,6 +158,18 @@ internal object KotlinCodeGen {
             .endControlFlow()
             .build()
         )
+        .build()
+  }
+
+  fun TypeName.createMapperFun(): FunSpec {
+    return FunSpec.builder("Mapper")
+        .addAnnotation(
+            AnnotationSpec.builder(Suppress::class)
+                .addMember("%S", "FunctionName")
+                .build()
+        )
+        .returns(ResponseFieldMapper::class.asClassName().parameterizedBy(this))
+        .addStatement("return %T { invoke(it) }", ResponseFieldMapper::class)
         .build()
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.compiler.ast.FieldType
 import com.apollographql.apollo.compiler.ast.ObjectType
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.asPropertySpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.asTypeName
+import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.createMapperFun
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.marshallerFunSpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.responseFieldsPropertySpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.toMapperFun
@@ -23,6 +24,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
       .addType(TypeSpec.companionObjectBuilder()
           .addProperty(responseFieldsPropertySpec(fields))
           .addFunction(fields.toMapperFun(ClassName("", name)))
+          .addFunction(ClassName("", name).createMapperFun())
           .build())
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
       .addFunction(fields.marshallerFunSpec(thisRef = name))
@@ -47,7 +49,8 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
       .addSuperinterface(kind.superInterface.asTypeName())
       .addType(TypeSpec.companionObjectBuilder()
           .addProperty(responseFieldsPropertySpec(fields))
-          .addFunction(fields.toMapperFun(ClassName.bestGuess(name)))
+          .addFunction(fields.toMapperFun(ClassName("", name)))
+          .addFunction(ClassName("", name).createMapperFun())
           .build())
       .addFunction(fields.marshallerFunSpec(override = true, thisRef = name))
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
@@ -69,7 +72,8 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
               .initializer("%S", kind.definition)
               .build()
           )
-          .addFunction(fields.toMapperFun(ClassName.bestGuess(name)))
+          .addFunction(fields.toMapperFun(ClassName("", name)))
+          .addFunction(ClassName("", name).createMapperFun())
           .build())
       .applyIf(fragmentsType != null) { addType(fragmentsType!!.fragmentsTypeSpec(generateAsInternal)) }
       .addFunction(fields.marshallerFunSpec(override = true, thisRef = name))
@@ -88,6 +92,7 @@ private fun ObjectType.fragmentsTypeSpec(generateAsInternal: Boolean = false): T
       .addType(TypeSpec.companionObjectBuilder()
           .addProperty(responseFieldsPropertySpec(fields))
           .addFunction(fields.toMapperFun(ClassName("", name)))
+          .addFunction(ClassName("", name).createMapperFun())
           .build())
       .addFunction(fields.marshallerFunSpec(thisRef = name))
       .addTypes(nestedObjects.map { (_, type) -> type.typeSpec() })

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo.compiler.ast.ObjectType
 import com.apollographql.apollo.compiler.ast.OperationType
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.asPropertySpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.asTypeName
+import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.createMapperFun
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.marshallerFunSpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.responseFieldsPropertySpec
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.suppressWarningsAnnotation
@@ -240,7 +241,8 @@ private fun ObjectType.toOperationDataTypeSpec(name: String) =
         .addProperties(fields.map { field -> field.asPropertySpec(initializer = CodeBlock.of(field.name)) })
         .addType(TypeSpec.companionObjectBuilder()
             .addProperty(responseFieldsPropertySpec(fields))
-            .addFunction(fields.toMapperFun(ClassName.bestGuess(name)))
+            .addFunction(fields.toMapperFun(ClassName("", name)))
+            .addFunction(ClassName("", name).createMapperFun())
             .build()
         )
         .addFunction(fields.marshallerFunSpec(override = true, thisRef = name))

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -107,6 +107,9 @@ data class TestQuery(
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -147,6 +150,9 @@ data class TestQuery(
           heroWithReview = heroWithReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -79,6 +79,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           commentary = commentary
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Review> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -110,6 +113,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           reviews = reviews
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -118,6 +118,9 @@ data class TestQuery(
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -142,6 +145,9 @@ data class TestQuery(
             heroDetails = heroDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -172,6 +178,9 @@ data class TestQuery(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -212,6 +221,9 @@ data class TestQuery(
           heroWithReview = heroWithReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.arguments_simple.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -65,6 +66,9 @@ data class HeroDetails(
         friendsConnection = friendsConnection
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Node(
@@ -95,6 +99,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -126,6 +133,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -170,6 +180,9 @@ data class HeroDetails(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -128,6 +128,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           links = links
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -151,6 +154,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -77,6 +77,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           links = links
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -100,6 +103,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -110,6 +110,9 @@ data class TestQuery(
           deprecatedBool = deprecatedBool
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -136,6 +139,9 @@ data class TestQuery(
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -98,6 +98,9 @@ data class TestQuery(
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -134,6 +137,9 @@ data class TestQuery(
             humanDetails = humanDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -158,6 +164,9 @@ data class TestQuery(
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ data class HeroDetails(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ data class HumanDetails(
         homePlanet = homePlanet
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -111,6 +111,9 @@ data class TestQuery(
           homePlanet = homePlanet
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -156,6 +159,9 @@ data class TestQuery(
           primaryFunction = primaryFunction
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -206,6 +212,9 @@ data class TestQuery(
           asDroid = asDroid
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -229,6 +238,9 @@ data class TestQuery(
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -91,6 +91,9 @@ data class TestQuery(
           totalCount = totalCount
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -134,6 +137,9 @@ data class TestQuery(
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -157,6 +163,9 @@ data class TestQuery(
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -92,6 +92,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           firstAppearsIn = firstAppearsIn
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -115,6 +118,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -67,6 +67,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -91,6 +94,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             heroDetails = heroDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -115,6 +121,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_friends_connection.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -71,6 +72,9 @@ data class HeroDetails(
         friendsConnection = friendsConnection
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Node(
@@ -99,6 +103,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -130,6 +137,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -174,6 +184,9 @@ data class HeroDetails(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -68,6 +68,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -92,6 +95,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
             starshipFragment = starshipFragment
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -124,6 +130,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -160,6 +169,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AllStarships> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -184,6 +196,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           allStarships = allStarships
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -62,6 +63,9 @@ data class PilotFragment(
         homeworld = homeworld
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<PilotFragment> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Homeworld(
@@ -87,6 +91,9 @@ data class PilotFragment(
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Homeworld> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -111,6 +118,9 @@ data class PilotFragment(
             planetFragment = planetFragment
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ data class PlanetFragment(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<PlanetFragment> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_in_fragment.type.CustomType
@@ -77,6 +78,9 @@ data class StarshipFragment(
         pilotConnection = pilotConnection
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<StarshipFragment> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Node(
@@ -102,6 +106,9 @@ data class StarshipFragment(
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -126,6 +133,9 @@ data class StarshipFragment(
             pilotFragment = pilotFragment
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -158,6 +168,9 @@ data class StarshipFragment(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,6 +207,9 @@ data class StarshipFragment(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<PilotConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -68,6 +68,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -101,6 +104,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             humanDetails = humanDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -125,6 +131,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -60,5 +61,8 @@ data class CharacterDetails(
         birthDate = birthDate
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<CharacterDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -54,6 +55,9 @@ data class HeroDetails(
         fragments = fragments
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Fragments(
@@ -78,6 +82,9 @@ data class HeroDetails(
           characterDetails = characterDetails
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -54,6 +55,9 @@ data class HumanDetails(
         fragments = fragments
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Fragments(
@@ -78,6 +82,9 @@ data class HumanDetails(
           characterDetails = characterDetails
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -90,6 +90,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -114,6 +117,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             heroDetails = heroDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -138,6 +144,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -57,5 +58,8 @@ data class DroidDetails(
         primaryFunction = primaryFunction
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<DroidDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -89,6 +90,9 @@ data class HeroDetails(
         asDroid = asDroid
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Fragments(
@@ -113,6 +117,9 @@ data class HeroDetails(
           humanDetails = humanDetails
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -142,6 +149,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -173,6 +183,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -217,6 +230,9 @@ data class HeroDetails(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -250,6 +266,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -281,6 +300,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -325,6 +347,9 @@ data class HeroDetails(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -369,6 +394,9 @@ data class HeroDetails(
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -393,6 +421,9 @@ data class HeroDetails(
             droidDetails = droidDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ data class HumanDetails(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -68,6 +68,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -101,6 +104,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             droidDetails = droidDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -128,6 +134,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -161,6 +170,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             droidDetails = droidDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -192,6 +204,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           luke = luke
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -57,5 +58,8 @@ data class DroidDetails(
         primaryFunction = primaryFunction
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<DroidDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -58,5 +59,8 @@ data class HumanDetails(
         height = height
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -68,6 +68,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -101,6 +104,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             droidDetails = droidDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -128,6 +134,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -161,6 +170,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             droidDetails = droidDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -192,6 +204,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           luke = luke
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -57,5 +58,8 @@ data class DroidDetails(
         primaryFunction = primaryFunction
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<DroidDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -58,5 +59,8 @@ data class HumanDetails(
         height = height
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -72,6 +72,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -103,6 +106,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -147,6 +153,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,6 +203,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -217,6 +229,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -71,6 +71,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -102,6 +105,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -146,6 +152,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -185,6 +194,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,6 +220,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -71,6 +71,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -102,6 +105,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -146,6 +152,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -185,6 +194,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,6 +220,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -71,6 +71,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -102,6 +105,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -146,6 +152,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -185,6 +194,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,6 +220,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -71,6 +71,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -102,6 +105,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -146,6 +152,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -185,6 +194,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,6 +220,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -78,6 +78,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           id = id
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -101,6 +104,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -96,6 +96,9 @@ data class TestQuery(
           commentary = commentary
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -129,6 +132,9 @@ data class TestQuery(
           createReview = createReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -120,6 +123,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asHuman = asHuman
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<NonOptionalHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,6 +150,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           nonOptionalHero = nonOptionalHero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -72,6 +72,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -103,6 +106,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -139,6 +145,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -187,6 +196,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           profileLink = profileLink
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -210,6 +222,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -75,6 +75,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           bar = bar
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsBar> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -110,6 +113,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asBar = asBar
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Foo> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -136,6 +142,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           foo = foo
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           appearsIn = appearsIn
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -134,6 +137,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -163,6 +169,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           id = id
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -215,6 +224,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -262,6 +274,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asDroid = asDroid
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -285,6 +300,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -100,6 +100,9 @@ data class TestQuery(
           commentary = commentary
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -129,6 +132,9 @@ data class TestQuery(
           createReview = createReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -67,6 +67,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<QueryType> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -93,6 +96,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -139,6 +145,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           types = types
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<__Schema> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -165,6 +174,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<__Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -196,6 +208,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           __type = __type
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -90,6 +90,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -114,6 +117,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             heroDetails = heroDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -138,6 +144,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.java_beans_semantic_naming.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -90,6 +91,9 @@ data class HeroDetails(
         asDroid = asDroid
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Node(
@@ -118,6 +122,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -149,6 +156,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -175,6 +185,9 @@ data class HeroDetails(
           hasNextPage = hasNextPage
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<PageInfo> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -237,6 +250,9 @@ data class HeroDetails(
           isEmpty = isEmpty
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -270,6 +286,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -301,6 +320,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -327,6 +349,9 @@ data class HeroDetails(
           hasNextPage = hasNextPage
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<PageInfo1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -389,6 +414,9 @@ data class HeroDetails(
           isEmpty = isEmpty
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -436,6 +464,9 @@ data class HeroDetails(
           primaryFunction = primaryFunction
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -95,6 +95,9 @@ internal data class CreateReviewForEpisode(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<ListOfListOfObject> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -214,6 +217,9 @@ internal data class CreateReviewForEpisode(
           listOfListOfObject = listOfListOfObject
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,6 +249,9 @@ internal data class CreateReviewForEpisode(
           createReview = createReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -101,6 +101,9 @@ data class CreateReviewForEpisodeMutation(
           commentary = commentary
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -130,6 +133,9 @@ data class CreateReviewForEpisodeMutation(
           createReview = createReview
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -109,6 +109,9 @@ data class TestQuery(
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -147,6 +150,9 @@ data class TestQuery(
           asHuman1 = asHuman1
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -191,6 +197,9 @@ data class TestQuery(
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -233,6 +242,9 @@ data class TestQuery(
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -271,6 +283,9 @@ data class TestQuery(
           asHuman2 = asHuman2
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -315,6 +330,9 @@ data class TestQuery(
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -362,6 +380,9 @@ data class TestQuery(
           asDroid = asDroid
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -388,6 +409,9 @@ data class TestQuery(
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -78,6 +78,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           id = id
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -101,6 +104,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -79,6 +79,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Yield_> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -112,6 +115,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsCharacter> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -142,6 +148,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asCharacter = asCharacter
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Object> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -178,6 +187,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           objects = objects
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -68,6 +68,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -101,6 +104,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
             humanDetails = humanDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -125,6 +131,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -54,6 +55,9 @@ internal data class HeroDetails(
         fragments = fragments
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   internal data class Fragments(
@@ -78,6 +82,9 @@ internal data class HeroDetails(
           humanDetails = humanDetails
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ internal data class HumanDetails(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HumanDetails> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -119,6 +122,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           primaryFunction = primaryFunction
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -166,6 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asDroid = asDroid
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -189,6 +198,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           hero = hero
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -113,6 +113,9 @@ data class TestQuery(
           coordinates = coordinates
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -139,6 +142,9 @@ data class TestQuery(
           starship = starship
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -95,6 +95,9 @@ data class TestSubscription(
           content = content
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CommentAdded> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -124,6 +127,9 @@ data class TestSubscription(
           commentAdded = commentAdded
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -70,6 +70,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -107,6 +110,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -138,6 +144,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           luke = luke
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -72,6 +72,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -103,6 +106,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -147,6 +153,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -186,6 +195,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -215,6 +227,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -246,6 +261,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -290,6 +308,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -337,6 +358,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friendsConnection = friendsConnection
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -368,6 +392,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           luke = luke
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -69,6 +69,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Search> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -102,6 +105,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
             starship = starship
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -132,6 +138,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           search = search
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -7,6 +7,7 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.union_fragment.type.CustomType
@@ -58,5 +59,8 @@ data class Character(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<Character> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -7,6 +7,7 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -48,5 +49,8 @@ data class Starship(
         name = name
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -81,6 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           firstAppearsIn = firstAppearsIn
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -133,6 +136,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -171,6 +177,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           deprecated = deprecated
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -223,6 +232,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsDroid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -270,6 +282,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asDroid = asDroid
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -322,6 +337,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsCharacter> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -351,6 +369,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsStarship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -390,6 +411,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           asStarship = asStarship
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Search> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -419,6 +443,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           search = search
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -74,6 +74,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           fragments = fragments
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
 
     data class Fragments(
@@ -98,6 +101,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
             heroDetails = heroDetails
           )
         }
+
+        @Suppress("FunctionName")
+        fun Mapper(): ResponseFieldMapper<Fragments> = ResponseFieldMapper { invoke(it) }
       }
     }
   }
@@ -156,6 +162,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           friends = friends
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,6 +217,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           height = height
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -237,6 +249,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -290,6 +305,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           asHuman = asHuman
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailQuery> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -313,6 +331,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           heroDetailQuery = heroDetailQuery
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.unique_type_name.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -71,6 +72,9 @@ data class HeroDetails(
         friendsConnection = friendsConnection
       )
     }
+
+    @Suppress("FunctionName")
+    fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
   data class Node(
@@ -99,6 +103,9 @@ data class HeroDetails(
           name = name
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -130,6 +137,9 @@ data class HeroDetails(
           node = node
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -174,6 +184,9 @@ data class HeroDetails(
           edges = edges
         )
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 }


### PR DESCRIPTION
Generate `fun Mapper():ResponseFieldMapper` that behaves as constructor for `ResponseFieldMapper` interface to be more aligned with generated Java models.

Closes https://github.com/apollographql/apollo-android/issues/2111