### PR TITLE
Add full exceptions for better error output on CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
@@ -74,6 +75,12 @@ subprojects {
     kotlinOptions {
       jvmTarget = JavaVersion.VERSION_1_8.toString()
       freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+  }
+
+  tasks.withType<Test> {
+    testLogging {
+      exceptionFormat = TestExceptionFormat.FULL
     }
   }
 


### PR DESCRIPTION
Here is how it looks like now when a test fails.

![image](https://user-images.githubusercontent.com/763339/79055828-5136df80-7c50-11ea-8332-e1b6dcd5f499.png)
