### PR TITLE
Small: Revert deprecation for 2.0

### DIFF
--- a/apollo-normalized-cache-api/src/main/java/com/apollographql/apollo/cache/normalized/CacheKey.kt
+++ b/apollo-normalized-cache-api/src/main/java/com/apollographql/apollo/cache/normalized/CacheKey.kt
@@ -24,7 +24,6 @@ class CacheKey(val key: String) {
     val NO_KEY = CacheKey("")
 
     @JvmStatic
-    @Deprecated("Use constructor to instantiate CacheKey", replaceWith = ReplaceWith(expression = "CacheKey(key)"))
     fun from(key: String): CacheKey = CacheKey(key)
   }
 


### PR DESCRIPTION
I deprecated the `CacheKey.from` while converting to Kotlin. 

While going through deprecations, I see no reason to deprecate this function since it is just fine as is. That's why I wanted to remove deprecation since the original API is also nice