### PR TITLE
Update maven publishing

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.withType<Test> {
   setForkEvery(8L)
   dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
-  dependsOn("publishDefaultPublicationToPluginTestRepository")
+  dependsOn("publishAllPublicationsToPluginTestRepository")
 
   inputs.dir("src/test/files")
 }

--- a/apollo-normalized-cache-sqlite/gradle.properties
+++ b/apollo-normalized-cache-sqlite/gradle.properties
@@ -1,4 +1,4 @@
-POM_ARTIFACT_ID=apollo-sqlite-cache
+POM_ARTIFACT_ID=apollo-normalized-cache-sqlite
 POM_NAME=Apollo GraphQL SQLite Cache
 POM_DESCRIPTION=Apollo GraphQL SQLite Cache
 POM_PACKAGING=jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -225,7 +225,9 @@ fun Project.configurePublishing() {
             if (javaComponent != null) {
               from(javaComponent)
             } else if (android != null) {
-              from(components.findByName("release"))
+              afterEvaluate {
+                from(components.findByName("release"))
+              }
             }
 
             if (javadocJarTaskProvider != null) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -321,58 +321,6 @@ fun PublicationContainer.setDefaultPomFields() {
   }
 }
 
-val publishToOjo = tasks.register("publishToOjo") {
-  dependsOn(subprojects.flatMap { subproject ->
-    subproject.tasks.matching {
-      if (it.name == "apollo-gradle-plugin") {
-        it.name in arrayOf("publishDefaultPublicationToOjoRepository",
-            "publishApolloGradlePluginPluginMarkerMavenPublicationToOjoRepository")
-      } else {
-        it.name == "publishAllPublicationsToOjoRepository"
-      }
-    }
-  })
-  doLast {
-    project.logger.log(LogLevel.LIFECYCLE, "Snapshot deployed on OJO!")
-  }
-}
-
-val publishToBintray = tasks.register("publishToBintray") {
-  dependsOn(subprojects.flatMap { subproject ->
-    subproject.tasks.matching {
-      if (it.name == "apollo-gradle-plugin") {
-        it.name in arrayOf("publishDefaultPublicationToBintrayRepository",
-            "publishApolloGradlePluginPluginMarkerMavenPublicationToBintrayMarkerRepository")
-      } else {
-        it.name == "publishAllPublicationsToBintrayRepository"
-      }
-    }
-  })
-}
-
-val publishToOss = tasks.register("publishToOss") {
-  dependsOn(subprojects.flatMap { subproject ->
-    subproject.tasks.matching {
-      if (it.name == "apollo-gradle-plugin") {
-        it.name in arrayOf("publishDefaultPublicationToOssRepository",
-            "publishApolloGradlePluginPluginMarkerMavenPublicationToOssRepository")
-      } else {
-        it.name == "publishAllPublicationsToOssRepository"
-      }
-    }
-  })
-  doLast {
-    project.logger.log(LogLevel.LIFECYCLE, "Snapshot deployed on OSS!")
-  }
-}
-
-val publishToGradlePortal = tasks.register("publishToGradlePortal") {
-  dependsOn(":apollo-gradle-plugin:publishPlugin")
-  doLast {
-    project.logger.log(LogLevel.LIFECYCLE, "Plugin deployed Gradle Plugin Portal!")
-  }
-}
-
 tasks.register("publishIfNeeded") {
   val eventName = System.getenv("GITHUB_EVENT_NAME")
   val ref = System.getenv("GITHUB_REF")
@@ -383,16 +331,16 @@ tasks.register("publishIfNeeded") {
 
   if (eventName == "push" && ref == "refs/heads/master") {
     project.logger.log(LogLevel.LIFECYCLE, "Deploying snapshot to OJO...")
-    dependsOn(publishToOjo)
+    dependsOn("publishAllPublicationsToOjoRepository")
     project.logger.log(LogLevel.LIFECYCLE, "Deploying snapshot to OSS...")
-    dependsOn(publishToOss)
+    dependsOn("publishAllPublicationsToOssRepository")
   }
 
   if (ref?.startsWith("refs/tags/") == true) {
     project.logger.log(LogLevel.LIFECYCLE, "Deploying release to Bintray...")
-    dependsOn(publishToBintray)
+    dependsOn("publishAllPublicationsToBintrayRepository")
 
     project.logger.log(LogLevel.LIFECYCLE, "Deploying release to Gradle Portal...")
-    dependsOn(publishToGradlePortal)
+    dependsOn(":apollo-gradle-plugin:publishPlugin")
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,7 +255,7 @@ fun Project.configurePublishing() {
 
       maven {
         name = "bintray"
-        url = uri("https://api.bintray.com/maven/apollographql/android/${project.property("POM_ARTIFACT_ID")}/;publish=1;override=1")
+        url = uri("https://api.bintray.com/maven/apollographql/android/apollo/;publish=1;override=1")
         credentials {
           username = System.getenv("BINTRAY_USER")
           password = System.getenv("BINTRAY_API_KEY")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,13 +211,24 @@ fun Project.configurePublishing() {
       when {
         plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> {
           withType<MavenPublication>().getByName("jvm") {
+            // multiplatform doesn't add javadoc by default so add it here
             if (javadocJarTaskProvider != null) {
               artifact(javadocJarTaskProvider.get())
             }
           }
         }
         plugins.hasPlugin("java-gradle-plugin") -> {
-          // do nothing, the plugin will create the publications for us
+          // java-gradle-plugin doesn't add javadoc/sources by default so add it here
+          withType<MavenPublication>().all {
+            if (name == "pluginMaven") {
+              if (javadocJarTaskProvider != null) {
+                artifact(javadocJarTaskProvider.get())
+              }
+              if (sourcesJarTaskProvider != null) {
+                artifact(sourcesJarTaskProvider.get())
+              }
+            }
+          }
         }
         else -> {
           create<MavenPublication>("default") {


### PR DESCRIPTION
* use the Android software components available with AGP 3.6
* do not create publications if the java-gradle-plugin or org.jetbrains.kotlin.multiplatform did it for us
* properly configure the pom metadata
* remove the bintrayMarker repository
* upload everything to the merged `apollo` package
* since the publications do not overlap anymore, we can call "publishAllPublications"