### PR TITLE
Enable support for generics Objective-C interop

### DIFF
--- a/samples/multiplatform/kmp-ios-app/kmp-ios-app/SceneDelegate.swift
+++ b/samples/multiplatform/kmp-ios-app/kmp-ios-app/SceneDelegate.swift
@@ -46,7 +46,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
      
             // Convert HTTP Response Data to a String
             if let data = data, let dataString = String(data: data, encoding: .utf8) {
-                query.parse(source: OkioBuffer())
+                let viewer: GithubRepositoriesQuery.Viewer = query.parse(source: OkioBuffer()).data!.viewer
+                print(viewer)
+                
                 print("Response data string:\n" + (dataString.data(using: .utf8)!.prettyPrintedJSONString! as String))
                 
             }

--- a/samples/multiplatform/kmp-lib-sample/build.gradle.kts
+++ b/samples/multiplatform/kmp-lib-sample/build.gradle.kts
@@ -20,6 +20,8 @@ kotlin {
       if (!buildForDevice) {
         embedBitcode("disable")
       }
+
+      freeCompilerArgs = freeCompilerArgs + "-Xobjc-generics"
     }
   }
 


### PR DESCRIPTION
With this compiler argument generated Objective-C headers contains info required for generics interop.