### PR TITLE
Fix cloned watcher leaking (#2164)

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -23,7 +23,8 @@ import kotlinx.coroutines.flow.callbackFlow
  */
 @ExperimentalCoroutinesApi
 fun <T> ApolloCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
-  clone().enqueue(
+  val clone = clone()
+  clone.enqueue(
       object : ApolloCall.Callback<T>() {
         override fun onResponse(response: Response<T>) {
           runCatching {
@@ -42,7 +43,7 @@ fun <T> ApolloCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
         }
       }
   )
-  awaitClose { this@toFlow.cancel() }
+  awaitClose { clone.cancel() }
 }
 
 /**
@@ -53,7 +54,8 @@ fun <T> ApolloCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
  */
 @ExperimentalCoroutinesApi
 fun <T> ApolloQueryWatcher<T>.toFlow(): Flow<Response<T>> = callbackFlow {
-  clone().enqueueAndWatch(
+  val clone = clone()
+  clone.enqueueAndWatch(
       object : ApolloCall.Callback<T>() {
         override fun onResponse(response: Response<T>) {
           runCatching {
@@ -72,7 +74,7 @@ fun <T> ApolloQueryWatcher<T>.toFlow(): Flow<Response<T>> = callbackFlow {
         }
       }
   )
-  awaitClose { this@toFlow.cancel() }
+  awaitClose { clone.cancel() }
 }
 
 
@@ -116,7 +118,8 @@ fun <T> ApolloCall<T>.toDeferred(): Deferred<Response<T>> {
  */
 @ExperimentalCoroutinesApi
 fun <T> ApolloSubscriptionCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
-  clone().execute(
+  val clone = clone()
+  clone.execute(
       object : ApolloSubscriptionCall.Callback<T> {
         override fun onConnected() {
         }
@@ -140,7 +143,7 @@ fun <T> ApolloSubscriptionCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
         }
       }
   )
-  awaitClose { this@toFlow.cancel() }
+  awaitClose { clone.cancel() }
 }
 
 /**


### PR DESCRIPTION
I wanted to add a test case, but couldn't reproduce it without a schema that has a root object, since #2033 wouldn't be triggered. I'm aware the names there aren't ideal, but since I'm not sure if there's a more straightforward way to test I didn't invest time into them. The problem with testing I see is that I don't have a reference to the cloned watcher, so the only observable effect is an additional API call. Is there some other way to trigger refetching of open calls? Anyway, suggestions for testing and/or names are welcome.

I didn't add test for all `toFlow()` variants but applied the same fix. I could try to fit them in a single test case or add a separate test case for each, if needed.