### PR TITLE
Try to workaround the metaspace error

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.withType<Test> {
   // It's not clear if it's a real ClassLoader leak or something else. The okio timeout thread does hold some ClassLoaders
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
-  setForkEvery(2L)
+  setForkEvery(1L)
   dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ tasks.withType<Test> {
   // It's not clear if it's a real ClassLoader leak or something else. The okio timeout thread does hold some ClassLoaders
   // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
   // See https://github.com/gradle/gradle/issues/8354
-  setForkEvery(8L)
+  setForkEvery(2L)
   dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")


### PR DESCRIPTION
Fork a gradle daemon even more often to try to workaround a MetaSpace error

See https://github.com/apollographql/apollo-android/pull/2175#issuecomment-614393777