### PR TITLE
bump the plugin-publish version.

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("java")
   id("org.jetbrains.kotlin.jvm")
   id("java-gradle-plugin")
-  id("com.gradle.plugin-publish") version "0.10.1"
+  id("com.gradle.plugin-publish") version "0.11.0"
 }
 
 // groovy strings with double quotes are GString.


### PR DESCRIPTION
This should fix the plugin upload that was disabled for security reasons