### PR TITLE
Replace DetachedObjectGraph wrapper with stable ref.

### DIFF
--- a/samples/multiplatform/kmp-lib-sample/src/iosMain/kotlin/com/apollographql/apollo/kmpsample/data/ApolloNetworkClient.kt
+++ b/samples/multiplatform/kmp-lib-sample/src/iosMain/kotlin/com/apollographql/apollo/kmpsample/data/ApolloNetworkClient.kt
@@ -2,15 +2,11 @@ package com.apollographql.apollo.kmpsample.data
 
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
-import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.COpaquePointer
-import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.convert
-import kotlinx.cinterop.get
-import kotlinx.cinterop.reinterpret
 import kotlinx.cinterop.staticCFunction
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.CancellableContinuation
@@ -37,8 +33,6 @@ import platform.darwin.dispatch_async_f
 import platform.darwin.dispatch_get_main_queue
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
-import kotlin.native.concurrent.DetachedObjectGraph
-import kotlin.native.concurrent.attach
 import kotlin.native.concurrent.freeze
 
 internal class ApolloNetworkClient(
@@ -119,25 +113,24 @@ internal class ApolloNetworkClient(
     }
   }
 
-  private fun NSData.toByteArray(): ByteArray {
-    val data: CPointer<ByteVar> = bytes!!.reinterpret()
-    return ByteArray(length.toInt()) { index -> data[index] }
-  }
-
   @Suppress("NAME_SHADOWING")
   private fun <T : Operation.Data> Result<T>.dispatchOnMain(continuationRef: COpaquePointer) {
+    val continuationWithResultRef = StableRef.create((continuationRef to this).freeze())
     dispatch_async_f(
         queue = dispatch_get_main_queue(),
-        context = DetachedObjectGraph { (continuationRef to this).freeze() }.asCPointer(),
-        work = staticCFunction { it ->
-          val continuationRefAndResponse = DetachedObjectGraph<Pair<COpaquePointer, Result<T>>>(it).attach()
-          val continuationRef = continuationRefAndResponse.first.asStableRef<CancellableContinuation<Response<T>>>()
+        context = continuationWithResultRef.asCPointer(),
+        work = staticCFunction { ref ->
+          val continuationWithResultRef = ref!!.asStableRef<Pair<COpaquePointer, Result<T>>>()
+          val (continuationPointer, result) = continuationWithResultRef.get()
+          continuationWithResultRef.dispose()
+
+          val continuationRef = continuationPointer.asStableRef<CancellableContinuation<Response<T>>>()
           val continuation = continuationRef.get()
           continuationRef.dispose()
 
-          when (val response = continuationRefAndResponse.second) {
-            is Result.Success -> continuation.resume(response.value)
-            is Result.Failure -> continuation.resumeWithException(response.error)
+          when (result) {
+            is Result.Success -> continuation.resume(result.value)
+            is Result.Failure -> continuation.resumeWithException(result.error)
           }
         }
     )


### PR DESCRIPTION
When passing pointer from background thread to main there is no need to wrap object into `DetachedObjectGraph` as for any frozen objects `StableRef` should be enough.