### PR TITLE
Add missing Java/Kotlin Docs generation for generated classes

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -14,6 +14,7 @@ import javax.lang.model.element.Modifier
 
 class SchemaTypeSpecBuilder(
     typeName: String,
+    private val description: String = "",
     private val schemaType: String = "",
     private val fields: List<Field>,
     private val fragmentRefs: List<FragmentRef>,
@@ -57,6 +58,7 @@ class SchemaTypeSpecBuilder(
       SchemaTypeSpecBuilder(
           typeName = formatUniqueTypeName("As${normalizeGraphQlType(schemaType).capitalize()}",
               context.reservedTypeNames),
+          description = description,
           schemaType = schemaType,
           fields = fields,
           fragmentRefs = fragmentRefs,
@@ -69,6 +71,7 @@ class SchemaTypeSpecBuilder(
       null
     }
     return TypeSpec.interfaceBuilder(uniqueTypeName)
+        .applyIf(description.isNotBlank()) { addJavadoc("\$L\n", description) }
         .addModifiers(*modifiers)
         .addMethods(methods)
         .addMethod(marshallerAccessorMethodSpec)
@@ -101,6 +104,7 @@ class SchemaTypeSpecBuilder(
     val nameOverrideMap = nestedTypeSpecs.plus(inlineFragmentTypeSpecs).map { it.first to it.second.name }.toMap()
     val responseFieldSpecs = responseFieldSpecs(nameOverrideMap)
     return TypeSpec.classBuilder(uniqueTypeName)
+        .applyIf(description.isNotBlank()) { addJavadoc("\$L\n", description) }
         .addModifiers(*modifiers)
         .addTypes(nestedTypeSpecs.map { it.second })
         .addFields(fieldSpecs(nameOverrideMap))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
@@ -54,6 +54,7 @@ internal data class OperationType(
 internal data class ObjectType(
     val name: String,
     val schemaTypeName: String,
+    val description: String,
     val fields: List<Field>,
     val fragmentsType: ObjectType?,
     val kind: Kind,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/Context.kt
@@ -25,6 +25,7 @@ internal class Context(
   fun registerObjectType(
       name: String,
       schemaTypeName: String,
+      description: String,
       fragmentRefs: List<FragmentRef>,
       inlineFragments: List<InlineFragment>,
       fields: List<Field>,
@@ -68,6 +69,7 @@ internal class Context(
     objectTypeContainer[uniqueTypeRef] = ObjectType(
         name = uniqueTypeRef.name,
         schemaTypeName = schemaTypeName,
+        description = description,
         fields = fields.map { it.ast(this) }
             .let { if (fragmentsField != null) it + fragmentsField else it }
             + inlineFragmentFields,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
@@ -12,6 +12,7 @@ internal fun Fragment.ast(context: Context): ObjectType {
   val typeRef = context.registerObjectType(
       name = fragmentName.capitalize().escapeKotlinReservedWord(),
       schemaTypeName = typeCondition,
+      description = "",
       fragmentRefs = fragmentRefs,
       inlineFragments = emptyList(),
       fields = fields,
@@ -52,6 +53,7 @@ internal fun Map<FragmentRef, Fragment>.astFragmentsObjectFieldType(
   val type = ObjectType(
       name = "Fragments",
       schemaTypeName = "",
+      description = "",
       fields = map { (fragmentRef, fragment) ->
         val isOptional = fragmentRef.conditions.isNotEmpty() || fragment.typeCondition != parentFieldSchemaTypeName
         val possibleTypes = fragment.takeIf { fragment.typeCondition != parentFieldSchemaTypeName }?.possibleTypes ?: emptyList()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/InlineFragmentTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/InlineFragmentTypeBuilder.kt
@@ -14,6 +14,7 @@ internal fun Context.registerInlineFragmentSuper(type: String, schemaType: Strin
   return registerObjectType(
       name = superInterfaceName.escapeKotlinReservedWord(),
       schemaTypeName = "",
+      description = "",
       fragmentRefs = emptyList(),
       inlineFragments = emptyList(),
       fields = emptyList(),
@@ -30,6 +31,7 @@ internal fun InlineFragment.inlineFragmentField(
   val typeRef = context.registerObjectType(
       name = "As$normalizedClassName",
       schemaTypeName = typeCondition,
+      description = description,
       fragmentRefs = fragmentRefs,
       inlineFragments = emptyList(),
       fields = fields,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
@@ -40,6 +40,7 @@ private fun Field.array(context: Context): ObjectType.Field {
         context.registerObjectType(
             name = responseName.replace("[", "").replace("]", "").replace("!", ""),
             schemaTypeName = type.replace("[", "").replace("]", "").replace("!", ""),
+            description = typeDescription,
             fragmentRefs = fragmentRefs,
             inlineFragments = inlineFragments,
             fields = fields,
@@ -81,6 +82,7 @@ private fun Field.`object`(context: Context): ObjectType.Field {
   val typeRef = context.registerObjectType(
       name = responseName.replace("[", "").replace("[", "").replace("!", ""),
       schemaTypeName = type.replace("[", "").replace("[", "").replace("!", ""),
+      description = typeDescription,
       fragmentRefs = fragmentRefs,
       inlineFragments = inlineFragments,
       fields = fields,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
@@ -16,6 +16,7 @@ internal fun Operation.ast(
   val dataTypeRef = context.registerObjectType(
       name = "Data",
       schemaTypeName = "",
+      description = "Data from the response after executing this GraphQL operation",
       fragmentRefs = emptyList(),
       inlineFragments = emptyList(),
       fields = fields,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/ObjectType.kt
@@ -19,6 +19,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
       .classBuilder(name)
       .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
       .addModifiers(KModifier.DATA)
+      .apply { if (description.isNotBlank()) addKdoc("%L\n", description) }
       .primaryConstructor(primaryConstructorSpec)
       .addProperties(fields.map { it.asPropertySpec(initializer = CodeBlock.of(it.name)) })
       .addType(TypeSpec.companionObjectBuilder()
@@ -44,6 +45,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
   is ObjectType.Kind.InlineFragment -> TypeSpec
       .classBuilder(name)
       .addModifiers(KModifier.DATA)
+      .apply { if (description.isNotBlank()) addKdoc("%L\n", description) }
       .primaryConstructor(primaryConstructorSpec)
       .addProperties(fields.map { it.asPropertySpec(initializer = CodeBlock.of(it.name)) })
       .addSuperinterface(kind.superInterface.asTypeName())
@@ -61,6 +63,7 @@ internal fun ObjectType.typeSpec(generateAsInternal: Boolean = false): TypeSpec 
       .classBuilder(name)
       .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
       .addModifiers(KModifier.DATA)
+      .apply { if (description.isNotBlank()) addKdoc("%L\n", description) }
       .addSuperinterface(GraphqlFragment::class.java)
       .addAnnotation(KotlinCodeGen.suppressWarningsAnnotation)
       .primaryConstructor(primaryConstructorSpec)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -238,6 +238,7 @@ private fun ObjectType.toOperationDataTypeSpec(name: String) =
         .classBuilder(name)
         .addModifiers(KModifier.DATA)
         .addSuperinterface(Operation.Data::class)
+        .apply { if (description.isNotBlank()) addKdoc("%L\n", description) }
         .primaryConstructor(FunSpec.constructorBuilder()
             .addParameters(fields.map { field ->
               val typeName = field.type.asTypeName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -8,6 +8,7 @@ data class Field(
     val responseName: String,
     val fieldName: String,
     val type: String,
+    val typeDescription: String,
     val args: List<Argument> = emptyList(),
     val isConditional: Boolean = false,
     val fields: List<Field> = emptyList(),
@@ -24,6 +25,7 @@ data class Field(
     val fields = if (isNonScalar()) fields else emptyList()
     return SchemaTypeSpecBuilder(
         typeName = formatClassName(),
+        description = typeDescription,
         schemaType = type,
         fields = fields,
         fragmentRefs = fragmentRefs,
@@ -167,6 +169,7 @@ data class Field(
         responseName = "__typename",
         fieldName = "__typename",
         type = "String!",
+        typeDescription = "",
         fragmentRefs = emptyList(),
         sourceLocation = SourceLocation.UNKNOWN
     )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/InlineFragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/InlineFragment.kt
@@ -10,6 +10,7 @@ import javax.lang.model.element.Modifier
 data class InlineFragment(
     val typeCondition: String,
     val possibleTypes: List<String> = emptyList(),
+    val description: String,
     val fields: List<Field>,
     val fragmentRefs: List<FragmentRef>,
     val sourceLocation: SourceLocation,
@@ -19,6 +20,7 @@ data class InlineFragment(
   override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec {
     return SchemaTypeSpecBuilder(
         typeName = formatClassName(),
+        description = description,
         fields = fields,
         fragmentRefs = fragmentRefs,
         inlineFragments = emptyList(),

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -29,6 +29,7 @@ data class Operation(
           .build(Modifier.PUBLIC, Modifier.STATIC)
           .toBuilder()
           .addSuperinterface(Operation.Data::class.java)
+          .addJavadoc("\$L\n", "Data from the response after executing this GraphQL operation")
           .build()
           .let {
             if (context.generateModelBuilder) {
@@ -46,6 +47,7 @@ data class Operation(
   }
 
   private fun normalizedOperationName(useSemanticNaming: Boolean, operationNameSuffix: String): String {
+    "".run {  }
     return if (useSemanticNaming && !operationName.endsWith(operationNameSuffix)) {
       operationName.capitalize() + operationNameSuffix
     } else {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -47,7 +47,6 @@ data class Operation(
   }
 
   private fun normalizedOperationName(useSemanticNaming: Boolean, operationNameSuffix: String): String {
-    "".run {  }
     return if (useSemanticNaming && !operationName.endsWith(operationNameSuffix)) {
       operationName.capitalize() + operationNameSuffix
     } else {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/GraphQLDocumentParser.kt
@@ -299,6 +299,7 @@ class GraphQLDocumentParser(val schema: Schema, private val packageNameProvider:
             responseName = responseName,
             fieldName = fieldName,
             type = schemaField.type.asGraphQLType(),
+            typeDescription = schemaFieldType.description ?: "",
             args = arguments.result,
             isConditional = conditions.isNotEmpty(),
             fields = mergedFields,
@@ -440,6 +441,7 @@ class GraphQLDocumentParser(val schema: Schema, private val packageNameProvider:
         result = InlineFragment(
             typeCondition = typeCondition,
             possibleTypes = possibleTypes,
+            description = schemaType.description ?: "",
             fields = fields.result,
             fragmentRefs = selectionSet().fragmentRefs(),
             sourceLocation = SourceLocation(start),

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.java
@@ -235,6 +235,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("heroWithReview", "heroWithReview", new UnmodifiableMapBuilder<String, Object>(3)
@@ -337,6 +340,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class HeroWithReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -111,6 +111,9 @@ data class TestQuery(
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class HeroWithReview(
     val __typename: String = "Human",
     /**
@@ -152,6 +155,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val heroWithReview: HeroWithReview?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.java
@@ -150,6 +150,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forList("reviews", "reviews", new UnmodifiableMapBuilder<String, Object>(3)
@@ -247,6 +250,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   public static class Review {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * Represents a review for a movie
+   */
   data class Review(
     val __typename: String = "Review",
     /**
@@ -122,6 +125,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val reviews: List<Review?>?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.java
@@ -290,6 +290,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", new UnmodifiableMapBuilder<String, Object>(2)
@@ -408,6 +411,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -597,6 +603,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class HeroWithReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -123,6 +123,9 @@ data class TestQuery(
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -188,6 +191,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class HeroWithReview(
     val __typename: String = "Human",
     /**
@@ -220,6 +226,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?,
     val heroWithReview: HeroWithReview?

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.java
@@ -142,6 +142,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -270,6 +273,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -368,6 +374,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -71,6 +71,9 @@ data class HeroDetails(
     fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -105,6 +108,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -139,6 +145,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.java
@@ -155,6 +155,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -236,6 +239,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -84,6 +84,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -171,6 +174,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.java
@@ -149,6 +149,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -230,6 +233,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -83,6 +83,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -120,6 +123,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -204,6 +204,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
@@ -290,6 +293,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -104,6 +104,9 @@ data class TestQuery(
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -154,6 +157,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.java
@@ -218,6 +218,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -299,6 +302,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -103,6 +103,9 @@ data class TestQuery(
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -179,6 +182,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.java
@@ -214,6 +214,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -295,6 +298,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Hero {
     @NotNull String __typename();
 
@@ -370,6 +376,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -496,6 +505,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   public static class AsDroid implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -622,6 +634,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -105,6 +105,9 @@ data class TestQuery(
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -153,6 +156,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**
@@ -201,6 +207,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -254,6 +263,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.java
@@ -210,6 +210,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -291,6 +294,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -411,6 +417,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -101,6 +101,9 @@ data class TestQuery(
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -133,6 +136,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -179,6 +185,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.java
@@ -151,6 +151,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -232,6 +235,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -135,6 +138,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.java
@@ -163,6 +163,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -244,6 +247,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -81,6 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -136,6 +139,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.java
@@ -154,6 +154,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -282,6 +285,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -380,6 +386,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -77,6 +77,9 @@ data class HeroDetails(
     fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -109,6 +112,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -143,6 +149,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.java
@@ -183,6 +183,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("allStarships", "allStarships", new UnmodifiableMapBuilder<String, Object>(1)
@@ -266,6 +269,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     }
   }
 
+  /**
+   * A connection to a list of items.
+   */
   public static class AllStarships1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -376,6 +382,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     }
   }
 
+  /**
+   * An edge in a connection.
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -474,6 +483,9 @@ public final class AllStarships implements Query<AllStarships.Data, Optional<All
     }
   }
 
+  /**
+   * A single transport craft that has hyperdrive capability.
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -82,6 +82,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A single transport craft that has hyperdrive capability.
+   */
   data class Node(
     val __typename: String = "Starship",
     val fragments: Fragments
@@ -137,6 +140,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     }
   }
 
+  /**
+   * An edge in a connection.
+   */
   data class Edge(
     val __typename: String = "StarshipsEdge",
     /**
@@ -171,6 +177,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     }
   }
 
+  /**
+   * A connection to a list of items.
+   */
   data class AllStarships(
     val __typename: String = "StarshipsConnection",
     /**
@@ -210,6 +219,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val allStarships: AllStarships?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.java
@@ -145,6 +145,10 @@ public class PilotFragment implements GraphqlFragment {
     }
   }
 
+  /**
+   * A large mass, planet or planetoid in the Star Wars Universe, at the time of
+   * 0 ABY.
+   */
   public static class Homeworld {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -68,6 +68,10 @@ data class PilotFragment(
     fun Mapper(): ResponseFieldMapper<PilotFragment> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * A large mass, planet or planetoid in the Star Wars Universe, at the time of
+   * 0 ABY.
+   */
   data class Homeworld(
     val __typename: String = "Planet",
     val fragments: Fragments

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.java
@@ -168,6 +168,9 @@ public class StarshipFragment implements GraphqlFragment {
     }
   }
 
+  /**
+   * A connection to a list of items.
+   */
   public static class PilotConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -278,6 +281,9 @@ public class StarshipFragment implements GraphqlFragment {
     }
   }
 
+  /**
+   * An edge in a connection.
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -376,6 +382,9 @@ public class StarshipFragment implements GraphqlFragment {
     }
   }
 
+  /**
+   * An individual person or character within the Star Wars universe.
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -83,6 +83,9 @@ data class StarshipFragment(
     fun Mapper(): ResponseFieldMapper<StarshipFragment> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * An individual person or character within the Star Wars universe.
+   */
   data class Node(
     val __typename: String = "Person",
     val fragments: Fragments
@@ -138,6 +141,9 @@ data class StarshipFragment(
     }
   }
 
+  /**
+   * An edge in a connection.
+   */
   data class Edge(
     val __typename: String = "StarshipPilotsEdge",
     /**
@@ -172,6 +178,9 @@ data class StarshipFragment(
     }
   }
 
+  /**
+   * A connection to a list of items.
+   */
   data class PilotConnection(
     val __typename: String = "StarshipPilotsConnection",
     /**

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.java
@@ -166,6 +166,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -247,6 +250,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -146,6 +149,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.java
@@ -181,6 +181,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -296,6 +299,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -83,6 +83,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -159,6 +162,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.java
@@ -104,6 +104,9 @@ public interface HeroDetails extends GraphqlFragment {
     T visit(@NotNull AsCharacter asCharacter);
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   interface FriendsConnection {
     @NotNull String __typename();
 
@@ -120,6 +123,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   interface Edge {
     @NotNull String __typename();
 
@@ -131,6 +137,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   interface Node {
     @NotNull String __typename();
 
@@ -142,6 +151,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   class AsDroid implements HeroDetails {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -455,6 +467,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   class FriendsConnection1 implements FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -643,6 +658,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   class Edge1 implements Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -784,6 +802,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   class Node1 implements Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1224,6 +1245,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   class FriendsConnection2 implements FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1412,6 +1436,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   class Edge2 implements Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1553,6 +1580,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   class Node2 implements Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -123,6 +123,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -155,6 +158,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -189,6 +195,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -240,6 +249,9 @@ data class HeroDetails(
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node1(
     val __typename: String = "Character",
     /**
@@ -272,6 +284,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge1(
     val __typename: String = "FriendsEdge",
     /**
@@ -306,6 +321,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection1(
     val __typename: String = "FriendsConnection",
     /**
@@ -353,6 +371,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.java
@@ -166,6 +166,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("r2", "hero", null, true, Collections.<ResponseField.Condition>emptyList()),
@@ -268,6 +271,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class R2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -469,6 +475,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class R2(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -148,6 +151,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Luke(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -214,6 +220,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val r2: R2?,
     val luke: Luke?

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
@@ -163,6 +163,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("r2", "hero", null, true, Collections.<ResponseField.Condition>emptyList()),
@@ -265,6 +268,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class R2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -460,6 +466,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class R2(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -148,6 +151,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Luke(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -214,6 +220,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val r2: R2?,
     val luke: Luke?

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.java
@@ -162,6 +162,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -243,6 +246,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -382,6 +388,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -510,6 +519,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -608,6 +620,9 @@ public final class HeroDetails implements Query<HeroDetails.Data, Optional<HeroD
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -83,6 +83,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -115,6 +118,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -149,6 +155,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -196,6 +205,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -246,6 +258,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.java
@@ -160,6 +160,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -241,6 +244,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -357,6 +363,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -485,6 +494,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -583,6 +595,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -114,6 +117,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -148,6 +154,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -195,6 +204,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -237,6 +249,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.java
@@ -160,6 +160,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -241,6 +244,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -357,6 +363,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -485,6 +494,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -583,6 +595,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -114,6 +117,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -148,6 +154,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -195,6 +204,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -237,6 +249,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.java
@@ -157,6 +157,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -238,6 +241,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -354,6 +360,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -482,6 +491,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -580,6 +592,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -114,6 +117,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -148,6 +154,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -195,6 +204,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -237,6 +249,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.java
@@ -160,6 +160,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -241,6 +244,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -357,6 +363,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -485,6 +494,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -583,6 +595,9 @@ public final class HeroDetailsQuery implements Query<HeroDetailsQuery.Data, Opti
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -82,6 +82,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -114,6 +117,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -148,6 +154,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -195,6 +204,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -237,6 +249,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -153,6 +153,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -234,6 +237,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -81,6 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -121,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.java
@@ -201,6 +201,9 @@ public final class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVe
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("heroAVeryAVeryAVeryAVeryAVeryAVeryAV", "hero", new UnmodifiableMapBuilder<String, Object>(1)
@@ -287,6 +290,9 @@ public final class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVe
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class HeroAVeryAVeryAVeryAVeryAVeryAVeryAV {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
@@ -108,6 +108,9 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(
     val __typename: String = "Character",
     /**
@@ -147,6 +150,9 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val heroAVeryAVeryAVeryAVeryAVeryAVeryAV: HeroAVeryAVeryAVeryAVeryAVeryAVeryAV?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
@@ -186,6 +186,9 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("createReview", "createReview", new UnmodifiableMapBuilder<String, Object>(2)
@@ -281,6 +284,9 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   public static class CreateReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -87,6 +87,9 @@ data class TestQuery(
     scalarTypeAdapters = DEFAULT
   )
 
+  /**
+   * Represents a review for a movie
+   */
   data class CreateReview(
     val __typename: String = "Review",
     /**
@@ -127,6 +130,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.java
@@ -153,6 +153,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("nonOptionalHero", "nonOptionalHero", new UnmodifiableMapBuilder<String, Object>(1)
@@ -236,6 +239,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface NonOptionalHero {
     @NotNull String __typename();
 
@@ -290,6 +296,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements NonOptionalHero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -398,6 +407,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements NonOptionalHero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -85,6 +85,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -125,6 +128,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class NonOptionalHero(
     val __typename: String = "Character",
     /**
@@ -166,6 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val nonOptionalHero: NonOptionalHero
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.java
@@ -173,6 +173,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -254,6 +257,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -387,6 +393,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -497,6 +506,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -595,6 +607,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -83,6 +83,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -115,6 +118,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -149,6 +155,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -188,6 +197,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -239,6 +251,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.java
@@ -151,6 +151,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("foo", "foo", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -235,6 +238,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * For testing fragment type coercion
+   */
   public interface Foo {
     @NotNull String __typename();
 
@@ -286,6 +292,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * For testing fragment type coercion
+   */
   public static class AsBar implements Foo {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -388,6 +397,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * For testing fragment type coercion
+   */
   public static class AsFoo implements Foo {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -84,6 +84,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * For testing fragment type coercion
+   */
   data class AsBar(
     val __typename: String = "Bar",
     val foo: String,
@@ -118,6 +121,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * For testing fragment type coercion
+   */
   data class Foo(
     val __typename: String = "Foo",
     val foo: String,
@@ -156,6 +162,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     /**
      * For testing fragment type coercion

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.java
@@ -166,6 +166,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -247,6 +250,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Hero {
     @NotNull String __typename();
 
@@ -319,6 +325,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -464,6 +473,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -567,6 +579,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   public static class AsDroid implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -712,6 +727,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -803,6 +821,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -88,6 +88,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend(
     val __typename: String = "Character",
     /**
@@ -125,6 +128,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -180,6 +186,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend1(
     val __typename: String = "Character",
     /**
@@ -212,6 +221,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**
@@ -267,6 +279,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -317,6 +332,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -205,6 +205,9 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("createReview", "createReview", new UnmodifiableMapBuilder<String, Object>(2)
@@ -295,6 +298,9 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   public static class CreateReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -91,6 +91,9 @@ data class TestQuery(
     scalarTypeAdapters = DEFAULT
   )
 
+  /**
+   * Represents a review for a movie
+   */
   data class CreateReview(
     val __typename: String = "Review",
     /**
@@ -131,6 +134,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.java
@@ -160,6 +160,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("__schema", "__schema", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -264,6 +267,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
+   */
   public static class __Schema {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -399,6 +405,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   public static class QueryType {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -487,6 +498,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   public static class Type {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -575,6 +591,11 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   public static class __Type {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -81,6 +81,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in
+   * GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar
+   * types provide no information beyond a name and description, while Enum types provide their values.
+   * Object and Interface types provide the fields they describe. Abstract types, Union and Interface,
+   * provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   data class QueryType(
     val __typename: String = "__Type",
     val name: String?
@@ -110,6 +119,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in
+   * GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar
+   * types provide no information beyond a name and description, while Enum types provide their values.
+   * Object and Interface types provide the fields they describe. Abstract types, Union and Interface,
+   * provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   data class Type(
     val __typename: String = "__Type",
     val name: String?
@@ -139,6 +157,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types
+   * and directives on the server, as well as the entry points for query, mutation, and subscription
+   * operations.
+   */
   data class __Schema(
     val __typename: String = "__Schema",
     /**
@@ -188,6 +211,15 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in
+   * GraphQL as represented by the `__TypeKind` enum.
+   *
+   * Depending on the kind of a type, certain fields describe information about that type. Scalar
+   * types provide no information beyond a name and description, while Enum types provide their values.
+   * Object and Interface types provide the fields they describe. Abstract types, Union and Interface,
+   * provide the Object types possible at runtime. List and NonNull types compose other types.
+   */
   data class __Type(
     val __typename: String = "__Type",
     val name: String?
@@ -217,6 +249,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val __schema: __Schema,
     val __type: __Type?

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.java
@@ -176,6 +176,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -257,6 +260,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -83,6 +83,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -159,6 +162,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.java
@@ -90,6 +90,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   interface FriendsConnection {
     @NotNull String get__typename();
 
@@ -116,6 +119,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   interface Edge {
     @NotNull String get__typename();
 
@@ -127,6 +133,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   interface Node {
     @NotNull String get__typename();
 
@@ -138,6 +147,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * Information for paginating this connection
+   */
   interface PageInfo {
     @NotNull String get__typename();
 
@@ -146,6 +158,9 @@ public interface HeroDetails extends GraphqlFragment {
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   class AsDroid implements HeroDetails {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -279,6 +294,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   class FriendsConnection1 implements FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -448,6 +466,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   class Edge1 implements Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -546,6 +567,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   class Node1 implements Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -637,6 +661,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * Information for paginating this connection
+   */
   class PageInfo1 implements PageInfo {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -841,6 +868,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   class FriendsConnection2 implements FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1010,6 +1040,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   class Edge2 implements Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1108,6 +1141,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   class Node2 implements Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1199,6 +1235,9 @@ public interface HeroDetails extends GraphqlFragment {
     }
   }
 
+  /**
+   * Information for paginating this connection
+   */
   class PageInfo2 implements PageInfo {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/fragment/HeroDetails.kt
@@ -96,6 +96,9 @@ data class HeroDetails(
     fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -128,6 +131,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -162,6 +168,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * Information for paginating this connection
+   */
   data class PageInfo(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
@@ -191,6 +200,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -260,6 +272,9 @@ data class HeroDetails(
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node1(
     val __typename: String = "Character",
     /**
@@ -292,6 +307,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge1(
     val __typename: String = "FriendsEdge",
     /**
@@ -326,6 +344,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * Information for paginating this connection
+   */
   data class PageInfo1(
     val __typename: String = "PageInfo",
     val hasNextPage: Boolean
@@ -355,6 +376,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection1(
     val __typename: String = "FriendsConnection",
     /**
@@ -420,6 +444,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -215,6 +215,9 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("createReview", "createReview", new UnmodifiableMapBuilder<String, Object>(2)
@@ -305,6 +308,9 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   public static class CreateReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -588,6 +594,9 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class ListOfListOfObject {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -94,6 +94,9 @@ internal data class CreateReviewForEpisode(
     scalarTypeAdapters = DEFAULT
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class ListOfListOfObject(
     val __typename: String = "Character",
     /**
@@ -126,6 +129,9 @@ internal data class CreateReviewForEpisode(
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   data class CreateReview(
     val __typename: String = "Review",
     /**
@@ -248,6 +254,9 @@ internal data class CreateReviewForEpisode(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -205,6 +205,9 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("createReview", "createReview", new UnmodifiableMapBuilder<String, Object>(2)
@@ -295,6 +298,9 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     }
   }
 
+  /**
+   * Represents a review for a movie
+   */
   public static class CreateReview {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -92,6 +92,9 @@ data class CreateReviewForEpisodeMutation(
     scalarTypeAdapters = DEFAULT
   )
 
+  /**
+   * Represents a review for a movie
+   */
   data class CreateReview(
     val __typename: String = "Review",
     /**
@@ -132,6 +135,9 @@ data class CreateReviewForEpisodeMutation(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val createReview: CreateReview?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.java
@@ -222,6 +222,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", new UnmodifiableMapBuilder<String, Object>(1)
@@ -308,6 +311,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Hero {
     @NotNull String __typename();
 
@@ -380,6 +386,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -508,6 +517,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Friend {
     @NotNull String __typename();
 
@@ -562,6 +574,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman1 implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -672,6 +687,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -763,6 +781,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   public static class AsDroid implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -891,6 +912,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Friend1 {
     @NotNull String __typename();
 
@@ -945,6 +969,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman2 implements Friend1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1055,6 +1082,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter1 implements Friend1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1146,6 +1176,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter2 implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -113,6 +113,9 @@ data class TestQuery(
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman1(
     val __typename: String = "Human",
     /**
@@ -154,6 +157,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend(
     val __typename: String = "Character",
     /**
@@ -195,6 +201,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -246,6 +255,9 @@ data class TestQuery(
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman2(
     val __typename: String = "Human",
     /**
@@ -287,6 +299,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend1(
     val __typename: String = "Character",
     /**
@@ -328,6 +343,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**
@@ -375,6 +393,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -425,6 +446,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.java
@@ -153,6 +153,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -234,6 +237,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -81,6 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -121,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.java
@@ -157,6 +157,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("yield", "hero", null, true, Collections.<ResponseField.Condition>emptyList()),
@@ -273,6 +276,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Yield {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -430,6 +436,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Object {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -82,6 +82,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Yield_(
     val __typename: String = "Character",
     /**
@@ -126,6 +129,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class AsCharacter(
     val __typename: String = "Character",
     /**
@@ -191,6 +197,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val yield_: Yield_?,
     val objects: List<Object?>?

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -160,6 +160,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -241,6 +244,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -82,6 +82,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -146,6 +149,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.java
@@ -155,6 +155,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("hero", "hero", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -236,6 +239,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Hero {
     @NotNull String __typename();
 
@@ -308,6 +314,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -416,6 +425,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   public static class AsDroid implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -525,6 +537,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Hero {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -85,6 +85,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -125,6 +128,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**
@@ -165,6 +171,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Hero(
     val __typename: String = "Character",
     /**
@@ -215,6 +224,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val hero: Hero?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.java
@@ -196,6 +196,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("starship", "starship", new UnmodifiableMapBuilder<String, Object>(1)

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -156,6 +156,9 @@ data class TestQuery(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val starship: Starship?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
@@ -185,6 +185,9 @@ public final class TestSubscription implements Subscription<TestSubscription.Dat
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("commentAdded", "commentAdded", new UnmodifiableMapBuilder<String, Object>(1)
@@ -274,6 +277,9 @@ public final class TestSubscription implements Subscription<TestSubscription.Dat
     }
   }
 
+  /**
+   * A comment about an entry, submitted by a user
+   */
   public static class CommentAdded {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -86,6 +86,9 @@ data class TestSubscription(
     scalarTypeAdapters = DEFAULT
   )
 
+  /**
+   * A comment about an entry, submitted by a user
+   */
   data class CommentAdded(
     val __typename: String = "Comment",
     /**
@@ -126,6 +129,9 @@ data class TestSubscription(
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     /**
      * Subscription fires on every comment added

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.java
@@ -154,6 +154,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("r2", "hero", null, true, Collections.<ResponseField.Condition>emptyList()),
@@ -258,6 +261,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class R2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -349,6 +355,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -81,6 +81,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class R2(
     val __typename: String = "Character",
     /**
@@ -113,6 +116,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Luke(
     val __typename: String = "Character",
     /**
@@ -153,6 +159,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val r2: R2?,
     val luke: Luke?

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.java
@@ -178,6 +178,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("r2", "hero", null, true, Collections.<ResponseField.Condition>emptyList()),
@@ -282,6 +285,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class R2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -398,6 +404,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -526,6 +535,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -624,6 +636,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -715,6 +730,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Luke {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -848,6 +866,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -976,6 +997,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1074,6 +1098,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -83,6 +83,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -115,6 +118,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -149,6 +155,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**
@@ -196,6 +205,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class R2(
     val __typename: String = "Character",
     /**
@@ -238,6 +250,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node1(
     val __typename: String = "Character",
     /**
@@ -270,6 +285,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge1(
     val __typename: String = "FriendsEdge",
     /**
@@ -304,6 +322,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection1(
     val __typename: String = "FriendsConnection",
     /**
@@ -351,6 +372,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Luke(
     val __typename: String = "Character",
     /**
@@ -401,6 +425,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val r2: R2?,
     val luke: Luke?

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
@@ -159,6 +159,9 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forList("search", "search", new UnmodifiableMapBuilder<String, Object>(1)

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -149,6 +149,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -182,6 +182,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forList("search", "search", new UnmodifiableMapBuilder<String, Object>(1)
@@ -344,6 +347,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements Search {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -489,6 +495,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Friend {
     @NotNull String __typename();
 
@@ -561,6 +570,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -706,6 +718,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -803,6 +818,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   public static class AsDroid implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -948,6 +966,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -1058,6 +1079,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter1 implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -92,6 +92,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend(
     val __typename: String = "Character",
     /**
@@ -124,6 +127,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -179,6 +185,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend1(
     val __typename: String = "Character",
     /**
@@ -220,6 +229,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * An autonomous mechanical character in the Star Wars universe
+   */
   data class AsDroid(
     val __typename: String = "Droid",
     /**
@@ -275,6 +287,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend2(
     val __typename: String = "Character",
     /**
@@ -325,6 +340,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class AsCharacter(
     val __typename: String = "Character",
     /**
@@ -454,6 +472,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val search: List<Search?>?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.java
@@ -182,6 +182,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   public static class Data implements Operation.Data {
     static final ResponseField[] $responseFields = {
       ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true, Collections.<ResponseField.Condition>emptyList())
@@ -263,6 +266,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface HeroDetailQuery1 {
     @NotNull String __typename();
 
@@ -322,6 +328,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public interface Friend {
     @NotNull String __typename();
 
@@ -333,6 +342,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     ResponseFieldMarshaller marshaller();
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   public static class AsHuman implements HeroDetailQuery1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -478,6 +490,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend1 implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -635,6 +650,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -805,6 +823,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class AsCharacter implements HeroDetailQuery1 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -933,6 +954,9 @@ public final class HeroDetailQuery implements Query<HeroDetailQuery.Data, Option
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Friend3 implements Friend {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -88,6 +88,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     fun marshaller(): ResponseFieldMarshaller
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend1(
     val __typename: String = "Character",
     val fragments: Fragments
@@ -143,6 +146,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend(
     val __typename: String = "Character",
     /**
@@ -203,6 +209,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
+  /**
+   * A humanoid creature from the Star Wars universe
+   */
   data class AsHuman(
     val __typename: String = "Human",
     /**
@@ -258,6 +267,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Friend2(
     val __typename: String = "Character",
     /**
@@ -290,6 +302,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class HeroDetailQuery(
     val __typename: String = "Character",
     /**
@@ -346,6 +361,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
     }
   }
 
+  /**
+   * Data from the response after executing this GraphQL operation
+   */
   data class Data(
     val heroDetailQuery: HeroDetailQuery?
   ) : Operation.Data {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.java
@@ -154,6 +154,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   public static class FriendsConnection {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -282,6 +285,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   public static class Edge {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
@@ -380,6 +386,9 @@ public class HeroDetails implements GraphqlFragment {
     }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   public static class Node {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -77,6 +77,9 @@ data class HeroDetails(
     fun Mapper(): ResponseFieldMapper<HeroDetails> = ResponseFieldMapper { invoke(it) }
   }
 
+  /**
+   * A character from the Star Wars universe
+   */
   data class Node(
     val __typename: String = "Character",
     /**
@@ -109,6 +112,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * An edge object for a character's friends
+   */
   data class Edge(
     val __typename: String = "FriendsEdge",
     /**
@@ -143,6 +149,9 @@ data class HeroDetails(
     }
   }
 
+  /**
+   * A connection object for a character's friends
+   */
   data class FriendsConnection(
     val __typename: String = "FriendsConnection",
     /**


### PR DESCRIPTION
Use `description` from the GraphQL schema type definition (see `GraphQLDocumentParser.kt`) and use it to generate docs for model classes