### PR TITLE
Fix eager `asFlow()` completion

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -66,12 +66,6 @@ fun <T> ApolloQueryWatcher<T>.toFlow(): Flow<Response<T>> = callbackFlow {
         override fun onFailure(e: ApolloException) {
           close(e)
         }
-
-        override fun onStatusEvent(event: ApolloCall.StatusEvent) {
-          if (event == ApolloCall.StatusEvent.COMPLETED) {
-            close()
-          }
-        }
       }
   )
   awaitClose { clone.cancel() }


### PR DESCRIPTION
Fixes: https://github.com/apollographql/apollo-android/issues/2207

As far as I understand returned Flow shoudln't finish when single ApolloCall completes. This PR changes `toFlow()` behavior to match [RxJava based](https://github.com/apollographql/apollo-android/blob/master/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java#L58) one.
