### PR TITLE
Generate Java / Kotlin docs for queries and fragments

### DIFF
--- a/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphQL.g4
+++ b/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphQL.g4
@@ -196,7 +196,7 @@ WS
    : [ \t\n\r]+ -> skip
    ;
 COMMENT
-    : '#' ~[\n\r]* -> skip
+    : '#' ~[\n\r]* -> channel(2)
     ;
 COMMA
     : ',' -> skip

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -40,6 +40,7 @@ class OperationTypeSpecBuilder(
     return TypeSpec.classBuilder(operationTypeName)
         .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
         .addSuperinterface(operationSuperInterface(context))
+        .applyIf(operation.description.isNotBlank()) { addJavadoc("\$L\n", operation.description) }
         .addOperationId(operation, newContext)
         .addQueryDocumentDefinition()
         .addConstructor(context)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
@@ -39,6 +39,7 @@ internal data class OperationType(
     val name: String,
     val type: Type,
     val operationName: String,
+    val description: String,
     val operationId: String,
     val queryDocument: String,
     val variables: InputType,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
@@ -12,7 +12,7 @@ internal fun Fragment.ast(context: Context): ObjectType {
   val typeRef = context.registerObjectType(
       name = fragmentName.capitalize().escapeKotlinReservedWord(),
       schemaTypeName = typeCondition,
-      description = "",
+      description = description,
       fragmentRefs = fragmentRefs,
       inlineFragments = emptyList(),
       fields = fields,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
@@ -36,6 +36,7 @@ internal fun Operation.ast(
       name = operationClassName,
       type = operationType,
       operationName = operationName,
+      description = description,
       operationId = operationId,
       queryDocument = sourceWithFragments,
       variables = InputType(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -48,6 +48,7 @@ internal fun OperationType.typeSpec(targetPackage: String, generateAsInternal: B
     .addAnnotation(suppressWarningsAnnotation)
     .addSuperinterface(superInterfaceType(targetPackage))
     .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
+    .applyIf(description.isNotBlank()) { addKdoc("%L", description) }
     .applyIf(variables.fields.isNotEmpty()) {
       addModifiers(KModifier.DATA)
       primaryConstructor(primaryConstructorSpec)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Fragment.kt
@@ -10,6 +10,7 @@ import javax.lang.model.element.Modifier
 data class Fragment(
     val fragmentName: String,
     val source: String,
+    val description: String,
     val typeCondition: String,
     val possibleTypes: List<String>,
     val fields: List<Field>,
@@ -24,6 +25,7 @@ data class Fragment(
     return SchemaTypeSpecBuilder(
         typeName = fragmentName.capitalize(),
         schemaType = typeCondition,
+        description = description,
         fields = fields,
         fragmentRefs = fragmentRefs,
         inlineFragments = inlineFragments,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Operation.kt
@@ -9,6 +9,7 @@ import javax.lang.model.element.Modifier
 data class Operation(
     val operationName: String,
     val operationType: String,
+    val description: String,
     val variables: List<Variable>,
     val source: String,
     val sourceWithFragments: String,
@@ -20,6 +21,7 @@ data class Operation(
   override fun toTypeSpec(context: CodeGenerationContext, abstract: Boolean): TypeSpec =
       SchemaTypeSpecBuilder(
           typeName = DATA_TYPE_NAME,
+          description = "Data from the response after executing this GraphQL operation",
           fields = fields,
           fragmentRefs = emptyList(),
           inlineFragments = emptyList(),
@@ -29,7 +31,6 @@ data class Operation(
           .build(Modifier.PUBLIC, Modifier.STATIC)
           .toBuilder()
           .addSuperinterface(Operation.Data::class.java)
-          .addJavadoc("\$L\n", "Data from the response after executing this GraphQL operation")
           .build()
           .let {
             if (context.generateModelBuilder) {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestOperation.graphql
@@ -1,4 +1,6 @@
-# some comment
+# This is a sample query to fetch hero name
+# that demonstrates Java / Kotlin docs generations
+# for query data model
 query TestQuery {
   # another comment
   hero {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.java
@@ -33,6 +33,11 @@ import okio.ByteString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ *  This is a sample query to fetch hero name
+ *  that demonstrates Java / Kotlin docs generations
+ *  for query data model
+ */
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
   public static final String OPERATION_ID = "c10c6dfe569b0fbb60c67e42c973f7ffef2314b43004c527a03bdd790ef0f5dc";
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -29,6 +29,11 @@ import okio.BufferedSource
 import okio.ByteString
 import okio.IOException
 
+/**
+ *  This is a sample query to fetch hero name
+ *  that demonstrates Java / Kotlin docs generations
+ *  for query data model
+ */
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestOperation.graphql
@@ -1,3 +1,5 @@
+# Demonstration of Java / Kotlin docs generation
+# for both query and fragments
 query TestQuery {
   hero {
     __typename
@@ -6,12 +8,15 @@ query TestQuery {
   }
 }
 
+# Fragment with Java / Kotlin docs generation
+# with multi lines support
 fragment HeroDetails on Character {
   __typename
   name
   ... HumanDetails
 }
 
+# Fragment with Java / Kotlin docs generation
 fragment HumanDetails on Human {
   __typename
   name

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.java
@@ -35,6 +35,10 @@ import okio.ByteString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ *  Demonstration of Java / Kotlin docs generation
+ *  for both query and fragments
+ */
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
   public static final String OPERATION_ID = "11b6156b253df199195798f2de386724580e3882c9888f7e5d1685c42b64e0cf";
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -30,6 +30,10 @@ import okio.BufferedSource
 import okio.ByteString
 import okio.IOException
 
+/**
+ *  Demonstration of Java / Kotlin docs generation
+ *  for both query and fragments
+ */
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.java
@@ -22,6 +22,10 @@ import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ *  Fragment with Java / Kotlin docs generation
+ *  with multi lines support
+ */
 public class HeroDetails implements GraphqlFragment {
   static final ResponseField[] $responseFields = {
     ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -14,6 +14,10 @@ import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 
+/**
+ *  Fragment with Java / Kotlin docs generation
+ *  with multi lines support
+ */
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 internal data class HeroDetails(

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.java
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.java
@@ -19,6 +19,9 @@ import java.lang.SuppressWarnings;
 import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ *  Fragment with Java / Kotlin docs generation
+ */
 public class HumanDetails implements GraphqlFragment {
   static final ResponseField[] $responseFields = {
     ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -14,6 +14,9 @@ import kotlin.Array
 import kotlin.String
 import kotlin.Suppress
 
+/**
+ *  Fragment with Java / Kotlin docs generation
+ */
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 internal data class HumanDetails(


### PR DESCRIPTION
This is a feature proposal to generate docs for queries and fragments with description extracted from GraphQL comments.

For example:
```
# This is a sample query to fetch hero name
# that demonstrates Java / Kotlin docs generations
# for query data model
query TestQuery {
 ...
}
```

Will produce smth like:
```
/**
 *  This is a sample query to fetch hero name
 *  that demonstrates Java / Kotlin docs generations
 *  for query data model
 */
@Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
    "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
```

See test fixtures.