### PR TITLE
Make sure generated code do not produce warnings

### DIFF
--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -108,11 +108,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     /**
      * Profile link
      */
-    val profileLink: java.lang.String,
+    val profileLink: String,
     /**
      * Links
      */
-    val links: List<java.lang.String>
+    val links: List<String>
   ) {
     fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
@@ -153,10 +153,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         }!!.map { it!! }
         val fieldWithUnsupportedType = readCustomType<Any>(RESPONSE_FIELDS[4] as
             ResponseField.CustomTypeField)!!
-        val profileLink = readCustomType<java.lang.String>(RESPONSE_FIELDS[5] as
+        val profileLink = readCustomType<String>(RESPONSE_FIELDS[5] as
             ResponseField.CustomTypeField)!!
-        val links = readList<java.lang.String>(RESPONSE_FIELDS[6]) { reader ->
-          reader.readCustomType<java.lang.String>(CustomType.URL)
+        val links = readList<String>(RESPONSE_FIELDS[6]) { reader ->
+          reader.readCustomType<String>(CustomType.URL)
         }!!.map { it!! }
         Hero(
           __typename = __typename,

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/type/CustomType.kt
@@ -18,13 +18,13 @@ enum class CustomType : ScalarType {
   ID {
     override fun typeName(): String = "ID"
 
-    override fun className(): String = "java.lang.Integer"
+    override fun className(): String = "kotlin.Int"
   },
 
   URL {
     override fun typeName(): String = "URL"
 
-    override fun className(): String = "java.lang.String"
+    override fun className(): String = "kotlin.String"
   },
 
   UNSUPPORTEDTYPE {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -122,7 +122,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])!!
         val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readString()?.let { Episode.safeValueOf(it) }
+          Episode.safeValueOf(reader.readString())
         }!!
         val firstAppearsIn = Episode.safeValueOf(readString(RESPONSE_FIELDS[3])!!)
         Hero(

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -120,7 +120,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])!!
         val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readString()?.let { Episode.safeValueOf(it) }
+          Episode.safeValueOf(reader.readString())
         }!!
         val fragments = Fragments(reader)
         Hero(

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -115,7 +115,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
       operator fun invoke(reader: ResponseReader): Friend = reader.run {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readString()?.let { Episode.safeValueOf(it) }
+          Episode.safeValueOf(reader.readString())
         }!!
         Friend(
           __typename = __typename,

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/CustomType.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/CustomType.kt
@@ -18,6 +18,6 @@ enum class CustomType : ScalarType {
   ID {
     override fun typeName(): String = "ID"
 
-    override fun className(): String = "java.lang.Integer"
+    override fun className(): String = "kotlin.Int"
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/TestQuery.kt
@@ -120,7 +120,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])!!
         val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readString()?.let { Episode.safeValueOf(it) }
+          Episode.safeValueOf(reader.readString())
         }!!
         val fragments = Fragments(reader)
         Hero(

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/CustomType.kt
@@ -18,6 +18,6 @@ internal enum class CustomType : ScalarType {
   ID {
     override fun typeName(): String = "ID"
 
-    override fun className(): String = "java.lang.Integer"
+    override fun className(): String = "kotlin.Int"
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestOperation.graphql
@@ -19,7 +19,6 @@ query TestQuery {
           primaryFunction
           friends {
             id
-            deprecated
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.java
@@ -24,7 +24,6 @@ import com.apollographql.apollo.api.internal.Utils;
 import com.example.union_inline_fragments.type.CustomType;
 import com.example.union_inline_fragments.type.Episode;
 import java.io.IOException;
-import java.lang.Deprecated;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -39,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, Operation.Variables> {
-  public static final String OPERATION_ID = "d917122adce28477721dc274dd7fce307cb1b714452af1df8bb26087b8ec33d0";
+  public static final String OPERATION_ID = "5450032fd838d0216d8b419846d25e09f98228b403e520aacd7eb68cd838f4da";
 
   public static final String QUERY_DOCUMENT = QueryDocumentMinifier.minify(
     "query TestQuery {\n"
@@ -67,7 +66,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         + "          friends {\n"
         + "            __typename\n"
         + "            id\n"
-        + "            deprecated\n"
         + "          }\n"
         + "        }\n"
         + "      }\n"
@@ -972,15 +970,12 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
   public static class Friend2 {
     static final ResponseField[] $responseFields = {
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
-      ResponseField.forCustomType("id", "id", null, false, CustomType.ID, Collections.<ResponseField.Condition>emptyList()),
-      ResponseField.forString("deprecated", "deprecated", null, false, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forCustomType("id", "id", null, false, CustomType.ID, Collections.<ResponseField.Condition>emptyList())
     };
 
     final @NotNull String __typename;
 
     final @NotNull String id;
-
-    final @NotNull @Deprecated String deprecated;
 
     private transient volatile String $toString;
 
@@ -988,11 +983,9 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     private transient volatile boolean $hashCodeMemoized;
 
-    public Friend2(@NotNull String __typename, @NotNull String id,
-        @NotNull @Deprecated String deprecated) {
+    public Friend2(@NotNull String __typename, @NotNull String id) {
       this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.id = Utils.checkNotNull(id, "id == null");
-      this.deprecated = Utils.checkNotNull(deprecated, "deprecated == null");
     }
 
     public @NotNull String __typename() {
@@ -1006,14 +999,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return this.id;
     }
 
-    /**
-     * Test deprecated field
-     * @deprecated For test purpose only
-     */
-    public @NotNull @Deprecated String deprecated() {
-      return this.deprecated;
-    }
-
     @SuppressWarnings({"rawtypes", "unchecked"})
     public ResponseFieldMarshaller marshaller() {
       return new ResponseFieldMarshaller() {
@@ -1021,7 +1006,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         public void marshal(ResponseWriter writer) {
           writer.writeString($responseFields[0], __typename);
           writer.writeCustom((ResponseField.CustomTypeField) $responseFields[1], id);
-          writer.writeString($responseFields[2], deprecated);
         }
       };
     }
@@ -1031,8 +1015,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if ($toString == null) {
         $toString = "Friend2{"
           + "__typename=" + __typename + ", "
-          + "id=" + id + ", "
-          + "deprecated=" + deprecated
+          + "id=" + id
           + "}";
       }
       return $toString;
@@ -1046,8 +1029,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       if (o instanceof Friend2) {
         Friend2 that = (Friend2) o;
         return this.__typename.equals(that.__typename)
-         && this.id.equals(that.id)
-         && this.deprecated.equals(that.deprecated);
+         && this.id.equals(that.id);
       }
       return false;
     }
@@ -1060,8 +1042,6 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         h ^= __typename.hashCode();
         h *= 1000003;
         h ^= id.hashCode();
-        h *= 1000003;
-        h ^= deprecated.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -1073,8 +1053,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       public Friend2 map(ResponseReader reader) {
         final String __typename = reader.readString($responseFields[0]);
         final String id = reader.readCustomType((ResponseField.CustomTypeField) $responseFields[1]);
-        final String deprecated = reader.readString($responseFields[2]);
-        return new Friend2(__typename, id, deprecated);
+        return new Friend2(__typename, id);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -23,7 +23,6 @@ import com.example.union_inline_fragments.type.CustomType
 import com.example.union_inline_fragments.type.Episode
 import kotlin.Array
 import kotlin.Boolean
-import kotlin.Deprecated
 import kotlin.String
 import kotlin.Suppress
 import kotlin.collections.List
@@ -193,34 +192,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     /**
      * The ID of the character
      */
-    val id: String,
-    /**
-     * Test deprecated field
-     */
-    @Deprecated(message = "For test purpose only")
-    val deprecated: String
+    val id: String
   ) {
     fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@Friend1.__typename)
       writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, this@Friend1.id)
-      writer.writeString(RESPONSE_FIELDS[2], this@Friend1.deprecated)
     }
 
     companion object {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
           ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
-          ResponseField.forString("deprecated", "deprecated", null, false, null)
+          ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
           )
 
       operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val deprecated = readString(RESPONSE_FIELDS[2])!!
         Friend1(
           __typename = __typename,
-          id = id,
-          deprecated = deprecated
+          id = id
         )
       }
 
@@ -509,7 +499,7 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
 
   companion object {
     const val OPERATION_ID: String =
-        "d917122adce28477721dc274dd7fce307cb1b714452af1df8bb26087b8ec33d0"
+        "5450032fd838d0216d8b419846d25e09f98228b403e520aacd7eb68cd838f4da"
 
     val QUERY_DOCUMENT: String = QueryDocumentMinifier.minify(
           """
@@ -538,7 +528,6 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           |          friends {
           |            __typename
           |            id
-          |            deprecated
           |          }
           |        }
           |      }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -189,7 +189,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])!!
         val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readString()?.let { Episode.safeValueOf(it) }
+          Episode.safeValueOf(reader.readString())
         }!!
         val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
           reader.readObject<Friend1> { reader ->


### PR DESCRIPTION
Enable Kotlin flag `allWarningsAsErrors` except for the tests where we expect warnings.

After doing this, discovered a small issue and fixed it.

This will make sure that problems like #2209 will not happen.