### PR TITLE
Sql Cache record update fix + test (#2231)

### DIFF
--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
@@ -9,90 +9,91 @@ import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter
 import okio.IOException
 
 class SqlNormalizedCache internal constructor(
-        private val recordFieldAdapter: RecordFieldJsonAdapter,
-        private val cacheQueries: CacheQueries
+    private val recordFieldAdapter: RecordFieldJsonAdapter,
+    private val cacheQueries: CacheQueries
 ) : NormalizedCache() {
 
-    override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
-        val record = selectRecordForKey(key)
+  override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
+    val record = selectRecordForKey(key)
 
-        if (record != null) {
-            if (cacheHeaders.hasHeader(EVICT_AFTER_READ)) {
-                deleteRecord(key)
-            }
-            return record
+    if (record != null) {
+      if (cacheHeaders.hasHeader(EVICT_AFTER_READ)) {
+        deleteRecord(key)
+      }
+      return record
+    }
+    return nextCache?.loadRecord(key, cacheHeaders)
+  }
+
+  override fun clearAll() {
+    nextCache?.clearAll()
+    cacheQueries.deleteAll()
+  }
+
+  override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
+    val result: Boolean = nextCache?.remove(cacheKey, cascade) ?: false
+    if (result) {
+      return true
+    }
+    return if (cascade) {
+      selectRecordForKey(cacheKey.key)
+          ?.referencedFields()
+          ?.all { remove(CacheKey(it.key), cascade = true) }
+          ?: false
+    } else {
+      deleteRecord(cacheKey.key)
+    }
+  }
+
+  override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {
+    val oldRecord = selectRecordForKey(apolloRecord.key)
+    return if (oldRecord == null) {
+      cacheQueries.insert(apolloRecord.key, recordFieldAdapter.toJson(apolloRecord.fields))
+      emptySet()
+    } else {
+      oldRecord.mergeWith(apolloRecord).also {
+        if (it.isNotEmpty()) {
+          cacheQueries.update(oldRecord.fields["_id"] as Long?
+              ?: 0L, oldRecord.key, recordFieldAdapter.toJson(oldRecord.fields))
         }
-        return nextCache?.loadRecord(key, cacheHeaders)
+      }
     }
+  }
 
-    override fun clearAll() {
-        nextCache?.clearAll()
-        cacheQueries.deleteAll()
+  fun selectRecordForKey(key: String): Record? {
+    return try {
+      cacheQueries.recordForKey(key)
+          .executeAsList()
+          .firstOrNull()
+          ?.let {
+            Record.builder(it.key)
+                .addFields(recordFieldAdapter.from(it.record)!!)
+                .addField("_id", it._id)
+                .build()
+          }
+    } catch (e: IOException) {
+      null
     }
+  }
 
-    override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
-        val result: Boolean = nextCache?.remove(cacheKey, cascade) ?: false
-        if (result) {
-            return true
-        }
-        return if (cascade) {
-            selectRecordForKey(cacheKey.key)
-                    ?.referencedFields()
-                    ?.all { remove(CacheKey(it.key), cascade = true) }
-                    ?: false
-        } else {
-            deleteRecord(cacheKey.key)
-        }
+  private inline fun <T> Collection<T>.all(predicate: (T) -> Boolean): Boolean {
+    var result = true
+    for (element in this) {
+      result = result && predicate(element)
     }
+    return result
+  }
 
-    override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {
-        val oldRecord = selectRecordForKey(apolloRecord.key)
-        return if (oldRecord == null) {
-            cacheQueries.insert(apolloRecord.key, recordFieldAdapter.toJson(apolloRecord.fields))
-            emptySet()
-        } else {
-            oldRecord.mergeWith(apolloRecord).also {
-                if (it.isNotEmpty()) {
-                    cacheQueries.update(oldRecord.fields["_id"] as Long? ?: 0L, oldRecord.key, recordFieldAdapter.toJson(oldRecord.fields))
-                }
-            }
-        }
+  fun deleteRecord(key: String): Boolean {
+    var changes = 0L
+    cacheQueries.transaction {
+      cacheQueries.delete(key)
+      changes = cacheQueries.changes().executeAsOne()
     }
+    return changes > 0
+  }
 
-    fun selectRecordForKey(key: String): Record? {
-        return try {
-            cacheQueries.recordForKey(key)
-                    .executeAsList()
-                    .firstOrNull()
-                    ?.let {
-                        Record.builder(it.key)
-                                .addFields(recordFieldAdapter.from(it.record)!!)
-                                .addField("_id", it._id)
-                                .build()
-                    }
-        } catch (e: IOException) {
-            null
-        }
-    }
-
-    private inline fun <T> Collection<T>.all(predicate: (T) -> Boolean): Boolean {
-        var result = true
-        for (element in this) {
-            result = result && predicate(element)
-        }
-        return result
-    }
-
-    fun deleteRecord(key: String): Boolean {
-        var changes = 0L
-        cacheQueries.transaction {
-            cacheQueries.delete(key)
-            changes = cacheQueries.changes().executeAsOne()
-        }
-        return changes > 0
-    }
-
-    fun createRecord(key: String, fields: String) {
-        cacheQueries.insert(key, fields)
-    }
+  fun createRecord(key: String, fields: String) {
+    cacheQueries.insert(key, fields)
+  }
 }

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
@@ -9,89 +9,90 @@ import com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter
 import okio.IOException
 
 class SqlNormalizedCache internal constructor(
-    private val recordFieldAdapter: RecordFieldJsonAdapter,
-    private val cacheQueries: CacheQueries
+        private val recordFieldAdapter: RecordFieldJsonAdapter,
+        private val cacheQueries: CacheQueries
 ) : NormalizedCache() {
 
-  override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
-    val record = selectRecordForKey(key)
+    override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
+        val record = selectRecordForKey(key)
 
-    if (record != null) {
-      if (cacheHeaders.hasHeader(EVICT_AFTER_READ)) {
-        deleteRecord(key)
-      }
-      return record
-    }
-    return nextCache?.loadRecord(key, cacheHeaders)
-  }
-
-  override fun clearAll() {
-    nextCache?.clearAll()
-    cacheQueries.deleteAll()
-  }
-
-  override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
-    val result: Boolean = nextCache?.remove(cacheKey, cascade) ?: false
-    if (result) {
-      return true
-    }
-    return if (cascade) {
-      selectRecordForKey(cacheKey.key)
-          ?.referencedFields()
-          ?.all { remove(CacheKey(it.key), cascade = true) }
-          ?: false
-    } else {
-      deleteRecord(cacheKey.key)
-    }
-  }
-
-  override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {
-    val oldRecord = selectRecordForKey(apolloRecord.key)
-    return if (oldRecord == null) {
-      cacheQueries.insert(apolloRecord.key, recordFieldAdapter.toJson(apolloRecord.fields))
-      emptySet()
-    } else {
-      oldRecord.mergeWith(apolloRecord).also {
-        if (it.isNotEmpty()) {
-          cacheQueries.update(oldRecord.key, recordFieldAdapter.toJson(oldRecord.fields))
+        if (record != null) {
+            if (cacheHeaders.hasHeader(EVICT_AFTER_READ)) {
+                deleteRecord(key)
+            }
+            return record
         }
-      }
+        return nextCache?.loadRecord(key, cacheHeaders)
     }
-  }
 
-  fun selectRecordForKey(key: String): Record? {
-    return try {
-      cacheQueries.recordForKey(key)
-          .executeAsList()
-          .firstOrNull()
-          ?.let {
-            Record.builder(it.key)
-                .addFields(recordFieldAdapter.from(it.record)!!)
-                .build()
-          }
-    } catch (e: IOException) {
-      null
+    override fun clearAll() {
+        nextCache?.clearAll()
+        cacheQueries.deleteAll()
     }
-  }
 
-  private inline fun <T> Collection<T>.all(predicate: (T) -> Boolean): Boolean {
-    var result = true
-    for (element in this) {
-      result = result && predicate(element)
+    override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
+        val result: Boolean = nextCache?.remove(cacheKey, cascade) ?: false
+        if (result) {
+            return true
+        }
+        return if (cascade) {
+            selectRecordForKey(cacheKey.key)
+                    ?.referencedFields()
+                    ?.all { remove(CacheKey(it.key), cascade = true) }
+                    ?: false
+        } else {
+            deleteRecord(cacheKey.key)
+        }
     }
-    return result
-  }
 
-  fun deleteRecord(key: String): Boolean {
-    var changes = 0L
-    cacheQueries.transaction {
-      cacheQueries.delete(key)
-      changes = cacheQueries.changes().executeAsOne()
+    override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {
+        val oldRecord = selectRecordForKey(apolloRecord.key)
+        return if (oldRecord == null) {
+            cacheQueries.insert(apolloRecord.key, recordFieldAdapter.toJson(apolloRecord.fields))
+            emptySet()
+        } else {
+            oldRecord.mergeWith(apolloRecord).also {
+                if (it.isNotEmpty()) {
+                    cacheQueries.update(oldRecord.fields["_id"] as Long? ?: 0L, oldRecord.key, recordFieldAdapter.toJson(oldRecord.fields))
+                }
+            }
+        }
     }
-    return changes > 0
-  }
 
-  fun createRecord(key: String, fields: String) {
-    cacheQueries.insert(key, fields)
-  }
+    fun selectRecordForKey(key: String): Record? {
+        return try {
+            cacheQueries.recordForKey(key)
+                    .executeAsList()
+                    .firstOrNull()
+                    ?.let {
+                        Record.builder(it.key)
+                                .addFields(recordFieldAdapter.from(it.record)!!)
+                                .addField("_id", it._id)
+                                .build()
+                    }
+        } catch (e: IOException) {
+            null
+        }
+    }
+
+    private inline fun <T> Collection<T>.all(predicate: (T) -> Boolean): Boolean {
+        var result = true
+        for (element in this) {
+            result = result && predicate(element)
+        }
+        return result
+    }
+
+    fun deleteRecord(key: String): Boolean {
+        var changes = 0L
+        cacheQueries.transaction {
+            cacheQueries.delete(key)
+            changes = cacheQueries.changes().executeAsOne()
+        }
+        return changes > 0
+    }
+
+    fun createRecord(key: String, fields: String) {
+        cacheQueries.insert(key, fields)
+    }
 }

--- a/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
+++ b/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
@@ -1,10 +1,8 @@
 CREATE TABLE records (
-  _id INTEGER PRIMARY KEY AUTOINCREMENT,
   key TEXT NOT NULL,
-  record TEXT NOT NULL
+  record TEXT NOT NULL,
+  PRIMARY KEY (key)
 );
-
-CREATE INDEX idx_records_key ON records(key);
 
 recordForKey:
 SELECT key, record FROM records WHERE key=?;
@@ -13,7 +11,7 @@ insert:
 INSERT INTO records (key, record) VALUES (?,?);
 
 update:
-UPDATE records SET record=:record WHERE key=:key;
+INSERT OR REPLACE INTO records (key, record) VALUES(?,?);
 
 delete:
 DELETE FROM records WHERE key=?;

--- a/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
+++ b/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
@@ -1,17 +1,19 @@
 CREATE TABLE records (
+  _id INTEGER PRIMARY KEY AUTOINCREMENT,
   key TEXT NOT NULL,
-  record TEXT NOT NULL,
-  PRIMARY KEY (key)
+  record TEXT NOT NULL
 );
 
+CREATE INDEX idx_records_key ON records(key);
+
 recordForKey:
-SELECT key, record FROM records WHERE key=?;
+SELECT _id, key, record FROM records WHERE key=?;
 
 insert:
 INSERT INTO records (key, record) VALUES (?,?);
 
 update:
-INSERT OR REPLACE INTO records (key, record) VALUES(?,?);
+INSERT OR REPLACE INTO records (_id, key, record) VALUES(?,?,?);
 
 delete:
 DELETE FROM records WHERE key=?;

--- a/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class SqlNormalizedCacheTest {
-  
+
   private val cache: SqlNormalizedCache = SqlNormalizedCacheFactory(createDriver()).create(RecordFieldJsonAdapter())
 
   @BeforeTest
@@ -54,7 +54,19 @@ class SqlNormalizedCacheTest {
   }
 
   @Test
-  fun testRecordMerge() {
+  fun testRecordMerge_noOldRecord() {
+    cache.merge(Record.builder(STANDARD_KEY)
+            .addField("fieldKey", "valueUpdated")
+            .addField("newFieldKey", true).build(), CacheHeaders.NONE)
+    val record = cache.selectRecordForKey(STANDARD_KEY)
+    assertNotNull(record)
+    assertEquals(expected = "valueUpdated", actual = record.fields["fieldKey"])
+    assertEquals(expected = true, actual = record.fields["newFieldKey"])
+  }
+
+  @Test
+  fun testRecordMerge_withOldRecord() {
+    createRecord(STANDARD_KEY)
     cache.merge(Record.builder(STANDARD_KEY)
         .addField("fieldKey", "valueUpdated")
         .addField("newFieldKey", true).build(), CacheHeaders.NONE)


### PR DESCRIPTION
#2231

Not sure if you wanna still keep the _id field, in that case we should retreive it from the old record and pass it when updating it