### PR TITLE
Fix issues with Kotlin Multiplatform setup

### DIFF
--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
   }
 
   android {
-    publishLibraryVariants("release")
+    publishAllLibraryVariants()
   }
   jvm()
 
@@ -71,7 +71,6 @@ kotlin {
       dependsOn(iosMain)
     }
 
-
     val commonTest by getting {
       dependencies {
         implementation(kotlin("test-common"))
@@ -87,6 +86,10 @@ kotlin {
         implementation(groovy.util.Eval.x(project, "x.dep.junit"))
         implementation(groovy.util.Eval.x(project, "x.dep.truth"))
       }
+    }
+
+    val androidTest by getting {
+      dependsOn(jvmTest)
     }
 
     val iosTest by getting {

--- a/apollo-normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/apollo-normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -18,14 +18,17 @@ actual class SqlNormalizedCacheFactory internal actual constructor(
        */
       url: String,
       properties: Properties = Properties()
-  ) : this(JdbcSqliteDriver(url, properties))
-
-  init {
-    ApolloDatabase.Schema.create(driver)
-  }
+  ) : this(createDriverAndDatabase(url, properties))
 
   private val apolloDatabase = ApolloDatabase(driver)
 
   override fun create(recordFieldAdapter: RecordFieldJsonAdapter) =
       SqlNormalizedCache(recordFieldAdapter, apolloDatabase.cacheQueries)
+
+  companion object {
+    private fun createDriverAndDatabase(url: String, properties: Properties) =
+        JdbcSqliteDriver(url, properties).also {
+          ApolloDatabase.Schema.create(it)
+        }
+  }
 }

--- a/apollo-normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/apollo/cache/normalized/sql/CreateDriver.kt
+++ b/apollo-normalized-cache-sqlite/src/jvmTest/kotlin/com/apollographql/apollo/cache/normalized/sql/CreateDriver.kt
@@ -4,4 +4,6 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 
 actual fun createDriver(): SqlDriver =
-    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY).also {
+      ApolloDatabase.Schema.create(it)
+    }

--- a/samples/java-sample/build.gradle.kts
+++ b/samples/java-sample/build.gradle.kts
@@ -18,8 +18,20 @@ extensions.findByType(BaseExtension::class.java)!!.apply {
 
   lintOptions {
     textReport = true
+    isCheckReleaseBuilds = false
     textOutput("stdout")
     ignore("InvalidPackage", "GoogleAppIndexingWarning", "AllowBackup")
+  }
+
+  // PLEASE DO NOT COPY
+  // Only in java samples. This is something to do with composite builds + Kotlin Multiplatform
+  buildTypes {
+    getByName("debug") {
+      matchingFallbacks = listOf("release")
+    }
+    getByName("release") {
+      matchingFallbacks = listOf("debug")
+    }
   }
 }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -5,7 +5,7 @@ set -x
 
 export PATH="$ANDROID_HOME"/tools/bin:$PATH
 
-./gradlew clean build connectedCheck -x checkstyleTest --stacktrace --max-workers=2
+./gradlew clean build -x checkstyleTest --stacktrace --max-workers=2
 ./gradlew -p composite build
 
 ./gradlew publishIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET" --parallel


### PR DESCRIPTION
- Publish all Android variants
- Make Android unit tests depend on Jvm unit tests
  - Create DB on JVM appropriately.
- Somehow fix variant issues on `java-sample` in a very hacky way.