### PR TITLE
Give more metaspace to tests processes

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -29,11 +29,6 @@ dependencies {
 }
 
 tasks.withType<Test> {
-  // Restart the daemon once in a while or we end up running out of MetaSpace
-  // It's not clear if it's a real ClassLoader leak or something else. The okio timeout thread does hold some ClassLoaders
-  // for up to 60s. The heap dumps also show some process reaper threads but it might just as well be a temporary thing, not sure.
-  // See https://github.com/gradle/gradle/issues/8354
-  setForkEvery(1L)
   dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/util/TestUtils.kt
@@ -26,6 +26,10 @@ object TestUtils {
     val dest = File(System.getProperty("user.dir")).child("build", "testProject")
     dest.deleteRecursively()
 
+    // See https://github.com/apollographql/apollo-android/issues/2184
+    dest.mkdirs()
+    File(dest, "gradle.properties").writeText("org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g")
+
     block(dest)
 
     // It's ok to not delete the directory as it will be deleted before next test
@@ -145,7 +149,7 @@ object TestUtils {
     block(dest)
   }
 
-  fun withGeneratedAccessorsProject(apolloConfiguration: String,  block: (File) -> Unit) = withDirectory {dir->
+  fun withGeneratedAccessorsProject(apolloConfiguration: String, block: (File) -> Unit) = withDirectory { dir ->
     fixturesDirectory().child("gradle", "settings.gradle.kts").copyTo(dir.child("settings.gradle.kts"))
     fixturesDirectory().child("gradle", "build.gradle.kts").copyTo(dir.child("build.gradle.kts"))
 
@@ -154,10 +158,11 @@ object TestUtils {
     block(dir)
   }
 
-  fun withTestProject(name: String, block: (File) -> Unit) = withDirectory {dir ->
+  fun withTestProject(name: String, block: (File) -> Unit) = withDirectory { dir ->
     File(System.getProperty("user.dir"), "testProjects/$name").copyRecursively(dir, overwrite = true)
     block(dir)
   }
+
   /**
    * creates a simple java non-android non-kotlin-gradle project
    */

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-rc-4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR gives more MetaSpace to the test processes. 

fixes https://github.com/apollographql/apollo-android/issues/2184.

It also bumps Gradle to 6.4-rc-4. I was hoping that this could somehow help but doesn't look like it does. Still, I think it's worth upgrading for the nicer error messages and to stay on the Gradle bleeding edge. Happy to revert to 6.3 if you think this is risky.

More context on the Gradle community slack: https://gradle-community.slack.com/archives/CA745PZHN/p1588352513265400