### PR TITLE
Minor documentation tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Apollo-android features:
 
 ## Adding Apollo-Android to your Project
 
-The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo-gradle-plugin/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
+The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
 
 To use this plugin, add the dependency to your project's root build.gradle file:
 

--- a/README.md
+++ b/README.md
@@ -234,11 +234,6 @@ Latest development changes are available in Sonatype's snapshots repository:
   }
 ```
 
-## Migrating to 1.3.x
-
-Apollo-Android version 1.3.0 introduces some fixes and improvements that are incompatible with 1.2.x. Please refer to
-[Migration Guide](https://www.apollographql.com/docs/android/essentials/migration/) for details.
-
 ## Advanced topics
 
 Advanced topics are available in [the official docs](https://www.apollographql.com/docs/android/):
@@ -252,6 +247,7 @@ Advanced topics are available in [the official docs](https://www.apollographql.c
 * [persisted-queries.md](https://www.apollographql.com/docs/android/advanced/persisted-queries/)
 * [no-runtime.md](https://www.apollographql.com/docs/android/advanced/no-runtime/) 
 * [subscriptions.md](https://www.apollographql.com/docs/android/advanced/subscriptions/)
+* [migrations.md](https://www.apollographql.com/docs/android/essentials/migration/)
 
 
 ## Changelog

--- a/docs/source/essentials/caching.md
+++ b/docs/source/essentials/caching.md
@@ -11,7 +11,7 @@ Apollo GraphQL client allows you to cache responses, making it suitable for use 
 ## Http Cache
 
 To enable HTTP Cache support, add the dependency to your project's build.gradle file. The latest version is
-[![Download](https://api.bintray.com/packages/apollographql/android/apollo-http-cache/images/download.svg)](https://bintray.com/apollographql/android/apollo-http-cache/_latestVersion)
+[![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg)](https://bintray.com/apollographql/android/apollo-http-cache/_latestVersion)
 
 ```kotlin:title=build.gradle
 dependencies {
@@ -100,7 +100,7 @@ and will be evicted from the http cache, `expireAfter(expireTimeout, timeUnit)`.
 ## Normalized Disk Cache:
 
 To enable Normalized Disk Cache support, add the dependency to your project's build.gradle file. The latest version is
-[![Download](https://api.bintray.com/packages/apollographql/android/apollo-normalized-cache-sqlite/images/download.svg)](https://bintray.com/apollographql/android/apollo-normalized-cache-sqlite/_latestVersion)
+[![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg)](https://bintray.com/apollographql/android/apollo-normalized-cache-sqlite/_latestVersion)
 
 ```kotlin:title=build.gradle
 dependencies {
@@ -175,7 +175,7 @@ ApolloClient apolloClient = ApolloClient.builder()
 ## Normalized In-Memory Cache:
 
 To enable Normalized In-Memory Cache support, add the dependency to your project's build.gradle file. The latest version is
-[![Download](https://api.bintray.com/packages/apollographql/android/apollo-normalized-cache/images/download.svg)](https://bintray.com/apollographql/android/apollo-normalized-cache/_latestVersion)
+[![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg)](https://bintray.com/apollographql/android/apollo-normalized-cache/_latestVersion)
 
 ```kotlin:title=build.gradle
 dependencies {


### PR DESCRIPTION
* Unbreak the download badge that got broken when merging the bintray packages
* Put migrations as an advanced topic since there is now a "2.0" migration in addition to "1.3"