### PR TITLE
Feature to generate GraphQL enum types as sealed classes

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -37,7 +37,8 @@ class GraphQLCompiler {
           useSemanticNaming = args.useSemanticNaming,
           packageNameProvider = args.packageNameProvider,
           generateAsInternal = args.generateAsInternal,
-          kotlinMultiPlatformProject = args.kotlinMultiPlatformProject
+          kotlinMultiPlatformProject = args.kotlinMultiPlatformProject,
+          enumAsSealedClassPatternFilters = args.enumAsSealedClassPatternFilters.map { it.toRegex() }
       ).write(args.outputDir)
     } else {
       ir.writeJavaFiles(
@@ -121,7 +122,8 @@ class GraphQLCompiler {
       val generateKotlinModels: Boolean = false,
       val operationOutputFile: File? = null,
       val generateAsInternal: Boolean = false,
-
+      // only if generateKotlinModels = true
+      val enumAsSealedClassPatternFilters: List<String>,
       // only if generateKotlinModels = false
       val nullableValueType: NullableValueType,
       // only if generateKotlinModels = false

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/SchemaBuilder.kt
@@ -1,7 +1,11 @@
 package com.apollographql.apollo.compiler.ast.builder
 
 import com.apollographql.apollo.compiler.OperationIdGenerator
-import com.apollographql.apollo.compiler.ast.*
+import com.apollographql.apollo.compiler.ast.CustomTypes
+import com.apollographql.apollo.compiler.ast.EnumType
+import com.apollographql.apollo.compiler.ast.FieldType
+import com.apollographql.apollo.compiler.ast.Schema
+import com.apollographql.apollo.compiler.ast.TypeRef
 import com.apollographql.apollo.compiler.escapeKotlinReservedWord
 import com.apollographql.apollo.compiler.ir.CodeGenerationIR
 import com.apollographql.apollo.compiler.ir.ScalarType

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/EnumType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/EnumType.kt
@@ -4,19 +4,32 @@ import com.apollographql.apollo.compiler.applyIf
 import com.apollographql.apollo.compiler.ast.EnumType
 import com.squareup.kotlinpoet.*
 
-internal fun EnumType.typeSpec(generateAsInternal: Boolean = false) =
-    TypeSpec
-        .enumBuilder(name)
-        .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
-        .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
-        .primaryConstructor(primaryConstructorSpec)
-        .addProperty(rawValuePropertySpec)
-        .apply {
-          values.forEach { value -> addEnumConstant(value.constName, value.enumConstTypeSpec) }
-          addEnumConstant("UNKNOWN__", unknownEnumConstTypeSpec)
-        }
-        .addType(companionObjectSpec)
-        .build()
+internal fun EnumType.typeSpec(
+    generateAsInternal: Boolean = false,
+    enumAsSealedClassPatternFilters: List<Regex>
+): TypeSpec {
+  val asSealedClass = enumAsSealedClassPatternFilters.isNotEmpty() && enumAsSealedClassPatternFilters.any { pattern ->
+    name.matches(pattern)
+  }
+
+  return if (asSealedClass) toSealedClassTypeSpec(generateAsInternal)
+  else toEnumTypeSpec(generateAsInternal)
+}
+
+private fun EnumType.toEnumTypeSpec(generateAsInternal: Boolean): TypeSpec {
+  return TypeSpec
+      .enumBuilder(name)
+      .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
+      .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
+      .primaryConstructor(primaryConstructorSpec)
+      .addProperty(rawValuePropertySpec)
+      .apply {
+        values.forEach { value -> addEnumConstant(value.constName, value.enumConstTypeSpec) }
+        addEnumConstant("UNKNOWN__", unknownEnumConstTypeSpec)
+      }
+      .addType(enumCompanionObjectSpec)
+      .build()
+}
 
 private val primaryConstructorSpec =
     FunSpec
@@ -40,27 +53,88 @@ private val EnumType.Value.enumConstTypeSpec: TypeSpec
         .build()
   }
 
-private val unknownEnumConstTypeSpec: TypeSpec =
-    TypeSpec
+private val unknownEnumConstTypeSpec: TypeSpec
+  get() {
+    return TypeSpec
         .anonymousClassBuilder()
         .addKdoc("%L", "Auto generated constant for unknown enum values\n")
         .addSuperclassConstructorParameter("%S", "UNKNOWN__")
         .build()
+  }
 
-private val EnumType.companionObjectSpec: TypeSpec
+private val EnumType.enumCompanionObjectSpec: TypeSpec
   get() {
     return TypeSpec
         .companionObjectBuilder()
-        .addFunction(safeValueOfFunSpec)
+        .addFunction(enumSafeValueOfFunSpec)
         .build()
   }
 
-private val EnumType.safeValueOfFunSpec: FunSpec
+private val EnumType.enumSafeValueOfFunSpec: FunSpec
   get() {
     return FunSpec
         .builder("safeValueOf")
         .addParameter("rawValue", String::class)
         .returns(ClassName("", name))
         .addStatement("return values().find·{·it.rawValue·==·rawValue·} ?: UNKNOWN__")
+        .build()
+  }
+
+private fun EnumType.toSealedClassTypeSpec(generateAsInternal: Boolean): TypeSpec {
+  return TypeSpec
+      .classBuilder(name)
+      .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
+      .applyIf(generateAsInternal) { addModifiers(KModifier.INTERNAL) }
+      .addModifiers(KModifier.SEALED)
+      .primaryConstructor(primaryConstructorSpec)
+      .addProperty(rawValuePropertySpec)
+      .addTypes(values.map { value -> value.toObjectTypeSpec(ClassName("", name)) })
+      .addType(unknownValueTypeSpec)
+      .addType(sealedClassCompanionObjectSpec)
+      .build()
+}
+
+private fun EnumType.Value.toObjectTypeSpec(superClass: TypeName): TypeSpec {
+  return TypeSpec.objectBuilder(constName)
+      .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
+      .applyIf(isDeprecated) { addAnnotation(KotlinCodeGen.deprecatedAnnotation(deprecationReason)) }
+      .superclass(superClass)
+      .addSuperclassConstructorParameter("rawValue = %S", value)
+      .build()
+}
+
+private val EnumType.unknownValueTypeSpec: TypeSpec
+  get() {
+    return TypeSpec.classBuilder("UNKNOWN__")
+        .addKdoc("%L", "Auto generated constant for unknown enum values\n")
+        .primaryConstructor(primaryConstructorSpec)
+        .superclass(ClassName("", name))
+        .addSuperclassConstructorParameter("rawValue = rawValue")
+        .build()
+  }
+
+private val EnumType.sealedClassCompanionObjectSpec: TypeSpec
+  get() {
+    return TypeSpec
+        .companionObjectBuilder()
+        .addFunction(sealedClassSafeValueOfFunSpec)
+        .build()
+  }
+
+private val EnumType.sealedClassSafeValueOfFunSpec: FunSpec
+  get() {
+    val returnClassName = ClassName("", name)
+    return FunSpec
+        .builder("safeValueOf")
+        .addParameter("rawValue", String::class)
+        .returns(returnClassName)
+        .beginControlFlow("return when(rawValue)")
+        .addCode(
+            values
+                .map { CodeBlock.of("%S -> %L", it.value, it.constName) }
+                .joinToCode(separator = "\n", suffix = "\n")
+        )
+        .addCode("else -> UNKNOWN__(rawValue)\n")
+        .endControlFlow()
         .build()
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/GraphQLKompiler.kt
@@ -17,7 +17,8 @@ class GraphQLKompiler(
     private val useSemanticNaming: Boolean,
     private val generateAsInternal: Boolean = false,
     private val operationIdGenerator: OperationIdGenerator,
-    private val kotlinMultiPlatformProject: Boolean
+    private val kotlinMultiPlatformProject: Boolean,
+    private val enumAsSealedClassPatternFilters: List<Regex>
 ) {
   fun write(outputDir: File) {
     val customTypeMap = customTypeMap.supportedCustomTypes(ir.typesUsed)
@@ -28,11 +29,11 @@ class GraphQLKompiler(
         useSemanticNaming = useSemanticNaming,
         operationIdGenerator = operationIdGenerator
     )
-
     val schemaCodegen = SchemaCodegen(
         packageNameProvider = packageNameProvider,
         generateAsInternal = generateAsInternal,
-        kotlinMultiPlatformProject = kotlinMultiPlatformProject
+        kotlinMultiPlatformProject = kotlinMultiPlatformProject,
+        enumAsSealedClassPatternFilters = enumAsSealedClassPatternFilters
     )
     schemaCodegen.apply(schema::accept).writeTo(outputDir)
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/SchemaCodegen.kt
@@ -1,7 +1,12 @@
 package com.apollographql.apollo.compiler.codegen.kotlin
 
 import com.apollographql.apollo.compiler.PackageNameProvider
-import com.apollographql.apollo.compiler.ast.*
+import com.apollographql.apollo.compiler.ast.CustomTypes
+import com.apollographql.apollo.compiler.ast.EnumType
+import com.apollographql.apollo.compiler.ast.InputType
+import com.apollographql.apollo.compiler.ast.ObjectType
+import com.apollographql.apollo.compiler.ast.OperationType
+import com.apollographql.apollo.compiler.ast.SchemaVisitor
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodeGen.patchKotlinNativeOptionalArrayProperties
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
@@ -10,7 +15,8 @@ import java.io.File
 internal class SchemaCodegen(
     private val packageNameProvider: PackageNameProvider,
     private val generateAsInternal: Boolean = false,
-    private val kotlinMultiPlatformProject: Boolean
+    private val kotlinMultiPlatformProject: Boolean,
+    private val enumAsSealedClassPatternFilters: List<Regex>
 ) : SchemaVisitor {
   private var fileSpecs: List<FileSpec> = emptyList()
 
@@ -19,7 +25,10 @@ internal class SchemaCodegen(
   }
 
   override fun visit(enumType: EnumType) {
-    fileSpecs = fileSpecs + enumType.typeSpec(generateAsInternal).fileSpec(packageNameProvider.typesPackageName)
+    fileSpecs = fileSpecs + enumType.typeSpec(
+        generateAsInternal = generateAsInternal,
+        enumAsSealedClassPatternFilters = enumAsSealedClassPatternFilters
+    ).fileSpec(packageNameProvider.typesPackageName)
   }
 
   override fun visit(inputType: InputType) {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.kt
@@ -11,43 +11,51 @@ import kotlin.String
 /**
  * The episodes in the Star Wars trilogy
  */
-enum class Episode(
+sealed class Episode(
   val rawValue: String
 ) {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE("NEWHOPE"),
+  object NEWHOPE : Episode(rawValue = "NEWHOPE")
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE("EMPIRE"),
+  object EMPIRE : Episode(rawValue = "EMPIRE")
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI("JEDI"),
+  object JEDI : Episode(rawValue = "JEDI")
 
   /**
    * Test deprecated enum value
    */
   @Deprecated(message = "For test purpose only")
-  DEPRECATED("DEPRECATED"),
+  object DEPRECATED : Episode(rawValue = "DEPRECATED")
 
   /**
    * Test java reserved word
    */
   @Deprecated(message = "For test purpose only")
-  NEW("new"),
+  object NEW : Episode(rawValue = "new")
 
   /**
    * Auto generated constant for unknown enum values
    */
-  UNKNOWN__("UNKNOWN__");
+  class UNKNOWN__(
+    rawValue: String
+  ) : Episode(rawValue = rawValue)
 
   companion object {
-    fun safeValueOf(rawValue: String): Episode = values().find { it.rawValue == rawValue } ?:
-        UNKNOWN__
+    fun safeValueOf(rawValue: String): Episode = when(rawValue) {
+      "NEWHOPE" -> NEWHOPE
+      "EMPIRE" -> EMPIRE
+      "JEDI" -> JEDI
+      "DEPRECATED" -> DEPRECATED
+      "new" -> NEW
+      else -> UNKNOWN__(rawValue)
+    }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.kt
@@ -11,43 +11,51 @@ import kotlin.String
 /**
  * The episodes in the Star Wars trilogy
  */
-enum class Episode(
+sealed class Episode(
   val rawValue: String
 ) {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */
-  NEWHOPE("NEWHOPE"),
+  object NEWHOPE : Episode(rawValue = "NEWHOPE")
 
   /**
    * Star Wars Episode V: The Empire Strikes Back, released in 1980.
    */
-  EMPIRE("EMPIRE"),
+  object EMPIRE : Episode(rawValue = "EMPIRE")
 
   /**
    * Star Wars Episode VI: Return of the Jedi, released in 1983.
    */
-  JEDI("JEDI"),
+  object JEDI : Episode(rawValue = "JEDI")
 
   /**
    * Test deprecated enum value
    */
   @Deprecated(message = "For test purpose only")
-  DEPRECATED("DEPRECATED"),
+  object DEPRECATED : Episode(rawValue = "DEPRECATED")
 
   /**
    * Test java reserved word
    */
   @Deprecated(message = "For test purpose only")
-  NEW("new"),
+  object NEW : Episode(rawValue = "new")
 
   /**
    * Auto generated constant for unknown enum values
    */
-  UNKNOWN__("UNKNOWN__");
+  class UNKNOWN__(
+    rawValue: String
+  ) : Episode(rawValue = rawValue)
 
   companion object {
-    fun safeValueOf(rawValue: String): Episode = values().find { it.rawValue == rawValue } ?:
-        UNKNOWN__
+    fun safeValueOf(rawValue: String): Episode = when(rawValue) {
+      "NEWHOPE" -> NEWHOPE
+      "EMPIRE" -> EMPIRE
+      "JEDI" -> JEDI
+      "DEPRECATED" -> DEPRECATED
+      "new" -> NEW
+      else -> UNKNOWN__(rawValue)
+    }
   }
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -156,8 +156,11 @@ interface CompilerParams {
   val generateAsInternal: Property<Boolean>
 
   /**
-   * Whether to generate GraphQL enum types by matching as Kotlin sealed classes if they match one of provided regex patterns.
-   * By default any GraphQL enum type is generated as `enum class`.
+   * A list of [Regex] patterns for GraphQL enums that should be generated as Kotlin sealed classes instead
+   * of the default Kotlin enums.
+   * Use this if you want your client to have access to the rawValue of the enum. This can be useful if new
+   * GraphQL enums are added but the client was compiled against an older schema that doesn't have knowledge
+   * of the new enums.
    */
   val generateEnumAsSealedClass: ListProperty<String>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -156,11 +156,10 @@ interface CompilerParams {
   val generateAsInternal: Property<Boolean>
 
   /**
-   * A list of [Regex] patterns for GraphQL enums that should be generated as Kotlin sealed classes instead
-   * of the default Kotlin enums.
-   * Use this if you want your client to have access to the rawValue of the enum. This can be useful if new
-   * GraphQL enums are added but the client was compiled against an older schema that doesn't have knowledge
-   * of the new enums.
+   * A list of [Regex] patterns for GraphQL enums that should be generated as Kotlin sealed classes instead of the default Kotlin enums.
+   *
+   * Use this if you want your client to have access to the rawValue of the enum. This can be useful if new GraphQL enums are added but
+   * the client was compiled against an older schema that doesn't have knowledge of the new enums.
    */
-  val generateEnumAsSealedClass: ListProperty<String>
+  val sealedClassesForEnumsMatching: ListProperty<String>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -3,9 +3,9 @@ package com.apollographql.apollo.gradle.api
 import com.apollographql.apollo.compiler.OperationIdGenerator
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 
 /**
  * CompilerParams contains all the parameters needed to invoke the apollo compiler.
@@ -154,4 +154,10 @@ interface CompilerParams {
    * Default value: false
    */
   val generateAsInternal: Property<Boolean>
+
+  /**
+   * Whether to generate GraphQL enum types by matching as Kotlin sealed classes if they match one of provided regex patterns.
+   * By default any GraphQL enum type is generated as `enum class`.
+   */
+  val generateEnumAsSealedClass: ListProperty<String>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -99,6 +99,10 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   @get:Optional
   abstract val kotlinMultiPlatformProject: Property<Boolean>
 
+  @get:Input
+  @get:Optional
+  abstract val generateEnumAsSealedClass: ListProperty<String>
+
   @TaskAction
   fun taskAction() {
 
@@ -139,7 +143,8 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         packageNameProvider = packageNameProvider,
         operationOutputFile = operationOutputFile.orNull?.asFile,
         generateAsInternal = generateAsInternal.getOrElse(false),
-        kotlinMultiPlatformProject = kotlinMultiPlatformProject.getOrElse(false)
+        kotlinMultiPlatformProject = kotlinMultiPlatformProject.getOrElse(false),
+        enumAsSealedClassPatternFilters = generateEnumAsSealedClass.getOrElse(emptyList())
     )
 
     GraphQLCompiler().write(args)

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -101,7 +101,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val generateEnumAsSealedClass: ListProperty<String>
+  abstract val sealedClassesForEnumsMatching: ListProperty<String>
 
   @TaskAction
   fun taskAction() {
@@ -144,7 +144,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         operationOutputFile = operationOutputFile.orNull?.asFile,
         generateAsInternal = generateAsInternal.getOrElse(false),
         kotlinMultiPlatformProject = kotlinMultiPlatformProject.getOrElse(false),
-        enumAsSealedClassPatternFilters = generateEnumAsSealedClass.getOrElse(emptyList())
+        enumAsSealedClassPatternFilters = sealedClassesForEnumsMatching.getOrElse(emptyList())
     )
 
     GraphQLCompiler().write(args)

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -154,6 +154,7 @@ open class ApolloPlugin : Plugin<Project> {
         it.generateAsInternal.set(compilerParams.generateAsInternal)
         it.operationIdGenerator.set(compilerParams.operationIdGenerator)
         it.kotlinMultiPlatformProject.set(project.isKotlinMultiplatform)
+        it.generateEnumAsSealedClass.set(compilerParams.generateEnumAsSealedClass)
         Unit
       }
     }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -154,7 +154,7 @@ open class ApolloPlugin : Plugin<Project> {
         it.generateAsInternal.set(compilerParams.generateAsInternal)
         it.operationIdGenerator.set(compilerParams.operationIdGenerator)
         it.kotlinMultiPlatformProject.set(project.isKotlinMultiplatform)
-        it.generateEnumAsSealedClass.set(compilerParams.generateEnumAsSealedClass)
+        it.sealedClassesForEnumsMatching.set(compilerParams.sealedClassesForEnumsMatching)
         Unit
       }
     }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -25,6 +25,7 @@ fun CompilerParams.withFallback(objects: ObjectFactory, other: CompilerParams): 
   merge.rootPackageName.set(this.rootPackageName.orElse(other.rootPackageName))
   merge.generateAsInternal.set(this.generateAsInternal.orElse(other.generateAsInternal))
   merge.operationIdGenerator.set(this.operationIdGenerator.orElse(other.operationIdGenerator))
+  merge.generateEnumAsSealedClass.set(this.generateEnumAsSealedClass.orElse(other.generateEnumAsSealedClass))
 
   return merge
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -25,7 +25,7 @@ fun CompilerParams.withFallback(objects: ObjectFactory, other: CompilerParams): 
   merge.rootPackageName.set(this.rootPackageName.orElse(other.rootPackageName))
   merge.generateAsInternal.set(this.generateAsInternal.orElse(other.generateAsInternal))
   merge.operationIdGenerator.set(this.operationIdGenerator.orElse(other.operationIdGenerator))
-  merge.generateEnumAsSealedClass.set(this.generateEnumAsSealedClass.orElse(other.generateEnumAsSealedClass))
+  merge.sealedClassesForEnumsMatching.set(this.sealedClassesForEnumsMatching.orElse(other.sealedClassesForEnumsMatching))
 
   return merge
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -2,9 +2,9 @@ package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.compiler.OperationIdGenerator
 import com.apollographql.apollo.gradle.api.CompilerParams
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import javax.inject.Inject
@@ -23,6 +23,7 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory)
   init {
     // see https://github.com/gradle/gradle/issues/7485
     customTypeMapping.set(null as Map<String, String>?)
+    generateEnumAsSealedClass.set(null as List<String>?)
   }
 
   abstract override val suppressRawTypesWarning : Property<Boolean>
@@ -40,4 +41,6 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory)
   abstract override val rootPackageName : Property<String>
 
   abstract override val generateAsInternal: Property<Boolean>
+
+  abstract override val generateEnumAsSealedClass: ListProperty<String>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilerParams.kt
@@ -23,7 +23,7 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory)
   init {
     // see https://github.com/gradle/gradle/issues/7485
     customTypeMapping.set(null as Map<String, String>?)
-    generateEnumAsSealedClass.set(null as List<String>?)
+    sealedClassesForEnumsMatching.set(null as List<String>?)
   }
 
   abstract override val suppressRawTypesWarning : Property<Boolean>
@@ -42,5 +42,5 @@ abstract class DefaultCompilerParams @Inject constructor(objects: ObjectFactory)
 
   abstract override val generateAsInternal: Property<Boolean>
 
-  abstract override val generateEnumAsSealedClass: ListProperty<String>
+  abstract override val sealedClassesForEnumsMatching: ListProperty<String>
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -4,9 +4,7 @@ import com.apollographql.apollo.gradle.internal.child
 import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.TestUtils.withProject
 import com.apollographql.apollo.gradle.util.generatedChild
-import org.gradle.testkit.runner.TaskOutcome
 import org.hamcrest.CoreMatchers
-import org.junit.Assert
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -64,6 +62,36 @@ class KotlinCodegenTests {
 
       assertTrue(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.kt").isFile)
       assertThat(dir.generatedChild("main/service/com/example/fragment/SpeciesInformation.kt").readText(), CoreMatchers.containsString("internal data class"))
+    }
+  }
+
+  @Test
+  fun `when generateEnumAsSealedClass to match all - generated enum type as sealed class`() {
+    val apolloConfiguration = """
+      apollo {
+        service("githunt") {
+          sourceFolder = "githunt"
+        }
+        generateKotlinModels = true
+        generateEnumAsSealedClass = [".*"]
+      }
+    """.trimIndent()
+    withProject(
+        usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)
+    ) { dir ->
+      val source = TestUtils.fixturesDirectory()
+
+      val target = dir.child("src", "main", "graphql", "githunt")
+      source.child("githunt").copyRecursively(target = target, overwrite = true)
+
+      dir.child("src", "main", "graphql", "com").deleteRecursively()
+
+      TestUtils.executeTask("build", dir)
+
+      assertTrue(dir.generatedChild("main/githunt/type/FeedType.kt").isFile)
+      assertThat(dir.generatedChild("main/githunt/type/FeedType.kt").readText(), CoreMatchers.containsString("sealed class"))
     }
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/KotlinCodegenTests.kt
@@ -66,14 +66,14 @@ class KotlinCodegenTests {
   }
 
   @Test
-  fun `when generateEnumAsSealedClass to match all - generated enum type as sealed class`() {
+  fun `when sealedClassesForEnumsMatching to match all - generated enum type as sealed class`() {
     val apolloConfiguration = """
       apollo {
         service("githunt") {
           sourceFolder = "githunt"
         }
         generateKotlinModels = true
-        generateEnumAsSealedClass = [".*"]
+        sealedClassesForEnumsMatching = [".*"]
       }
     """.trimIndent()
     withProject(

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -50,7 +50,7 @@ ext.dep = [
         api    : "com.apollographql.apollo:apollo-api:$versions.apollo",
     ],
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
-    kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.5",
+    kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.8",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     errorProneCore        : "com.google.errorprone:error_prone_core:2.1.1",
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",


### PR DESCRIPTION
Update Kotlin compiler to generate GraphQL enum type as sealed class.

Closes https://github.com/apollographql/apollo-android/issues/2065