### PR TITLE
Prevent incorrect caching of partial responses with errors.

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -123,6 +123,9 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
 
   Set<String> cacheResponse(final InterceptorResponse networkResponse,
       final InterceptorRequest request) {
+    if (networkResponse.parsedResponse.isPresent() && networkResponse.parsedResponse.get().hasErrors()) {
+      return Collections.emptySet();
+    }
     final Optional<List<Record>> records = networkResponse.cacheRecords.map(
         new Function<Collection<Record>, List<Record>>() {
           @NotNull @Override public List<Record> apply(@NotNull Collection<Record> records) {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -31,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.truth.Truth.assertThat;
 
 @SuppressWarnings("unchecked") public class ApolloExceptionTest {
-  private static long TIMEOUT_SECONDS = 2;
+  private static long timeoutSeconds = 2;
 
   @Rule public final MockWebServer server = new MockWebServer();
   private ApolloClient apolloClient;
@@ -41,8 +41,8 @@ import static com.google.common.truth.Truth.assertThat;
     apolloClient = ApolloClient.builder()
         .serverUrl(server.url("/"))
         .okHttpClient(new OkHttpClient.Builder()
-            .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-            .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .connectTimeout(timeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(timeoutSeconds, TimeUnit.SECONDS)
             .build())
         .build();
 
@@ -97,7 +97,11 @@ import static com.google.common.truth.Truth.assertThat;
         throw new UnsupportedOperationException();
       }
 
-      @NotNull @Override public ByteString composeRequestBody(boolean autoPersistQueries, boolean withQueryDocument, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      @NotNull @Override public ByteString composeRequestBody(
+          boolean autoPersistQueries,
+          boolean withQueryDocument,
+          @NotNull ScalarTypeAdapters scalarTypeAdapters
+      ) {
         return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
       }
 
@@ -125,7 +129,7 @@ import static com.google.common.truth.Truth.assertThat;
           }
         })
         .test()
-        .awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .awaitDone(timeoutSeconds, TimeUnit.SECONDS)
         .assertError(ApolloHttpException.class);
 
     ApolloHttpException e = (ApolloHttpException) errorRef.get();
@@ -140,7 +144,7 @@ import static com.google.common.truth.Truth.assertThat;
     Rx2Apollo
         .from(apolloClient.prefetch(emptyQuery))
         .test()
-        .awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .awaitDone(timeoutSeconds, TimeUnit.SECONDS)
         .assertNoValues()
         .assertError(ApolloHttpException.class);
   }
@@ -149,7 +153,7 @@ import static com.google.common.truth.Truth.assertThat;
     Rx2Apollo
         .from(apolloClient.query(emptyQuery))
         .test()
-        .awaitDone(TIMEOUT_SECONDS * 2, TimeUnit.SECONDS)
+        .awaitDone(timeoutSeconds * 2, TimeUnit.SECONDS)
         .assertNoValues()
         .assertError(new Predicate<Throwable>() {
           @Override public boolean test(Throwable throwable) throws Exception {
@@ -165,7 +169,7 @@ import static com.google.common.truth.Truth.assertThat;
     Rx2Apollo
         .from(apolloClient.prefetch(emptyQuery))
         .test()
-        .awaitDone(TIMEOUT_SECONDS * 2, TimeUnit.SECONDS)
+        .awaitDone(timeoutSeconds * 2, TimeUnit.SECONDS)
         .assertNoValues()
         .assertError(new Predicate<Throwable>() {
           @Override public boolean test(Throwable throwable) throws Exception {
@@ -182,7 +186,7 @@ import static com.google.common.truth.Truth.assertThat;
     Rx2Apollo
         .from(apolloClient.query(emptyQuery))
         .test()
-        .awaitDone(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .awaitDone(timeoutSeconds, TimeUnit.SECONDS)
         .assertNoValues()
         .assertError(new Predicate<Throwable>() {
           @Override public boolean test(Throwable throwable) throws Exception {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
@@ -77,7 +77,11 @@ public class ResponseFetcherTest {
         throw new UnsupportedOperationException();
       }
 
-     @NotNull @Override public ByteString composeRequestBody(boolean autoPersistQueries, boolean withQueryDocument, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+     @NotNull @Override public ByteString composeRequestBody(
+         boolean autoPersistQueries,
+         boolean withQueryDocument,
+         @NotNull ScalarTypeAdapters scalarTypeAdapters
+     ) {
         return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
       }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptorTest.java
@@ -96,7 +96,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
                   com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
                       .errors(
                           Collections.singletonList(
-                              new Error("PersistedQueryNotFound", Collections.<Error.Location>emptyList(), Collections.<String, Object>emptyMap())
+                              new Error("PersistedQueryNotFound", Collections.emptyList(), Collections.emptyMap())
                           )
                       )
                       .build(),
@@ -149,7 +149,7 @@ public class ApolloAutoPersistedQueryInterceptorTest {
                   com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
                       .errors(
                           Collections.singletonList(
-                              new Error("PersistedQueryNotSupported", Collections.<Error.Location>emptyList(), Collections.<String, Object>emptyMap())
+                              new Error("PersistedQueryNotSupported", Collections.emptyList(), Collections.emptyMap())
                           )
                       )
                       .build(),
@@ -313,7 +313,10 @@ public class ApolloAutoPersistedQueryInterceptorTest {
       throw new UnsupportedOperationException();
     }
 
-    @NotNull @Override public com.apollographql.apollo.api.Response<Data> parse(@NotNull BufferedSource source, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+    @NotNull @Override public com.apollographql.apollo.api.Response<Data> parse(
+        @NotNull BufferedSource source,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters
+    ) {
       throw new UnsupportedOperationException();
     }
 
@@ -321,7 +324,10 @@ public class ApolloAutoPersistedQueryInterceptorTest {
       throw new UnsupportedOperationException();
     }
 
-    @NotNull @Override public com.apollographql.apollo.api.Response parse(@NotNull ByteString byteString, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+    @NotNull @Override public com.apollographql.apollo.api.Response parse(
+        @NotNull ByteString byteString,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters
+    ) {
       throw new UnsupportedOperationException();
     }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -1,0 +1,91 @@
+package com.apollographql.apollo.internal.interceptor;
+
+import com.apollographql.apollo.Logger;
+import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.internal.ApolloLogger;
+import com.apollographql.apollo.api.internal.ResponseFieldMapper;
+import com.apollographql.apollo.cache.normalized.ApolloStore;
+import com.apollographql.apollo.cache.normalized.Record;
+import com.apollographql.apollo.interceptor.ApolloInterceptor;
+import okhttp3.MediaType;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class ApolloCacheInterceptorTest {
+  private ApolloCacheInterceptor interceptor;
+  private ApolloStore apolloStore;
+  private Logger logger;
+  private okhttp3.Response okHttpResponse;
+
+  @Rule public final MockWebServer server = new MockWebServer();
+
+  @Before
+  public void setUp() {
+    apolloStore = mock(ApolloStore.class);
+    logger = mock(Logger.class);
+    okHttpResponse = new okhttp3.Response.Builder()
+        .request(new Request.Builder().url(server.url("/")).build())
+        .protocol(Protocol.HTTP_2)
+        .code(200)
+        .message("Intercepted")
+        .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
+        .build();
+
+    interceptor = new ApolloCacheInterceptor(apolloStore, mock(ResponseFieldMapper.class), mock(Executor.class), new ApolloLogger(logger));
+  }
+
+  @Test
+  public void testDoesNotCacheErrorResponse() {
+    Operation<?, ?, ?> operation = mock(Operation.class);
+    Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
+    ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
+        okHttpResponse,
+        com.apollographql.apollo.api.Response.builder(operation).errors(Collections.singletonList(error)).build(),
+        new ArrayList<Record>()
+    );
+    ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(operation).build();
+
+    Set<String> cachedKeys = interceptor.cacheResponse(networkResponse, request);
+
+    assertThat(cachedKeys).isEmpty();
+    verifyZeroInteractions(apolloStore, logger);
+  }
+
+  @Test
+  public void testDoesCachesNonErrorResponse() {
+    Operation<?, ?, ?> operation = mock(Operation.class);
+    ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
+        okHttpResponse,
+        com.apollographql.apollo.api.Response.builder(operation).build(),
+        new ArrayList<Record>()
+    );
+    ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(operation).build();
+    Set<String> expectedCachedKeys = Collections.singleton("cacheKey");
+
+    when(apolloStore.writeTransaction(any())).thenReturn(expectedCachedKeys);
+
+    Set<String> cachedKeys = interceptor.cacheResponse(networkResponse, request);
+
+    assertThat(cachedKeys).isEqualTo(expectedCachedKeys);
+    verify(apolloStore).writeTransaction(any());
+    verifyZeroInteractions(logger);
+  }
+}

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.java
@@ -86,7 +86,11 @@ public class ApolloCallTrackerTest {
       throw new UnsupportedOperationException();
     }
 
-    @NotNull @Override public ByteString composeRequestBody(boolean autoPersistQueries, boolean withQueryDocument, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+    @NotNull @Override public ByteString composeRequestBody(
+        boolean autoPersistQueries,
+        boolean withQueryDocument,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters
+    ) {
         return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
       }
 
@@ -124,7 +128,7 @@ public class ApolloCallTrackerTest {
   }
 
   @Test
-  public void testRunningCallsCount_whenSyncPrefetchCallIsMade() throws InterruptedException {
+  public void testRunningCallsCountWhenSyncPrefetchCallIsMade() throws InterruptedException {
     assertThat(apolloClient.activeCallsCount()).isEqualTo(0);
     Rx2Apollo
         .from(apolloClient.prefetch(EMPTY_QUERY))
@@ -135,7 +139,7 @@ public class ApolloCallTrackerTest {
   }
 
   @Test
-  public void testRunningCallsCount_whenAsyncPrefetchCallIsMade() throws InterruptedException {
+  public void testRunningCallsCountWhenAsyncPrefetchCallIsMade() throws InterruptedException {
     assertThat(apolloClient.activeCallsCount()).isEqualTo(0);
     server.enqueue(createMockResponse());
     Rx2Apollo
@@ -147,7 +151,7 @@ public class ApolloCallTrackerTest {
   }
 
   @Test
-  public void testRunningCallsCount_whenAsyncApolloCallIsMade() throws InterruptedException {
+  public void testRunningCallsCountWhenAsyncApolloCallIsMade() throws InterruptedException {
     assertThat(apolloClient.activeCallsCount()).isEqualTo(0);
     server.enqueue(createMockResponse());
     Rx2Apollo
@@ -159,7 +163,7 @@ public class ApolloCallTrackerTest {
   }
 
   @Test
-  public void testIdleCallBackIsInvoked_whenApolloClientBecomesIdle() throws InterruptedException, TimeoutException {
+  public void testIdleCallBackIsInvokedWhenApolloClientBecomesIdle() throws InterruptedException, TimeoutException {
     server.enqueue(createMockResponse());
     final AtomicBoolean idle = new AtomicBoolean();
     IdleResourceCallback idleResourceCallback = new IdleResourceCallback() {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
@@ -111,24 +111,24 @@ public class SubscriptionAutoPersistTest {
     final UUID subscriptionId = new ArrayList<>(subscriptionManager.subscriptions.keySet()).get(0);
     if (isWriteDocument) {
       assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage.toJsonString()).isEqualTo(
-          "" +
-              "{\"id\":\"" + subscriptionId.toString() + "\"," +
-              "\"type\":\"start\"," +
-              "\"payload\":{" +
-              "\"variables\":{}," +
-              "\"operationName\":\"SomeSubscription\"," +
-              "\"query\":\"subscription{\\ncommentAdded(repoFullName:\\\"repo\\\"){\\n__typename\\nid\\ncontent\\n}\\n}\"," +
-              "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
+          ""
+              + "{\"id\":\"" + subscriptionId.toString() + "\","
+              + "\"type\":\"start\","
+              + "\"payload\":{"
+              + "\"variables\":{},"
+              + "\"operationName\":\"SomeSubscription\","
+              + "\"query\":\"subscription{\\ncommentAdded(repoFullName:\\\"repo\\\"){\\n__typename\\nid\\ncontent\\n}\\n}\","
+              + "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
       );
     } else {
       assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage.toJsonString()).isEqualTo(
-          "" +
-              "{\"id\":\"" + subscriptionId.toString() + "\"," +
-              "\"type\":\"start\"," +
-              "\"payload\":{" +
-              "\"variables\":{}," +
-              "\"operationName\":\"SomeSubscription\"," +
-              "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
+          ""
+              + "{\"id\":\"" + subscriptionId.toString() + "\","
+              + "\"type\":\"start\","
+              + "\"payload\":{"
+              + "\"variables\":{},"
+              + "\"operationName\":\"SomeSubscription\","
+              + "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"MockSubscription\"}}}}"
       );
     }
   }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -55,15 +55,16 @@ public class WebSocketSubscriptionTransportMessageTest {
                 .build()
         )
     );
-    assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo("{\"type\":\"connection_init\",\"payload\":{\"param1\":true,\"param2\":\"value\"}}");
+    assertThat(webSocketFactory.webSocket.lastSentMessage)
+        .isEqualTo("{\"type\":\"connection_init\",\"payload\":{\"param1\":true,\"param2\":\"value\"}}");
   }
 
   @Test public void startSubscriptionAutoPersistSubscriptionDisabled() {
     subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter<?>>emptyMap()), false, false));
 
-    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
-        "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\"}}";
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{},"
+        + "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\"}}";
 
     assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
   }
@@ -72,19 +73,19 @@ public class WebSocketSubscriptionTransportMessageTest {
     subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter<?>>emptyMap()), true, true));
 
-    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
-        "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\"," +
-        "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{},"
+        + "\"operationName\":\"SomeSubscription\",\"query\":\"subscription{commentAdded{id  name}\","
+        + "\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
 
     assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
   }
 
-    @Test public void startSubscriptionAutoPersistSubscriptionEnabledSendDocumentDisabled() {
+  @Test public void startSubscriptionAutoPersistSubscriptionEnabledSendDocumentDisabled() {
     subscriptionTransport.send(new OperationClientMessage.Start("subscriptionId", new MockSubscription(),
         new ScalarTypeAdapters(Collections.<ScalarType, CustomTypeAdapter<?>>emptyMap()), true, false));
 
-    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{}," +
-        "\"operationName\":\"SomeSubscription\",\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
+    String expected = "{\"id\":\"subscriptionId\",\"type\":\"start\",\"payload\":{\"variables\":{},"
+        + "\"operationName\":\"SomeSubscription\",\"extensions\":{\"persistedQuery\":{\"version\":1,\"sha256Hash\":\"someId\"}}}}";
 
     assertThat(webSocketFactory.webSocket.lastSentMessage).isEqualTo(expected);
   }
@@ -106,26 +107,38 @@ public class WebSocketSubscriptionTransportMessageTest {
 
   @SuppressWarnings("unchecked")
   @Test public void data() {
-    webSocketFactory.webSocket.listener.onMessage(webSocketFactory.webSocket, "{\"type\":\"data\",\"id\":\"subscriptionId\",\"payload\":{\"data\":{\"commentAdded\":{\"__typename\":\"Comment\",\"id\":10,\"content\":\"test10\"}}}}");
+    webSocketFactory.webSocket.listener.onMessage(
+        webSocketFactory.webSocket,
+        "{\"type\":\"data\",\"id\":\"subscriptionId\",\"payload\":{\"data\":{\"commentAdded\":"
+            + "{\"__typename\":\"Comment\",\"id\":10,\"content\":\"test10\"}}}}");
     assertThat(transportCallback.lastMessage).isInstanceOf(OperationServerMessage.Data.class);
     assertThat(((OperationServerMessage.Data) transportCallback.lastMessage).id).isEqualTo("subscriptionId");
-    assertThat((Map<String, Object>) ((Map<String, Object>) ((OperationServerMessage.Data) transportCallback.lastMessage).payload.get("data")).get("commentAdded"))
-        .containsExactlyEntriesIn(new UnmodifiableMapBuilder<String, Object>()
+    assertThat((Map<String, Object>)
+        ((Map<String, Object>) ((OperationServerMessage.Data) transportCallback.lastMessage).payload.get("data")).get("commentAdded")
+    ).containsExactlyEntriesIn(
+        new UnmodifiableMapBuilder<String, Object>()
             .put("__typename", "Comment")
             .put("id", BigDecimal.valueOf(10))
             .put("content", "test10")
             .build()
-        );
+    );
   }
 
   @Test public void connectionError() {
-    webSocketFactory.webSocket.listener.onMessage(webSocketFactory.webSocket, "{\"type\":\"connection_error\",\"payload\":{\"message\":\"Connection Error\"}}");
+    webSocketFactory.webSocket.listener.onMessage(
+        webSocketFactory.webSocket,
+        "{\"type\":\"connection_error\",\"payload\":{\"message\":\"Connection Error\"}}"
+    );
     assertThat(transportCallback.lastMessage).isInstanceOf(OperationServerMessage.ConnectionError.class);
-    assertThat(((OperationServerMessage.ConnectionError) transportCallback.lastMessage).payload).containsExactly("message", "Connection Error");
+    assertThat(((OperationServerMessage.ConnectionError) transportCallback.lastMessage).payload)
+        .containsExactly("message", "Connection Error");
   }
 
   @Test public void error() {
-    webSocketFactory.webSocket.listener.onMessage(webSocketFactory.webSocket, "{\"type\":\"error\", \"id\":\"subscriptionId\", \"payload\":{\"message\":\"Error\"}}");
+    webSocketFactory.webSocket.listener.onMessage(
+        webSocketFactory.webSocket,
+        "{\"type\":\"error\", \"id\":\"subscriptionId\", \"payload\":{\"message\":\"Error\"}}"
+    );
     assertThat(transportCallback.lastMessage).isInstanceOf(OperationServerMessage.Error.class);
     assertThat(((OperationServerMessage.Error) transportCallback.lastMessage).id).isEqualTo("subscriptionId");
     assertThat(((OperationServerMessage.Error) transportCallback.lastMessage).payload).containsExactly("message", "Error");


### PR DESCRIPTION
- Fixes https://github.com/apollographql/apollo-android/issues/2280 by preventing the response from being cached with errors are present in the response
- Added unit tests for prevention of caching response behavior
- Updated files so that ./gradlew check passes lint checks