### PR TITLE
make master 2.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=2.1.0-SNAPSHOT
+VERSION_NAME=2.0.4-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=2.0.3-SNAPSHOT
+VERSION_NAME=2.1.0-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=2.0.4-SNAPSHOT
+VERSION_NAME=2.1.0-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ def versions = [
     minAndroidPlugin      : '3.4.2',
     androidPlugin         : '3.6.2',
     androidxSqlite        : '2.1.0',
-    apollo                : '2.0.3-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
+    apollo                : '2.1.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',
     compiletesting        : '0.15',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ def versions = [
     minAndroidPlugin      : '3.4.2',
     androidPlugin         : '3.6.2',
     androidxSqlite        : '2.1.0',
-    apollo                : '2.1.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
+    apollo                : '2.0.4-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',
     compiletesting        : '0.15',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ def versions = [
     minAndroidPlugin      : '3.4.2',
     androidPlugin         : '3.6.2',
     androidxSqlite        : '2.1.0',
-    apollo                : '2.0.4-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
+    apollo                : '2.1.0-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',
     compiletesting        : '0.15',


### PR DESCRIPTION
master actually contains new features in new features in `apollo-runtime-kotlin` so we could do a `2.1.0` but these features are really early and not really ready for prime time so I think 2.0.4 makes more sense.

**Edit**: it will be a 2.1.0 in the end

2.1.0 will have: 
* okhttp 3.12
* performance improvements
* multiplatform `apollo-normalized-cache-sqlite`
* sealedClassesForEnumsMatching
* enforced same version for all modules, including rootProject