### PR TITLE
create the directory for the user if needed

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -82,7 +82,10 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
       throw Exception("cannot get schema: ${response.code}:\n${response.body?.string()}")
     }
 
-    project.projectDir.child(schemaFilePath.get()).writeText(response.body!!.string())
+    val jsonFile = project.projectDir.child(schemaFilePath.get())
+
+    jsonFile.parentFile.mkdirs()
+    jsonFile.writeText(response.body!!.string())
   }
 
   companion object {


### PR DESCRIPTION
When calling `./gradlew downloadApolloSchema`, create the intermediate directories if needed