### PR TITLE
Build pushes only to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
With every pull request we are building both the branch and the PR. Building the branches is just redundant.

This PR changes so that they run only on `master` branch