### PR TITLE
[Plugin] simplify the downloadApolloSchema task

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultIntrospection.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultIntrospection.kt
@@ -11,6 +11,7 @@ import javax.inject.Inject
 abstract class DefaultIntrospection @Inject constructor(val objects: ObjectFactory): Introspection {
   abstract override val endpointUrl: Property<String>
 
+  @Deprecated("add query parameters to endpointUrl instead")
   abstract override val queryParameters: MapProperty<String, String>
 
   abstract override val headers: MapProperty<String, String>

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
@@ -1,0 +1,149 @@
+package com.apollographql.apollo.gradle.internal
+
+import com.squareup.moshi.JsonWriter
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.buffer
+import okio.sink
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object SchemaDownloader {
+  fun download(
+      endpoint: String,
+      schema: File,
+      headers: Map<String, String>,
+      readTimeoutSeconds: Long,
+      connectTimeoutSeconds: Long
+  ) {
+    val byteArrayOutputStream = ByteArrayOutputStream()
+    JsonWriter.of(byteArrayOutputStream.sink().buffer())
+        .apply {
+          beginObject()
+          name("query")
+          value(introspectionQuery)
+          endObject()
+          flush()
+        }
+
+    val body = byteArrayOutputStream.toByteArray().toRequestBody("application/json".toMediaTypeOrNull())
+    val request = Request.Builder()
+        .post(body)
+        .apply {
+          headers.entries.forEach {
+            addHeader(it.key, it.value)
+          }
+        }
+        .url(endpoint)
+        .build()
+
+    val response = OkHttpClient.Builder()
+        .connectTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
+        .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
+        .build()
+        .newCall(request).execute()
+
+    if (!response.isSuccessful) {
+      throw Exception("cannot get schema: ${response.code}:\n${response.body?.string()}")
+    }
+
+    schema.parentFile?.mkdirs()
+    schema.writeText(response.body!!.string())
+  }
+
+  val introspectionQuery = """
+    query IntrospectionQuery {
+      __schema {
+        queryType { name }
+        mutationType { name }
+        subscriptionType { name }
+        types {
+          ...FullType
+        }
+        directives {
+          name
+          description
+          locations
+          args {
+            ...InputValue
+          }
+        }
+      }
+    }
+
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      fields(includeDeprecated: true) {
+        name
+        description
+        args {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields {
+        ...InputValue
+      }
+      interfaces {
+        ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
+    }
+
+    fragment InputValue on __InputValue {
+      name
+      description
+      type { ...TypeRef }
+      defaultValue
+    }
+
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }""".trimIndent()
+}


### PR DESCRIPTION
Looking at the documentation, I found this Gradle [@Option annotation](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/options/Option.html) that allows to pass task inputs directly from the commandline. That will simplify downloading the schema:

**before:**

```
./gradlew downloadApolloSchema -Pcom.apollographql.apollo.endpoint="https://..." -Pcom.apollographql.apollo.schema="src/main/graphql/..."
```

**after:**

```
./gradlew downloadApolloSchema --endpoint="https://..." --schema="src/main/graphql/..."
```