### PR TITLE
[Docs] move the README.md to Kotlin and other fixes

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -9,11 +9,10 @@ If you instead have a usage question kindly ask on Stackoverflow.com using the t
 Project Setup
 -------------
 
-This project is being developed using IntelliJ IDEA or Android Studio. With [introduction of Kotlin Multiplatform](https://github.com/apollographql/apollo-android/blob/master/apollo-api/build.gradle.kts#L10-L21),
-build may require installation of xcodebuild tools and Xcode 11.
+This project is being developed using IntelliJ IDEA or Android Studio. To build multiplatform projets, you will need a MacOS, and the Xcode developer tools.
  
-It is recommended to import/open `composite` instead of root folder since that includes `apollo-integration` tests
-and all sample projects under `samples` folder by using Gradle Composite builds.
+It is recommended to import/open `composite` instead of the root folder since the [composite build](https://docs.gradle.org/current/userguide/composite_builds.html) also includes `apollo-integration` tests
+and all sample projects under `samples` folder.
 
 DOs and DON'Ts
 --------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![CI](https://github.com/apollographql/apollo-android/workflows/CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/apollographql/apollo-android.svg)](https://github.com/apollographql/apollo-android/releases/latest)
 
-Apollo-Android is a GraphQL compliant client that generates Java and Kotlin models from standard GraphQL queries. These models give you a typesafe API to work with GraphQL servers.  Apollo will help you keep your GraphQL query statements together, organized, and easy to access. Change a query and recompile your project - Apollo code gen will rebuild your data model.  Code generation also allows Apollo to read and unmarshal responses from the network without the need of any reflection.
+Apollo-Android is a GraphQL client that generates Java and Kotlin models from GraphQL queries. These models give you a typesafe API to work with GraphQL servers.  Apollo will help you keep your GraphQL query statements together, organized, and easy to access. Change a query and recompile your project - Apollo code gen will rebuild your data model.  Code generation also allows Apollo to read and unmarshal responses from the network without the need of any reflection.
 
 Apollo-Android is designed primarily with Android in mind but you can use it in any Java/Kotlin app. The android-only parts are in `apollo-android-support` and are only needed to use SQLite as a cache or the android main thread for callbacks.
 
@@ -25,122 +25,95 @@ Apollo-android features:
 
 The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
 
-To use this plugin, add the dependency to your project's root build.gradle file:
+In your app Gradle file, apply the `com.apollographql.apollo` plugin and add the Apollo dependencies:
 
 ```groovy
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath("com.apollographql.apollo:apollo-gradle-plugin:x.y.z")
-  }
+// app/build.gradle or app/build.gradle.kts
+plugins {
+  id("com.apollographql.apollo").version("x.y.z")
 }
-```
-
-Then add the dependencies to your app's build.gradle and apply file and apply the `com.apollographql.apollo` plugin:
-
-```groovy
-apply plugin: 'com.apollographql.apollo'
 
 repositories {
-    jcenter()
+  jcenter()
 }
 
 dependencies {
   implementation("com.apollographql.apollo:apollo-runtime:x.y.z")
   
-  // If not already on your classpath, you might need the jetbrains annotations
-  compileOnly("org.jetbrains:annotations:13.0")
-  testCompileOnly("org.jetbrains:annotations:13.0")
+  // optional: if you want to use the normalized cache
+  implementation("com.apollographql.apollo:apollo-normalized-cache-sqlite:x.y.z")
+  // optional: for coroutines support
+  implementation("com.apollographql.apollo:apollo-coroutines-support:x.y.z")
+  // optional: for RxJava3 support  
+  implementation("com.apollographql.apollo:apollo-rx3-support:x.y.z")
 }
+```
+
+## Downloading a schema.json file
+
+Apollo-Android requires an introspection schema. You can get a schema.json file by running an introspection query on your endpoint. The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help with this. You can download a schema by specifying your endpoint and the location where you want the schema to be downloaded:
+
+```bash
+./gradlew downloadApolloSchema --endpoint=https://your.graphql.endpoint --schema=app/src/main/graphql/com/example/schema.json
+```
+
+If your endpoint requires authentication, you can pass custom HTTP headers:
+
+```
+./gradlew downloadApolloSchema --endpoint="https://your.graphql.endpoint" --schema="app/src/main/graphql/com/example" --header="Authorization: Bearer $TOKEN"
 ```
 
 ## Generating models from your queries
 
 1) Create a directory for your GraphQL files like you would do for Java/Kotlin: `src/main/graphql/com/example/`. Apollo-Android will generate models in the `com.apollographql.apollo.sample` package.
 2) Add your `schema.json` to the directory at `src/main/graphql/com/example/schema.json`. If you don't have a `schema.json` file yet, read the section about [downloading a schema file](#downloading-a-schemajson-file). 
-3) Put your GraphQL queries in a `.graphql` files. For an example: `src/main/graphql/com/example/feed.graphql`: 
+3) Put your GraphQL queries in a `.graphql` files. For an example: `src/main/graphql/com/example/LaunchDetails.graphql`: 
 
-```
-query FeedQuery($type: FeedType!, $limit: Int!) {
-  feed(type: $type, limit: $limit) {
-    comments {
-      ...FeedCommentFragment
-    }
-    repository {
-      ...RepositoryFragment
-    }
-    postedBy {
-      login
+```graphql
+query LaunchDetails($id:ID!) {
+  launch(id: $id) {
+    id
+    site
+    mission {
+      name
+      missionPatch(size:LARGE)
     }
   }
-}
-
-fragment RepositoryFragment on Repository {
-  name
-  full_name
-  owner {
-    login
-  }
-}
-
-fragment FeedCommentFragment on Comment {
-  id
-  postedBy {
-    login
-  }
-  content
 }
 ```
 
 4) Decide if you want to generate Kotlin or Java models:
 
 ```groovy
-// build.gradle or build.gradle.kts
+// app/build.gradle or app/build.gradle.kts
 apollo {
   generateKotlinModels.set(true) // or false for Java models
 }
 ```
 
-5) Execute `./gradlew generateApolloSources` to generate the models from your queries. This will create a generated `FeedQuery` Java or Kotlin source file for your query.
+5) Execute `./gradlew generateApolloSources` to generate the models from your queries. This will create a generated `LaunchDetailsQuery` Java or Kotlin source file for your query.
 
-## Consuming Code
+## Executing queries
 
 Apollo includes an `ApolloClient` to interact with your server and cache.
 
 To make a query using the generated models:
-```java
-apolloClient.query(
-  FeedQuery.builder()
-    .limit(10)
-    .type(FeedType.HOT)
-    .build()
-).enqueue(new ApolloCall.Callback<FeedQuery.Data>() {
 
-  @Override public void onResponse(@NotNull Response<FeedQuery.Data> dataResponse) {
+```kotlin
+val apolloClient = ApolloClient.builder()
+                .serverUrl("https://")
+                .build()
 
-    final StringBuffer buffer = new StringBuffer();
-    for (FeedQuery.Data.Feed feed : dataResponse.data().feed()) {
-      buffer.append("name:" + feed.repository().fragments().repositoryFragment().name());
-().login());
-      buffer.append(" postedBy: " + feed.postedBy().login());
-    }
+            apolloClient.query(LaunchDetailsQuery(id = "83"))
+                .enqueue(object : ApolloCall.Callback<LaunchDetailsQuery.Data>() {
+                    override fun onFailure(e: ApolloException) {
+                        Log.e("Apollo", "Error", e)
+                    }
 
-    // onResponse returns on a background thread. If you want to make UI updates make sure they are done on the Main Thread.
-    MainActivity.this.runOnUiThread(new Runnable() {
-      @Override public void run() {
-        TextView txtResponse = (TextView) findViewById(R.id.txtResponse);
-        txtResponse.setText(buffer.toString());
-      }
-    });
-      
-  }
-
-  @Override public void onFailure(@NotNull Throwable t) {
-    Log.e(TAG, t.getMessage(), t);
-  }
-});       
+                    override fun onResponse(response: Response<LaunchDetailsQuery.Data>) {
+                        Log.e("Apollo", "Launch site: ${response.data?.launch?.site}")
+                    }
+                })
 ```
 
 ## Custom Scalar Types
@@ -149,71 +122,42 @@ Apollo supports Custom Scalar Types like `Date`.
 
 You first need to define the mapping in your build.gradle file. This maps from the GraphQL type to the Java/Kotlin class to use in code.
 
-```groovy
+```
 apollo {
   customTypeMapping = [
     "Date" : "java.util.Date"
   ]
 }
+
+or in Kotlin:
+apollo {
+    customTypeMapping.set(mapOf(
+        "Date" to "java.util.Date"
+    ))
+}
 ```
 
 Next register your custom adapter & add it to your Apollo Client Builder:
 
-```java
- dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
-      @Override public Date decode(CustomTypeValue value) {
-        try {
-          return DATE_FORMAT.parse(value.value.toString());
-        } catch (ParseException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override public CustomTypeValue encode(Date value) {
-        return new CustomTypeValue.GraphQLString(DATE_FORMAT.format(value));
-      }
-    };
-
-ApolloClient.builder()
-  .serverUrl(serverUrl)
-  .okHttpClient(okHttpClient)
-  .addCustomTypeAdapter(CustomType.DATE, dateCustomTypeAdapter)
-  .build();
-```
-
-If you have compiler warnings as errors (`options.compilerArgs << "-Xlint" << "-Werror"`)
-turned on, your custom type will not compile. You can add a switch `suppressRawTypesWarning` to the
-apollo plugin configuration which will annotate your generated class with the proper suppression
-(`@SuppressWarnings("rawtypes")`:
-
-```groovy
-apollo {
-    customTypeMapping = [
-      "URL" : "java.lang.String"
-    ]
-    suppressRawTypesWarning = "true"
-}
-```
-
-## Downloading a schema.json file
-
-You can get a schema.json file by running an introspection query on your endpoint. The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help with this. You can download a schema by specifying your endpoint and the location where you want the schema to be downloaded:
-
-```
-./gradlew :module:downloadApolloSchema -Pcom.apollographql.apollo.endpoint=https://your.graphql.endpoint -Pcom.apollographql.apollo.schema=src/main/graphql/com/example/schema.json
-```
-
-If your endpoint requires authentication, you can pass query parameters and/or custom HTTP headers:
-
-```
-./gradlew :module:downloadApolloSchema -Pcom.apollographql.apollo.endpoint=https://your.graphql.endpoint -Pcom.apollographql.apollo.schema=src/main/graphql/com/example/schema.json  "-Pcom.apollographql.apollo.headers=Authorization=Bearer YOUR_TOKEN" "-Pcom.apollographql.apollo.query_params=key1=value1&key2=value2"
-```
-
-The `com.apollographql.apollo.headers` and `com.apollographql.apollo.query_params` properties both take a query string where key and values should be URL encoded.
-
-The default timeout for download operation is 1 minute. If you have a large `schema.json`, you may want to increase the timeout. Do that by adding the following into `gradle.properties`:
-```
-org.gradle.jvmargs=-DokHttp.connectTimeout=60 -DokHttp.readTimeout=60
+```kotlin
+    val dateCustomTypeAdapter = object : CustomTypeAdapter<Date> {
+         override fun decode(value: CustomTypeValue<*>): Date {
+             return try {
+                 DATE_FORMAT.parse(value.value.toString())
+             } catch (e: ParseException) {
+                 throw RuntimeException(e)
+             }
+         }
+    
+         override fun encode(value: Date): CustomTypeValue<*> {
+             return GraphQLString(DATE_FORMAT.format(value))
+         }
+     }
+    
+     ApolloClient.builder()
+         .serverUrl(serverUrl)
+         .addCustomTypeAdapter(CustomType.DATE, dateCustomTypeAdapter)
+         .build()
 ```
 
 ## Intellij Plugin
@@ -250,20 +194,14 @@ Advanced topics are available in [the official docs](https://www.apollographql.c
 * [subscriptions.md](https://www.apollographql.com/docs/android/advanced/subscriptions/)
 * [migrations.md](https://www.apollographql.com/docs/android/essentials/migration/)
 
-
-## Changelog
-[Read about the latest changes to the library](https://github.com/apollographql/apollo-android/releases)
-
 ## Contributing
 
-If you'd like to contribute, please refer to the [Apollo Contributor Guide](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
-
-*Note:* Running samples require importing `composite` folder instead of root.
+If you'd like to contribute, please refer to the [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
 
 ## License
 
 ```
 The MIT License (MIT)
 
-Copyright (c) 2019 Meteor Development Group, Inc.
+Copyright (c) 2020 Meteor Development Group, Inc.
 ```

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -3,23 +3,21 @@ title: Introduction
 description: Add GraphQL to your Android apps
 ---
 
-Apollo Client for Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin. [Get started with it here!](./essentials/get-started/)
+Apollo Client for Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin.
 
-Apollo Android has a Gradle Plugin to integrate into projects easily. Use Gradle docs for more details on the plugin APIs:
-- [Gradle Plugin](https://www.apollographql.com/docs/android/essentials/plugin-configuration/)
-- [Deprecated Gradle Plugin](https://github.com/apollographql/apollo-android/blob/v1.2.3/doc/plugin-configuration.md)
+## Getting started
+
+- [Get started here!](./essentials/get-started/)
 
 Once you started, you can dive into advanced topics by going into Advanced section from the left pane.
 
 ## Getting involved
 
-Apollo Android is a community-driven project with contributors from many companies. Check out the [blog post introducing the first public release of the project](https://blog.apollographql.com/launching-apollo-graphql-on-android-40ee0b5789bd) and the [project's README](https://github.com/apollographql/apollo-android) to learn about the current progress.
+Apollo Android is a community-driven project with contributors from many companies. Please read [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md) for more details.
 
-We're excited about the idea of further [unifying the clients for JavaScript, iOS and Android](https://blog.apollographql.com/one-graphql-client-for-javascript-ios-and-android-64993c1b7991), including sharing a cache between native and React Native.
+If you have questions or would like to contribute, please [open an issue on our GitHub repo](https://github.com/apollographql/apollo-android/issues) or [join the Spectrum Chat](https://spectrum.chat/apollo/apollo-android).
 
-If you have questions or would like to contribute, please join the [Apollo Android Community on Spectrum](https://spectrum.chat/apollo/apollo-android).
-
-## Other platforms
+## Related platforms
 
 - [Apollo iOS](https://github.com/apollographql/apollo-ios) is a GraphQL client for native iOS apps, written in Swift.
 - [Apollo Client for JS](http://dev.apollodata.com/react/) is a great option for your web or React Native apps.
@@ -27,6 +25,7 @@ If you have questions or would like to contribute, please join the [Apollo Andro
 ## Other resources
 
 - [GraphQL.org](http://graphql.org) for an introduction and reference to the GraphQL itself, partially written and maintained by the Apollo team.
-- [Our website](http://www.apollodata.com/) to learn about Apollo open source and commercial tools.
-- [Our blog](https://dev-blog.apollodata.com) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
+- [Our website](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
+- [Our blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
 - [Our Twitter](https://twitter.com/apollographql) for in-the-moment news.
+


### PR DESCRIPTION
Simplify README.md:

* sample code is now Kotlin
* simplify the schema download doc (see #2321)
* use the `plugins {}` block now that the plugin has a plugin Marker and is available from the gradle portal
* update index.mdx, which was pretty obsolete
* other small fixes
