### PR TITLE
[Doc] use Kotlin in README.md and other updates

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,33 +1,35 @@
 Contributing to Apollo Android GraphQL 
 ======================================
 
-The Apollo team welcomes contributions of all kinds, from simple bug reports through documentation, test cases,
-bugfixes, and features.
+The Apollo team welcomes contributions of all kinds, including bug reports, documentation, test cases, bug fixes, and features.
 
-If you instead have a usage question kindly ask on Stackoverflow.com using the tag [apollo-android]
+If you have a usage question, please ask on [Stack Overflow](https://stackoverflow.com/) using the tag `apollo-android`.
 
 Project Setup
 -------------
 
-This project is being developed using IntelliJ IDEA or Android Studio. To build multiplatform projets, you will need a MacOS, and the Xcode developer tools.
+This project is developed using either IntelliJ IDEA or Android Studio. To build multiplatform projects, you need MacOS and the Xcode developer tools.
  
-It is recommended to import/open `composite` instead of the root folder since the [composite build](https://docs.gradle.org/current/userguide/composite_builds.html) also includes `apollo-integration` tests
-and all sample projects under `samples` folder.
+It is recommended to import/open `composite` instead of the root directory, because the [composite build](https://docs.gradle.org/current/userguide/composite_builds.html) also includes `apollo-integration` tests and all sample projects in the `samples` directory.
 
 DOs and DON'Ts
 --------------
 
-* DO follow our coding style (as described below)
-* Do add labels to your issues and pull requests:  At least 1 for each Status/Type/Priority
-* DO give priority to the current style of the project or file you're changing even if it diverges from the general guidelines.
-* DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
-* DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
-* DO run all Gradle verification tasks (`./gradlew check`) before submitting a pull request
+### DO:
 
-* DO NOT send PRs for style changes.
-* DON'T surprise us with big pull requests. Instead, file an issue and start a discussion so we can agree on a direction before you invest a large amount of time.
-* DON'T commit code that you didn't write. If you find code that you think is a good fit, file an issue and start a discussion before proceeding.
-* DON'T submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
+* Follow our [coding style](#coding-style)
+* Add labels to your issues and pull requests (at least one label for each of Status/Type/Priority).
+* Give priority to the current style of the project or file you're changing, even if it diverges from the general guidelines.
+* Include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
+* Keep the discussions focused. When a new or related topic comes up, it's often better to create a new issue than to side track the discussion.
+* Run all Gradle verification tasks (`./gradlew check`) before submitting a pull request.
+
+### DON'T:
+
+* Send PRs for style changes.
+* Surprise us with big pull requests. Instead, file an issue and start a discussion so we can agree on a direction before you invest a large amount of time.
+* Commit code that you didn't write. If you find code that you think is a good fit, file an issue and start a discussion before proceeding.
+* Submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
 
 
 Coding Style

--- a/Contributing.md
+++ b/Contributing.md
@@ -9,11 +9,10 @@ If you instead have a usage question kindly ask on Stackoverflow.com using the t
 Project Setup
 -------------
 
-This project is being developed using IntelliJ IDEA or Android Studio. With [introduction of Kotlin Multiplatform](https://github.com/apollographql/apollo-android/blob/master/apollo-api/build.gradle.kts#L10-L21),
-build may require installation of xcodebuild tools and Xcode 11.
+This project is being developed using IntelliJ IDEA or Android Studio. To build multiplatform projets, you will need a MacOS, and the Xcode developer tools.
  
-It is recommended to import/open `composite` instead of root folder since that includes `apollo-integration` tests
-and all sample projects under `samples` folder by using Gradle Composite builds.
+It is recommended to import/open `composite` instead of the root folder since the [composite build](https://docs.gradle.org/current/userguide/composite_builds.html) also includes `apollo-integration` tests
+and all sample projects under `samples` folder.
 
 DOs and DON'Ts
 --------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![CI](https://github.com/apollographql/apollo-android/workflows/CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/apollographql/apollo-android.svg)](https://github.com/apollographql/apollo-android/releases/latest)
 
-Apollo-Android is a GraphQL compliant client that generates Java and Kotlin models from standard GraphQL queries. These models give you a typesafe API to work with GraphQL servers.  Apollo will help you keep your GraphQL query statements together, organized, and easy to access. Change a query and recompile your project - Apollo code gen will rebuild your data model.  Code generation also allows Apollo to read and unmarshal responses from the network without the need of any reflection.
+Apollo-Android is a GraphQL client that generates Java and Kotlin models from GraphQL queries. These models give you a typesafe API to work with GraphQL servers.  Apollo will help you keep your GraphQL query statements together, organized, and easy to access. Change a query and recompile your project - Apollo code gen will rebuild your data model.  Code generation also allows Apollo to read and unmarshal responses from the network without the need of any reflection.
 
 Apollo-Android is designed primarily with Android in mind but you can use it in any Java/Kotlin app. The android-only parts are in `apollo-android-support` and are only needed to use SQLite as a cache or the android main thread for callbacks.
 
@@ -25,122 +25,95 @@ Apollo-android features:
 
 The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
 
-To use this plugin, add the dependency to your project's root build.gradle file:
+In your app Gradle file, apply the `com.apollographql.apollo` plugin and add the Apollo dependencies:
 
 ```groovy
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath("com.apollographql.apollo:apollo-gradle-plugin:x.y.z")
-  }
+// app/build.gradle or app/build.gradle.kts
+plugins {
+  id("com.apollographql.apollo").version("x.y.z")
 }
-```
-
-Then add the dependencies to your app's build.gradle and apply file and apply the `com.apollographql.apollo` plugin:
-
-```groovy
-apply plugin: 'com.apollographql.apollo'
 
 repositories {
-    jcenter()
+  jcenter()
 }
 
 dependencies {
   implementation("com.apollographql.apollo:apollo-runtime:x.y.z")
   
-  // If not already on your classpath, you might need the jetbrains annotations
-  compileOnly("org.jetbrains:annotations:13.0")
-  testCompileOnly("org.jetbrains:annotations:13.0")
+  // optional: if you want to use the normalized cache
+  implementation("com.apollographql.apollo:apollo-normalized-cache-sqlite:x.y.z")
+  // optional: for coroutines support
+  implementation("com.apollographql.apollo:apollo-coroutines-support:x.y.z")
+  // optional: for RxJava3 support  
+  implementation("com.apollographql.apollo:apollo-rx3-support:x.y.z")
 }
+```
+
+## Downloading a schema.json file
+
+Apollo-Android requires an introspection schema. You can get a schema.json file by running an introspection query on your endpoint. The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help with this. You can download a schema by specifying your endpoint and the location where you want the schema to be downloaded:
+
+```bash
+./gradlew downloadApolloSchema --endpoint=https://your.graphql.endpoint --schema=app/src/main/graphql/com/example/schema.json
+```
+
+If your endpoint requires authentication, you can pass custom HTTP headers:
+
+```
+./gradlew downloadApolloSchema --endpoint="https://your.graphql.endpoint" --schema="app/src/main/graphql/com/example" --header="Authorization: Bearer $TOKEN"
 ```
 
 ## Generating models from your queries
 
 1) Create a directory for your GraphQL files like you would do for Java/Kotlin: `src/main/graphql/com/example/`. Apollo-Android will generate models in the `com.apollographql.apollo.sample` package.
 2) Add your `schema.json` to the directory at `src/main/graphql/com/example/schema.json`. If you don't have a `schema.json` file yet, read the section about [downloading a schema file](#downloading-a-schemajson-file). 
-3) Put your GraphQL queries in a `.graphql` files. For an example: `src/main/graphql/com/example/feed.graphql`: 
+3) Put your GraphQL queries in a `.graphql` files. For an example: `src/main/graphql/com/example/LaunchDetails.graphql`: 
 
-```
-query FeedQuery($type: FeedType!, $limit: Int!) {
-  feed(type: $type, limit: $limit) {
-    comments {
-      ...FeedCommentFragment
-    }
-    repository {
-      ...RepositoryFragment
-    }
-    postedBy {
-      login
+```graphql
+query LaunchDetails($id:ID!) {
+  launch(id: $id) {
+    id
+    site
+    mission {
+      name
+      missionPatch(size:LARGE)
     }
   }
-}
-
-fragment RepositoryFragment on Repository {
-  name
-  full_name
-  owner {
-    login
-  }
-}
-
-fragment FeedCommentFragment on Comment {
-  id
-  postedBy {
-    login
-  }
-  content
 }
 ```
 
 4) Decide if you want to generate Kotlin or Java models:
 
 ```groovy
-// build.gradle or build.gradle.kts
+// app/build.gradle or app/build.gradle.kts
 apollo {
   generateKotlinModels.set(true) // or false for Java models
 }
 ```
 
-5) Execute `./gradlew generateApolloSources` to generate the models from your queries. This will create a generated `FeedQuery` Java or Kotlin source file for your query.
+5) Execute `./gradlew generateApolloSources` to generate the models from your queries. This will create a generated `LaunchDetailsQuery` Java or Kotlin source file for your query.
 
-## Consuming Code
+## Executing queries
 
 Apollo includes an `ApolloClient` to interact with your server and cache.
 
 To make a query using the generated models:
-```java
-apolloClient.query(
-  FeedQuery.builder()
-    .limit(10)
-    .type(FeedType.HOT)
-    .build()
-).enqueue(new ApolloCall.Callback<FeedQuery.Data>() {
 
-  @Override public void onResponse(@NotNull Response<FeedQuery.Data> dataResponse) {
+```kotlin
+val apolloClient = ApolloClient.builder()
+                .serverUrl("https://")
+                .build()
 
-    final StringBuffer buffer = new StringBuffer();
-    for (FeedQuery.Data.Feed feed : dataResponse.data().feed()) {
-      buffer.append("name:" + feed.repository().fragments().repositoryFragment().name());
-().login());
-      buffer.append(" postedBy: " + feed.postedBy().login());
-    }
+            apolloClient.query(LaunchDetailsQuery(id = "83"))
+                .enqueue(object : ApolloCall.Callback<LaunchDetailsQuery.Data>() {
+                    override fun onFailure(e: ApolloException) {
+                        Log.e("Apollo", "Error", e)
+                    }
 
-    // onResponse returns on a background thread. If you want to make UI updates make sure they are done on the Main Thread.
-    MainActivity.this.runOnUiThread(new Runnable() {
-      @Override public void run() {
-        TextView txtResponse = (TextView) findViewById(R.id.txtResponse);
-        txtResponse.setText(buffer.toString());
-      }
-    });
-      
-  }
-
-  @Override public void onFailure(@NotNull Throwable t) {
-    Log.e(TAG, t.getMessage(), t);
-  }
-});       
+                    override fun onResponse(response: Response<LaunchDetailsQuery.Data>) {
+                        Log.e("Apollo", "Launch site: ${response.data?.launch?.site}")
+                    }
+                })
 ```
 
 ## Custom Scalar Types
@@ -149,71 +122,42 @@ Apollo supports Custom Scalar Types like `Date`.
 
 You first need to define the mapping in your build.gradle file. This maps from the GraphQL type to the Java/Kotlin class to use in code.
 
-```groovy
+```
 apollo {
   customTypeMapping = [
     "Date" : "java.util.Date"
   ]
 }
+
+or in Kotlin:
+apollo {
+    customTypeMapping.set(mapOf(
+        "Date" to "java.util.Date"
+    ))
+}
 ```
 
 Next register your custom adapter & add it to your Apollo Client Builder:
 
-```java
- dateCustomTypeAdapter = new CustomTypeAdapter<Date>() {
-      @Override public Date decode(CustomTypeValue value) {
-        try {
-          return DATE_FORMAT.parse(value.value.toString());
-        } catch (ParseException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override public CustomTypeValue encode(Date value) {
-        return new CustomTypeValue.GraphQLString(DATE_FORMAT.format(value));
-      }
-    };
-
-ApolloClient.builder()
-  .serverUrl(serverUrl)
-  .okHttpClient(okHttpClient)
-  .addCustomTypeAdapter(CustomType.DATE, dateCustomTypeAdapter)
-  .build();
-```
-
-If you have compiler warnings as errors (`options.compilerArgs << "-Xlint" << "-Werror"`)
-turned on, your custom type will not compile. You can add a switch `suppressRawTypesWarning` to the
-apollo plugin configuration which will annotate your generated class with the proper suppression
-(`@SuppressWarnings("rawtypes")`:
-
-```groovy
-apollo {
-    customTypeMapping = [
-      "URL" : "java.lang.String"
-    ]
-    suppressRawTypesWarning = "true"
-}
-```
-
-## Downloading a schema.json file
-
-You can get a schema.json file by running an introspection query on your endpoint. The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help with this. You can download a schema by specifying your endpoint and the location where you want the schema to be downloaded:
-
-```
-./gradlew :module:downloadApolloSchema -Pcom.apollographql.apollo.endpoint=https://your.graphql.endpoint -Pcom.apollographql.apollo.schema=src/main/graphql/com/example/schema.json
-```
-
-If your endpoint requires authentication, you can pass query parameters and/or custom HTTP headers:
-
-```
-./gradlew :module:downloadApolloSchema -Pcom.apollographql.apollo.endpoint=https://your.graphql.endpoint -Pcom.apollographql.apollo.schema=src/main/graphql/com/example/schema.json  "-Pcom.apollographql.apollo.headers=Authorization=Bearer YOUR_TOKEN" "-Pcom.apollographql.apollo.query_params=key1=value1&key2=value2"
-```
-
-The `com.apollographql.apollo.headers` and `com.apollographql.apollo.query_params` properties both take a query string where key and values should be URL encoded.
-
-The default timeout for download operation is 1 minute. If you have a large `schema.json`, you may want to increase the timeout. Do that by adding the following into `gradle.properties`:
-```
-org.gradle.jvmargs=-DokHttp.connectTimeout=60 -DokHttp.readTimeout=60
+```kotlin
+    val dateCustomTypeAdapter = object : CustomTypeAdapter<Date> {
+         override fun decode(value: CustomTypeValue<*>): Date {
+             return try {
+                 DATE_FORMAT.parse(value.value.toString())
+             } catch (e: ParseException) {
+                 throw RuntimeException(e)
+             }
+         }
+    
+         override fun encode(value: Date): CustomTypeValue<*> {
+             return GraphQLString(DATE_FORMAT.format(value))
+         }
+     }
+    
+     ApolloClient.builder()
+         .serverUrl(serverUrl)
+         .addCustomTypeAdapter(CustomType.DATE, dateCustomTypeAdapter)
+         .build()
 ```
 
 ## Intellij Plugin
@@ -250,20 +194,14 @@ Advanced topics are available in [the official docs](https://www.apollographql.c
 * [subscriptions.md](https://www.apollographql.com/docs/android/advanced/subscriptions/)
 * [migrations.md](https://www.apollographql.com/docs/android/essentials/migration/)
 
-
-## Changelog
-[Read about the latest changes to the library](https://github.com/apollographql/apollo-android/releases)
-
 ## Contributing
 
-If you'd like to contribute, please refer to the [Apollo Contributor Guide](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
-
-*Note:* Running samples require importing `composite` folder instead of root.
+If you'd like to contribute, please refer to the [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
 
 ## License
 
 ```
 The MIT License (MIT)
 
-Copyright (c) 2019 Meteor Development Group, Inc.
+Copyright (c) 2020 Meteor Development Group, Inc.
 ```

--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@
 ![CI](https://github.com/apollographql/apollo-android/workflows/CI/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/apollographql/apollo-android.svg)](https://github.com/apollographql/apollo-android/releases/latest)
 
-Apollo-Android is a GraphQL client that generates Java and Kotlin models from GraphQL queries. These models give you a typesafe API to work with GraphQL servers.  Apollo will help you keep your GraphQL query statements together, organized, and easy to access. Change a query and recompile your project - Apollo code gen will rebuild your data model.  Code generation also allows Apollo to read and unmarshal responses from the network without the need of any reflection.
+Apollo Android is a GraphQL client that generates Java and Kotlin models from GraphQL queries. These models give you a type-safe API to work with GraphQL servers.  Apollo helps you keep your GraphQL query statements together, organized, and easy to access. When you change a query and recompile your project, Apollo codegen rebuilds your data model. Code generation also allows Apollo to read and unmarshal responses from the network without the need for any reflection.
 
-Apollo-Android is designed primarily with Android in mind but you can use it in any Java/Kotlin app. The android-only parts are in `apollo-android-support` and are only needed to use SQLite as a cache or the android main thread for callbacks.
+This library is designed primarily with Android in mind, but you can use it in any Java/Kotlin app. All Android-specific functionality (such as using SQLite as a cache or the Android main thread for callbacks) is in `apollo-android-support`.
 
-Apollo-android features:
+## Features
 
-* Automatic generation of typesafe models.
-* Support for Java and Kotlin code generation.
-* Queries, Mutations and Subscriptions.
-* Reflection-free parsing of responses.
-* HTTP cache.
-* Normalized cache.
-* File Upload.
-* Custom scalar types.
-* Support for RxJava2, RxJava3, and Coroutines.
+* Automatic generation of typesafe models
+* Support for Java and Kotlin code generation
+* Queries, Mutations and Subscriptions
+* Reflection-free parsing of responses
+* HTTP cache
+* Normalized cache
+* File uploads
+* Custom scalar types
+* Support for RxJava2, RxJava3, and Coroutines
 
-## Adding Apollo-Android to your Project
+## Adding Apollo to your Project
 
 The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
 
@@ -53,13 +53,15 @@ dependencies {
 
 ## Downloading a schema.json file
 
-Apollo-Android requires an introspection schema. You can get a schema.json file by running an introspection query on your endpoint. The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help with this. You can download a schema by specifying your endpoint and the location where you want the schema to be downloaded:
+Apollo Android requires your GraphQL server's schema as a `schema.json` file. You can obtain the contents of this file by running an introspection query on your server.
+
+The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help you obtain your schema. Provide this task your server's GraphQL endpoint and the output location for the `schema.json` file:
 
 ```bash
 ./gradlew downloadApolloSchema --endpoint=https://your.graphql.endpoint --schema=app/src/main/graphql/com/example/schema.json
 ```
 
-If your endpoint requires authentication, you can pass custom HTTP headers:
+If your GraphQL endpoint requires authentication, you can pass custom HTTP headers:
 
 ```
 ./gradlew downloadApolloSchema --endpoint="https://your.graphql.endpoint" --schema="app/src/main/graphql/com/example" --header="Authorization: Bearer $TOKEN"
@@ -67,9 +69,9 @@ If your endpoint requires authentication, you can pass custom HTTP headers:
 
 ## Generating models from your queries
 
-1) Create a directory for your GraphQL files like you would do for Java/Kotlin: `src/main/graphql/com/example/`. Apollo-Android will generate models in the `com.apollographql.apollo.sample` package.
-2) Add your `schema.json` to the directory at `src/main/graphql/com/example/schema.json`. If you don't have a `schema.json` file yet, read the section about [downloading a schema file](#downloading-a-schemajson-file). 
-3) Put your GraphQL queries in a `.graphql` files. For an example: `src/main/graphql/com/example/LaunchDetails.graphql`: 
+1. Create a directory for your GraphQL files like you would do for Java/Kotlin: `src/main/graphql/com/example/`. Apollo Android will generate models in the `com.apollographql.apollo.sample` package.
+2. Add your `schema.json` to the directory at `src/main/graphql/com/example/schema.json`. If you don't have a `schema.json` file yet, see [Downloading a schema.json file](#downloading-a-schemajson-file). 
+3. Put each of your client's GraphQL queries in its own `.graphql` file, such as `src/main/graphql/com/example/LaunchDetails.graphql` for the following query: 
 
 ```graphql
 query LaunchDetails($id:ID!) {
@@ -84,7 +86,7 @@ query LaunchDetails($id:ID!) {
 }
 ```
 
-4) Decide if you want to generate Kotlin or Java models:
+4. Specify whether you want to generate Kotlin or Java models:
 
 ```groovy
 apollo {
@@ -92,13 +94,13 @@ apollo {
 }
 ```
 
-5) Build your project to generate the models from your queries. This will create a generated `LaunchDetailsQuery` Java or Kotlin source file for your query.
+5. Build your project to generate models from your queries. In the case of the example query above, this generates a `LaunchDetailsQuery` Java or Kotlin source file.
 
 ## Executing queries
 
-Apollo includes an `ApolloClient` to interact with your server and cache.
+You use an instance of the `ApolloClient` class to interact with your server and cache.
 
-To make a query using the generated models:
+To make a query using your generated models:
 
 ```kotlin
 val apolloClient = ApolloClient.builder()
@@ -117,20 +119,21 @@ val apolloClient = ApolloClient.builder()
                 })
 ```
 
-## Custom Scalar Types
+## Custom scalar types
 
-Apollo supports Custom Scalar Types like `Date`.
+Apollo supports [custom scalar types](https://www.apollographql.com/docs/apollo-server/schema/scalars-enums/), such as `Date`.
 
-You first need to define the mapping in your build.gradle file. This maps from the GraphQL type to the Java/Kotlin class to use in code.
+You first need to define the mapping in your `build.gradle` file. This maps from the GraphQL type to the Java/Kotlin class to use in code.
 
 ```
+// Java
 apollo {
   customTypeMapping = [
     "Date" : "java.util.Date"
   ]
 }
 
-or in Kotlin:
+// Kotlin
 apollo {
     customTypeMapping.set(mapOf(
         "Date" to "java.util.Date"
@@ -138,7 +141,7 @@ apollo {
 }
 ```
 
-Next register your custom adapter & add it to your Apollo Client Builder:
+Next, register your custom adapter and add it to your ApolloClient builder:
 
 ```kotlin
     val dateCustomTypeAdapter = object : CustomTypeAdapter<Date> {
@@ -161,9 +164,9 @@ Next register your custom adapter & add it to your Apollo Client Builder:
          .build()
 ```
 
-## Intellij Plugin
+## IntelliJ Plugin
 
-The [JS Graphql Intellij Plugin](https://jimkyndemeyer.github.io/js-graphql-intellij-plugin/) provides auto-completion, error highlighting, and go-to-definition functionality for your graphql files. You can create a [.graphqlconfig](https://jimkyndemeyer.github.io/js-graphql-intellij-plugin/docs/developer-guide#working-with-graphql-endpoints-and-scratch-files) file in order to use GraphQL scratch files to work with your schema outside product code, e.g. by writing temporary queries to test resolvers.
+The [JS Graphql IntelliJ Plugin](https://jimkyndemeyer.github.io/js-graphql-intellij-plugin/) provides auto-completion, error highlighting, and go-to-definition functionality for your `.graphql` files. You can create a [`.graphqlconfig`](https://jimkyndemeyer.github.io/js-graphql-intellij-plugin/docs/developer-guide#working-with-graphql-endpoints-and-scratch-files) file to use GraphQL scratch files to work with your schema outside product code (such as to write temporary queries to test resolvers).
 
 ## Releases
 
@@ -197,7 +200,7 @@ Advanced topics are available in [the official docs](https://www.apollographql.c
 
 ## Contributing
 
-If you'd like to contribute, please refer to the [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
+If you'd like to contribute, please see [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ apollo {
 }
 ```
 
-5) Execute `./gradlew generateApolloSources` to generate the models from your queries. This will create a generated `LaunchDetailsQuery` Java or Kotlin source file for your query.
+5) Build your project to generate the models from your queries. This will create a generated `LaunchDetailsQuery` Java or Kotlin source file for your query.
 
 ## Executing queries
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ repositories {
 
 dependencies {
   implementation("com.apollographql.apollo:apollo-runtime:x.y.z")
-  
+
   // optional: if you want to use the normalized cache
   implementation("com.apollographql.apollo:apollo-normalized-cache-sqlite:x.y.z")
   // optional: for coroutines support
   implementation("com.apollographql.apollo:apollo-coroutines-support:x.y.z")
   // optional: for RxJava3 support  
   implementation("com.apollographql.apollo:apollo-rx3-support:x.y.z")
+
+  // optional: if you just want the generated models and parser write your own HTTP code/cache code   
+  implementation("com.apollographql.apollo:apollo-api:x.y.z")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,9 @@ Apollo-android features:
 
 The latest Gradle plugin version is [ ![Download](https://api.bintray.com/packages/apollographql/android/apollo/images/download.svg) ](https://bintray.com/apollographql/android/apollo-gradle-plugin/_latestVersion)
 
-In your app Gradle file, apply the `com.apollographql.apollo` plugin and add the Apollo dependencies:
+In your module Gradle file, apply the `com.apollographql.apollo` plugin and add the Apollo dependencies:
 
 ```groovy
-// app/build.gradle or app/build.gradle.kts
 plugins {
   id("com.apollographql.apollo").version("x.y.z")
 }
@@ -85,7 +84,6 @@ query LaunchDetails($id:ID!) {
 4) Decide if you want to generate Kotlin or Java models:
 
 ```groovy
-// app/build.gradle or app/build.gradle.kts
 apollo {
   generateKotlinModels.set(true) // or false for Java models
 }
@@ -166,7 +164,7 @@ The [JS Graphql Intellij Plugin](https://jimkyndemeyer.github.io/js-graphql-inte
 
 ## Releases
 
-Our [release history](https://github.com/apollographql/apollo-android/releases) has the release history. 
+Our [changelog](https://github.com/apollographql/apollo-android/releases) has the release history. 
 
 Releases are hosted on [jcenter](https://jcenter.bintray.com/com/apollographql/apollo/).
 

--- a/docs/source/advanced/android.md
+++ b/docs/source/advanced/android.md
@@ -2,7 +2,7 @@
 title: Android support
 ---
 
-Apollo-Android has support artifacts to help with caching and testing.
+Apollo Android has support artifacts to help with caching and testing.
 
 ## SqlNormalizedCacheFactory
 

--- a/docs/source/advanced/persisted-queries.md
+++ b/docs/source/advanced/persisted-queries.md
@@ -29,7 +29,7 @@ ApolloClient.builder()
 
 ## OperationOutput.json
 
-If your backend uses custom persisted queries, Apollo-Android can generate an OperationOutput json from your .graphql queries. They will match what the client is sending exactly so you can persist them on your server.
+If your backend uses custom persisted queries, Apollo Android can generate an OperationOutput json from your .graphql queries. They will match what the client is sending exactly so you can persist them on your server.
 
 ```
 apollo {

--- a/docs/source/advanced/rxjava2.md
+++ b/docs/source/advanced/rxjava2.md
@@ -2,7 +2,7 @@
 title: RxJava
 ---
 
-Apollo Client for Android includes support for RxJava 2.x.
+Apollo Android includes support for RxJava 2.x.
 
 Apollo types can be converted to RxJava2 `Observable` *types* using wrapper functions `Rx2Apollo.from(...)` in Java or using extension functions in Kotlin.
 

--- a/docs/source/advanced/rxjava3.md
+++ b/docs/source/advanced/rxjava3.md
@@ -2,7 +2,7 @@
 title: RxJava
 ---
 
-Apollo Client for Android includes support for RxJava 3.x.
+Apollo Android includes support for RxJava 3.x.
 
 Apollo types can be converted to RxJava3 `Observable` *types* using wrapper functions `Rx3Apollo.from(...)` in Java or using extension functions in Kotlin.
 

--- a/docs/source/essentials/caching.md
+++ b/docs/source/essentials/caching.md
@@ -31,7 +31,7 @@ val size: Long = 1024 * 1024
 // Create the http response cache store
 val cacheStore = DiskLruHttpCacheStore(file, size)
 
-// Build the Apollo Client
+// Build the ApolloClient
 val apolloClient = ApolloClient.builder()
     .serverUrl("/")
     .httpCache(ApolloHttpCache(cacheStore))
@@ -55,7 +55,7 @@ long size = 1024*1024;
 //Create the http response cache store
 DiskLruHttpCacheStore cacheStore = new DiskLruHttpCacheStore(file, size); 
 
-//Build the Apollo Client
+//Build the ApolloClient
 ApolloClient apolloClient = ApolloClient.builder()
   .serverUrl("/")
   .httpCache(new ApolloHttpCache(cacheStore))
@@ -177,7 +177,7 @@ CacheKeyResolver resolver =  new CacheKeyResolver() {
    }
 };
 
-//Build the Apollo Client
+//Build the ApolloClient
 ApolloClient apolloClient = ApolloClient.builder()
   .serverUrl("/")
   .normalizedCache(cacheFactory, resolver)
@@ -202,7 +202,7 @@ dependencies {
 // Create NormalizedCacheFactory
 val cacheFactory = LruNormalizedCacheFactory(EvictionPolicy.builder().maxSizeBytes(10 * 1024).build())
 
-// Build the Apollo Client
+// Build the ApolloClient
 val apolloClient = ApolloClient.builder()
   .serverUrl("/")
   .normalizedCache(cacheFactory, resolver)
@@ -214,7 +214,7 @@ val apolloClient = ApolloClient.builder()
 // Create NormalizedCacheFactory
 NormalizedCacheFactory cacheFactory = new LruNormalizedCacheFactory(EvictionPolicy.builder().maxSizeBytes(10 * 1024).build());
 
-// Build the Apollo Client
+// Build the ApolloClient
 ApolloClient apolloClient = ApolloClient.builder()
   .serverUrl("/")
   .normalizedCache(cacheFactory, resolver)

--- a/docs/source/essentials/migration.md
+++ b/docs/source/essentials/migration.md
@@ -70,7 +70,7 @@ https://www.apollographql.com/docs/android/essentials/migration/#gradle-plugin-c
 
 ## Migrating to 1.3.x
 
-Apollo-Android version 1.3.0 introduces some fixes and improvements that are incompatible with 1.2.x. Updating should be transparent for
+Apollo Android version 1.3.0 introduces some fixes and improvements that are incompatible with 1.2.x. Updating should be transparent for
 simple use cases and your project should compile fine. If you're using more advanced features such as custom schema/graphql files location,
 Kotlin Gradle scripts and/or transformed queries, or if you encounter a build error after updating, read on for details about the changes.
 

--- a/docs/source/essentials/mutations.md
+++ b/docs/source/essentials/mutations.md
@@ -151,7 +151,7 @@ Call your mutation with mimetype and a valid `File`.
 
 ## Next steps
 
-Learning how to build `Mutation` components to update your data is an important part of developing applications with Apollo Client. Now that you're well-versed in updating data, why not try executing client-side mutations with `apollo-link-state`? Here are some resources we think will help you level up your skills:
+Learning how to build `Mutation` components to update your data is an important part of developing applications with Apollo Android. Now that you're well-versed in updating data, why not try executing client-side mutations with `apollo-link-state`? Here are some resources we think will help you level up your skills:
 
 - [#125, Fragmented Podcast](http://fragmentedpodcast.com/episodes/125/): Why's and How's about Apollo Android and the entire journey.
 - [Caching in Apollo](/essentials/caching/): Dive deep into the Apollo cache and how it's normalized in our advanced guide on caching. Understanding the cache is helpful when writing your mutation's `update` function!

--- a/docs/source/essentials/plugin-configuration.md
+++ b/docs/source/essentials/plugin-configuration.md
@@ -108,7 +108,7 @@ The up-to-date list of options can be found in [CompilerParams](https://github.c
   val suppressRawTypesWarning: Property<Boolean>
 
   /**
-   * When true, Apollo-Android will make sure all the generated classes end with 'Query' or 'Mutation'.
+   * When true, Apollo Android will make sure all the generated classes end with 'Query' or 'Mutation'.
    * If you write `query droid { ... }`, the generated class will be named 'DroidQuery'.
    *
    * Default value: true
@@ -132,7 +132,7 @@ The up-to-date list of options can be found in [CompilerParams](https://github.c
   val generateModelBuilder: Property<Boolean>
 
   /**
-   * When true, Apollo-Android will use java beans getters in the models. If you request a property named 'user', the generated
+   * When true, Apollo Android will use java beans getters in the models. If you request a property named 'user', the generated
    * model will have a `getUser()` property instead of `user()`
    *
    * Default value: false

--- a/docs/source/essentials/queries.md
+++ b/docs/source/essentials/queries.md
@@ -6,9 +6,9 @@ Fetching data in a simple, predictable way is one of the core features of Apollo
 You'll also learn how Apollo-android Client simplifies your data management code by tracking different error states for you.
 
 This page assumes some familiarity with building GraphQL queries. If you'd like a refresher, we recommend [reading this guide](http://graphql.org/learn/queries/) and practicing [running queries in GraphiQL](https://graphql.github.io/swapi-graphql/).
-Since Apollo Client queries are just standard GraphQL, anything you can type into the GraphiQL query explorer can also be put into `.graphql` files in your project.
+Since Apollo queries are just standard GraphQL, anything you can type into the GraphiQL query explorer can also be put into `.graphql` files in your project.
 
-The following examples assume that you've already set up Apollo Client for your Android/Java application. Read our [getting started](/essentials/get-started/) guide if you need help with either of those steps.
+The following examples assume that you've already set up Apollo Android for your Android/Java application. Read our [getting started](/essentials/get-started/) guide if you need help with either of those steps.
 
 > All code snippets are taken from the apollo-sample project and can be found [here](https://github.com/apollographql/apollo-android/tree/master/apollo-sample).
 
@@ -134,11 +134,8 @@ Because the above query won't fetch `appearsIn`, this property is not part of th
 
 ## Next steps
 
-Learning how to build `Query` components to fetch data is one of the most important skills to mastering development with Apollo Client. Now that you're a pro at fetching data, why not try building `Mutation` components to update your data? Here are some resources we think will help you level up your skills:
+Learning how to build `Query` components to fetch data is one of the most important skills to mastering development with Apollo Android. Now that you're a pro at fetching data, why not try building `Mutation` components to update your data? Here are some resources we think will help you level up your skills:
 
 - [More about queries](https://graphql.org/learn/queries/): Read more about queries directly from the official GraphQL docs.
 - [Caching responses](/essentials/caching/): Learn how to cache responses with apollo-android.
 - [Mutations](/essentials/mutations/): Learn how to update data with mutations and when you'll need to update the Apollo cache. For a full list of options, check out the API reference for `Mutation` components.
-- [Local state management](https://www.apollographql.com/docs/react/essentials/local-state): Learn how to query local data with `apollo-link-state`.
-- [Pagination](https://www.apollographql.com/docs/react/features/pagination#relay-cursors): Building lists has never been easier thanks to Apollo Client's `fetchMore` function. Learn more in our pagination tutorial.
-- [Query component video by Sara Vieira](https://youtu.be/YHJ2CaS0vpM): If you need a refresher or learn best by watching videos, check out this tutorial on `Query` components by Sara!

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -3,29 +3,28 @@ title: Introduction
 description: Add GraphQL to your Android apps
 ---
 
-Apollo Client for Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin.
+Apollo Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin.
 
 ## Getting started
 
-- [Get started here!](./essentials/get-started/)
+[Get started here!](./essentials/get-started/)
 
-Once you started, you can dive into advanced topics by going into Advanced section from the left pane.
+After you get up and running, explore additional documentation in the left navigation.
 
 ## Getting involved
 
-Apollo Android is a community-driven project with contributors from many companies. Please read [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md) for more details.
+Apollo Android is a community-driven project with contributors from many organizations. Please read [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md) for more details.
 
 If you have questions or would like to contribute, please [open an issue on our GitHub repo](https://github.com/apollographql/apollo-android/issues) or [join the Spectrum Chat](https://spectrum.chat/apollo/apollo-android).
 
-## Related platforms
+## Other versions of Apollo Client
 
-- [Apollo iOS](https://github.com/apollographql/apollo-ios) is a GraphQL client for native iOS apps, written in Swift.
-- [Apollo Client for JS](http://dev.apollodata.com/react/) is a great option for your web or React Native apps.
+- [Apollo iOS](https://www.apollographql.com/docs/ios/)
+- [Apollo Client (JavaScript / React)](https://www.apollographql.com/docs/react/)
 
-## Other resources
+## Additional resources
 
-- [GraphQL.org](http://graphql.org) for an introduction and reference to the GraphQL itself, partially written and maintained by the Apollo team.
-- [Our website](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
-- [Our blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
-- [Our Twitter](https://twitter.com/apollographql) for in-the-moment news.
-
+- [GraphQL.org](http://graphql.org) for an introduction and reference to GraphQL itself.
+- [apollographql.com](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
+- [The Apollo blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
+- [The Apollo Twitter account](https://twitter.com/apollographql) for in-the-moment news.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -3,23 +3,21 @@ title: Introduction
 description: Add GraphQL to your Android apps
 ---
 
-Apollo Client for Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin. [Get started with it here!](./essentials/get-started/)
+Apollo Client for Android is a strongly-typed, caching GraphQL client for Android that supports both Java and Kotlin.
 
-Apollo Android has a Gradle Plugin to integrate into projects easily. Use Gradle docs for more details on the plugin APIs:
-- [Gradle Plugin](https://www.apollographql.com/docs/android/essentials/plugin-configuration/)
-- [Deprecated Gradle Plugin](https://github.com/apollographql/apollo-android/blob/v1.2.3/doc/plugin-configuration.md)
+## Getting started
+
+- [Get started here!](./essentials/get-started/)
 
 Once you started, you can dive into advanced topics by going into Advanced section from the left pane.
 
 ## Getting involved
 
-Apollo Android is a community-driven project with contributors from many companies. Check out the [blog post introducing the first public release of the project](https://blog.apollographql.com/launching-apollo-graphql-on-android-40ee0b5789bd) and the [project's README](https://github.com/apollographql/apollo-android) to learn about the current progress.
+Apollo Android is a community-driven project with contributors from many companies. Please read [Contributing.md](https://github.com/apollographql/apollo-android/blob/master/Contributing.md) for more details.
 
-We're excited about the idea of further [unifying the clients for JavaScript, iOS and Android](https://blog.apollographql.com/one-graphql-client-for-javascript-ios-and-android-64993c1b7991), including sharing a cache between native and React Native.
+If you have questions or would like to contribute, please [open an issue on our GitHub repo](https://github.com/apollographql/apollo-android/issues) or [join the Spectrum Chat](https://spectrum.chat/apollo/apollo-android).
 
-If you have questions or would like to contribute, please join the [Apollo Android Community on Spectrum](https://spectrum.chat/apollo/apollo-android).
-
-## Other platforms
+## Related platforms
 
 - [Apollo iOS](https://github.com/apollographql/apollo-ios) is a GraphQL client for native iOS apps, written in Swift.
 - [Apollo Client for JS](http://dev.apollodata.com/react/) is a great option for your web or React Native apps.
@@ -27,6 +25,7 @@ If you have questions or would like to contribute, please join the [Apollo Andro
 ## Other resources
 
 - [GraphQL.org](http://graphql.org) for an introduction and reference to the GraphQL itself, partially written and maintained by the Apollo team.
-- [Our website](http://www.apollodata.com/) to learn about Apollo open source and commercial tools.
-- [Our blog](https://dev-blog.apollodata.com) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
+- [Our website](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
+- [Our blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
 - [Our Twitter](https://twitter.com/apollographql) for in-the-moment news.
+


### PR DESCRIPTION
Simplify README.md:

* sample code is now Kotlin
* simplify the schema download doc (see #2321)
* use the plugins {} block now that the plugin has a plugin Marker and is available from the gradle portal
* update index.mdx, which was pretty obsolete
* other small fixes