### PR TITLE
Change constructor visibility for WebSocketSubscribtionTransport

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
@@ -21,7 +21,7 @@ public final class WebSocketSubscriptionTransport implements SubscriptionTranspo
   final AtomicReference<WebSocket> webSocket = new AtomicReference<>();
   final AtomicReference<WebSocketListener> webSocketListener = new AtomicReference<>();
 
-  WebSocketSubscriptionTransport(Request webSocketRequest, WebSocket.Factory webSocketConnectionFactory,
+  public WebSocketSubscriptionTransport(Request webSocketRequest, WebSocket.Factory webSocketConnectionFactory,
       Callback callback) {
     this.webSocketRequest = webSocketRequest;
     this.webSocketConnectionFactory = webSocketConnectionFactory;


### PR DESCRIPTION
Linked to #2347 . 

I'm not sure what's your git workflow, feel free to change the base if it's not supposed to be merged directly to `master`. 

I only made the `WebSocketSubscriptionTransport` constructor public, to be able to use this class in a custom implementation of `SubscriptionTransport.Factory`. 