### PR TITLE
Add opt-in to cache responses with errors

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/ApolloCacheHeaders.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/ApolloCacheHeaders.kt
@@ -15,4 +15,9 @@ object ApolloCacheHeaders {
    * Records from this request should be evicted after being read.
    */
   const val EVICT_AFTER_READ = "evict-after-read"
+
+  /**
+   * Records from this request should be stored even if the response contains errors, and the records might not be complete.
+   */
+  const val STORE_PARTIAL_RESPONSES = "store-partial-responses"
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -6,6 +6,7 @@ import com.apollographql.apollo.api.internal.ApolloLogger;
 import com.apollographql.apollo.api.internal.Function;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.api.internal.ResponseFieldMapper;
+import com.apollographql.apollo.cache.ApolloCacheHeaders;
 import com.apollographql.apollo.cache.normalized.ApolloStore;
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.cache.normalized.Record;
@@ -123,8 +124,11 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
 
   Set<String> cacheResponse(final InterceptorResponse networkResponse,
       final InterceptorRequest request) {
-    if (networkResponse.parsedResponse.isPresent() && networkResponse.parsedResponse.get().hasErrors()) {
-      return Collections.emptySet();
+    if (networkResponse.parsedResponse.isPresent()
+        && networkResponse.parsedResponse.get().hasErrors()
+        && !request.cacheHeaders.hasHeader(ApolloCacheHeaders.STORE_PARTIAL_RESPONSES)
+    ) {
+        return Collections.emptySet();
     }
     final Optional<List<Record>> records = networkResponse.cacheRecords.map(
         new Function<Collection<Record>, List<Record>>() {


### PR DESCRIPTION
Most straightforward way to fix #2358 by implementing https://github.com/apollographql/apollo-android/pull/2281#issuecomment-631102371.

I could make `STORE_PARTIAL_RESPONSES` deprecated right away, if there's another suggestion to enable old behavior. Overall I consider this a quick workaround for people affected by the breaking change introduced in #2281