### PR TITLE
[Publishing] add `./gradlew publishToOssStagingIfNeeded`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,8 @@ buildscript {
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.sqldelight.plugin"))
+    // this plugin is added to the classpath but never applied, it is only used for the closeAndRelease code
+    classpath(groovy.util.Eval.x(project, "x.dep.vanniktechPlugin"))
   }
 }
 
@@ -390,4 +392,14 @@ tasks.register("publishToOssStagingIfNeeded") {
     project.logger.log(LogLevel.LIFECYCLE, "Deploying release to OSS staging...")
     dependsOn(subprojectTasks("publishAllPublicationsToOssStagingRepository"))
   }
+}
+
+
+tasks.register("closeAndReleaseRepository") {
+  com.vanniktech.maven.publish.nexus.Nexus(
+      username = System.getenv("SONATYPE_NEXUS_USERNAME"),
+      password = System.getenv("SONATYPE_NEXUS_PASSWORD"),
+      baseUrl = "https://oss.sonatype.org/service/local/",
+      groupId = "com.apollographql"
+  ).closeAndReleaseRepository()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -396,10 +396,12 @@ tasks.register("publishToOssStagingIfNeeded") {
 
 
 tasks.register("closeAndReleaseRepository") {
-  com.vanniktech.maven.publish.nexus.Nexus(
-      username = System.getenv("SONATYPE_NEXUS_USERNAME"),
-      password = System.getenv("SONATYPE_NEXUS_PASSWORD"),
-      baseUrl = "https://oss.sonatype.org/service/local/",
-      groupId = "com.apollographql"
-  ).closeAndReleaseRepository()
+  doLast {
+    com.vanniktech.maven.publish.nexus.Nexus(
+        username = System.getenv("SONATYPE_NEXUS_USERNAME"),
+        password = System.getenv("SONATYPE_NEXUS_PASSWORD"),
+        baseUrl = "https://oss.sonatype.org/service/local/",
+        groupId = "com.apollographql"
+    ).closeAndReleaseRepository()
+  }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -57,6 +57,7 @@ ext.dep = [
     errorProneCore        : "com.google.errorprone:error_prone_core:2.1.1",
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
     gradleErrorpronePlugin: "net.ltgt.gradle:gradle-errorprone-plugin:0.0.12",
+    vanniktechPlugin      : "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
     guavaJre              : "com.google.guava:guava:$versions.guava",
     jetbrainsAnnotations  : "org.jetbrains:annotations:$versions.jetbrainsAnnotations",
     junit                 : "junit:junit:$versions.junit",

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -9,3 +9,5 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 ./gradlew -p composite build
 
 ./gradlew publishIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET" --parallel
+# this is a separate task because sonatype does not support --parallel
+./gradlew publishToOssStagingIfNeeded


### PR DESCRIPTION
Add `./gradlew publishToOssStagingIfNeeded` like there is  `./gradlew publishIfNeeded`. The reason this is a separate task is that Sonatype does not support the `--parallel` option (it might be specifying a profile Id but I'm not sure how to do this). 

Also add `publishToOssStagingIfNeeded` to the ci script so that Sonatype publishing is done on Github Actions starting with version 2.2.2. 

This PR also adds `closeAndReleaseRepository` based on https://github.com/vanniktech/gradle-maven-publish-plugin/pull/63. It makes it possible to release on Maven Central without having to log in at https://oss.sonatype.org/ and would therefore potentially make the release 100% automated.

I haven't added it to the CI yet, I'll do it if it works well on `2.2.2`