### PR TITLE
[Plugin] check versions lazily

### DIFF
--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConfigurationTests.kt
@@ -434,6 +434,28 @@ class ConfigurationTests {
   }
 
   @Test
+  fun `changing a dependency checks versions again`() {
+    withSimpleProject { dir ->
+
+      TestUtils.executeTaskAndAssertSuccess(":generateApolloSources", dir)
+
+      val result = TestUtils.executeTask("checkApolloVersions", dir)
+      assert(result.task(":checkApolloVersions")?.outcome == TaskOutcome.UP_TO_DATE)
+
+      File(dir, "build.gradle").replaceInText("dep.apollo.api", "\"com.apollographql.apollo:apollo-api:1.2.0\"")
+
+      var exception: Exception? = null
+      try {
+        TestUtils.executeTask("checkApolloVersions", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        exception = e
+        assertThat(e.message, containsString("All apollo versions should be the same"))
+      }
+      assertNotNull(exception)
+    }
+  }
+
+  @Test
   fun `versions are enforced even in rootProject`() {
     withTestProject("mismatchedVersions") { dir ->
       var exception: Exception? = null


### PR DESCRIPTION
closes #2393 

~This pull request is dependent on https://github.com/apollographql/apollo-android/pull/2399, I'll rebase once it is merged.~
This PR moves checking the versions to task configuration (instead of plugin application before). This gives more time to other plugins like the Kotlin plugin to change dependencies if needed.