### PR TITLE
Fix marshal function with nullable fragments

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/SchemaTypeSpecBuilder.kt
@@ -222,7 +222,7 @@ class SchemaTypeSpecBuilder(
     fun responseMarshallerSpec(fieldSpecs: List<FieldSpec>): MethodSpec {
       val code = fieldSpecs
           .map { fieldSpec ->
-            if (fieldSpec.type.isOptional()) {
+            if (fieldSpec.type.isNullable()) {
               CodeBlock.builder()
                   .addStatement("final \$T \$L = \$L", fieldSpec.type.unwrapOptionalType().withoutAnnotations(),
                       "\$${fieldSpec.name}", fieldSpec.type.unwrapOptionalValue(fieldSpec.name))

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.java
@@ -377,8 +377,14 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            writer.writeFragment(humanDetails.marshaller());
-            writer.writeFragment(droidDetails.marshaller());
+            final HumanDetails $humanDetails = humanDetails;
+            if ($humanDetails != null) {
+              writer.writeFragment($humanDetails.marshaller());
+            }
+            final DroidDetails $droidDetails = droidDetails;
+            if ($droidDetails != null) {
+              writer.writeFragment($droidDetails.marshaller());
+            }
           }
         };
       }
@@ -575,8 +581,14 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            writer.writeFragment(humanDetails.marshaller());
-            writer.writeFragment(droidDetails.marshaller());
+            final HumanDetails $humanDetails = humanDetails;
+            if ($humanDetails != null) {
+              writer.writeFragment($humanDetails.marshaller());
+            }
+            final DroidDetails $droidDetails = droidDetails;
+            if ($droidDetails != null) {
+              writer.writeFragment($droidDetails.marshaller());
+            }
           }
         };
       }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.java
@@ -363,8 +363,14 @@ public final class TestQuery implements Query<TestQuery.Data, TestQuery.Data, Op
         return new ResponseFieldMarshaller() {
           @Override
           public void marshal(ResponseWriter writer) {
-            writer.writeFragment(character.marshaller());
-            writer.writeFragment(starship.marshaller());
+            final Character $character = character;
+            if ($character != null) {
+              writer.writeFragment($character.marshaller());
+            }
+            final Starship $starship = starship;
+            if ($starship != null) {
+              writer.writeFragment($starship.marshaller());
+            }
           }
         };
       }


### PR DESCRIPTION
While upgrading to release 2.1.0 I came across a strange problem where the generated `marshal` function was no longer checking nullability of fragment before executing `writer.writeFragment`. This resulted in a null pointe exception when calling `marshaller()`. Although this did not cause any problem during normal execution we do have a point in the app where we write a fragment back to `apolloStore`. This is where the NullPointer Exception would occur.

**Before**
```
    public ResponseFieldMarshaller marshaller() {
      return new ResponseFieldMarshaller() {
        @Override
        public void marshal(ResponseWriter writer) {
          writer.writeFragment(downloadAppDeepLinkFragment.marshaller());
        }
      };
    }
```

**After**
```
    public ResponseFieldMarshaller marshaller() {
      return new ResponseFieldMarshaller() {
        @Override
        public void marshal(ResponseWriter writer) {
          final DownloadAppDeepLinkFragment $downloadAppDeepLinkFragment = downloadAppDeepLinkFragment;
          if ($downloadAppDeepLinkFragment != null) {
            $downloadAppDeepLinkFragment.marshaller().marshal(writer);
          }
        }
      };
    }
```