### PR TITLE
[Tooling] 🛠️  Add tasks to check if the API is backward compatible

### DIFF
--- a/apollo-android-support/api.txt
+++ b/apollo-android-support/api.txt
@@ -1,0 +1,24 @@
+package com.apollographql.apollo {
+
+  public final class ApolloCallback<T> {
+    ctor public ApolloCallback(ApolloCall.Callback<T>, Handler);
+    method public void onFailure(ApolloException);
+    method public void onHttpError(ApolloHttpException);
+    method public void onNetworkError(ApolloNetworkException);
+    method public void onParseError(ApolloParseException);
+    method public void onResponse(Response<T>);
+    method public void onStatusEvent(ApolloCall.StatusEvent);
+    method public static <T> com.apollographql.apollo.ApolloCallback<T> wrap(ApolloCall.Callback<T>, Handler);
+  }
+
+  public final class ApolloPrefetchCallback {
+    ctor public ApolloPrefetchCallback(ApolloPrefetch.Callback, Handler);
+    method public void onFailure(ApolloException);
+    method public void onHttpError(ApolloHttpException);
+    method public void onNetworkError(ApolloNetworkException);
+    method public void onSuccess();
+    method public static <T> com.apollographql.apollo.ApolloPrefetchCallback wrap(ApolloPrefetch.Callback, Handler);
+  }
+
+}
+

--- a/apollo-api/api.txt
+++ b/apollo-api/api.txt
@@ -1,0 +1,383 @@
+package com.apollographql.apollo {
+
+  public abstract interface Logger {
+    method public abstract void log(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass...);
+    field public static final com.apollographql.apollo.Logger.Companion Companion;
+    field public static final int DEBUG = 3; // 0x3
+    field public static final int ERROR = 6; // 0x6
+    field public static final int WARN = 5; // 0x5
+  }
+
+  public static final class Logger.Companion {
+    field public static final int DEBUG = 3; // 0x3
+    field public static final int ERROR = 6; // 0x6
+    field public static final int WARN = 5; // 0x5
+  }
+
+}
+
+package com.apollographql.apollo.api {
+
+  public abstract class ApolloExperimental implements java.lang.annotation.Annotation {
+  }
+
+  public final class BigDecimal {
+    ctor public BigDecimal(error.NonExistentClass);
+    ctor public BigDecimal(error.NonExistentClass);
+    ctor public BigDecimal(error.NonExistentClass);
+    ctor public BigDecimal(error.NonExistentClass);
+    method public com.apollographql.apollo.api.BigDecimal add(com.apollographql.apollo.api.BigDecimal);
+    method public error.NonExistentClass compareTo(com.apollographql.apollo.api.BigDecimal);
+    method public com.apollographql.apollo.api.BigDecimal divide(com.apollographql.apollo.api.BigDecimal);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+    method public com.apollographql.apollo.api.BigDecimal multiply(com.apollographql.apollo.api.BigDecimal);
+    method public com.apollographql.apollo.api.BigDecimal negate();
+    method public error.NonExistentClass signum();
+    method public com.apollographql.apollo.api.BigDecimal subtract(com.apollographql.apollo.api.BigDecimal);
+    method public error.NonExistentClass toByte();
+    method public error.NonExistentClass toChar();
+    method public error.NonExistentClass toDouble();
+    method public error.NonExistentClass toFloat();
+    method public error.NonExistentClass toInt();
+    method public error.NonExistentClass toLong();
+    method public error.NonExistentClass toShort();
+    method public error.NonExistentClass toString();
+  }
+
+  public final class BigDecimalKt {
+    ctor public BigDecimalKt();
+  }
+
+  public abstract interface CustomTypeAdapter<T> {
+    method public abstract T decode(com.apollographql.apollo.api.CustomTypeValue<?>);
+    method public abstract com.apollographql.apollo.api.CustomTypeValue<?> encode(T);
+  }
+
+  public sealed abstract class CustomTypeValue<T> {
+    method public final T getValue();
+    field public static final com.apollographql.apollo.api.CustomTypeValue.Companion Companion;
+  }
+
+  public static final class CustomTypeValue.Companion {
+    method public com.apollographql.apollo.api.CustomTypeValue<?> fromRawValue(error.NonExistentClass);
+  }
+
+  public static final class CustomTypeValue.GraphQLBoolean extends com.apollographql.apollo.api.CustomTypeValue {
+    ctor public CustomTypeValue.GraphQLBoolean(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+  }
+
+  public static final class CustomTypeValue.GraphQLJsonList extends com.apollographql.apollo.api.CustomTypeValue {
+    ctor public CustomTypeValue.GraphQLJsonList(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+  }
+
+  public static final class CustomTypeValue.GraphQLJsonObject extends com.apollographql.apollo.api.CustomTypeValue {
+    ctor public CustomTypeValue.GraphQLJsonObject(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+  }
+
+  public static final class CustomTypeValue.GraphQLNumber extends com.apollographql.apollo.api.CustomTypeValue {
+    ctor public CustomTypeValue.GraphQLNumber(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+  }
+
+  public static final class CustomTypeValue.GraphQLString extends com.apollographql.apollo.api.CustomTypeValue {
+    ctor public CustomTypeValue.GraphQLString(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass hashCode();
+  }
+
+  public final class Error {
+    ctor public Error(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass customAttributes();
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getCustomAttributes();
+    method public error.NonExistentClass getLocations();
+    method public error.NonExistentClass getMessage();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass locations();
+    method public error.NonExistentClass message();
+  }
+
+  public static final class Error.Location {
+    ctor public Error.Location(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass column();
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getColumn();
+    method public error.NonExistentClass getLine();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass line();
+  }
+
+  public abstract interface ExecutionContext {
+    method public abstract <R> R fold(R, kotlin.jvm.functions.Function2<? super R, ? super com.apollographql.apollo.api.ExecutionContext.Element, ? extends R>);
+    method public operator abstract <E extends com.apollographql.apollo.api.ExecutionContext.Element> E get(com.apollographql.apollo.api.ExecutionContext.Key<E>);
+    method public abstract com.apollographql.apollo.api.ExecutionContext minusKey(com.apollographql.apollo.api.ExecutionContext.Key<?>);
+    method public default operator com.apollographql.apollo.api.ExecutionContext plus(com.apollographql.apollo.api.ExecutionContext);
+    field public static final com.apollographql.apollo.api.ExecutionContext.Companion Companion;
+  }
+
+  public static final class ExecutionContext.Companion {
+    method public com.apollographql.apollo.api.ExecutionContext getEmpty();
+    property public final com.apollographql.apollo.api.ExecutionContext Empty;
+  }
+
+  public static abstract interface ExecutionContext.Element implements com.apollographql.apollo.api.ExecutionContext {
+    method public default <R> R fold(R, kotlin.jvm.functions.Function2<? super R, ? super com.apollographql.apollo.api.ExecutionContext.Element, ? extends R>);
+    method public default operator <E extends com.apollographql.apollo.api.ExecutionContext.Element> E get(com.apollographql.apollo.api.ExecutionContext.Key<E>);
+    method public abstract com.apollographql.apollo.api.ExecutionContext.Key<?> getKey();
+    method public default com.apollographql.apollo.api.ExecutionContext minusKey(com.apollographql.apollo.api.ExecutionContext.Key<?>);
+    property public abstract com.apollographql.apollo.api.ExecutionContext.Key<?> key;
+  }
+
+  public static abstract interface ExecutionContext.Key<E extends com.apollographql.apollo.api.ExecutionContext.Element> {
+  }
+
+  public final class FileUpload {
+    ctor public FileUpload(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getFilePath();
+    method public error.NonExistentClass getMimetype();
+    method public error.NonExistentClass hashCode();
+  }
+
+  public abstract interface GraphqlFragment {
+    method public abstract com.apollographql.apollo.api.internal.ResponseFieldMarshaller marshaller();
+  }
+
+  public final class Input<V> {
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getDefined();
+    method public V getValue();
+    method public error.NonExistentClass hashCode();
+    field public static final com.apollographql.apollo.api.Input.Companion Companion;
+  }
+
+  public static final class Input.Companion {
+    method public <V> com.apollographql.apollo.api.Input<V> absent();
+    method public <V> com.apollographql.apollo.api.Input<V> fromNullable(V);
+    method public <V> com.apollographql.apollo.api.Input<V> optional(V);
+  }
+
+  public abstract interface InputType {
+    method public abstract com.apollographql.apollo.api.internal.InputFieldMarshaller marshaller();
+  }
+
+  public final class KotlinExtensions {
+    ctor public KotlinExtensions();
+    method public static inline <T> com.apollographql.apollo.api.Input<T> toInput(T);
+  }
+
+  public abstract interface Mutation<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> implements com.apollographql.apollo.api.Operation {
+  }
+
+  public abstract interface Operation<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> {
+    method public abstract error.NonExistentClass composeRequestBody(com.apollographql.apollo.api.ScalarTypeAdapters);
+    method public abstract error.NonExistentClass composeRequestBody();
+    method public abstract com.apollographql.apollo.api.OperationName name();
+    method public abstract error.NonExistentClass operationId();
+    method public abstract com.apollographql.apollo.api.Response<T> parse(error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
+    method public abstract com.apollographql.apollo.api.Response<T> parse(error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
+    method public abstract com.apollographql.apollo.api.Response<T> parse(error.NonExistentClass);
+    method public abstract com.apollographql.apollo.api.Response<T> parse(error.NonExistentClass);
+    method public abstract error.NonExistentClass queryDocument();
+    method public abstract com.apollographql.apollo.api.internal.ResponseFieldMapper<D> responseFieldMapper();
+    method public abstract V variables();
+    method public abstract T wrapData(D);
+    field public static final com.apollographql.apollo.api.Operation.Companion Companion;
+  }
+
+  public static final class Operation.Companion {
+    method public com.apollographql.apollo.api.Operation.Variables getEMPTY_VARIABLES();
+    property public final com.apollographql.apollo.api.Operation.Variables EMPTY_VARIABLES;
+  }
+
+  public static abstract interface Operation.Data {
+    method public abstract com.apollographql.apollo.api.internal.ResponseFieldMarshaller marshaller();
+  }
+
+  public static class Operation.Variables {
+    ctor public Operation.Variables();
+    method public final error.NonExistentClass marshal();
+    method public final error.NonExistentClass marshal(com.apollographql.apollo.api.ScalarTypeAdapters);
+    method public com.apollographql.apollo.api.internal.InputFieldMarshaller marshaller();
+    method public error.NonExistentClass valueMap();
+  }
+
+  public final class OperationDataJsonSerializer {
+    ctor public OperationDataJsonSerializer();
+    method public static error.NonExistentClass toJson(com.apollographql.apollo.api.Operation.Data, error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
+  }
+
+  public abstract interface OperationName {
+    method public abstract error.NonExistentClass name();
+  }
+
+  public abstract interface Query<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> implements com.apollographql.apollo.api.Operation {
+    method public abstract error.NonExistentClass composeRequestBody(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
+  }
+
+  public final class Response<T> {
+    ctor public Response(com.apollographql.apollo.api.Operation<?, ?, ?>, T, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ExecutionContext);
+    ctor public Response(com.apollographql.apollo.api.Response.Builder<T>);
+    method public com.apollographql.apollo.api.Operation<?, ?, ?> component1();
+    method public T component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public error.NonExistentClass component6();
+    method public com.apollographql.apollo.api.ExecutionContext component7();
+    method public com.apollographql.apollo.api.Response<T> copy(com.apollographql.apollo.api.Operation<?, ?, ?>, T, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ExecutionContext);
+    method public T data();
+    method public error.NonExistentClass dependentKeys();
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass errors();
+    method public error.NonExistentClass extensions();
+    method public error.NonExistentClass fromCache();
+    method public T getData();
+    method public error.NonExistentClass getDependentKeys();
+    method public error.NonExistentClass getErrors();
+    method public com.apollographql.apollo.api.ExecutionContext getExecutionContext();
+    method public error.NonExistentClass getExtensions();
+    method public error.NonExistentClass getFromCache();
+    method public com.apollographql.apollo.api.Operation<?, ?, ?> getOperation();
+    method public error.NonExistentClass hasErrors();
+    method public error.NonExistentClass hashCode();
+    method public com.apollographql.apollo.api.Operation<?, ?, ?> operation();
+    method public com.apollographql.apollo.api.Response.Builder<T> toBuilder();
+    method public java.lang.String toString();
+    field public static final com.apollographql.apollo.api.Response.Companion Companion;
+  }
+
+  public static final class Response.Builder<T> {
+    method public com.apollographql.apollo.api.Response<T> build();
+    method public error.NonExistentClass data(T);
+    method public error.NonExistentClass dependentKeys(error.NonExistentClass);
+    method public error.NonExistentClass errors(error.NonExistentClass);
+    method public error.NonExistentClass executionContext(com.apollographql.apollo.api.ExecutionContext);
+    method public error.NonExistentClass extensions(error.NonExistentClass);
+    method public error.NonExistentClass fromCache(error.NonExistentClass);
+  }
+
+  public static final class Response.Companion {
+    method public <T> com.apollographql.apollo.api.Response.Builder<T> builder(com.apollographql.apollo.api.Operation<?, ?, ?>);
+  }
+
+  public class ResponseField {
+    method public final error.NonExistentClass arguments();
+    method public final error.NonExistentClass conditions();
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public final error.NonExistentClass fieldName();
+    method public final error.NonExistentClass getArguments();
+    method public final error.NonExistentClass getConditions();
+    method public final error.NonExistentClass getFieldName();
+    method public final error.NonExistentClass getOptional();
+    method public final error.NonExistentClass getResponseName();
+    method public final com.apollographql.apollo.api.ResponseField.Type getType();
+    method public error.NonExistentClass hashCode();
+    method public final error.NonExistentClass optional();
+    method public final error.NonExistentClass resolveArgument(error.NonExistentClass, com.apollographql.apollo.api.Operation.Variables);
+    method public final error.NonExistentClass responseName();
+    method public final com.apollographql.apollo.api.ResponseField.Type type();
+    field public static final com.apollographql.apollo.api.ResponseField.Companion Companion;
+    field public static final java.lang.String VARIABLE_NAME_KEY = "variableName";
+  }
+
+  public static final class ResponseField.BooleanCondition extends com.apollographql.apollo.api.ResponseField.Condition {
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getInverted();
+    method public error.NonExistentClass getVariableName();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass inverted();
+    method public error.NonExistentClass variableName();
+  }
+
+  public static final class ResponseField.Companion {
+    method public com.apollographql.apollo.api.ResponseField forBoolean(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField.CustomTypeField forCustomType(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ScalarType, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forDouble(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forEnum(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forFragment(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forInt(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forList(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forLong(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forObject(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField forString(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass isArgumentValueVariableType(error.NonExistentClass);
+  }
+
+  public static class ResponseField.Condition {
+    field public static final com.apollographql.apollo.api.ResponseField.Condition.Companion Companion;
+  }
+
+  public static final class ResponseField.Condition.Companion {
+    method public com.apollographql.apollo.api.ResponseField.BooleanCondition booleanCondition(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.ResponseField.TypeNameCondition typeCondition(error.NonExistentClass);
+  }
+
+  public static final class ResponseField.CustomTypeField extends com.apollographql.apollo.api.ResponseField {
+    method public com.apollographql.apollo.api.ScalarType getScalarType();
+    method public com.apollographql.apollo.api.ScalarType scalarType();
+  }
+
+  public static class ResponseField.Type {
+    method public static com.apollographql.apollo.api.ResponseField.Type valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.api.ResponseField.Type[] values();
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type BOOLEAN;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type CUSTOM;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type DOUBLE;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type ENUM;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type FRAGMENT;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type FRAGMENTS;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type INT;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type LIST;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type LONG;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type OBJECT;
+    enum_constant public static final com.apollographql.apollo.api.ResponseField.Type STRING;
+  }
+
+  public static final class ResponseField.TypeNameCondition extends com.apollographql.apollo.api.ResponseField.Condition {
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getTypeNames();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass typeNames();
+  }
+
+  public abstract interface ScalarType {
+    method public abstract error.NonExistentClass className();
+    method public abstract error.NonExistentClass typeName();
+  }
+
+  public final class ScalarTypeAdapters {
+    ctor public ScalarTypeAdapters(error.NonExistentClass);
+    method public <T> com.apollographql.apollo.api.CustomTypeAdapter<T> adapterFor(com.apollographql.apollo.api.ScalarType);
+    method public error.NonExistentClass getCustomAdapters();
+    field public static final com.apollographql.apollo.api.ScalarTypeAdapters.Companion Companion;
+  }
+
+  public static final class ScalarTypeAdapters.Companion {
+    method public com.apollographql.apollo.api.ScalarTypeAdapters getDEFAULT();
+    property public final com.apollographql.apollo.api.ScalarTypeAdapters DEFAULT;
+  }
+
+  public abstract interface Subscription<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> implements com.apollographql.apollo.api.Operation {
+  }
+
+}
+
+package com.apollographql.apollo.exception {
+
+  public class ApolloException {
+    ctor public ApolloException(error.NonExistentClass);
+    ctor public ApolloException(error.NonExistentClass, error.NonExistentClass);
+  }
+
+}
+

--- a/apollo-compiler/api.txt
+++ b/apollo-compiler/api.txt
@@ -1,0 +1,1407 @@
+package com.apollographql.android {
+
+  public final class VersionKt {
+    ctor public VersionKt();
+    method public static java.lang.String getVERSION();
+  }
+
+}
+
+package com.apollographql.apollo.compiler {
+
+  public final class Annotations {
+    method public error.NonExistentClass getDEPRECATED();
+    method public error.NonExistentClass getNONNULL();
+    method public error.NonExistentClass getNULLABLE();
+    method public error.NonExistentClass getOVERRIDE();
+    method public error.NonExistentClass getSUPPRESS_RAW_VALUE_AND_UNCHECKED_WARNING();
+    method public error.NonExistentClass getSUPPRESS_RAW_VALUE_WARNING();
+    method public error.NonExistentClass getSUPPRESS_UNCHECKED_WARNING();
+    property public final error.NonExistentClass DEPRECATED;
+    property public final error.NonExistentClass NONNULL;
+    property public final error.NonExistentClass NULLABLE;
+    property public final error.NonExistentClass OVERRIDE;
+    property public final error.NonExistentClass SUPPRESS_RAW_VALUE_AND_UNCHECKED_WARNING;
+    property public final error.NonExistentClass SUPPRESS_RAW_VALUE_WARNING;
+    property public final error.NonExistentClass SUPPRESS_UNCHECKED_WARNING;
+    field public static final com.apollographql.apollo.compiler.Annotations INSTANCE;
+  }
+
+  public final class BuilderTypeSpecBuilder {
+    ctor public BuilderTypeSpecBuilder(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass build();
+    method public error.NonExistentClass getBuildableTypes();
+    method public error.NonExistentClass getFieldDefaultValues();
+    method public error.NonExistentClass getFieldJavaDocs();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getTargetObjectClassName();
+    method public error.NonExistentClass getTypeDeclarations();
+    field public static final com.apollographql.apollo.compiler.BuilderTypeSpecBuilder.Companion Companion;
+    field public static final java.lang.String TO_BUILDER_METHOD_NAME = "toBuilder";
+  }
+
+  public static final class BuilderTypeSpecBuilder.Companion {
+    method public error.NonExistentClass builderFactoryMethod();
+  }
+
+  public final class ClassNames {
+    method public error.NonExistentClass getAPI_UTILS();
+    method public error.NonExistentClass getARRAY_LIST();
+    method public error.NonExistentClass getBUILDER();
+    method public error.NonExistentClass getFRAGMENT();
+    method public error.NonExistentClass getGRAPHQL_MUTATION();
+    method public error.NonExistentClass getGRAPHQL_OPERATION();
+    method public error.NonExistentClass getGRAPHQL_OPERATION_VARIABLES();
+    method public error.NonExistentClass getGRAPHQL_QUERY();
+    method public error.NonExistentClass getGRAPHQL_SUBSCRIPTION();
+    method public error.NonExistentClass getGUAVA_OPTIONAL();
+    method public error.NonExistentClass getHASH_MAP();
+    method public error.NonExistentClass getINPUT();
+    method public error.NonExistentClass getINPUT_TYPE();
+    method public error.NonExistentClass getJAVA_OPTIONAL();
+    method public error.NonExistentClass getLIST();
+    method public error.NonExistentClass getMAP();
+    method public error.NonExistentClass getMUTATOR();
+    method public error.NonExistentClass getOBJECT();
+    method public error.NonExistentClass getOPTIONAL();
+    method public error.NonExistentClass getSTRING();
+    method public error.NonExistentClass getUNMODIFIABLE_MAP_BUILDER();
+    method public error.NonExistentClass parameterizedGuavaOptional(error.NonExistentClass);
+    method public <K, V> error.NonExistentClass parameterizedHashMapOf(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass parameterizedInputType(error.NonExistentClass);
+    method public error.NonExistentClass parameterizedJavaOptional(error.NonExistentClass);
+    method public <K> error.NonExistentClass parameterizedListOf(error.NonExistentClass);
+    method public error.NonExistentClass parameterizedListOf(error.NonExistentClass);
+    method public <K, V> error.NonExistentClass parameterizedMapOf(error.NonExistentClass, error.NonExistentClass);
+    method public <K> error.NonExistentClass parameterizedOptional(error.NonExistentClass);
+    method public error.NonExistentClass parameterizedOptional(error.NonExistentClass);
+    method public <K, V> error.NonExistentClass parameterizedUnmodifiableMapBuilderOf(error.NonExistentClass, error.NonExistentClass);
+    property public final error.NonExistentClass API_UTILS;
+    property public final error.NonExistentClass ARRAY_LIST;
+    property public final error.NonExistentClass BUILDER;
+    property public final error.NonExistentClass FRAGMENT;
+    property public final error.NonExistentClass GRAPHQL_MUTATION;
+    property public final error.NonExistentClass GRAPHQL_OPERATION;
+    property public final error.NonExistentClass GRAPHQL_OPERATION_VARIABLES;
+    property public final error.NonExistentClass GRAPHQL_QUERY;
+    property public final error.NonExistentClass GRAPHQL_SUBSCRIPTION;
+    property public final error.NonExistentClass GUAVA_OPTIONAL;
+    property public final error.NonExistentClass HASH_MAP;
+    property public final error.NonExistentClass INPUT;
+    property public final error.NonExistentClass INPUT_TYPE;
+    property public final error.NonExistentClass JAVA_OPTIONAL;
+    property public final error.NonExistentClass LIST;
+    property public final error.NonExistentClass MAP;
+    property public final error.NonExistentClass MUTATOR;
+    property public final error.NonExistentClass OBJECT;
+    property public final error.NonExistentClass OPTIONAL;
+    property public final error.NonExistentClass STRING;
+    property public final error.NonExistentClass UNMODIFIABLE_MAP_BUILDER;
+    field public static final com.apollographql.apollo.compiler.ClassNames INSTANCE;
+  }
+
+  public final class CustomEnumTypeSpecBuilder {
+    ctor public CustomEnumTypeSpecBuilder(com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass build();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext getContext();
+    field public static final com.apollographql.apollo.compiler.CustomEnumTypeSpecBuilder.Companion Companion;
+  }
+
+  public static final class CustomEnumTypeSpecBuilder.Companion {
+    method public error.NonExistentClass className(com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+  }
+
+  public final class DefaultPackageNameProvider implements com.apollographql.apollo.compiler.PackageNameProvider {
+    ctor public DefaultPackageNameProvider(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass filePackageName(error.NonExistentClass);
+    method public error.NonExistentClass getFragmentsPackageName();
+    method public error.NonExistentClass getTypesPackageName();
+    method public error.NonExistentClass operationPackageName(error.NonExistentClass);
+    property public error.NonExistentClass fragmentsPackageName;
+    property public error.NonExistentClass typesPackageName;
+  }
+
+  public final class DefaultPackageNameProviderKt {
+    ctor public DefaultPackageNameProviderKt();
+    method public static error.NonExistentClass appendPackageName(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class FragmentsResponseMapperBuilder {
+    ctor public FragmentsResponseMapperBuilder(error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass build();
+    field public static final com.apollographql.apollo.compiler.FragmentsResponseMapperBuilder.Companion Companion;
+  }
+
+  public static final class FragmentsResponseMapperBuilder.Companion {
+  }
+
+  public final class GraphQLCompiler {
+    ctor public GraphQLCompiler();
+    method public void write(com.apollographql.apollo.compiler.GraphQLCompiler.Arguments);
+    field public static final com.apollographql.apollo.compiler.GraphQLCompiler.Companion Companion;
+  }
+
+  public static final class GraphQLCompiler.Arguments {
+    ctor public GraphQLCompiler.Arguments(com.apollographql.apollo.compiler.ir.CodeGenerationIR, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.OperationIdGenerator, error.NonExistentClass, com.apollographql.apollo.compiler.PackageNameProvider, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.NullableValueType, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR component1();
+    method public error.NonExistentClass component10();
+    method public com.apollographql.apollo.compiler.NullableValueType component11();
+    method public error.NonExistentClass component12();
+    method public error.NonExistentClass component13();
+    method public error.NonExistentClass component14();
+    method public error.NonExistentClass component15();
+    method public error.NonExistentClass component16();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.OperationIdGenerator component4();
+    method public error.NonExistentClass component5();
+    method public com.apollographql.apollo.compiler.PackageNameProvider component6();
+    method public error.NonExistentClass component7();
+    method public error.NonExistentClass component8();
+    method public error.NonExistentClass component9();
+    method public com.apollographql.apollo.compiler.GraphQLCompiler.Arguments copy(com.apollographql.apollo.compiler.ir.CodeGenerationIR, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.OperationIdGenerator, error.NonExistentClass, com.apollographql.apollo.compiler.PackageNameProvider, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.NullableValueType, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getCustomTypeMap();
+    method public error.NonExistentClass getEnumAsSealedClassPatternFilters();
+    method public error.NonExistentClass getGenerateAsInternal();
+    method public error.NonExistentClass getGenerateKotlinModels();
+    method public error.NonExistentClass getGenerateModelBuilder();
+    method public error.NonExistentClass getGenerateVisitorForPolymorphicDatatypes();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR getIr();
+    method public error.NonExistentClass getKotlinMultiPlatformProject();
+    method public com.apollographql.apollo.compiler.NullableValueType getNullableValueType();
+    method public com.apollographql.apollo.compiler.OperationIdGenerator getOperationIdGenerator();
+    method public error.NonExistentClass getOperationOutputFile();
+    method public error.NonExistentClass getOutputDir();
+    method public com.apollographql.apollo.compiler.PackageNameProvider getPackageNameProvider();
+    method public error.NonExistentClass getSuppressRawTypesWarning();
+    method public error.NonExistentClass getUseJavaBeansSemanticNaming();
+    method public error.NonExistentClass getUseSemanticNaming();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphQLCompiler.Companion {
+  }
+
+  public final class InflectorKt {
+    ctor public InflectorKt();
+    method public static error.NonExistentClass singularize(error.NonExistentClass);
+  }
+
+  public final class InputFieldSpec {
+    ctor public InputFieldSpec(com.apollographql.apollo.compiler.InputFieldSpec.Type, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext getContext();
+    method public error.NonExistentClass getGraphQLType();
+    method public error.NonExistentClass getJavaType();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.InputFieldSpec.Type getType();
+    method public error.NonExistentClass writeValueCode(error.NonExistentClass, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.InputFieldSpec.Companion Companion;
+  }
+
+  public static final class InputFieldSpec.Companion {
+    method public com.apollographql.apollo.compiler.InputFieldSpec build(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext, com.apollographql.apollo.compiler.NullableValueType);
+  }
+
+  public static class InputFieldSpec.Type {
+    method public static com.apollographql.apollo.compiler.InputFieldSpec.Type valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.compiler.InputFieldSpec.Type[] values();
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type BOOLEAN;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type CUSTOM;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type DOUBLE;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type ENUM;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type INT;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type LIST;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type LONG;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type OBJECT;
+    enum_constant public static final com.apollographql.apollo.compiler.InputFieldSpec.Type STRING;
+  }
+
+  public final class InputTypeSpecBuilder {
+    ctor public InputTypeSpecBuilder(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass build();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext getContext();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    field public static final com.apollographql.apollo.compiler.InputTypeSpecBuilder.Companion Companion;
+  }
+
+  public static final class InputTypeSpecBuilder.Companion {
+  }
+
+  public final class JavaTypeResolver {
+    ctor public JavaTypeResolver(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass resolve(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.NullableValueType);
+  }
+
+  public class NullableValueType {
+    method public final error.NonExistentClass getValue();
+    method public static com.apollographql.apollo.compiler.NullableValueType valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.compiler.NullableValueType[] values();
+    enum_constant public static final com.apollographql.apollo.compiler.NullableValueType ANNOTATED;
+    enum_constant public static final com.apollographql.apollo.compiler.NullableValueType APOLLO_OPTIONAL;
+    enum_constant public static final com.apollographql.apollo.compiler.NullableValueType GUAVA_OPTIONAL;
+    enum_constant public static final com.apollographql.apollo.compiler.NullableValueType INPUT_TYPE;
+    enum_constant public static final com.apollographql.apollo.compiler.NullableValueType JAVA_OPTIONAL;
+  }
+
+  public abstract interface OperationIdGenerator {
+    method public abstract error.NonExistentClass apply(error.NonExistentClass, error.NonExistentClass);
+    method public abstract error.NonExistentClass getVersion();
+    property public abstract error.NonExistentClass version;
+  }
+
+  public static final class OperationIdGenerator.Sha256 implements com.apollographql.apollo.compiler.OperationIdGenerator {
+    ctor public OperationIdGenerator.Sha256();
+    method public error.NonExistentClass apply(error.NonExistentClass, error.NonExistentClass);
+    method public java.lang.String getVersion();
+    property public java.lang.String version;
+  }
+
+  public final class OperationTypeSpecBuilder implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public OperationTypeSpecBuilder(com.apollographql.apollo.compiler.ir.Operation, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getFragments();
+    method public com.apollographql.apollo.compiler.ir.Operation getOperation();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.OperationTypeSpecBuilder.Companion Companion;
+  }
+
+  public static final class OperationTypeSpecBuilder.Companion {
+  }
+
+  public abstract interface PackageNameProvider {
+    method public abstract error.NonExistentClass getFragmentsPackageName();
+    method public abstract error.NonExistentClass getTypesPackageName();
+    method public abstract error.NonExistentClass operationPackageName(error.NonExistentClass);
+    property public abstract error.NonExistentClass fragmentsPackageName;
+    property public abstract error.NonExistentClass typesPackageName;
+  }
+
+  public final class ResponseFieldSpec {
+    ctor public ResponseFieldSpec(com.apollographql.apollo.compiler.ir.Field, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass factoryCode();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext getContext();
+    method public error.NonExistentClass getFieldSpec();
+    method public com.apollographql.apollo.compiler.ir.Field getIrField();
+    method public error.NonExistentClass getNormalizedFieldSpec();
+    method public error.NonExistentClass getResponseFieldType();
+    method public error.NonExistentClass getTypeConditions();
+    method public error.NonExistentClass readValueCode(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass writeValueCode(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.ResponseFieldSpec.Companion Companion;
+  }
+
+  public static final class ResponseFieldSpec.Companion {
+  }
+
+  public final class SchemaTypeSpecBuilder {
+    ctor public SchemaTypeSpecBuilder(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    method public error.NonExistentClass build(error.NonExistentClass...);
+    field public static final com.apollographql.apollo.compiler.SchemaTypeSpecBuilder.Companion Companion;
+  }
+
+  public static final class SchemaTypeSpecBuilder.Companion {
+    method public error.NonExistentClass getFRAGMENTS_FIELD();
+    property public final error.NonExistentClass FRAGMENTS_FIELD;
+  }
+
+  public final class Util {
+    method public error.NonExistentClass getSCALAR_TYPES();
+    property public final error.NonExistentClass SCALAR_TYPES;
+    field public static final error.NonExistentClass FIELD_MAPPER_SUFFIX;
+    field public static final com.apollographql.apollo.compiler.Util INSTANCE;
+    field public static final error.NonExistentClass MEMOIZED_HASH_CODE_FLAG_VAR;
+    field public static final error.NonExistentClass MEMOIZED_HASH_CODE_VAR;
+    field public static final error.NonExistentClass MEMOIZED_TO_STRING_VAR;
+    field public static final error.NonExistentClass RESPONSE_FIELD_MAPPER_TYPE_NAME;
+  }
+
+  public final class UtilKt {
+    ctor public UtilKt();
+    method public static error.NonExistentClass castTo(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass conformToProtocol(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass defaultOptionalValue(error.NonExistentClass);
+    method public static java.lang.String escapeJavaReservedWord(error.NonExistentClass);
+    method public static java.lang.String escapeKotlinReservedWord(error.NonExistentClass);
+    method public static error.NonExistentClass flatNestedTypeSpecs(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass flatten(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass isCustomScalarType(error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public static boolean isEnum(error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public static boolean isList(error.NonExistentClass);
+    method public static error.NonExistentClass isNullable(error.NonExistentClass);
+    method public static error.NonExistentClass isOptional(error.NonExistentClass, error.NonExistentClass);
+    method public static boolean isScalar(error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public static error.NonExistentClass listParamType(error.NonExistentClass);
+    method public static error.NonExistentClass mapperFieldName(error.NonExistentClass);
+    method public static error.NonExistentClass normalizeGraphQlType(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass overrideReturnType(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass overrideType(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass overrideTypeName(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass rawType(error.NonExistentClass);
+    method public static error.NonExistentClass removeNestedTypeSpecs(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass toJavaBeansSemanticNaming(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass toJavaType(error.NonExistentClass);
+    method public static error.NonExistentClass unwrapOptionalType(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass unwrapOptionalValue(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static error.NonExistentClass withBuilder(error.NonExistentClass);
+    method public static error.NonExistentClass withEqualsImplementation(error.NonExistentClass);
+    method public static error.NonExistentClass withHashCodeImplementation(error.NonExistentClass);
+    method public static error.NonExistentClass withToStringImplementation(error.NonExistentClass);
+    method public static error.NonExistentClass withValueInitConstructor(error.NonExistentClass, com.apollographql.apollo.compiler.NullableValueType);
+    method public static error.NonExistentClass withWildCardReturnType(error.NonExistentClass, error.NonExistentClass);
+    method public static error.NonExistentClass wrapOptionalValue(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class VariablesTypeSpecBuilder {
+    ctor public VariablesTypeSpecBuilder(error.NonExistentClass, com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass build();
+    method public error.NonExistentClass builder(error.NonExistentClass);
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext getContext();
+    method public error.NonExistentClass getVariables();
+    field public static final com.apollographql.apollo.compiler.VariablesTypeSpecBuilder.Companion Companion;
+  }
+
+  public static final class VariablesTypeSpecBuilder.Companion {
+  }
+
+  public final class VisitorInterfaceSpec {
+    ctor public VisitorInterfaceSpec(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass createVisitorInterface();
+  }
+
+  public final class VisitorMethodSpec {
+    ctor public VisitorMethodSpec(error.NonExistentClass);
+    method public error.NonExistentClass createVisitorMethod();
+  }
+
+  public final class VisitorSpec {
+    method public error.NonExistentClass getVISITOR_TYPE_VARIABLE();
+    property public final error.NonExistentClass VISITOR_TYPE_VARIABLE;
+    field public static final java.lang.String DEFAULT_VISITOR_METHOD_NAME = "visitDefault";
+    field public static final com.apollographql.apollo.compiler.VisitorSpec INSTANCE;
+    field public static final java.lang.String VISITOR_CLASSNAME = "Visitor";
+    field public static final java.lang.String VISITOR_METHOD_NAME = "visit";
+  }
+
+}
+
+package com.apollographql.apollo.compiler.ast.builder {
+
+  public final class EnumTypeBuilderKt {
+    ctor public EnumTypeBuilderKt();
+  }
+
+  public final class FragmentTypeBuilderKt {
+    ctor public FragmentTypeBuilderKt();
+  }
+
+  public final class InlineFragmentTypeBuilderKt {
+    ctor public InlineFragmentTypeBuilderKt();
+  }
+
+  public final class InputTypeBuilderKt {
+    ctor public InputTypeBuilderKt();
+  }
+
+  public final class ObjectFieldBuilderKt {
+    ctor public ObjectFieldBuilderKt();
+  }
+
+  public final class OperationTypeBuilderKt {
+    ctor public OperationTypeBuilderKt();
+  }
+
+  public final class SchemaBuilderKt {
+    ctor public SchemaBuilderKt();
+  }
+
+}
+
+package com.apollographql.apollo.compiler.codegen.kotlin {
+
+  public final class CustomTypeKt {
+    ctor public CustomTypeKt();
+  }
+
+  public final class EnumTypeKt {
+    ctor public EnumTypeKt();
+  }
+
+  public final class GraphQLKompiler {
+    ctor public GraphQLKompiler(com.apollographql.apollo.compiler.ir.CodeGenerationIR, error.NonExistentClass, com.apollographql.apollo.compiler.PackageNameProvider, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.OperationIdGenerator, error.NonExistentClass, error.NonExistentClass);
+    method public void write(error.NonExistentClass);
+  }
+
+  public final class InputTypeKt {
+    ctor public InputTypeKt();
+  }
+
+  public final class KotlinCodeGenUtilKt {
+    ctor public KotlinCodeGenUtilKt();
+    method public static error.NonExistentClass throws(error.NonExistentClass, error.NonExistentClass...);
+    method public static error.NonExistentClass throwsMultiplatformIOException(error.NonExistentClass);
+  }
+
+  public final class ObjectTypeKt {
+    ctor public ObjectTypeKt();
+  }
+
+  public final class OperationTypeKt {
+    ctor public OperationTypeKt();
+  }
+
+}
+
+package com.apollographql.apollo.compiler.ir {
+
+  public final class Argument {
+    ctor public Argument(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component4();
+    method public com.apollographql.apollo.compiler.ir.Argument copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getType();
+    method public error.NonExistentClass getValue();
+    method public error.NonExistentClass hashCode();
+    method public java.lang.String toString();
+  }
+
+  public final class CodeGenerationContext {
+    ctor public CodeGenerationContext(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.OperationIdGenerator, com.apollographql.apollo.compiler.NullableValueType, com.apollographql.apollo.compiler.ir.CodeGenerationIR, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.PackageNameProvider);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component10();
+    method public error.NonExistentClass component11();
+    method public com.apollographql.apollo.compiler.PackageNameProvider component12();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.OperationIdGenerator component4();
+    method public com.apollographql.apollo.compiler.NullableValueType component5();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR component6();
+    method public error.NonExistentClass component7();
+    method public error.NonExistentClass component8();
+    method public error.NonExistentClass component9();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationContext copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.OperationIdGenerator, com.apollographql.apollo.compiler.NullableValueType, com.apollographql.apollo.compiler.ir.CodeGenerationIR, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.PackageNameProvider);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getCustomTypeMap();
+    method public error.NonExistentClass getGenerateModelBuilder();
+    method public error.NonExistentClass getGenerateVisitorForPolymorphicDatatypes();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR getIr();
+    method public com.apollographql.apollo.compiler.NullableValueType getNullableValueType();
+    method public com.apollographql.apollo.compiler.OperationIdGenerator getOperationIdGenerator();
+    method public com.apollographql.apollo.compiler.PackageNameProvider getPackageNameProvider();
+    method public error.NonExistentClass getReservedTypeNames();
+    method public error.NonExistentClass getSuppressRawTypesWarning();
+    method public error.NonExistentClass getTypeDeclarations();
+    method public error.NonExistentClass getUseJavaBeansSemanticNaming();
+    method public error.NonExistentClass getUseSemanticNaming();
+    method public int hashCode();
+    method public void setReservedTypeNames(error.NonExistentClass);
+    method public java.lang.String toString();
+  }
+
+  public final class CodeGenerationIR {
+    ctor public CodeGenerationIR(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getFragments();
+    method public error.NonExistentClass getOperations();
+    method public error.NonExistentClass getTypesUsed();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public abstract interface CodeGenerator {
+    method public abstract error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+  }
+
+  public final class Condition {
+    ctor public Condition(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component4();
+    method public com.apollographql.apollo.compiler.ir.Condition copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getInverted();
+    method public error.NonExistentClass getKind();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getVariableName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static class Condition.Kind {
+    method public final error.NonExistentClass getRawValue();
+    method public static com.apollographql.apollo.compiler.ir.Condition.Kind valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.compiler.ir.Condition.Kind[] values();
+    enum_constant public static final com.apollographql.apollo.compiler.ir.Condition.Kind BOOLEAN;
+  }
+
+  public final class Field implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public Field(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass accessorMethodSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass argumentCodeBlock();
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component10();
+    method public error.NonExistentClass component11();
+    method public error.NonExistentClass component12();
+    method public error.NonExistentClass component13();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component14();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public error.NonExistentClass component6();
+    method public error.NonExistentClass component7();
+    method public error.NonExistentClass component8();
+    method public error.NonExistentClass component9();
+    method public com.apollographql.apollo.compiler.ir.Field copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass fieldSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext);
+    method public error.NonExistentClass formatClassName();
+    method public error.NonExistentClass getArgs();
+    method public error.NonExistentClass getConditions();
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFieldName();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getFragmentRefs();
+    method public error.NonExistentClass getInlineFragments();
+    method public error.NonExistentClass getResponseName();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getType();
+    method public error.NonExistentClass getTypeDescription();
+    method public int hashCode();
+    method public error.NonExistentClass isConditional();
+    method public error.NonExistentClass isDeprecated();
+    method public boolean isNonScalar();
+    method public error.NonExistentClass isOptional();
+    method public java.lang.String toString();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.ir.Field.Companion Companion;
+  }
+
+  public static final class Field.Companion {
+    method public com.apollographql.apollo.compiler.ir.Field getTYPE_NAME_FIELD();
+    property public final com.apollographql.apollo.compiler.ir.Field TYPE_NAME_FIELD;
+  }
+
+  public final class Fragment implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public Fragment(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component10();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public error.NonExistentClass component6();
+    method public error.NonExistentClass component7();
+    method public error.NonExistentClass component8();
+    method public error.NonExistentClass component9();
+    method public com.apollographql.apollo.compiler.ir.Fragment copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getFilePath();
+    method public error.NonExistentClass getFragmentName();
+    method public error.NonExistentClass getFragmentRefs();
+    method public error.NonExistentClass getInlineFragments();
+    method public error.NonExistentClass getPossibleTypes();
+    method public error.NonExistentClass getSource();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getTypeCondition();
+    method public int hashCode();
+    method public java.lang.String toString();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.ir.Fragment.Companion Companion;
+    field public static final error.NonExistentClass FRAGMENT_DEFINITION_FIELD_NAME;
+  }
+
+  public static final class Fragment.Companion {
+  }
+
+  public final class FragmentRef {
+    ctor public FragmentRef(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component3();
+    method public com.apollographql.apollo.compiler.ir.FragmentRef copy(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getConditions();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass hashCode();
+    method public java.lang.String toString();
+  }
+
+  public final class InlineFragment implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public InlineFragment(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component6();
+    method public error.NonExistentClass component7();
+    method public com.apollographql.apollo.compiler.ir.InlineFragment copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass fieldSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    method public error.NonExistentClass formatClassName();
+    method public error.NonExistentClass getConditions();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getFragments();
+    method public error.NonExistentClass getPossibleTypes();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getTypeCondition();
+    method public int hashCode();
+    method public java.lang.String toString();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+  }
+
+  public final class Operation implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public Operation(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component10();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public error.NonExistentClass component6();
+    method public error.NonExistentClass component7();
+    method public error.NonExistentClass component8();
+    method public error.NonExistentClass component9();
+    method public com.apollographql.apollo.compiler.ir.Operation copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getFilePath();
+    method public error.NonExistentClass getFragments();
+    method public error.NonExistentClass getFragmentsReferenced();
+    method public error.NonExistentClass getOperationName();
+    method public error.NonExistentClass getOperationType();
+    method public error.NonExistentClass getSource();
+    method public error.NonExistentClass getSourceWithFragments();
+    method public error.NonExistentClass getVariables();
+    method public int hashCode();
+    method public boolean isMutation();
+    method public boolean isQuery();
+    method public boolean isSubscription();
+    method public error.NonExistentClass normalizedOperationName(error.NonExistentClass);
+    method public java.lang.String toString();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.ir.Operation.Companion Companion;
+    field public static final java.lang.String DATA_TYPE_NAME = "Data";
+    field public static final java.lang.String TYPE_MUTATION = "mutation";
+    field public static final java.lang.String TYPE_QUERY = "query";
+    field public static final java.lang.String TYPE_SUBSCRIPTION = "subscription";
+  }
+
+  public static final class Operation.Companion {
+  }
+
+  public sealed abstract class ScalarType {
+    method public final error.NonExistentClass getName();
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.Companion Companion;
+  }
+
+  public static final class ScalarType.BOOLEAN extends com.apollographql.apollo.compiler.ir.ScalarType {
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.BOOLEAN INSTANCE;
+  }
+
+  public static final class ScalarType.Companion {
+    method public com.apollographql.apollo.compiler.ir.ScalarType forName(error.NonExistentClass);
+  }
+
+  public static final class ScalarType.FLOAT extends com.apollographql.apollo.compiler.ir.ScalarType {
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.FLOAT INSTANCE;
+  }
+
+  public static final class ScalarType.ID extends com.apollographql.apollo.compiler.ir.ScalarType {
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.ID INSTANCE;
+  }
+
+  public static final class ScalarType.INT extends com.apollographql.apollo.compiler.ir.ScalarType {
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.INT INSTANCE;
+  }
+
+  public static final class ScalarType.STRING extends com.apollographql.apollo.compiler.ir.ScalarType {
+    field public static final com.apollographql.apollo.compiler.ir.ScalarType.STRING INSTANCE;
+  }
+
+  public final class SourceLocation {
+    ctor public SourceLocation(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation copy(error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getLine();
+    method public error.NonExistentClass getPosition();
+    method public int hashCode();
+    method public error.NonExistentClass toString();
+    field public static final com.apollographql.apollo.compiler.ir.SourceLocation.Companion Companion;
+  }
+
+  public static final class SourceLocation.Companion {
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getUNKNOWN();
+    property public final com.apollographql.apollo.compiler.ir.SourceLocation UNKNOWN;
+  }
+
+  public final class TypeDeclaration implements com.apollographql.apollo.compiler.ir.CodeGenerator {
+    ctor public TypeDeclaration(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public com.apollographql.apollo.compiler.ir.TypeDeclaration copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getKind();
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getValues();
+    method public int hashCode();
+    method public java.lang.String toString();
+    method public error.NonExistentClass toTypeSpec(com.apollographql.apollo.compiler.ir.CodeGenerationContext, error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.ir.TypeDeclaration.Companion Companion;
+  }
+
+  public static final class TypeDeclaration.Companion {
+    method public error.NonExistentClass getENUM_SAFE_VALUE_OF();
+    method public error.NonExistentClass getENUM_UNKNOWN_CONSTANT();
+    method public error.NonExistentClass getKIND_ENUM();
+    method public error.NonExistentClass getKIND_INPUT_OBJECT_TYPE();
+    method public error.NonExistentClass getKIND_SCALAR_TYPE();
+    property public final error.NonExistentClass ENUM_SAFE_VALUE_OF;
+    property public final error.NonExistentClass ENUM_UNKNOWN_CONSTANT;
+    property public final error.NonExistentClass KIND_ENUM;
+    property public final error.NonExistentClass KIND_INPUT_OBJECT_TYPE;
+    property public final error.NonExistentClass KIND_SCALAR_TYPE;
+  }
+
+  public final class TypeDeclarationField {
+    ctor public TypeDeclarationField(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.ir.TypeDeclarationField copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDefaultValue();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getType();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public final class TypeDeclarationValue {
+    ctor public TypeDeclarationValue(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.ir.TypeDeclarationValue copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public error.NonExistentClass isDeprecated();
+    method public java.lang.String toString();
+  }
+
+  public final class Variable {
+    ctor public Variable(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation component3();
+    method public com.apollographql.apollo.compiler.ir.Variable copy(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.ir.SourceLocation);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.ir.SourceLocation getSourceLocation();
+    method public error.NonExistentClass getType();
+    method public int hashCode();
+    method public error.NonExistentClass optional();
+    method public java.lang.String toString();
+  }
+
+}
+
+package com.apollographql.apollo.compiler.operationoutput {
+
+  public final class OperationDescriptor {
+    ctor public OperationDescriptor(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getSource();
+  }
+
+  public final class OperationOutputKt {
+    ctor public OperationOutputKt();
+    method public static error.NonExistentClass OperationOutput(error.NonExistentClass);
+    method public static error.NonExistentClass adapter(error.NonExistentClass);
+    method public static error.NonExistentClass toJson(error.NonExistentClass, error.NonExistentClass);
+  }
+
+}
+
+package com.apollographql.apollo.compiler.parser {
+
+  public final class FieldMergerKt {
+    ctor public FieldMergerKt();
+  }
+
+  public final class GraphQLDocumentParser {
+    ctor public GraphQLDocumentParser(com.apollographql.apollo.compiler.parser.Schema, com.apollographql.apollo.compiler.PackageNameProvider);
+    method public com.apollographql.apollo.compiler.parser.Schema getSchema();
+    method public com.apollographql.apollo.compiler.ir.CodeGenerationIR parse(error.NonExistentClass);
+  }
+
+  public final class GraphQLDocumentSourceBuilder {
+    method public error.NonExistentClass getGraphQLDocumentSource(error.NonExistentClass);
+    method public error.NonExistentClass getGraphQLDocumentSource(error.NonExistentClass);
+    property public final error.NonExistentClass graphQLDocumentSource;
+    property public final error.NonExistentClass graphQLDocumentSource;
+    field public static final com.apollographql.apollo.compiler.parser.GraphQLDocumentSourceBuilder INSTANCE;
+  }
+
+  public final class IntrospectionQuery {
+    field public static final com.apollographql.apollo.compiler.parser.IntrospectionQuery INSTANCE;
+  }
+
+  public static final class IntrospectionQuery.MutationType {
+    ctor public IntrospectionQuery.MutationType(error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.MutationType copy(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class IntrospectionQuery.QueryType {
+    ctor public IntrospectionQuery.QueryType(error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.QueryType copy(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class IntrospectionQuery.Schema {
+    ctor public IntrospectionQuery.Schema(com.apollographql.apollo.compiler.parser.IntrospectionQuery.QueryType, com.apollographql.apollo.compiler.parser.IntrospectionQuery.MutationType, com.apollographql.apollo.compiler.parser.IntrospectionQuery.SubscriptionType, error.NonExistentClass);
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.QueryType component1();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.MutationType component2();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.SubscriptionType component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.Schema copy(com.apollographql.apollo.compiler.parser.IntrospectionQuery.QueryType, com.apollographql.apollo.compiler.parser.IntrospectionQuery.MutationType, com.apollographql.apollo.compiler.parser.IntrospectionQuery.SubscriptionType, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.MutationType getMutationType();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.QueryType getQueryType();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.SubscriptionType getSubscriptionType();
+    method public error.NonExistentClass getTypes();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class IntrospectionQuery.SubscriptionType {
+    ctor public IntrospectionQuery.SubscriptionType(error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.compiler.parser.IntrospectionQuery.SubscriptionType copy(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public final class Schema {
+    ctor public Schema(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getMutationType();
+    method public error.NonExistentClass getQueryType();
+    method public error.NonExistentClass getSubscriptionType();
+    method public error.NonExistentClass getTypes();
+    field public static final com.apollographql.apollo.compiler.parser.Schema.Companion Companion;
+  }
+
+  public static final class Schema.Companion {
+    method public operator com.apollographql.apollo.compiler.parser.Schema invoke(error.NonExistentClass);
+  }
+
+  public static final class Schema.Field {
+    ctor public Schema.Field(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef component5();
+    method public error.NonExistentClass component6();
+    method public com.apollographql.apollo.compiler.parser.Schema.Field copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getArgs();
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef getType();
+    method public int hashCode();
+    method public error.NonExistentClass isDeprecated();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Field.Argument {
+    ctor public Schema.Field.Argument(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef component5();
+    method public error.NonExistentClass component6();
+    method public com.apollographql.apollo.compiler.parser.Schema.Field.Argument copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDefaultValue();
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef getType();
+    method public int hashCode();
+    method public error.NonExistentClass isDeprecated();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.InputField {
+    ctor public Schema.InputField(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef component5();
+    method public error.NonExistentClass component6();
+    method public com.apollographql.apollo.compiler.parser.Schema.InputField copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDefaultValue();
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef getType();
+    method public int hashCode();
+    method public error.NonExistentClass isDeprecated();
+    method public java.lang.String toString();
+  }
+
+  public static class Schema.Kind {
+    method public static com.apollographql.apollo.compiler.parser.Schema.Kind valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.compiler.parser.Schema.Kind[] values();
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind ENUM;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind INPUT_OBJECT;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind INTERFACE;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind LIST;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind NON_NULL;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind OBJECT;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind SCALAR;
+    enum_constant public static final com.apollographql.apollo.compiler.parser.Schema.Kind UNION;
+  }
+
+  public static sealed abstract class Schema.Type {
+    method public abstract error.NonExistentClass getDescription();
+    method public final com.apollographql.apollo.compiler.parser.Schema.Kind getKind();
+    method public abstract error.NonExistentClass getName();
+    property public abstract error.NonExistentClass description;
+    property public abstract error.NonExistentClass name;
+  }
+
+  public static final class Schema.Type.Enum extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.Enum(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Enum copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getEnumValues();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.Enum.Value {
+    ctor public Schema.Type.Enum.Value(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Enum.Value copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDeprecationReason();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public error.NonExistentClass isDeprecated();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.InputObject extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.InputObject(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.InputObject copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getInputFields();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.Interface extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.Interface(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Interface copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getPossibleTypes();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.Object extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.Object(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Object copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.Scalar extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.Scalar(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Scalar copy(error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.Type.Union extends com.apollographql.apollo.compiler.parser.Schema.Type {
+    ctor public Schema.Type.Union(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.Schema.Type.Union copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getPossibleTypes();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class Schema.TypeRef {
+    ctor public Schema.TypeRef(com.apollographql.apollo.compiler.parser.Schema.Kind, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef);
+    method public com.apollographql.apollo.compiler.parser.Schema.Kind component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef component3();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef copy(com.apollographql.apollo.compiler.parser.Schema.Kind, error.NonExistentClass, com.apollographql.apollo.compiler.parser.Schema.TypeRef);
+    method public boolean equals(java.lang.Object);
+    method public com.apollographql.apollo.compiler.parser.Schema.Kind getKind();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef getOfType();
+    method public com.apollographql.apollo.compiler.parser.Schema.TypeRef getRawType();
+    method public int hashCode();
+    method public java.lang.String toString();
+    property public final com.apollographql.apollo.compiler.parser.Schema.TypeRef rawType;
+  }
+
+  public final class UtilsKt {
+    ctor public UtilsKt();
+  }
+
+  public final class ValidationKt {
+    ctor public ValidationKt();
+  }
+
+}
+
+package com.apollographql.apollo.compiler.parser.sdl {
+
+  public final class GraphSDLSchemaParser {
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema parse(error.NonExistentClass);
+    field public static final com.apollographql.apollo.compiler.parser.sdl.GraphSDLSchemaParser INSTANCE;
+  }
+
+  public final class GraphSdlSchema {
+    ctor public GraphSdlSchema(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Schema, error.NonExistentClass);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Schema component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema copy(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Schema, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Schema getSchema();
+    method public error.NonExistentClass getTypeDefinitions();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.Directive {
+    ctor public GraphSdlSchema.Directive(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Directive copy(error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getArguments();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.Schema {
+    ctor public GraphSdlSchema.Schema(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named component3();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named component5();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.Schema copy(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named getMutationRootOperationType();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named getQueryRootOperationType();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named getSubscriptionRootOperationType();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static sealed abstract class GraphSdlSchema.TypeDefinition {
+    method public abstract error.NonExistentClass getDescription();
+    method public abstract error.NonExistentClass getDirectives();
+    method public abstract error.NonExistentClass getName();
+    property public abstract error.NonExistentClass description;
+    property public abstract error.NonExistentClass directives;
+    property public abstract error.NonExistentClass name;
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Enum extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.Enum(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Enum copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getEnumValues();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Enum.Value {
+    ctor public GraphSdlSchema.TypeDefinition.Enum.Value(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Enum.Value copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Field {
+    ctor public GraphSdlSchema.TypeDefinition.Field(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef component4();
+    method public error.NonExistentClass component5();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Field copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getArguments();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef getType();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Field.Argument {
+    ctor public GraphSdlSchema.TypeDefinition.Field.Argument(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef component5();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Field.Argument copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDefaultValue();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef getType();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.InputField {
+    ctor public GraphSdlSchema.TypeDefinition.InputField(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef component5();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.InputField copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDefaultValue();
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef getType();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.InputObject extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.InputObject(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.InputObject copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Interface extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.Interface(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Interface copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Object extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.Object(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public error.NonExistentClass component5();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Object copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getInterfaces();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Scalar extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.Scalar(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Scalar copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeDefinition.Union extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition {
+    ctor public GraphSdlSchema.TypeDefinition.Union(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public error.NonExistentClass component3();
+    method public error.NonExistentClass component4();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeDefinition.Union copy(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getDescription();
+    method public error.NonExistentClass getDirectives();
+    method public error.NonExistentClass getName();
+    method public error.NonExistentClass getTypeRefs();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static sealed abstract class GraphSdlSchema.TypeRef {
+  }
+
+  public static final class GraphSdlSchema.TypeRef.List extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef {
+    ctor public GraphSdlSchema.TypeRef.List(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef component1();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.List copy(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public boolean equals(java.lang.Object);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef getTypeRef();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeRef.Named extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef {
+    ctor public GraphSdlSchema.TypeRef.Named(error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.Named copy(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getTypeName();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+  public static final class GraphSdlSchema.TypeRef.NonNull extends com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef {
+    ctor public GraphSdlSchema.TypeRef.NonNull(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef component1();
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef.NonNull copy(com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef);
+    method public boolean equals(java.lang.Object);
+    method public com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema.TypeRef getTypeRef();
+    method public int hashCode();
+    method public java.lang.String toString();
+  }
+
+}
+

--- a/apollo-coroutines-support/api.txt
+++ b/apollo-coroutines-support/api.txt
@@ -1,0 +1,13 @@
+package com.apollographql.apollo.coroutines {
+
+  public final class CoroutinesExtensionsKt {
+    ctor public CoroutinesExtensionsKt();
+    method public static <T> error.NonExistentClass toDeferred(error.NonExistentClass);
+    method public static <T> error.NonExistentClass toFlow(error.NonExistentClass);
+    method public static <T> error.NonExistentClass toFlow(error.NonExistentClass);
+    method public static <T> error.NonExistentClass toFlow(error.NonExistentClass);
+    method public static error.NonExistentClass toJob(error.NonExistentClass);
+  }
+
+}
+

--- a/apollo-gradle-plugin/api.txt
+++ b/apollo-gradle-plugin/api.txt
@@ -1,0 +1,78 @@
+package com.apollographql.apollo.gradle.api {
+
+  public abstract interface ApolloExtension implements com.apollographql.apollo.gradle.api.CompilerParams {
+    method public abstract void onCompilationUnit(error.NonExistentClass);
+    method public abstract void service(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public abstract interface CompilationUnit implements com.apollographql.apollo.gradle.api.CompilerParams {
+    method public abstract error.NonExistentClass getAndroidVariant();
+    method public abstract error.NonExistentClass getName();
+    method public abstract error.NonExistentClass getOperationOutputFile();
+    method public abstract error.NonExistentClass getOutputDir();
+    method public abstract error.NonExistentClass getServiceName();
+    method public abstract error.NonExistentClass getVariantName();
+    property public abstract error.NonExistentClass androidVariant;
+    property public abstract error.NonExistentClass name;
+    property public abstract error.NonExistentClass operationOutputFile;
+    property public abstract error.NonExistentClass outputDir;
+    property public abstract error.NonExistentClass serviceName;
+    property public abstract error.NonExistentClass variantName;
+  }
+
+  public abstract interface CompilerParams {
+    method public abstract error.NonExistentClass getCustomTypeMapping();
+    method public abstract error.NonExistentClass getGenerateAsInternal();
+    method public abstract error.NonExistentClass getGenerateKotlinModels();
+    method public abstract error.NonExistentClass getGenerateModelBuilder();
+    method public abstract error.NonExistentClass getGenerateOperationOutput();
+    method public abstract error.NonExistentClass getGenerateVisitorForPolymorphicDatatypes();
+    method public abstract error.NonExistentClass getGraphqlSourceDirectorySet();
+    method public abstract error.NonExistentClass getNullableValueType();
+    method public abstract error.NonExistentClass getOperationIdGenerator();
+    method public abstract error.NonExistentClass getRootPackageName();
+    method public abstract error.NonExistentClass getSchemaFile();
+    method public abstract error.NonExistentClass getSealedClassesForEnumsMatching();
+    method public abstract error.NonExistentClass getSuppressRawTypesWarning();
+    method public abstract error.NonExistentClass getUseJavaBeansSemanticNaming();
+    method public abstract error.NonExistentClass getUseSemanticNaming();
+    property public abstract error.NonExistentClass customTypeMapping;
+    property public abstract error.NonExistentClass generateAsInternal;
+    property public abstract error.NonExistentClass generateKotlinModels;
+    property public abstract error.NonExistentClass generateModelBuilder;
+    property public abstract error.NonExistentClass generateOperationOutput;
+    property public abstract error.NonExistentClass generateVisitorForPolymorphicDatatypes;
+    property public abstract error.NonExistentClass graphqlSourceDirectorySet;
+    property public abstract error.NonExistentClass nullableValueType;
+    property public abstract error.NonExistentClass operationIdGenerator;
+    property public abstract error.NonExistentClass rootPackageName;
+    property public abstract error.NonExistentClass schemaFile;
+    property public abstract error.NonExistentClass sealedClassesForEnumsMatching;
+    property public abstract error.NonExistentClass suppressRawTypesWarning;
+    property public abstract error.NonExistentClass useJavaBeansSemanticNaming;
+    property public abstract error.NonExistentClass useSemanticNaming;
+  }
+
+  public abstract interface Introspection {
+    method public abstract error.NonExistentClass getEndpointUrl();
+    method public abstract error.NonExistentClass getHeaders();
+    method public abstract error.NonExistentClass getQueryParameters();
+    method public abstract error.NonExistentClass getSourceSetName();
+    property public abstract error.NonExistentClass endpointUrl;
+    property public abstract error.NonExistentClass headers;
+    property public abstract error.NonExistentClass queryParameters;
+    property public abstract error.NonExistentClass sourceSetName;
+  }
+
+  public abstract interface Service implements com.apollographql.apollo.gradle.api.CompilerParams {
+    method public abstract error.NonExistentClass getExclude();
+    method public abstract error.NonExistentClass getSchemaPath();
+    method public abstract error.NonExistentClass getSourceFolder();
+    method public abstract void introspection(error.NonExistentClass);
+    property public abstract error.NonExistentClass exclude;
+    property public abstract error.NonExistentClass schemaPath;
+    property public abstract error.NonExistentClass sourceFolder;
+  }
+
+}
+

--- a/apollo-http-cache-api/api.txt
+++ b/apollo-http-cache-api/api.txt
@@ -1,0 +1,88 @@
+package com.apollographql.apollo.api.cache.http {
+
+  public abstract interface HttpCache {
+    method public abstract void clear();
+    method public abstract error.NonExistentClass interceptor();
+    method public abstract error.NonExistentClass read(error.NonExistentClass);
+    method public abstract error.NonExistentClass read(error.NonExistentClass, error.NonExistentClass);
+    method public abstract void remove(error.NonExistentClass);
+    method public abstract void removeQuietly(error.NonExistentClass);
+    field public static final java.lang.String CACHE_DO_NOT_STORE = "X-APOLLO-CACHE-DO-NOT-STORE";
+    field public static final java.lang.String CACHE_EXPIRE_AFTER_READ_HEADER = "X-APOLLO-EXPIRE-AFTER-READ";
+    field public static final java.lang.String CACHE_EXPIRE_TIMEOUT_HEADER = "X-APOLLO-EXPIRE-TIMEOUT";
+    field public static final java.lang.String CACHE_FETCH_STRATEGY_HEADER = "X-APOLLO-CACHE-FETCH-STRATEGY";
+    field public static final java.lang.String CACHE_KEY_HEADER = "X-APOLLO-CACHE-KEY";
+    field public static final java.lang.String CACHE_PREFETCH_HEADER = "X-APOLLO-PREFETCH";
+    field public static final java.lang.String CACHE_SERVED_DATE_HEADER = "X-APOLLO-SERVED-DATE";
+    field public static final com.apollographql.apollo.api.cache.http.HttpCache.Companion Companion;
+    field public static final java.lang.String FROM_CACHE = "X-APOLLO-FROM-CACHE";
+  }
+
+  public static final class HttpCache.Companion {
+    field public static final java.lang.String CACHE_DO_NOT_STORE = "X-APOLLO-CACHE-DO-NOT-STORE";
+    field public static final java.lang.String CACHE_EXPIRE_AFTER_READ_HEADER = "X-APOLLO-EXPIRE-AFTER-READ";
+    field public static final java.lang.String CACHE_EXPIRE_TIMEOUT_HEADER = "X-APOLLO-EXPIRE-TIMEOUT";
+    field public static final java.lang.String CACHE_FETCH_STRATEGY_HEADER = "X-APOLLO-CACHE-FETCH-STRATEGY";
+    field public static final java.lang.String CACHE_KEY_HEADER = "X-APOLLO-CACHE-KEY";
+    field public static final java.lang.String CACHE_PREFETCH_HEADER = "X-APOLLO-PREFETCH";
+    field public static final java.lang.String CACHE_SERVED_DATE_HEADER = "X-APOLLO-SERVED-DATE";
+    field public static final java.lang.String FROM_CACHE = "X-APOLLO-FROM-CACHE";
+  }
+
+  public final class HttpCachePolicy {
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy getCACHE_FIRST();
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy getCACHE_ONLY();
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy getNETWORK_FIRST();
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.Policy getNETWORK_ONLY();
+    property public final com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy CACHE_FIRST;
+    property public final com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy CACHE_ONLY;
+    property public final com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy NETWORK_FIRST;
+    property public final com.apollographql.apollo.api.cache.http.HttpCachePolicy.Policy NETWORK_ONLY;
+    field public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy INSTANCE;
+  }
+
+  public static final class HttpCachePolicy.ExpirePolicy extends com.apollographql.apollo.api.cache.http.HttpCachePolicy.Policy {
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy expireAfter(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.api.cache.http.HttpCachePolicy.ExpirePolicy expireAfterRead();
+  }
+
+  public static class HttpCachePolicy.FetchStrategy {
+    method public static com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy[] values();
+    enum_constant public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy CACHE_FIRST;
+    enum_constant public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy CACHE_ONLY;
+    enum_constant public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy NETWORK_FIRST;
+    enum_constant public static final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy NETWORK_ONLY;
+  }
+
+  public static class HttpCachePolicy.Policy {
+    ctor public HttpCachePolicy.Policy(com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public final error.NonExistentClass expireTimeoutMs();
+    method public final error.NonExistentClass getExpireAfterRead();
+    method public final error.NonExistentClass getExpireTimeUnit();
+    method public final error.NonExistentClass getExpireTimeout();
+    method public final com.apollographql.apollo.api.cache.http.HttpCachePolicy.FetchStrategy getFetchStrategy();
+  }
+
+  public abstract interface HttpCacheRecord {
+    method public abstract error.NonExistentClass bodySource();
+    method public abstract void close();
+    method public abstract error.NonExistentClass headerSource();
+  }
+
+  public abstract interface HttpCacheRecordEditor {
+    method public abstract void abort();
+    method public abstract error.NonExistentClass bodySink();
+    method public abstract void commit();
+    method public abstract error.NonExistentClass headerSink();
+  }
+
+  public abstract interface HttpCacheStore {
+    method public abstract com.apollographql.apollo.api.cache.http.HttpCacheRecord cacheRecord(error.NonExistentClass);
+    method public abstract com.apollographql.apollo.api.cache.http.HttpCacheRecordEditor cacheRecordEditor(error.NonExistentClass);
+    method public abstract void delete();
+    method public abstract void remove(error.NonExistentClass);
+  }
+
+}
+

--- a/apollo-http-cache/api.txt
+++ b/apollo-http-cache/api.txt
@@ -1,0 +1,24 @@
+package com.apollographql.apollo.cache.http {
+
+  public final class ApolloHttpCache {
+    ctor public ApolloHttpCache(HttpCacheStore);
+    ctor public ApolloHttpCache(HttpCacheStore, Logger);
+    method public void clear();
+    method public Interceptor interceptor();
+    method public Response read(String);
+    method public Response read(String, boolean);
+    method public void remove(String);
+    method public void removeQuietly(String);
+  }
+
+  public final class DiskLruHttpCacheStore {
+    ctor public DiskLruHttpCacheStore(File, long);
+    ctor public DiskLruHttpCacheStore(com.apollographql.apollo.cache.http.internal.FileSystem, File, long);
+    method public HttpCacheRecord cacheRecord(String);
+    method public HttpCacheRecordEditor cacheRecordEditor(String);
+    method public void delete();
+    method public void remove(String);
+  }
+
+}
+

--- a/apollo-idling-resource/api.txt
+++ b/apollo-idling-resource/api.txt
@@ -1,0 +1,11 @@
+package com.apollographql.apollo.test.espresso {
+
+  public final class ApolloIdlingResource {
+    method public static com.apollographql.apollo.test.espresso.ApolloIdlingResource create(String, ApolloClient);
+    method public String getName();
+    method public boolean isIdleNow();
+    method public void registerIdleTransitionCallback(ResourceCallback);
+  }
+
+}
+

--- a/apollo-normalized-cache-api/api.txt
+++ b/apollo-normalized-cache-api/api.txt
@@ -1,0 +1,161 @@
+package com.apollographql.apollo.cache {
+
+  public final class ApolloCacheHeaders {
+    field public static final java.lang.String DO_NOT_STORE = "do-not-store";
+    field public static final java.lang.String EVICT_AFTER_READ = "evict-after-read";
+    field public static final com.apollographql.apollo.cache.ApolloCacheHeaders INSTANCE;
+    field public static final java.lang.String STORE_PARTIAL_RESPONSES = "store-partial-responses";
+  }
+
+  public final class CacheHeaders {
+    method public error.NonExistentClass hasHeader(error.NonExistentClass);
+    method public error.NonExistentClass headerValue(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.CacheHeaders.Builder toBuilder();
+    field public static final com.apollographql.apollo.cache.CacheHeaders.Companion Companion;
+  }
+
+  public static final class CacheHeaders.Builder {
+    ctor public CacheHeaders.Builder();
+    method public error.NonExistentClass addHeader(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass addHeaders(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.CacheHeaders build();
+  }
+
+  public static final class CacheHeaders.Companion {
+    method public com.apollographql.apollo.cache.CacheHeaders.Builder builder();
+    method public com.apollographql.apollo.cache.CacheHeaders getNONE();
+    property public final com.apollographql.apollo.cache.CacheHeaders NONE;
+  }
+
+}
+
+package com.apollographql.apollo.cache.normalized {
+
+  public final class CacheKey {
+    ctor public CacheKey(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass key();
+    method public error.NonExistentClass toString();
+    field public static final com.apollographql.apollo.cache.normalized.CacheKey.Companion Companion;
+  }
+
+  public static final class CacheKey.Companion {
+    method public com.apollographql.apollo.cache.normalized.CacheKey from(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.CacheKey getNO_KEY();
+    property public final com.apollographql.apollo.cache.normalized.CacheKey NO_KEY;
+  }
+
+  public abstract class CacheKeyResolver {
+    ctor public CacheKeyResolver();
+    method public abstract com.apollographql.apollo.cache.normalized.CacheKey fromFieldArguments(error.NonExistentClass, error.NonExistentClass);
+    method public abstract com.apollographql.apollo.cache.normalized.CacheKey fromFieldRecordSet(error.NonExistentClass, error.NonExistentClass);
+    field public static final com.apollographql.apollo.cache.normalized.CacheKeyResolver.Companion Companion;
+  }
+
+  public static final class CacheKeyResolver.Companion {
+    method public com.apollographql.apollo.cache.normalized.CacheKeyResolver getDEFAULT();
+    method public com.apollographql.apollo.cache.normalized.CacheKey rootKeyForOperation(error.NonExistentClass);
+    property public final com.apollographql.apollo.cache.normalized.CacheKeyResolver DEFAULT;
+  }
+
+  public final class CacheReference {
+    ctor public CacheReference(error.NonExistentClass);
+    method public error.NonExistentClass equals(error.NonExistentClass);
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass key();
+    method public error.NonExistentClass serialize();
+    method public error.NonExistentClass toString();
+    field public static final com.apollographql.apollo.cache.normalized.CacheReference.Companion Companion;
+  }
+
+  public static final class CacheReference.Companion {
+    method public error.NonExistentClass canDeserialize(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.CacheReference deserialize(error.NonExistentClass);
+  }
+
+  public abstract class NormalizedCache {
+    ctor public NormalizedCache();
+    method public final error.NonExistentClass chain(com.apollographql.apollo.cache.normalized.NormalizedCache);
+    method public abstract void clearAll();
+    method public error.NonExistentClass dump();
+    method public final com.apollographql.apollo.cache.normalized.NormalizedCache getNextCache();
+    method public abstract com.apollographql.apollo.cache.normalized.Record loadRecord(error.NonExistentClass, com.apollographql.apollo.cache.CacheHeaders);
+    method public final error.NonExistentClass loadRecords(error.NonExistentClass, com.apollographql.apollo.cache.CacheHeaders);
+    method public error.NonExistentClass merge(com.apollographql.apollo.cache.normalized.Record, com.apollographql.apollo.cache.CacheHeaders);
+    method public error.NonExistentClass merge(error.NonExistentClass, com.apollographql.apollo.cache.CacheHeaders);
+    method protected abstract error.NonExistentClass performMerge(com.apollographql.apollo.cache.normalized.Record, com.apollographql.apollo.cache.CacheHeaders);
+    method public final error.NonExistentClass remove(com.apollographql.apollo.cache.normalized.CacheKey);
+    method public abstract error.NonExistentClass remove(com.apollographql.apollo.cache.normalized.CacheKey, error.NonExistentClass);
+    property public final com.apollographql.apollo.cache.normalized.NormalizedCache nextCache;
+    field public static final com.apollographql.apollo.cache.normalized.NormalizedCache.Companion Companion;
+  }
+
+  public static final class NormalizedCache.Companion {
+    method public error.NonExistentClass prettifyDump(error.NonExistentClass);
+  }
+
+  public abstract class NormalizedCacheFactory<T extends com.apollographql.apollo.cache.normalized.NormalizedCache> {
+    ctor public NormalizedCacheFactory();
+    method public final error.NonExistentClass chain(com.apollographql.apollo.cache.normalized.NormalizedCacheFactory<?>);
+    method public abstract T create(com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter);
+    method public final com.apollographql.apollo.cache.normalized.NormalizedCache createChain(com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter);
+  }
+
+  public final class Record {
+    method public com.apollographql.apollo.cache.normalized.Record clone();
+    method public error.NonExistentClass field(error.NonExistentClass);
+    method public error.NonExistentClass fields();
+    method public error.NonExistentClass getFields();
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass getMutationId();
+    method public error.NonExistentClass hasField(error.NonExistentClass);
+    method public error.NonExistentClass key();
+    method public error.NonExistentClass keys();
+    method public error.NonExistentClass mergeWith(com.apollographql.apollo.cache.normalized.Record);
+    method public error.NonExistentClass mutationId();
+    method public error.NonExistentClass referencedFields();
+    method public error.NonExistentClass sizeEstimateBytes();
+    method public com.apollographql.apollo.cache.normalized.Record.Builder toBuilder();
+    method public error.NonExistentClass toString();
+    property public final error.NonExistentClass fields;
+    property public final error.NonExistentClass mutationId;
+    field public static final com.apollographql.apollo.cache.normalized.Record.Companion Companion;
+  }
+
+  public static final class Record.Builder {
+    ctor public Record.Builder(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.Record.Builder addField(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.Record.Builder addFields(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.Record build();
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass key();
+    method public com.apollographql.apollo.cache.normalized.Record.Builder mutationId(error.NonExistentClass);
+  }
+
+  public static final class Record.Companion {
+    method public com.apollographql.apollo.cache.normalized.Record.Builder builder(error.NonExistentClass);
+  }
+
+  public final class RecordFieldJsonAdapter {
+    ctor public RecordFieldJsonAdapter();
+    method public error.NonExistentClass from(error.NonExistentClass);
+    method public error.NonExistentClass toJson(error.NonExistentClass);
+    field public static final com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter.Companion Companion;
+  }
+
+  public static final class RecordFieldJsonAdapter.Companion {
+    method public com.apollographql.apollo.cache.normalized.RecordFieldJsonAdapter create();
+  }
+
+  public final class RecordSet {
+    ctor public RecordSet();
+    method public error.NonExistentClass allRecords();
+    method public operator com.apollographql.apollo.cache.normalized.Record get(error.NonExistentClass);
+    method public error.NonExistentClass merge(com.apollographql.apollo.cache.normalized.Record);
+  }
+
+}
+

--- a/apollo-normalized-cache-sqlite/api.txt
+++ b/apollo-normalized-cache-sqlite/api.txt
@@ -1,0 +1,44 @@
+package com.apollographql.apollo.cache.normalized.sql {
+
+  public final deprecated class ApolloSqlHelper {
+    ctor public ApolloSqlHelper(error.NonExistentClass, error.NonExistentClass);
+    field public static final com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper.Companion Companion;
+  }
+
+  public static final class ApolloSqlHelper.Companion {
+    method public com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper create(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class SqlNormalizedCache {
+    method public void clearAll();
+    method public void createRecord(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass deleteRecord(error.NonExistentClass);
+    method public error.NonExistentClass loadRecord(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass performMerge(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass remove(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass selectRecordForKey(error.NonExistentClass);
+  }
+
+  public final class SqlNormalizedCacheFactory {
+    ctor public SqlNormalizedCacheFactory();
+    ctor public SqlNormalizedCacheFactory(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCache create(error.NonExistentClass);
+  }
+
+  public final class SqlNormalizedCacheFactory {
+    ctor public SqlNormalizedCacheFactory(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCache create(error.NonExistentClass);
+    field public static final com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory.Companion Companion;
+  }
+
+  public static final class SqlNormalizedCacheFactory.Companion {
+  }
+
+  public final class SqlNormalizedCacheFactory {
+    ctor public SqlNormalizedCacheFactory(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    ctor public SqlNormalizedCacheFactory(com.apollographql.apollo.cache.normalized.sql.ApolloSqlHelper);
+    method public com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCache create(error.NonExistentClass);
+  }
+
+}
+

--- a/apollo-normalized-cache/api.txt
+++ b/apollo-normalized-cache/api.txt
@@ -1,0 +1,120 @@
+package com.apollographql.apollo.cache.normalized {
+
+  public abstract interface ApolloStore {
+    method public abstract error.NonExistentClass cacheKeyResolver();
+    method public abstract com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer<error.NonExistentClass> cacheResponseNormalizer();
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> clearAll();
+    method public abstract com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer<error.NonExistentClass> networkResponseNormalizer();
+    method public abstract error.NonExistentClass normalizedCache();
+    method public abstract void publish(error.NonExistentClass);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<T> read(error.NonExistentClass);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> read(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer<error.NonExistentClass>, error.NonExistentClass);
+    method public abstract <F> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<F> read(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public abstract <R> R readTransaction(com.apollographql.apollo.cache.normalized.internal.Transaction<error.NonExistentClass, R>);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> remove(error.NonExistentClass);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> remove(error.NonExistentClass, error.NonExistentClass);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> remove(error.NonExistentClass);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> rollbackOptimisticUpdates(error.NonExistentClass);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> rollbackOptimisticUpdatesAndPublish(error.NonExistentClass);
+    method public abstract void subscribe(com.apollographql.apollo.cache.normalized.ApolloStore.RecordChangeSubscriber);
+    method public abstract void unsubscribe(com.apollographql.apollo.cache.normalized.ApolloStore.RecordChangeSubscriber);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> write(error.NonExistentClass, D);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> write(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> writeAndPublish(error.NonExistentClass, D);
+    method public abstract com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> writeAndPublish(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> writeOptimisticUpdates(error.NonExistentClass, D, error.NonExistentClass);
+    method public abstract <D, T, V> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<error.NonExistentClass> writeOptimisticUpdatesAndPublish(error.NonExistentClass, D, error.NonExistentClass);
+    method public abstract <R> R writeTransaction(com.apollographql.apollo.cache.normalized.internal.Transaction<error.NonExistentClass, R>);
+    field public static final com.apollographql.apollo.cache.normalized.ApolloStore.Companion Companion;
+  }
+
+  public static final class ApolloStore.Companion {
+    method public com.apollographql.apollo.cache.normalized.ApolloStore getNO_APOLLO_STORE();
+    property public final com.apollographql.apollo.cache.normalized.ApolloStore NO_APOLLO_STORE;
+  }
+
+  public static abstract interface ApolloStore.RecordChangeSubscriber {
+    method public abstract void onCacheRecordsChanged(error.NonExistentClass);
+  }
+
+  public abstract class ApolloStoreOperation<T> {
+    ctor protected ApolloStoreOperation(error.NonExistentClass);
+    method public void enqueue(com.apollographql.apollo.cache.normalized.ApolloStoreOperation.Callback<T>);
+    method public final T execute();
+    method public final void notifyFailure(error.NonExistentClass);
+    method public final void notifySuccess(T);
+    method protected abstract T perform();
+    field public static final com.apollographql.apollo.cache.normalized.ApolloStoreOperation.Companion Companion;
+  }
+
+  public static abstract interface ApolloStoreOperation.Callback<T> {
+    method public abstract void onFailure(error.NonExistentClass);
+    method public abstract void onSuccess(T);
+  }
+
+  public static final class ApolloStoreOperation.Companion {
+    method public error.NonExistentClass emptyExecutor();
+    method public <T> com.apollographql.apollo.cache.normalized.ApolloStoreOperation<T> emptyOperation(T);
+  }
+
+  public final class OptimisticNormalizedCache {
+    ctor public OptimisticNormalizedCache();
+    method public void clearAll();
+    method public error.NonExistentClass dump();
+    method public error.NonExistentClass loadRecord(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass mergeOptimisticUpdate(error.NonExistentClass);
+    method public error.NonExistentClass mergeOptimisticUpdates(error.NonExistentClass);
+    method public error.NonExistentClass performMerge(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass remove(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass removeOptimisticUpdates(error.NonExistentClass);
+  }
+
+}
+
+package com.apollographql.apollo.cache.normalized.lru {
+
+  public final class EvictionPolicy {
+    method public error.NonExistentClass expireAfterAccess();
+    method public error.NonExistentClass expireAfterAccessTimeUnit();
+    method public error.NonExistentClass expireAfterWrite();
+    method public error.NonExistentClass expireAfterWriteTimeUnit();
+    method public error.NonExistentClass getExpireAfterAccess();
+    method public error.NonExistentClass getExpireAfterAccessTimeUnit();
+    method public error.NonExistentClass getExpireAfterWrite();
+    method public error.NonExistentClass getExpireAfterWriteTimeUnit();
+    method public error.NonExistentClass getMaxEntries();
+    method public error.NonExistentClass getMaxSizeBytes();
+    method public error.NonExistentClass maxEntries();
+    method public error.NonExistentClass maxSizeBytes();
+    field public static final com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Companion Companion;
+  }
+
+  public static final class EvictionPolicy.Builder {
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy build();
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Builder expireAfterAccess(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Builder expireAfterWrite(error.NonExistentClass, error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Builder maxEntries(error.NonExistentClass);
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Builder maxSizeBytes(error.NonExistentClass);
+  }
+
+  public static final class EvictionPolicy.Companion {
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy.Builder builder();
+    method public com.apollographql.apollo.cache.normalized.lru.EvictionPolicy getNO_EVICTION();
+    property public final com.apollographql.apollo.cache.normalized.lru.EvictionPolicy NO_EVICTION;
+  }
+
+  public final class LruNormalizedCache {
+    method public void clearAll();
+    method public error.NonExistentClass dump();
+    method public error.NonExistentClass loadRecord(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass performMerge(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass remove(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class LruNormalizedCacheFactory {
+    ctor public LruNormalizedCacheFactory(com.apollographql.apollo.cache.normalized.lru.EvictionPolicy);
+    method public com.apollographql.apollo.cache.normalized.lru.LruNormalizedCache create(error.NonExistentClass);
+  }
+
+}
+

--- a/apollo-runtime-kotlin/api.txt
+++ b/apollo-runtime-kotlin/api.txt
@@ -1,0 +1,342 @@
+package com.apollographql.apollo {
+
+  public final class ApolloBearerTokenException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloBearerTokenException(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getToken();
+  }
+
+  public abstract interface ApolloCall<T> {
+    method public abstract error.NonExistentClass execute(error.NonExistentClass);
+  }
+
+  public final class ApolloClient {
+    ctor public ApolloClient(com.apollographql.apollo.network.NetworkTransport, com.apollographql.apollo.network.NetworkTransport, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public <D, V> com.apollographql.apollo.ApolloMutationCall<D> mutate(error.NonExistentClass);
+    method public <D, V> com.apollographql.apollo.ApolloQueryCall<D> query(error.NonExistentClass);
+    method public <D, V> com.apollographql.apollo.ApolloQueryCall<D> subscribe(error.NonExistentClass);
+  }
+
+  public sealed abstract class ApolloException {
+  }
+
+  public final class ApolloHttpException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloHttpException(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getHeaders();
+    method public error.NonExistentClass getStatusCode();
+  }
+
+  public abstract interface ApolloMutationCall<T> implements com.apollographql.apollo.ApolloCall {
+  }
+
+  public final class ApolloNetworkException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloNetworkException(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class ApolloParseException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloParseException(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public abstract interface ApolloQueryCall<T> implements com.apollographql.apollo.ApolloCall {
+  }
+
+  public final class ApolloSerializationException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloSerializationException(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public abstract interface ApolloSubscriptionCall<T> implements com.apollographql.apollo.ApolloCall {
+  }
+
+  public final class ApolloWebSocketException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloWebSocketException(error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public final class ApolloWebSocketServerException extends com.apollographql.apollo.ApolloException {
+    ctor public ApolloWebSocketServerException(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getPayload();
+  }
+
+}
+
+package com.apollographql.apollo.dispatcher {
+
+  public final class ApolloCoroutineDispatcherContext {
+    ctor public ApolloCoroutineDispatcherContext(error.NonExistentClass);
+    method public error.NonExistentClass getDefault();
+    method public error.NonExistentClass getKey();
+    property public error.NonExistentClass key;
+    field public static final com.apollographql.apollo.dispatcher.ApolloCoroutineDispatcherContext.Key Key;
+  }
+
+  public static final class ApolloCoroutineDispatcherContext.Key {
+    method public com.apollographql.apollo.dispatcher.ApolloCoroutineDispatcherContext.Key getKEY();
+    property public final com.apollographql.apollo.dispatcher.ApolloCoroutineDispatcherContext.Key KEY;
+  }
+
+}
+
+package com.apollographql.apollo.interceptor {
+
+  public abstract interface ApolloInterceptorChain {
+    method public abstract error.NonExistentClass canProceed();
+    method public abstract <D> error.NonExistentClass proceed(com.apollographql.apollo.interceptor.ApolloRequest<D>);
+  }
+
+  public final class ApolloRequest<D> {
+    ctor public ApolloRequest(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getExecutionContext();
+    method public error.NonExistentClass getOperation();
+    method public error.NonExistentClass getRequestUuid();
+    method public error.NonExistentClass getScalarTypeAdapters();
+    property public final error.NonExistentClass requestUuid;
+  }
+
+  public abstract interface ApolloRequestInterceptor {
+    method public abstract <D> error.NonExistentClass intercept(com.apollographql.apollo.interceptor.ApolloRequest<D>, com.apollographql.apollo.interceptor.ApolloInterceptorChain);
+  }
+
+  public final class ApolloResponse<D> {
+    ctor public ApolloResponse(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getExecutionContext();
+    method public error.NonExistentClass getRequestUuid();
+    method public error.NonExistentClass getResponse();
+  }
+
+  public final class BearerTokenInterceptor implements com.apollographql.apollo.interceptor.ApolloRequestInterceptor {
+    ctor public BearerTokenInterceptor(com.apollographql.apollo.interceptor.TokenProvider);
+    method public <D> error.NonExistentClass intercept(com.apollographql.apollo.interceptor.ApolloRequest<D>, com.apollographql.apollo.interceptor.ApolloInterceptorChain);
+  }
+
+  public final class NetworkRequestInterceptor implements com.apollographql.apollo.interceptor.ApolloRequestInterceptor {
+    ctor public NetworkRequestInterceptor(com.apollographql.apollo.network.NetworkTransport, com.apollographql.apollo.network.NetworkTransport);
+    method public <D> error.NonExistentClass intercept(com.apollographql.apollo.interceptor.ApolloRequest<D>, com.apollographql.apollo.interceptor.ApolloInterceptorChain);
+  }
+
+  public abstract interface TokenProvider {
+    method public suspend abstract java.lang.Object currentToken(java.lang.Object);
+    method public suspend abstract java.lang.Object refreshToken(error.NonExistentClass, java.lang.Object);
+  }
+
+}
+
+package com.apollographql.apollo.network {
+
+  public sealed abstract class HttpExecutionContext {
+  }
+
+  public static final class HttpExecutionContext.Request {
+    ctor public HttpExecutionContext.Request(error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public com.apollographql.apollo.network.HttpExecutionContext.Request copy(error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getHeaders();
+    method public error.NonExistentClass getKey();
+    method public int hashCode();
+    method public java.lang.String toString();
+    property public error.NonExistentClass key;
+    field public static final com.apollographql.apollo.network.HttpExecutionContext.Request.Key Key;
+  }
+
+  public static final class HttpExecutionContext.Request.Key {
+  }
+
+  public static final class HttpExecutionContext.Response {
+    ctor public HttpExecutionContext.Response(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass component1();
+    method public error.NonExistentClass component2();
+    method public com.apollographql.apollo.network.HttpExecutionContext.Response copy(error.NonExistentClass, error.NonExistentClass);
+    method public boolean equals(java.lang.Object);
+    method public error.NonExistentClass getHeaders();
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass getStatusCode();
+    method public int hashCode();
+    method public java.lang.String toString();
+    property public error.NonExistentClass key;
+    field public static final com.apollographql.apollo.network.HttpExecutionContext.Response.Key Key;
+  }
+
+  public static final class HttpExecutionContext.Response.Key {
+  }
+
+  public class HttpMethod {
+    method public static com.apollographql.apollo.network.HttpMethod valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.network.HttpMethod[] values();
+    enum_constant public static final com.apollographql.apollo.network.HttpMethod Get;
+    enum_constant public static final com.apollographql.apollo.network.HttpMethod Post;
+  }
+
+  public final class IosPlatformKt {
+    ctor public IosPlatformKt();
+    method public static error.NonExistentClass toNSData(error.NonExistentClass);
+  }
+
+  public abstract interface NetworkTransport {
+    method public abstract <D> error.NonExistentClass execute(com.apollographql.apollo.interceptor.ApolloRequest<D>, error.NonExistentClass);
+  }
+
+}
+
+package com.apollographql.apollo.network.http {
+
+  public final class ApolloHttpNetworkTransport implements com.apollographql.apollo.network.NetworkTransport {
+    ctor public ApolloHttpNetworkTransport(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.network.HttpMethod, kotlin.jvm.functions.Function2<? super error.NonExistentClass, ? super kotlin.jvm.functions.Function3<? super error.NonExistentClass, ? super error.NonExistentClass, ? super error.NonExistentClass, ? extends error.NonExistentClass>, ? extends error.NonExistentClass>);
+    ctor public ApolloHttpNetworkTransport(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.network.HttpMethod);
+    method public <D> error.NonExistentClass execute(com.apollographql.apollo.interceptor.ApolloRequest<D>, error.NonExistentClass);
+  }
+
+  public static sealed abstract class ApolloHttpNetworkTransport.Result {
+  }
+
+  public static final class ApolloHttpNetworkTransport.Result.Failure extends com.apollographql.apollo.network.http.ApolloHttpNetworkTransport.Result {
+    ctor public ApolloHttpNetworkTransport.Result.Failure(com.apollographql.apollo.ApolloException);
+    method public com.apollographql.apollo.ApolloException getCause();
+  }
+
+  public static final class ApolloHttpNetworkTransport.Result.Success extends com.apollographql.apollo.network.http.ApolloHttpNetworkTransport.Result {
+    ctor public ApolloHttpNetworkTransport.Result.Success(com.apollographql.apollo.interceptor.ApolloResponse<?>);
+    method public com.apollographql.apollo.interceptor.ApolloResponse<?> getResponse();
+  }
+
+  public final class ApolloHttpNetworkTransport implements com.apollographql.apollo.network.NetworkTransport {
+    ctor public ApolloHttpNetworkTransport(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.network.HttpMethod);
+    ctor public ApolloHttpNetworkTransport(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.network.HttpMethod);
+    method public <D> error.NonExistentClass execute(com.apollographql.apollo.interceptor.ApolloRequest<D>, error.NonExistentClass);
+  }
+
+  public final class ApolloHttpNetworkTransportKt {
+    ctor public ApolloHttpNetworkTransportKt();
+  }
+
+  public final class ApolloHttpNetworkTransportKt {
+    ctor public ApolloHttpNetworkTransportKt();
+  }
+
+}
+
+package com.apollographql.apollo.network.ws {
+
+  public sealed abstract class ApolloGraphQLClientMessage {
+    method public abstract error.NonExistentClass serialize();
+  }
+
+  public static final class ApolloGraphQLClientMessage.Init extends com.apollographql.apollo.network.ws.ApolloGraphQLClientMessage {
+    ctor public ApolloGraphQLClientMessage.Init(error.NonExistentClass);
+    method public error.NonExistentClass serialize();
+  }
+
+  public static final class ApolloGraphQLClientMessage.Start extends com.apollographql.apollo.network.ws.ApolloGraphQLClientMessage {
+    ctor public ApolloGraphQLClientMessage.Start(com.apollographql.apollo.interceptor.ApolloRequest<?>);
+    method public error.NonExistentClass serialize();
+  }
+
+  public static final class ApolloGraphQLClientMessage.Stop extends com.apollographql.apollo.network.ws.ApolloGraphQLClientMessage {
+    ctor public ApolloGraphQLClientMessage.Stop(error.NonExistentClass);
+    method public error.NonExistentClass serialize();
+  }
+
+  public static final class ApolloGraphQLClientMessage.Terminate extends com.apollographql.apollo.network.ws.ApolloGraphQLClientMessage {
+    method public error.NonExistentClass serialize();
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLClientMessage.Terminate INSTANCE;
+  }
+
+  public sealed abstract class ApolloGraphQLServerMessage {
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.Companion Companion;
+  }
+
+  public static final class ApolloGraphQLServerMessage.Companion {
+    method public com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage parse(error.NonExistentClass);
+  }
+
+  public static final class ApolloGraphQLServerMessage.Complete extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    ctor public ApolloGraphQLServerMessage.Complete(error.NonExistentClass);
+    method public error.NonExistentClass getId();
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.Complete.Companion Companion;
+    field public static final java.lang.String TYPE = "complete";
+  }
+
+  public static final class ApolloGraphQLServerMessage.Complete.Companion {
+  }
+
+  public static final class ApolloGraphQLServerMessage.ConnectionAcknowledge extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.ConnectionAcknowledge INSTANCE;
+    field public static final java.lang.String TYPE = "connection_ack";
+  }
+
+  public static final class ApolloGraphQLServerMessage.ConnectionError extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    ctor public ApolloGraphQLServerMessage.ConnectionError(error.NonExistentClass);
+    method public error.NonExistentClass getRawMessage();
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.ConnectionError.Companion Companion;
+    field public static final java.lang.String TYPE = "connection_error";
+  }
+
+  public static final class ApolloGraphQLServerMessage.ConnectionError.Companion {
+  }
+
+  public static final class ApolloGraphQLServerMessage.ConnectionKeepAlive extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.ConnectionKeepAlive INSTANCE;
+    field public static final java.lang.String TYPE = "ka";
+  }
+
+  public static final class ApolloGraphQLServerMessage.Data extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    ctor public ApolloGraphQLServerMessage.Data(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getId();
+    method public error.NonExistentClass getPayload();
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.Data.Companion Companion;
+    field public static final java.lang.String TYPE = "data";
+  }
+
+  public static final class ApolloGraphQLServerMessage.Data.Companion {
+  }
+
+  public static final class ApolloGraphQLServerMessage.Error extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    ctor public ApolloGraphQLServerMessage.Error(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getId();
+    method public error.NonExistentClass getPayload();
+    field public static final com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage.Error.Companion Companion;
+    field public static final java.lang.String TYPE = "error";
+  }
+
+  public static final class ApolloGraphQLServerMessage.Error.Companion {
+  }
+
+  public static final class ApolloGraphQLServerMessage.Unsupported extends com.apollographql.apollo.network.ws.ApolloGraphQLServerMessage {
+    ctor public ApolloGraphQLServerMessage.Unsupported(error.NonExistentClass);
+    method public error.NonExistentClass getRawMessage();
+  }
+
+  public final class ApolloWebSocketFactory implements com.apollographql.apollo.network.ws.WebSocketFactory {
+    ctor public ApolloWebSocketFactory(error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function2<? super error.NonExistentClass, ? super com.apollographql.apollo.network.ws.WebSocketConnectionListener, ? extends error.NonExistentClass>);
+    ctor public ApolloWebSocketFactory(error.NonExistentClass, error.NonExistentClass);
+    method public suspend java.lang.Object open(error.NonExistentClass, java.lang.Object);
+  }
+
+  public final class ApolloWebSocketFactory implements com.apollographql.apollo.network.ws.WebSocketFactory {
+    ctor public ApolloWebSocketFactory(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    ctor public ApolloWebSocketFactory(error.NonExistentClass, error.NonExistentClass);
+    method public suspend java.lang.Object open(error.NonExistentClass, java.lang.Object);
+  }
+
+  public final class ApolloWebSocketKt {
+    ctor public ApolloWebSocketKt();
+  }
+
+  public final class ApolloWebSocketNetworkTransport implements com.apollographql.apollo.network.NetworkTransport {
+    ctor public ApolloWebSocketNetworkTransport(com.apollographql.apollo.network.ws.WebSocketFactory, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+    method public <D> error.NonExistentClass execute(com.apollographql.apollo.interceptor.ApolloRequest<D>, error.NonExistentClass);
+  }
+
+  public abstract interface WebSocketConnection {
+    method public abstract void close();
+    method public abstract void send(error.NonExistentClass);
+  }
+
+  public abstract interface WebSocketConnectionListener {
+    method public abstract void onClose(error.NonExistentClass, error.NonExistentClass);
+    method public abstract void onOpen(error.NonExistentClass);
+  }
+
+  public abstract interface WebSocketFactory {
+    method public suspend abstract java.lang.Object open(error.NonExistentClass, java.lang.Object);
+  }
+
+}
+

--- a/apollo-runtime/api.txt
+++ b/apollo-runtime/api.txt
@@ -1,0 +1,470 @@
+package com.apollographql.apollo {
+
+  public abstract interface ApolloCall<T> implements com.apollographql.apollo.internal.util.Cancelable {
+    method public abstract com.apollographql.apollo.ApolloCall<T> cacheHeaders(CacheHeaders);
+    method public abstract void cancel();
+    method public abstract com.apollographql.apollo.ApolloCall<T> clone();
+    method public abstract void enqueue(com.apollographql.apollo.ApolloCall.Callback<T>);
+    method public abstract Operation operation();
+  }
+
+  public static abstract class ApolloCall.Callback<T> {
+    ctor public ApolloCall.Callback();
+    method public void onCanceledError(com.apollographql.apollo.exception.ApolloCanceledException);
+    method public abstract void onFailure(ApolloException);
+    method public void onHttpError(com.apollographql.apollo.exception.ApolloHttpException);
+    method public void onNetworkError(com.apollographql.apollo.exception.ApolloNetworkException);
+    method public void onParseError(com.apollographql.apollo.exception.ApolloParseException);
+    method public abstract void onResponse(Response<T>);
+    method public void onStatusEvent(com.apollographql.apollo.ApolloCall.StatusEvent);
+  }
+
+  public static final class ApolloCall.StatusEvent {
+    method public static com.apollographql.apollo.ApolloCall.StatusEvent valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.ApolloCall.StatusEvent[] values();
+    enum_constant public static final com.apollographql.apollo.ApolloCall.StatusEvent COMPLETED;
+    enum_constant public static final com.apollographql.apollo.ApolloCall.StatusEvent FETCH_CACHE;
+    enum_constant public static final com.apollographql.apollo.ApolloCall.StatusEvent FETCH_NETWORK;
+    enum_constant public static final com.apollographql.apollo.ApolloCall.StatusEvent SCHEDULED;
+  }
+
+  public final class ApolloClient implements com.apollographql.apollo.ApolloMutationCall.Factory com.apollographql.apollo.ApolloPrefetch.Factory com.apollographql.apollo.ApolloQueryCall.Factory com.apollographql.apollo.ApolloSubscriptionCall.Factory {
+    method public int activeCallsCount();
+    method public void addOnSubscriptionManagerStateChangeListener(com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener);
+    method public deprecated ApolloStore apolloStore();
+    method public static com.apollographql.apollo.ApolloClient.Builder builder();
+    method public void clearHttpCache();
+    method public void clearNormalizedCache(ApolloStoreOperation.Callback<Boolean>);
+    method public boolean clearNormalizedCache();
+    method public deprecated CacheHeaders defaultCacheHeaders();
+    method public void disableSubscriptions();
+    method public void enableSubscriptions();
+    method public ApolloStore getApolloStore();
+    method public List<ApolloInterceptorFactory> getApplicationInterceptorFactories();
+    method public List<ApolloInterceptor> getApplicationInterceptors();
+    method public CacheHeaders getDefaultCacheHeaders();
+    method public HttpCache getHttpCache();
+    method public ScalarTypeAdapters getScalarTypeAdapters();
+    method public HttpUrl getServerUrl();
+    method public com.apollographql.apollo.internal.subscription.SubscriptionManager getSubscriptionManager();
+    method public com.apollographql.apollo.subscription.SubscriptionManagerState getSubscriptionManagerState();
+    method public void idleCallback(com.apollographql.apollo.IdleResourceCallback);
+    method public <D extends Mutation.Data, T, V extends Mutation.Variables> com.apollographql.apollo.ApolloMutationCall<T> mutate(Mutation<D, T, V>);
+    method public <D extends Mutation.Data, T, V extends Mutation.Variables> com.apollographql.apollo.ApolloMutationCall<T> mutate(Mutation<D, T, V>, D);
+    method public com.apollographql.apollo.ApolloClient.Builder newBuilder();
+    method public <D extends Operation.Data, T, V extends Operation.Variables> com.apollographql.apollo.ApolloPrefetch prefetch(Operation<D, T, V>);
+    method public <D extends Query.Data, T, V extends Query.Variables> com.apollographql.apollo.ApolloQueryCall<T> query(Query<D, T, V>);
+    method public void removeOnSubscriptionManagerStateChangeListener(com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener);
+    method public <D extends Subscription.Data, T, V extends Subscription.Variables> com.apollographql.apollo.ApolloSubscriptionCall<T> subscribe(Subscription<D, T, V>);
+  }
+
+  public static class ApolloClient.Builder {
+    method public com.apollographql.apollo.ApolloClient.Builder addApplicationInterceptor(com.apollographql.apollo.interceptor.ApolloInterceptor);
+    method public com.apollographql.apollo.ApolloClient.Builder addApplicationInterceptorFactory(com.apollographql.apollo.interceptor.ApolloInterceptorFactory);
+    method public <T> com.apollographql.apollo.ApolloClient.Builder addCustomTypeAdapter(ScalarType, CustomTypeAdapter<T>);
+    method public com.apollographql.apollo.ApolloClient build();
+    method public com.apollographql.apollo.ApolloClient.Builder callFactory(Call.Factory);
+    method public com.apollographql.apollo.ApolloClient.Builder defaultCacheHeaders(CacheHeaders);
+    method public com.apollographql.apollo.ApolloClient.Builder defaultHttpCachePolicy(HttpCachePolicy.Policy);
+    method public com.apollographql.apollo.ApolloClient.Builder defaultResponseFetcher(com.apollographql.apollo.fetcher.ResponseFetcher);
+    method public com.apollographql.apollo.ApolloClient.Builder dispatcher(Executor);
+    method public com.apollographql.apollo.ApolloClient.Builder enableAutoPersistedQueries(boolean);
+    method public com.apollographql.apollo.ApolloClient.Builder enableAutoPersistedSubscriptions(boolean);
+    method public com.apollographql.apollo.ApolloClient.Builder httpCache(HttpCache);
+    method public com.apollographql.apollo.ApolloClient.Builder logger(Logger);
+    method public com.apollographql.apollo.ApolloClient.Builder normalizedCache(NormalizedCacheFactory);
+    method public com.apollographql.apollo.ApolloClient.Builder normalizedCache(NormalizedCacheFactory, CacheKeyResolver);
+    method public com.apollographql.apollo.ApolloClient.Builder okHttpClient(OkHttpClient);
+    method public com.apollographql.apollo.ApolloClient.Builder serverUrl(HttpUrl);
+    method public com.apollographql.apollo.ApolloClient.Builder serverUrl(String);
+    method public com.apollographql.apollo.ApolloClient.Builder subscriptionConnectionParams(com.apollographql.apollo.subscription.SubscriptionConnectionParams);
+    method public com.apollographql.apollo.ApolloClient.Builder subscriptionConnectionParams(com.apollographql.apollo.subscription.SubscriptionConnectionParamsProvider);
+    method public com.apollographql.apollo.ApolloClient.Builder subscriptionHeartbeatTimeout(long, TimeUnit);
+    method public com.apollographql.apollo.ApolloClient.Builder subscriptionTransportFactory(com.apollographql.apollo.subscription.SubscriptionTransport.Factory);
+    method public com.apollographql.apollo.ApolloClient.Builder useHttpGetMethodForPersistedQueries(boolean);
+    method public com.apollographql.apollo.ApolloClient.Builder useHttpGetMethodForQueries(boolean);
+  }
+
+  public abstract interface ApolloMutationCall<T> implements com.apollographql.apollo.ApolloCall {
+    method public abstract com.apollographql.apollo.ApolloMutationCall<T> cacheHeaders(CacheHeaders);
+    method public abstract com.apollographql.apollo.ApolloMutationCall<T> clone();
+    method public abstract com.apollographql.apollo.ApolloMutationCall<T> refetchQueries(OperationName...);
+    method public abstract com.apollographql.apollo.ApolloMutationCall<T> refetchQueries(Query...);
+    method public abstract com.apollographql.apollo.ApolloMutationCall<T> requestHeaders(com.apollographql.apollo.request.RequestHeaders);
+  }
+
+  public static abstract interface ApolloMutationCall.Factory {
+    method public abstract <D extends Mutation.Data, T, V extends Mutation.Variables> com.apollographql.apollo.ApolloMutationCall<T> mutate(Mutation<D, T, V>);
+    method public abstract <D extends Mutation.Data, T, V extends Mutation.Variables> com.apollographql.apollo.ApolloMutationCall<T> mutate(Mutation<D, T, V>, D);
+  }
+
+  public abstract interface ApolloPrefetch implements com.apollographql.apollo.internal.util.Cancelable {
+    method public abstract void cancel();
+    method public abstract com.apollographql.apollo.ApolloPrefetch clone();
+    method public abstract void enqueue(com.apollographql.apollo.ApolloPrefetch.Callback);
+    method public abstract Operation operation();
+  }
+
+  public static abstract class ApolloPrefetch.Callback {
+    ctor public ApolloPrefetch.Callback();
+    method public void onCanceledError(com.apollographql.apollo.exception.ApolloCanceledException);
+    method public abstract void onFailure(ApolloException);
+    method public void onHttpError(com.apollographql.apollo.exception.ApolloHttpException);
+    method public void onNetworkError(com.apollographql.apollo.exception.ApolloNetworkException);
+    method public abstract void onSuccess();
+  }
+
+  public static abstract interface ApolloPrefetch.Factory {
+    method public abstract <D extends Operation.Data, T, V extends Operation.Variables> com.apollographql.apollo.ApolloPrefetch prefetch(Operation<D, T, V>);
+  }
+
+  public abstract interface ApolloQueryCall<T> implements com.apollographql.apollo.ApolloCall {
+    method public abstract com.apollographql.apollo.ApolloQueryCall<T> cacheHeaders(CacheHeaders);
+    method public abstract com.apollographql.apollo.ApolloQueryCall<T> clone();
+    method public abstract com.apollographql.apollo.ApolloQueryCall<T> httpCachePolicy(HttpCachePolicy.Policy);
+    method public abstract com.apollographql.apollo.ApolloQueryCall<T> requestHeaders(com.apollographql.apollo.request.RequestHeaders);
+    method public abstract com.apollographql.apollo.ApolloQueryCall<T> responseFetcher(com.apollographql.apollo.fetcher.ResponseFetcher);
+    method public abstract com.apollographql.apollo.ApolloQueryWatcher<T> watcher();
+  }
+
+  public static abstract interface ApolloQueryCall.Factory {
+    method public abstract <D extends Query.Data, T, V extends Query.Variables> com.apollographql.apollo.ApolloQueryCall<T> query(Query<D, T, V>);
+  }
+
+  public abstract interface ApolloQueryWatcher<T> implements com.apollographql.apollo.internal.util.Cancelable {
+    method public abstract void cancel();
+    method public abstract com.apollographql.apollo.ApolloQueryWatcher<T> clone();
+    method public abstract com.apollographql.apollo.ApolloQueryWatcher<T> enqueueAndWatch(com.apollographql.apollo.ApolloCall.Callback<T>);
+    method public abstract Operation operation();
+    method public abstract void refetch();
+    method public abstract com.apollographql.apollo.ApolloQueryWatcher<T> refetchResponseFetcher(com.apollographql.apollo.fetcher.ResponseFetcher);
+  }
+
+  public abstract interface ApolloSubscriptionCall<T> implements com.apollographql.apollo.internal.util.Cancelable {
+    method public abstract com.apollographql.apollo.ApolloSubscriptionCall<T> cachePolicy(com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy);
+    method public abstract com.apollographql.apollo.ApolloSubscriptionCall<T> clone();
+    method public abstract void execute(com.apollographql.apollo.ApolloSubscriptionCall.Callback<T>);
+  }
+
+  public static final class ApolloSubscriptionCall.CachePolicy {
+    method public static com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy[] values();
+    enum_constant public static final com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy CACHE_AND_NETWORK;
+    enum_constant public static final com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy NETWORK_ONLY;
+    enum_constant public static final com.apollographql.apollo.ApolloSubscriptionCall.CachePolicy NO_CACHE;
+  }
+
+  public static abstract interface ApolloSubscriptionCall.Callback<T> {
+    method public abstract void onCompleted();
+    method public abstract void onConnected();
+    method public abstract void onFailure(ApolloException);
+    method public abstract void onResponse(Response<T>);
+    method public abstract void onTerminated();
+  }
+
+  public static abstract interface ApolloSubscriptionCall.Factory {
+    method public abstract <D extends Subscription.Data, T, V extends Subscription.Variables> com.apollographql.apollo.ApolloSubscriptionCall<T> subscribe(Subscription<D, T, V>);
+  }
+
+  public abstract interface IdleResourceCallback {
+    method public abstract void onIdle();
+  }
+
+}
+
+package com.apollographql.apollo.exception {
+
+  public final class ApolloCanceledException {
+    ctor public ApolloCanceledException();
+    ctor public ApolloCanceledException(String, Throwable);
+  }
+
+  public final class ApolloHttpException {
+    ctor public ApolloHttpException(okhttp3.Response);
+    method public int code();
+    method public String message();
+    method public Response rawResponse();
+  }
+
+  public final class ApolloNetworkException {
+    ctor public ApolloNetworkException(String);
+    ctor public ApolloNetworkException(String, Throwable);
+  }
+
+  public final class ApolloParseException {
+    ctor public ApolloParseException(String);
+    ctor public ApolloParseException(String, Throwable);
+  }
+
+}
+
+package com.apollographql.apollo.fetcher {
+
+  public final class ApolloResponseFetchers {
+    ctor public ApolloResponseFetchers();
+    field public static final com.apollographql.apollo.fetcher.ResponseFetcher CACHE_AND_NETWORK;
+    field public static final com.apollographql.apollo.fetcher.ResponseFetcher CACHE_FIRST;
+    field public static final com.apollographql.apollo.fetcher.ResponseFetcher CACHE_ONLY;
+    field public static final com.apollographql.apollo.fetcher.ResponseFetcher NETWORK_FIRST;
+    field public static final com.apollographql.apollo.fetcher.ResponseFetcher NETWORK_ONLY;
+  }
+
+  public abstract interface ResponseFetcher {
+    method public abstract com.apollographql.apollo.interceptor.ApolloInterceptor provideInterceptor(ApolloLogger);
+  }
+
+}
+
+package com.apollographql.apollo.http {
+
+  public final class OkHttpExecutionContext {
+    ctor public OkHttpExecutionContext(error.NonExistentClass);
+    method public error.NonExistentClass getKey();
+    method public error.NonExistentClass getResponse();
+    property public error.NonExistentClass key;
+    property public final error.NonExistentClass response;
+    field public static final com.apollographql.apollo.http.OkHttpExecutionContext.Key Key;
+  }
+
+  public static final class OkHttpExecutionContext.Key {
+    method public com.apollographql.apollo.http.OkHttpExecutionContext.Key getKEY();
+    property public final com.apollographql.apollo.http.OkHttpExecutionContext.Key KEY;
+  }
+
+}
+
+package com.apollographql.apollo.interceptor {
+
+  public abstract interface ApolloInterceptor {
+    method public abstract void dispose();
+    method public abstract void interceptAsync(com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest, com.apollographql.apollo.interceptor.ApolloInterceptorChain, Executor, com.apollographql.apollo.interceptor.ApolloInterceptor.CallBack);
+  }
+
+  public static abstract interface ApolloInterceptor.CallBack {
+    method public abstract void onCompleted();
+    method public abstract void onFailure(ApolloException);
+    method public abstract void onFetch(com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType);
+    method public abstract void onResponse(com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorResponse);
+  }
+
+  public static final class ApolloInterceptor.FetchSourceType {
+    method public static com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType[] values();
+    enum_constant public static final com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType CACHE;
+    enum_constant public static final com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType NETWORK;
+  }
+
+  public static final class ApolloInterceptor.InterceptorRequest {
+    method public static com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder builder(Operation);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder toBuilder();
+    field public final boolean autoPersistQueries;
+    field public final CacheHeaders cacheHeaders;
+    field public final boolean fetchFromCache;
+    field public final Operation operation;
+    field public final Optional<Operation.Data> optimisticUpdates;
+    field public final com.apollographql.apollo.request.RequestHeaders requestHeaders;
+    field public final boolean sendQueryDocument;
+    field public final UUID uniqueId;
+    field public final boolean useHttpGetMethodForQueries;
+  }
+
+  public static final class ApolloInterceptor.InterceptorRequest.Builder {
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder autoPersistQueries(boolean);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest build();
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder cacheHeaders(CacheHeaders);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder fetchFromCache(boolean);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder optimisticUpdates(Operation.Data);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder optimisticUpdates(Optional<Operation.Data>);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder requestHeaders(com.apollographql.apollo.request.RequestHeaders);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder sendQueryDocument(boolean);
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest.Builder useHttpGetMethodForQueries(boolean);
+  }
+
+  public static final class ApolloInterceptor.InterceptorResponse {
+    ctor public ApolloInterceptor.InterceptorResponse(okhttp3.Response);
+    ctor public ApolloInterceptor.InterceptorResponse(okhttp3.Response, Response, Collection<Record>);
+    field public final Optional<Collection<Record>> cacheRecords;
+    field public final Optional<okhttp3.Response> httpResponse;
+    field public final Optional<Response> parsedResponse;
+  }
+
+  public abstract interface ApolloInterceptorChain {
+    method public abstract void dispose();
+    method public abstract void proceedAsync(com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest, Executor, com.apollographql.apollo.interceptor.ApolloInterceptor.CallBack);
+  }
+
+  public abstract interface ApolloInterceptorFactory {
+    method public abstract com.apollographql.apollo.interceptor.ApolloInterceptor newInterceptor();
+  }
+
+}
+
+package com.apollographql.apollo.request {
+
+  public final class RequestHeaders {
+    method public static com.apollographql.apollo.request.RequestHeaders.Builder builder();
+    method public boolean hasHeader(String);
+    method public String headerValue(String);
+    method public Set<String> headers();
+    method public com.apollographql.apollo.request.RequestHeaders.Builder toBuilder();
+    field public static final com.apollographql.apollo.request.RequestHeaders NONE;
+  }
+
+  public static final class RequestHeaders.Builder {
+    ctor public RequestHeaders.Builder();
+    method public com.apollographql.apollo.request.RequestHeaders.Builder addHeader(String, String);
+    method public com.apollographql.apollo.request.RequestHeaders.Builder addHeaders(Map<String, String>);
+    method public com.apollographql.apollo.request.RequestHeaders build();
+  }
+
+}
+
+package com.apollographql.apollo.response {
+
+  public final class OperationResponseParser<D extends Operation.Data, W> {
+    ctor public OperationResponseParser(Operation<D, W, ?>, ResponseFieldMapper, ScalarTypeAdapters);
+    ctor public OperationResponseParser(Operation<D, W, ?>, ResponseFieldMapper, ScalarTypeAdapters, ResponseNormalizer<Map<String, Object>>);
+    method public Response<W> parse(Map<String, Object>);
+    method public Response<W> parse(BufferedSource);
+    method public static Error parseError(Map<String, Object>);
+  }
+
+}
+
+package com.apollographql.apollo.subscription {
+
+  public abstract interface OnSubscriptionManagerStateChangeListener {
+    method public abstract void onStateChange(com.apollographql.apollo.subscription.SubscriptionManagerState, com.apollographql.apollo.subscription.SubscriptionManagerState);
+  }
+
+  public abstract class OperationClientMessage {
+    method public String toJsonString();
+    method public abstract void writeToJson(JsonWriter);
+  }
+
+  public static final class OperationClientMessage.Init extends com.apollographql.apollo.subscription.OperationClientMessage {
+    ctor public OperationClientMessage.Init(Map<String, Object>);
+    method public void writeToJson(JsonWriter);
+  }
+
+  public static final class OperationClientMessage.Start extends com.apollographql.apollo.subscription.OperationClientMessage {
+    ctor public OperationClientMessage.Start(String, Subscription<?, ?, ?>, ScalarTypeAdapters, boolean, boolean);
+    method public void writeToJson(JsonWriter);
+    field public final boolean autoPersistSubscription;
+    field public final boolean sendSubscriptionDocument;
+    field public final Subscription<?, ?, ?> subscription;
+    field public final String subscriptionId;
+  }
+
+  public static final class OperationClientMessage.Stop extends com.apollographql.apollo.subscription.OperationClientMessage {
+    ctor public OperationClientMessage.Stop(String);
+    method public void writeToJson(JsonWriter);
+    field public final String subscriptionId;
+  }
+
+  public static final class OperationClientMessage.Terminate extends com.apollographql.apollo.subscription.OperationClientMessage {
+    ctor public OperationClientMessage.Terminate();
+    method public void writeToJson(JsonWriter);
+  }
+
+  public abstract class OperationServerMessage {
+    method public static com.apollographql.apollo.subscription.OperationServerMessage fromJsonString(String);
+  }
+
+  public static final class OperationServerMessage.Complete extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.Complete(String);
+    field public static final String TYPE;
+    field public final String id;
+  }
+
+  public static final class OperationServerMessage.ConnectionAcknowledge extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.ConnectionAcknowledge();
+    field public static final String TYPE;
+  }
+
+  public static final class OperationServerMessage.ConnectionError extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.ConnectionError(Map<String, Object>);
+    field public static final String TYPE;
+    field public final Map<String, Object> payload;
+  }
+
+  public static final class OperationServerMessage.ConnectionKeepAlive extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.ConnectionKeepAlive();
+    field public static final String TYPE;
+  }
+
+  public static final class OperationServerMessage.Data extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.Data(String, Map<String, Object>);
+    field public static final String TYPE;
+    field public final String id;
+    field public final Map<String, Object> payload;
+  }
+
+  public static final class OperationServerMessage.Error extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.Error(String, Map<String, Object>);
+    field public static final String TYPE;
+    field public final String id;
+    field public final Map<String, Object> payload;
+  }
+
+  public static final class OperationServerMessage.Unsupported extends com.apollographql.apollo.subscription.OperationServerMessage {
+    ctor public OperationServerMessage.Unsupported(String);
+    field public final String rawMessage;
+  }
+
+  public final class SubscriptionConnectionParams {
+    ctor public SubscriptionConnectionParams();
+    ctor public SubscriptionConnectionParams(Map<? extends String, ?>);
+  }
+
+  public abstract interface SubscriptionConnectionParamsProvider {
+    method public abstract com.apollographql.apollo.subscription.SubscriptionConnectionParams provide();
+  }
+
+  public static class SubscriptionConnectionParamsProvider.Const implements com.apollographql.apollo.subscription.SubscriptionConnectionParamsProvider {
+    ctor public SubscriptionConnectionParamsProvider.Const(com.apollographql.apollo.subscription.SubscriptionConnectionParams);
+    method public com.apollographql.apollo.subscription.SubscriptionConnectionParams provide();
+  }
+
+  public final class SubscriptionManagerState {
+    method public static com.apollographql.apollo.subscription.SubscriptionManagerState valueOf(java.lang.String);
+    method public static final com.apollographql.apollo.subscription.SubscriptionManagerState[] values();
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState ACTIVE;
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState CONNECTED;
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState CONNECTING;
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState DISCONNECTED;
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState STOPPED;
+    enum_constant public static final com.apollographql.apollo.subscription.SubscriptionManagerState STOPPING;
+  }
+
+  public abstract interface SubscriptionTransport {
+    method public abstract void connect();
+    method public abstract void disconnect(com.apollographql.apollo.subscription.OperationClientMessage);
+    method public abstract void send(com.apollographql.apollo.subscription.OperationClientMessage);
+  }
+
+  public static abstract interface SubscriptionTransport.Callback {
+    method public abstract void onClosed();
+    method public abstract void onConnected();
+    method public abstract void onFailure(Throwable);
+    method public abstract void onMessage(com.apollographql.apollo.subscription.OperationServerMessage);
+  }
+
+  public static abstract interface SubscriptionTransport.Factory {
+    method public abstract com.apollographql.apollo.subscription.SubscriptionTransport create(com.apollographql.apollo.subscription.SubscriptionTransport.Callback);
+  }
+
+  public final class WebSocketSubscriptionTransport implements com.apollographql.apollo.subscription.SubscriptionTransport {
+    ctor public WebSocketSubscriptionTransport(Request, WebSocket.Factory, com.apollographql.apollo.subscription.SubscriptionTransport.Callback);
+    method public void connect();
+    method public void disconnect(com.apollographql.apollo.subscription.OperationClientMessage);
+    method public void send(com.apollographql.apollo.subscription.OperationClientMessage);
+  }
+
+  public static final class WebSocketSubscriptionTransport.Factory implements com.apollographql.apollo.subscription.SubscriptionTransport.Factory {
+    ctor public WebSocketSubscriptionTransport.Factory(String, WebSocket.Factory);
+    method public com.apollographql.apollo.subscription.SubscriptionTransport create(com.apollographql.apollo.subscription.SubscriptionTransport.Callback);
+  }
+
+}
+

--- a/apollo-rx2-support/api.txt
+++ b/apollo-rx2-support/api.txt
@@ -1,0 +1,27 @@
+package com.apollographql.apollo.rx2 {
+
+  public final class KotlinExtensions {
+    ctor public KotlinExtensions();
+    method public static inline error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass, error.NonExistentClass);
+    method public static inline <D, T, V> error.NonExistentClass rxMutate(error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxMutate(error.NonExistentClass, error.NonExistentClass, D, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxPrefetch(error.NonExistentClass, error.NonExistentClass);
+    method public static inline <D, T, V> error.NonExistentClass rxQuery(error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxSubscribe(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public class Rx2Apollo {
+    method public static <T> Observable<Response<T>> from(ApolloQueryWatcher<T>);
+    method public static <T> Observable<Response<T>> from(ApolloCall<T>);
+    method public static Completable from(ApolloPrefetch);
+    method public static <T> Flowable<Response<T>> from(ApolloSubscriptionCall<T>);
+    method public static <T> Flowable<Response<T>> from(ApolloSubscriptionCall<T>, BackpressureStrategy);
+    method public static <T> Single<T> from(ApolloStoreOperation<T>);
+  }
+
+}
+

--- a/apollo-rx3-support/api.txt
+++ b/apollo-rx3-support/api.txt
@@ -1,0 +1,27 @@
+package com.apollographql.apollo.rx3 {
+
+  public final class KotlinExtensions {
+    ctor public KotlinExtensions();
+    method public static inline error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass);
+    method public static inline <T> error.NonExistentClass rx(error.NonExistentClass, error.NonExistentClass);
+    method public static inline <D, T, V> error.NonExistentClass rxMutate(error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxMutate(error.NonExistentClass, error.NonExistentClass, D, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxPrefetch(error.NonExistentClass, error.NonExistentClass);
+    method public static inline <D, T, V> error.NonExistentClass rxQuery(error.NonExistentClass, error.NonExistentClass, kotlin.jvm.functions.Function1<? super error.NonExistentClass, ? extends error.NonExistentClass>);
+    method public static inline <D, T, V> error.NonExistentClass rxSubscribe(error.NonExistentClass, error.NonExistentClass, error.NonExistentClass);
+  }
+
+  public class Rx3Apollo {
+    method public static <T> Observable<Response<T>> from(ApolloQueryWatcher<T>);
+    method public static <T> Observable<Response<T>> from(ApolloCall<T>);
+    method public static Completable from(ApolloPrefetch);
+    method public static <T> Flowable<Response<T>> from(ApolloSubscriptionCall<T>);
+    method public static <T> Flowable<Response<T>> from(ApolloSubscriptionCall<T>, BackpressureStrategy);
+    method public static <T> Single<T> from(ApolloStoreOperation<T>);
+  }
+
+}
+

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+  java
+  kotlin("jvm") version "1.3.41"
+}
+
+buildscript {
+  project.apply {
+    from(file("../gradle/dependencies.gradle"))
+  }
+
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+  }
+}
+
+repositories {
+  maven { url = uri("https://plugins.gradle.org/m2/") }
+  google()
+  jcenter()
+  mavenCentral()
+}
+
+dependencies {
+  implementation(kotlin("stdlib"))
+  implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.android.plugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.gradleErrorpronePlugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.plugin"))
+  // this plugin is added to the classpath but never applied, it is only used for the closeAndRelease code
+  implementation(groovy.util.Eval.x(project, "x.dep.vanniktechPlugin"))
+
+}

--- a/buildSrc/src/main/kotlin/ApiCompatibility.kt
+++ b/buildSrc/src/main/kotlin/ApiCompatibility.kt
@@ -1,0 +1,23 @@
+import JapiCmp.configureJapiCmp
+import MetalavaHelper.configureMetalava
+import org.gradle.api.Project
+
+object ApiCompatibility {
+  fun apply(project: Project) {
+
+    val downloadMetalavaJar = project.tasks.register("downloadMetalava", DownloadFileTask::class.java) {
+      it.url.set("https://storage.googleapis.com/android-ci/metalava-full-1.3.0-SNAPSHOT.jar")
+      it.output.set(project.layout.buildDirectory.file("metalava/metalava.jar"))
+    }
+
+    project.subprojects {
+      it.configureJapiCmp()
+      it.configureMetalava(downloadMetalavaJar)
+    }
+  }
+}
+
+
+
+
+

--- a/buildSrc/src/main/kotlin/DownloadFileTask.kt
+++ b/buildSrc/src/main/kotlin/DownloadFileTask.kt
@@ -1,0 +1,25 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+abstract class DownloadFileTask : DefaultTask() {
+  @get:Input
+  abstract val url: Property<String>
+
+  @get:org.gradle.api.tasks.OutputFile
+  abstract val output: RegularFileProperty
+
+  @TaskAction
+  fun taskAction() {
+    val client = okhttp3.OkHttpClient()
+    val request = okhttp3.Request.Builder().get().url(url.get()).build()
+
+    client.newCall(request).execute().body!!.byteStream().use { body ->
+      output.asFile.get().outputStream().buffered().use { file ->
+        body.copyTo(file)
+      }
+    }
+  }
+}

--- a/buildSrc/src/main/kotlin/JapiCmp.kt
+++ b/buildSrc/src/main/kotlin/JapiCmp.kt
@@ -1,0 +1,68 @@
+import com.squareup.moshi.Moshi
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.gradle.api.Project
+import java.io.File
+
+object JapiCmp {
+  fun Project.configureJapiCmp() {
+    val downloadBaselineJarTaskProvider = tasks.register("downloadBaseLineJar", DownloadFileTask::class.java) {
+      val artifact = when  {
+        project.pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform") -> "${project.name}-jvm"
+        else -> project.name
+      }
+
+      val version = project.findProperty("japicmpBaselineVersion") ?: latestVersion()
+      val jar = "$artifact-$version.jar"
+
+      it.url.set("https://jcenter.bintray.com/com/apollographql/apollo/$artifact/$version/$jar")
+      it.output.set(File(buildDir, "japicmp/cache/$jar"))
+    }
+
+    // TODO: Make this lazy
+    afterEvaluate {
+      val jarTaskName = when {
+        project.pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform") -> "jvmJar"
+        else -> "jar"
+      }
+      val jarTask = tasks.findByName(jarTaskName) as? org.gradle.jvm.tasks.Jar
+      if (jarTask != null) {
+        tasks.register("generateJapicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
+          it.dependsOn(downloadBaselineJarTaskProvider)
+          it.oldClasspath = files(downloadBaselineJarTaskProvider.get().output.asFile.get())
+          it.newClasspath = files(jarTask.archiveFile)
+          it.ignoreMissingClasses = true
+          it.packageExcludes = listOf("*.internal*")
+          it.onlyModified = true
+          it.failOnSourceIncompatibility = false
+          it.htmlOutputFile = file("$buildDir/reports/japicmp.html")
+          it.txtOutputFile = file("$buildDir/reports/japicmp.txt")
+        }
+        tasks.register("checkJapicmp", me.champeau.gradle.japicmp.JapicmpTask::class.java) {
+          it.dependsOn(downloadBaselineJarTaskProvider)
+          it.oldClasspath = files(downloadBaselineJarTaskProvider.get().output.asFile.get())
+          it.newClasspath = files(jarTask.archiveFile)
+          it.ignoreMissingClasses = true
+          it.packageExcludes = listOf("*.internal*")
+          it.onlyModified = true
+          it.failOnSourceIncompatibility = true
+          it.htmlOutputFile = file("$buildDir/reports/japicmp.html")
+          it.txtOutputFile = file("$buildDir/reports/japicmp.txt")
+        }
+      }
+    }
+  }
+
+
+  private fun latestVersion(): String {
+    return "https://api.bintray.com/packages/apollographql/android/apollo/versions/_latest"
+        .let {
+          Request.Builder().url(it).build()
+        }.let {
+          OkHttpClient().newCall(it).execute()
+              .body!!.string()
+        }.let {
+          (Moshi.Builder().build().adapter(Any::class.java).fromJson(it) as Map<String, Any>).get("name") as String
+        }
+  }
+}

--- a/buildSrc/src/main/kotlin/MetalavaHelper.kt
+++ b/buildSrc/src/main/kotlin/MetalavaHelper.kt
@@ -1,0 +1,54 @@
+import org.gradle.api.Project
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.konan.file.File
+
+object MetalavaHelper {
+  fun Project.configureMetalava(downloadMetalavaJar: TaskProvider<DownloadFileTask>) {
+    val tmpApiTxt = layout.buildDirectory.file("metalava/api.txt").get().asFile.absolutePath
+    val apiTxt = "api.txt"
+    registerMetalavaApiTxtTask("generateMetalava", apiTxt, downloadMetalavaJar)
+    val generateTmpMetalavaApi = registerMetalavaApiTxtTask("generateTmpMetalavaApi", tmpApiTxt, downloadMetalavaJar)
+
+    tasks.register("checkMetalava", JavaExec::class.java) {
+      it.dependsOn(generateTmpMetalavaApi)
+      it.classpath(downloadMetalavaJar.flatMap { it.output.asFile })
+
+      val args = listOf("--no-banner",
+          "--source-files", tmpApiTxt,
+          "--check-compatibility:api:current", apiTxt
+      )
+
+      it.setArgs(args)
+    }
+  }
+
+  fun Project.registerMetalavaApiTxtTask(name: String, apiTxt: String, downloadMetalavaJar: TaskProvider<DownloadFileTask>): TaskProvider<JavaExec> {
+    return tasks.register(name, JavaExec::class.java) {
+      it.classpath(downloadMetalavaJar.flatMap { it.output.asFile })
+
+      val sources = file("src").walk()
+          .maxDepth(2)
+          .onEnter { !it.name.toLowerCase().contains("test") }
+          .filter {
+            it.isDirectory
+                && (it.name == "java" || it.name == "kotlin")
+          }
+          .toList()
+
+      val hides = sources.flatMap {
+        it.walk().filter { it.isDirectory && it.name == "internal" }.toList()
+      }.map {
+        it.relativeTo(projectDir).path.split(File.separator).drop(3).joinToString(".")
+      }.distinct()
+
+      val sourcePaths = listOf("--source-path") + sources.joinToString(":")
+      val hidePackages = hides.flatMap { listOf("--hide-package", it) }
+
+      val args = listOf("--no-banner", "--api", apiTxt) + sourcePaths + hidePackages
+
+      it.setIgnoreExitValue(true)
+      it.setArgs(args)
+    }
+  }
+}

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,6 +7,7 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 
 ./gradlew clean build --stacktrace --max-workers=2
 ./gradlew -p composite build
+./gradlew checkMetalava
 
 ./gradlew publishIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET" --parallel
 # this is a separate task because sonatype does not support --parallel


### PR DESCRIPTION
Closes #1814 
This pull requests adds 4 new tasks in each module:

* **generateJapicmp**:  will compare against the latest released jar (or the `japicmpBaselineVersion` property) and fail if incompatible changes are found generate a report in $module/build/reports/japicmp/japicmp.html
* **checkJapicmp**: will compare against the latest released jar (or the `japicmpBaselineVersion` property) and fail if incompatible changes are found
* **generateMetalava**: generates a listing of the API in $module/api.txt
* **checkMetalava**: compares the current source against $module/api.txt. The nice thing with this is that contrary to japicmp, it can easily be source controled. Breaking an api will make the build fail until the author either fixes the api or commits a new `api.txt` if the breakage is intended

A lot of the inspiration comes from the [firebase-android-sdk repo](https://github.com/firebase/firebase-android-sdk/tree/631484a1407da3dde3cfce23324a466ffd3f01b3/buildSrc/src/main/java/com/google/firebase/gradle/plugins/apiinfo). [Metalava](https://android.googlesource.com/platform/tools/metalava/) is the tool Google uses to diff the API of the Android source code. I _think_ metalava isn't as precise as japicmp but the fact that it works on readable text files and not binary jars like japicmp makes it way easier to automate without having to store jars in the repo. 

`checkMetalava` is now called in CI so we know when the API moves. It won't consider anything under a `*.internal` package so it's safe to make breaking changes there. It might trigger a few false positive at the beginning. If that happens, calling `./gradle generateMetalava` and committing the resulting `api.txt` files should make the build pass again