### PR TITLE
Run SqlNormalizedCache merge in transaction

### DIFF
--- a/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -34,6 +34,6 @@ actual class SqlNormalizedCacheFactory internal actual constructor(
   private val apolloDatabase = ApolloDatabase(driver)
 
   override fun create(recordFieldAdapter: RecordFieldJsonAdapter) =
-      SqlNormalizedCache(recordFieldAdapter, apolloDatabase.cacheQueries)
+      SqlNormalizedCache(recordFieldAdapter, apolloDatabase, apolloDatabase.cacheQueries)
 
 }

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
@@ -10,6 +10,7 @@ import okio.IOException
 
 class SqlNormalizedCache internal constructor(
     private val recordFieldAdapter: RecordFieldJsonAdapter,
+    private val database: ApolloDatabase,
     private val cacheQueries: CacheQueries
 ) : NormalizedCache() {
 
@@ -43,6 +44,14 @@ class SqlNormalizedCache internal constructor(
     } else {
       deleteRecord(cacheKey.key)
     }
+  }
+
+  override fun merge(recordSet: Collection<Record>, cacheHeaders: CacheHeaders): Set<String> {
+    lateinit var records: Set<String>
+    database.transaction {
+      records = super.merge(recordSet, cacheHeaders)
+    }
+    return records
   }
 
   override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {

--- a/apollo-normalized-cache-sqlite/src/iosMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/apollo-normalized-cache-sqlite/src/iosMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -16,5 +16,5 @@ actual class SqlNormalizedCacheFactory internal actual constructor(
   private val apolloDatabase = ApolloDatabase(driver)
 
   override fun create(recordFieldAdapter: RecordFieldJsonAdapter) =
-      SqlNormalizedCache(recordFieldAdapter, apolloDatabase.cacheQueries)
+      SqlNormalizedCache(recordFieldAdapter, apolloDatabase, apolloDatabase.cacheQueries)
 }

--- a/apollo-normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/apollo-normalized-cache-sqlite/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -23,7 +23,7 @@ actual class SqlNormalizedCacheFactory internal actual constructor(
   private val apolloDatabase = ApolloDatabase(driver)
 
   override fun create(recordFieldAdapter: RecordFieldJsonAdapter) =
-      SqlNormalizedCache(recordFieldAdapter, apolloDatabase.cacheQueries)
+      SqlNormalizedCache(recordFieldAdapter, apolloDatabase, apolloDatabase.cacheQueries)
 
   companion object {
     private fun createDriverAndDatabase(url: String, properties: Properties) =


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/issues/2402 for benchmarks.

This improves performance of writes by roughly 300% whenever the writes contain records with new content.