### PR TITLE
Run ApolloCacheInterceptor store write on dispatcher thread

### DIFF
--- a/apollo-runtime/api.txt
+++ b/apollo-runtime/api.txt
@@ -74,6 +74,7 @@ package com.apollographql.apollo {
     method public com.apollographql.apollo.ApolloClient.Builder logger(Logger);
     method public com.apollographql.apollo.ApolloClient.Builder normalizedCache(NormalizedCacheFactory);
     method public com.apollographql.apollo.ApolloClient.Builder normalizedCache(NormalizedCacheFactory, CacheKeyResolver);
+    method public com.apollographql.apollo.ApolloClient.Builder normalizedCache(NormalizedCacheFactory, CacheKeyResolver, boolean);
     method public com.apollographql.apollo.ApolloClient.Builder okHttpClient(OkHttpClient);
     method public com.apollographql.apollo.ApolloClient.Builder serverUrl(HttpUrl);
     method public com.apollographql.apollo.ApolloClient.Builder serverUrl(String);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -760,7 +760,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
 
     private Executor defaultDispatcher() {
       return new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-          new SynchronousQueue<Runnable>(), new ThreadFactory() {
+          new SynchronousQueue<Runnable>(true), new ThreadFactory() {
         @Override
         public Thread newThread(@NotNull Runnable runnable) {
           return new Thread(runnable, "Apollo Dispatcher");

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -760,7 +760,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
 
     private Executor defaultDispatcher() {
       return new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-          new SynchronousQueue<Runnable>(true), new ThreadFactory() {
+          new SynchronousQueue<Runnable>(), new ThreadFactory() {
         @Override
         public Thread newThread(@NotNull Runnable runnable) {
           return new Thread(runnable, "Apollo Dispatcher");

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -76,6 +76,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final Optional<Operation.Data> optimisticUpdates;
   final boolean useHttpGetMethodForQueries;
   final boolean useHttpGetMethodForPersistedQueries;
+  final boolean writeToNormalizedCacheAsynchronously;
 
   public static <T> Builder<T> builder() {
     return new Builder<>();
@@ -124,7 +125,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     useHttpGetMethodForPersistedQueries = builder.useHttpGetMethodForPersistedQueries;
     interceptorChain = prepareInterceptorChain(operation);
     optimisticUpdates = builder.optimisticUpdates;
-
+    writeToNormalizedCacheAsynchronously = builder.writeToNormalizedCacheAsynchronously;
   }
 
   @Override public void enqueue(@Nullable final Callback<T> responseCallback) {
@@ -319,7 +320,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .refetchQueries(refetchQueries)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
-        .optimisticUpdates(optimisticUpdates);
+        .optimisticUpdates(optimisticUpdates)
+        .writeToNormalizedCacheAsynchronously(writeToNormalizedCacheAsynchronously);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -388,7 +390,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.addAll(applicationInterceptors);
 
     interceptors.add(responseFetcher.provideInterceptor(logger));
-    interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger));
+    interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger, writeToNormalizedCacheAsynchronously));
     if (operation instanceof Query && enableAutoPersistedQueries) {
       interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger, useHttpGetMethodForPersistedQueries));
     }
@@ -423,6 +425,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     Optional<Operation.Data> optimisticUpdates = Optional.absent();
     boolean useHttpGetMethodForQueries;
     boolean useHttpGetMethodForPersistedQueries;
+    boolean writeToNormalizedCacheAsynchronously;
 
     public Builder<T> operation(Operation operation) {
       this.operation = operation;
@@ -532,6 +535,11 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
     public Builder<T> useHttpGetMethodForPersistedQueries(boolean useHttpGetMethodForPersistedQueries) {
       this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries;
+      return this;
+    }
+
+    public Builder<T> writeToNormalizedCacheAsynchronously(boolean writeToNormalizedCacheAsynchronously) {
+      this.writeToNormalizedCacheAsynchronously = writeToNormalizedCacheAsynchronously;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -390,7 +390,13 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     interceptors.addAll(applicationInterceptors);
 
     interceptors.add(responseFetcher.provideInterceptor(logger));
-    interceptors.add(new ApolloCacheInterceptor(apolloStore, responseFieldMapper, dispatcher, logger, writeToNormalizedCacheAsynchronously));
+    interceptors.add(new ApolloCacheInterceptor(
+        apolloStore,
+        responseFieldMapper,
+        dispatcher,
+        logger,
+        writeToNormalizedCacheAsynchronously)
+    );
     if (operation instanceof Query && enableAutoPersistedQueries) {
       interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger, useHttpGetMethodForPersistedQueries));
     }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
@@ -70,10 +71,11 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
             @Override public void onResponse(@NotNull InterceptorResponse networkResponse) {
               if (disposed) return;
 
+              final CountDownLatch cacheWriteStarted = new CountDownLatch(1);
               dispatcher.execute(new Runnable() {
                 @Override public void run() {
                   try {
-                    Set<String> networkResponseCacheKeys = cacheResponse(networkResponse, request);
+                    Set<String> networkResponseCacheKeys = cacheResponse(networkResponse, request, cacheWriteStarted);
                     Set<String> rolledBackCacheKeys = rollbackOptimisticUpdates(request);
                     Set<String> changedCacheKeys = new HashSet<>();
                     changedCacheKeys.addAll(rolledBackCacheKeys);
@@ -85,7 +87,12 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
                   }
                 }
               });
-
+              // Guarantee that a cache write has started before returning data.
+              try {
+                cacheWriteStarted.await();
+              } catch (InterruptedException e) {
+                throw (new RuntimeException(e));
+              }
               callBack.onResponse(networkResponse);
               callBack.onCompleted();
             }
@@ -127,11 +134,12 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
   }
 
   Set<String> cacheResponse(final InterceptorResponse networkResponse,
-      final InterceptorRequest request) {
+      final InterceptorRequest request, final CountDownLatch cacheWriteStarted) {
     if (networkResponse.parsedResponse.isPresent()
         && networkResponse.parsedResponse.get().hasErrors()
         && !request.cacheHeaders.hasHeader(ApolloCacheHeaders.STORE_PARTIAL_RESPONSES)
     ) {
+        cacheWriteStarted.countDown();
         return Collections.emptySet();
     }
     final Optional<List<Record>> records = networkResponse.cacheRecords.map(
@@ -147,16 +155,19 @@ public final class ApolloCacheInterceptor implements ApolloInterceptor {
     );
 
     if (!records.isPresent()) {
+      cacheWriteStarted.countDown();
       return Collections.emptySet();
     }
 
     try {
       return apolloStore.writeTransaction(new Transaction<WriteableStore, Set<String>>() {
         @Nullable @Override public Set<String> execute(WriteableStore cache) {
+          cacheWriteStarted.countDown();
           return cache.merge(records.get(), request.cacheHeaders);
         }
       });
     } catch (Exception e) {
+      cacheWriteStarted.countDown();
       logger.e("Failed to cache operation response", e);
       return Collections.emptySet();
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -51,7 +51,7 @@ public class ApolloCacheInterceptorTest {
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build();
 
-    interceptor = new ApolloCacheInterceptor(apolloStore, mock(ResponseFieldMapper.class), mock(Executor.class), new ApolloLogger(logger));
+    interceptor = new ApolloCacheInterceptor(apolloStore, mock(ResponseFieldMapper.class), mock(Executor.class), new ApolloLogger(logger), false);
   }
 
   @Test

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -51,7 +51,13 @@ public class ApolloCacheInterceptorTest {
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build();
 
-    interceptor = new ApolloCacheInterceptor(apolloStore, mock(ResponseFieldMapper.class), mock(Executor.class), new ApolloLogger(logger), false);
+    interceptor = new ApolloCacheInterceptor(
+        apolloStore,
+        mock(ResponseFieldMapper.class),
+        mock(Executor.class),
+        new ApolloLogger(logger),
+        false
+    );
   }
 
   @Test


### PR DESCRIPTION
Discussed in https://github.com/apollographql/apollo-android/issues/2402

This allows cache writes to not block the response, as with the NormalizedCache the cache write can be relatively expensive (>100ms on larger responses).

I believe this is pretty safe:

1) The [Store is already thread safe ](https://github.com/apollographql/apollo-android/blob/master/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.java#L179)

2) All side effects of saving a response are [already dispatched on a new thread](https://github.com/apollographql/apollo-android/blob/master/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java#L178)

3) Because the entire cache interceptor is first [placed on the dispatcher](https://github.com/apollographql/apollo-android/blame/master/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.java#L54)
A new operation that is enqueued after a previous operation returns should have it's read always run after a previous operations write.

4) The [exception which is potentially thrown](https://github.com/apollographql/apollo-android/pull/2416/files#diff-fde3ac9879953bc292263db8c4be85c6R84) does not seem to be handled by any sync code, so moving it to a dispatcher shouldn't change behavior