### PR TITLE
Enable SDL schema Apollo Plugin support

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSDLSchemaParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSDLSchemaParser.kt
@@ -17,6 +17,38 @@ import java.io.IOException
 import java.util.Locale
 
 internal object GraphSDLSchemaParser {
+  private val builtInScalarTypes = listOf(
+      GraphSdlSchema.TypeDefinition.Scalar(
+          name = "Int",
+          description = "The `Int` scalar type represents non-fractional signed whole numeric values. " +
+              "Int can represent values between -(2^31) and 2^31 - 1. ",
+          directives = emptyList()
+      ),
+      GraphSdlSchema.TypeDefinition.Scalar(
+          name = "Float",
+          description = "The `Float` scalar type represents signed double-precision fractional values as specified by " +
+              "[IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          directives = emptyList()
+      ),
+      GraphSdlSchema.TypeDefinition.Scalar(
+          name = "String",
+          description = "The `String` scalar type represents textual data, represented as UTF-8 character sequences. " +
+              "The String type is most often used by GraphQL to represent free-form human-readable text.",
+          directives = emptyList()
+      ),
+      GraphSdlSchema.TypeDefinition.Scalar(
+          name = "Boolean",
+          description = "The `Boolean` scalar type represents `true` or `false`.",
+          directives = emptyList()
+      ),
+      GraphSdlSchema.TypeDefinition.Scalar(
+          name = "ID",
+          description = "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. " +
+              "The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. " +
+              "When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          directives = emptyList()
+      )
+  )
 
   fun File.parse(): GraphSdlSchema {
     val document = try {
@@ -77,6 +109,7 @@ internal object GraphSDLSchemaParser {
               ctx.scalarTypeDefinition()?.parse()
           )
         }
+        ?.plus(builtInScalarTypes)
         ?.associateBy { it.name }
 
     val schemaDefinition = schemaDefinition().firstOrNull()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
@@ -5,9 +5,8 @@ import com.apollographql.apollo.compiler.parser.error.ParseException
 import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
 import com.apollographql.apollo.compiler.parser.sdl.GraphSDLSchemaParser.parse
 import java.io.File
-import java.util.Locale
 
-internal data class GraphSdlSchema(
+data class GraphSdlSchema(
     val schema: Schema,
     val typeDefinitions: Map<String, TypeDefinition>
 ) {
@@ -122,7 +121,7 @@ internal data class GraphSdlSchema(
   }
 }
 
-internal fun GraphSdlSchema.toIntrospectionSchema(): IntrospectionSchema {
+fun GraphSdlSchema.toIntrospectionSchema(): IntrospectionSchema {
   return IntrospectionSchema(
       queryType = schema.queryRootOperationType.typeName,
       mutationType = schema.mutationRootOperationType.typeName,
@@ -226,35 +225,13 @@ private fun GraphSdlSchema.TypeDefinition.Scalar.toIntrospectionType(): Introspe
 private fun GraphSdlSchema.TypeRef.toIntrospectionType(schema: GraphSdlSchema): IntrospectionSchema.TypeRef {
   return when (this) {
     is GraphSdlSchema.TypeRef.Named -> {
-      when (typeName.toLowerCase(Locale.ENGLISH)) {
-        "int" -> IntrospectionSchema.TypeRef(
-            kind = IntrospectionSchema.Kind.SCALAR,
-            name = "Int"
-        )
-        "float" -> IntrospectionSchema.TypeRef(
-            kind = IntrospectionSchema.Kind.SCALAR,
-            name = "Float"
-        )
-        "string" -> IntrospectionSchema.TypeRef(
-            kind = IntrospectionSchema.Kind.SCALAR,
-            name = "String"
-        )
-        "boolean" -> IntrospectionSchema.TypeRef(
-            kind = IntrospectionSchema.Kind.SCALAR,
-            name = "Boolean"
-        )
-        "id" -> IntrospectionSchema.TypeRef(
-            kind = IntrospectionSchema.Kind.SCALAR,
-            name = "ID"
-        )
-        else -> IntrospectionSchema.TypeRef(
-            kind = schema.typeDefinitions[typeName]?.toIntrospectionType() ?: throw ParseException(
-                message = "Undefined GraphQL schema type `$typeName`",
-                sourceLocation = sourceLocation
-            ),
-            name = typeName
-        )
-      }
+      IntrospectionSchema.TypeRef(
+          kind = schema.typeDefinitions[typeName]?.toIntrospectionType() ?: throw ParseException(
+              message = "Undefined GraphQL schema type `$typeName`",
+              sourceLocation = sourceLocation
+          ),
+          name = typeName
+      )
     }
 
     is GraphSdlSchema.TypeRef.NonNull -> IntrospectionSchema.TypeRef(

--- a/apollo-compiler/src/test/sdl/schema.json
+++ b/apollo-compiler/src/test/sdl/schema.json
@@ -2556,6 +2556,56 @@
           "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         }
       ],
       "directives": [

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -107,7 +107,8 @@ abstract class DefaultCompilationUnit @Inject constructor(
           |  }
         """.trimMargin()
       }
-      return "ApolloGraphQL: By default only one schema.json file is supported.\nPlease use multiple services instead:\napollo {\n$services\n}"
+      return "ApolloGraphQL: By default only one schema.[json | sdl] file is supported.\n" +
+          "Please use multiple services instead:\napollo {\n$services\n}"
     }
 
     fun resolveDirectories(project: Project, sourceFolderProvider: Provider<String>, sourceSetNames: List<String>): List<String> {
@@ -147,16 +148,18 @@ abstract class DefaultCompilationUnit @Inject constructor(
         }
       } else {
         val candidates = directories.flatMap { srcDir ->
-          srcDir.walkTopDown().filter { it.name == "schema.json" }.toList()
+          srcDir.walkTopDown().filter { it.name == "schema.json" || it.name == "schema.sdl" }.toList()
         }
 
         require(candidates.size <= 1) {
           multipleSchemaError(candidates)
         }
+
         require(candidates.size == 1) {
-          "ApolloGraphQL: cannot find schema.json. Please specify it explicitely. Looked under:\n" +
-              directories.map { it.absolutePath }.joinToString("\n")
+          "ApolloGraphQL: cannot find schema.[json | sdl]. Please specify it explicitely. Looked under:\n" +
+              directories.joinToString("\n") { it.absolutePath }
         }
+
         return candidates.first().path
       }
     }

--- a/apollo-gradle-plugin/src/test/files/sdl/FeedRepositoryQuery.graphql
+++ b/apollo-gradle-plugin/src/test/files/sdl/FeedRepositoryQuery.graphql
@@ -1,0 +1,7 @@
+query FeedRepositoryQuery($type: FeedType!, $limit: Int!) {
+  feed(type: $type, limit: $limit) {
+    repository {
+      name
+    }
+  }
+}

--- a/apollo-gradle-plugin/src/test/files/sdl/schema.json
+++ b/apollo-gradle-plugin/src/test/files/sdl/schema.json
@@ -1,0 +1,1747 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": {
+        "name": "Mutation"
+      },
+      "subscriptionType": {
+        "name": "Subscription"
+      },
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "feed",
+              "description": "A feed of repository submissions",
+              "args": [
+                {
+                  "name": "type",
+                  "description": "The sort order for the feed",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "FeedType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "The number of items to skip, for pagination",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": "The number of items to fetch starting from the offset, for pagination",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Entry",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "entry",
+              "description": "A single entry",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentUser",
+              "description": "Return the currently logged in user, or null if nobody is logged in",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FeedType",
+          "description": "A list of options for the sort order of the feed",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "HOT",
+              "description": "Sort by a combination of freshness and score, using Reddit's algorithm",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NEW",
+              "description": "Newest entries first",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TOP",
+              "description": "Highest score entries first",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Entry",
+          "description": "Information about a GitHub repository submitted to GitHunt",
+          "fields": [
+            {
+              "name": "repository",
+              "description": "Information about the repository from GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Repository",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postedBy",
+              "description": "The GitHub user who submitted this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "A timestamp of when the entry was submitted",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "score",
+              "description": "The score of this repository, upvotes - downvotes",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "hotScore",
+              "description": "The hot score of this repository",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comments",
+              "description": "Comments posted about this repository",
+              "args": [
+                {
+                  "name": "limit",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Comment",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commentCount",
+              "description": "The number of comments posted about this repository",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": "The SQL ID of this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vote",
+              "description": "XXX to be changed",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vote",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Repository",
+          "description": "A repository object from the GitHub API. This uses the exact field names returned by the\nGitHub API for simplicity, even though the convention for GraphQL is usually to camel case.",
+          "fields": [
+            {
+              "name": "name",
+              "description": "Just the name of the repository, e.g. GitHunt-API",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "full_name",
+              "description": "The full name of the repository with the username, e.g. apollostack/GitHunt-API",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "The description of the repository",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "html_url",
+              "description": "The link to the repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stargazers_count",
+              "description": "The number of people who have starred this repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "open_issues_count",
+              "description": "The number of open issues on this repository on GitHub",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "owner",
+              "description": "The owner of this repository on GitHub, e.g. apollostack",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "User",
+          "description": "A user object from the GitHub API. This uses the exact field names returned from the GitHub API.",
+          "fields": [
+            {
+              "name": "login",
+              "description": "The name of the user, e.g. apollostack",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "avatar_url",
+              "description": "The URL to a directly embeddable image for this user's avatar",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "html_url",
+              "description": "The URL of this user's GitHub page",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point). ",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Comment",
+          "description": "A comment about an entry, submitted by a user",
+          "fields": [
+            {
+              "name": "id",
+              "description": "The SQL ID of this entry",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "postedBy",
+              "description": "The GitHub user who posted the comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "User",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": "A timestamp of when the comment was posted",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "content",
+              "description": "The text of the comment",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "repoName",
+              "description": "The repository which this comment is about",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Vote",
+          "description": "XXX to be removed",
+          "fields": [
+            {
+              "name": "vote_value",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Mutation",
+          "description": "",
+          "fields": [
+            {
+              "name": "submitRepository",
+              "description": "Submit a new repository, returns the new submission",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vote",
+              "description": "Vote on a repository submission, returns the submission that was voted on",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "type",
+                  "description": "The type of vote - UP, DOWN, or CANCEL",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "VoteType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Entry",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "submitComment",
+              "description": "Comment on a repository, returns the new comment",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "The full repository name from GitHub, e.g. \"apollostack/GitHunt-API\"",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "commentContent",
+                  "description": "The text content for the new comment",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "VoteType",
+          "description": "The type of vote to record, when submitting a vote",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "UP",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "DOWN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CANCEL",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subscription",
+          "description": "",
+          "fields": [
+            {
+              "name": "commentAdded",
+              "description": "Subscription fires on every comment added",
+              "args": [
+                {
+                  "name": "repoFullName",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Comment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue"
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted in [Markdown](https://daringfireball.net/projects/markdown/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apollo-gradle-plugin/src/test/files/sdl/schema.sdl
+++ b/apollo-gradle-plugin/src/test/files/sdl/schema.sdl
@@ -1,0 +1,178 @@
+"""A comment about an entry, submitted by a user"""
+type Comment {
+  """The text of the comment"""
+  content: String!
+
+  """A timestamp of when the comment was posted"""
+  createdAt: Float!
+
+  """The SQL ID of this entry"""
+  id: Int!
+
+  """The GitHub user who posted the comment"""
+  postedBy: User!
+
+  """The repository which this comment is about"""
+  repoName: String!
+}
+
+"""Information about a GitHub repository submitted to GitHunt"""
+type Entry {
+  """The number of comments posted about this repository"""
+  commentCount: Int!
+
+  """Comments posted about this repository"""
+  comments(limit: Int, offset: Int): [Comment]!
+
+  """A timestamp of when the entry was submitted"""
+  createdAt: Float!
+
+  """The hot score of this repository"""
+  hotScore: Float!
+
+  """The SQL ID of this entry"""
+  id: Int!
+
+  """The GitHub user who submitted this entry"""
+  postedBy: User!
+
+  """Information about the repository from GitHub"""
+  repository: Repository!
+
+  """The score of this repository, upvotes - downvotes"""
+  score: Int!
+
+  """XXX to be changed"""
+  vote: Vote!
+}
+
+"""A list of options for the sort order of the feed"""
+enum FeedType {
+  """Sort by a combination of freshness and score, using Reddit's algorithm"""
+  HOT
+
+  """Newest entries first"""
+  NEW
+
+  """Highest score entries first"""
+  TOP
+}
+
+type Mutation {
+  """Comment on a repository, returns the new comment"""
+  submitComment(
+    """
+    The full repository name from GitHub, e.g. "apollostack/GitHunt-API"
+    """
+    repoFullName: String!
+
+    """The text content for the new comment"""
+    commentContent: String!
+  ): Comment
+
+  """Submit a new repository, returns the new submission"""
+  submitRepository(
+    """
+    The full repository name from GitHub, e.g. "apollostack/GitHunt-API"
+    """
+    repoFullName: String!
+  ): Entry
+
+  """
+  Vote on a repository submission, returns the submission that was voted on
+  """
+  vote(
+    """
+    The full repository name from GitHub, e.g. "apollostack/GitHunt-API"
+    """
+    repoFullName: String!
+
+    """The type of vote - UP, DOWN, or CANCEL"""
+    type: VoteType!
+  ): Entry
+}
+
+type Query {
+  """Return the currently logged in user, or null if nobody is logged in"""
+  currentUser: User
+
+  """A single entry"""
+  entry(
+    """
+    The full repository name from GitHub, e.g. "apollostack/GitHunt-API"
+    """
+    repoFullName: String!
+  ): Entry
+
+  """A feed of repository submissions"""
+  feed(
+    """The sort order for the feed"""
+    type: FeedType!
+
+    """The number of items to skip, for pagination"""
+    offset: Int
+
+    """The number of items to fetch starting from the offset, for pagination"""
+    limit: Int
+  ): [Entry]
+}
+
+"""
+A repository object from the GitHub API. This uses the exact field names returned by the
+GitHub API for simplicity, even though the convention for GraphQL is usually to camel case.
+"""
+type Repository {
+  """The description of the repository"""
+  description: String
+
+  """
+  The full name of the repository with the username, e.g. apollostack/GitHunt-API
+  """
+  full_name: String!
+
+  """The link to the repository on GitHub"""
+  html_url: String!
+
+  """Just the name of the repository, e.g. GitHunt-API"""
+  name: String!
+
+  """The number of open issues on this repository on GitHub"""
+  open_issues_count: Int
+
+  """The owner of this repository on GitHub, e.g. apollostack"""
+  owner: User
+
+  """The number of people who have starred this repository on GitHub"""
+  stargazers_count: Int!
+}
+
+type Subscription {
+  """Subscription fires on every comment added"""
+  commentAdded(repoFullName: String!): Comment
+}
+
+"""
+A user object from the GitHub API. This uses the exact field names returned from the GitHub API.
+"""
+type User {
+  """The URL to a directly embeddable image for this user's avatar"""
+  avatar_url: String!
+
+  """The URL of this user's GitHub page"""
+  html_url: String!
+
+  """The name of the user, e.g. apollostack"""
+  login: String!
+}
+
+"""XXX to be removed"""
+type Vote {
+  vote_value: Int!
+}
+
+"""The type of vote to record, when submitting a vote"""
+enum VoteType {
+  UP
+  DOWN
+  CANCEL
+}

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/MultipleServicesTests.kt
@@ -5,7 +5,9 @@ import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.TestUtils.withProject
 import com.apollographql.apollo.gradle.util.generatedChild
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert
 import org.junit.Assert.*
 import org.junit.Test
 import java.io.File
@@ -30,14 +32,15 @@ class MultipleServicesTests {
   @Test
   fun `multiple schema files without using service is not supported`() {
     withMultipleServicesProject("") { dir ->
-      var exception: Exception? = null
       try {
         TestUtils.executeTask("generateApolloSources", dir)
+        fail("expected to fail")
       } catch (e: UnexpectedBuildFailure) {
-        exception = e
-        assertThat(e.message, containsString("By default only one schema.json file is supported."))
+        MatcherAssert.assertThat(
+            e.message,
+            containsString("ApolloGraphQL: By default only one schema.[json | sdl] file is supported.")
+        )
       }
-      assertNotNull(exception)
     }
   }
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SchemaResolutionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SchemaResolutionTests.kt
@@ -1,0 +1,109 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.internal.child
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.apollographql.apollo.gradle.util.TestUtils.executeTask
+import com.apollographql.apollo.gradle.util.TestUtils.withProject
+import com.apollographql.apollo.gradle.util.generatedChild
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class SchemaResolutionTests {
+
+  @Test
+  fun `when SDL schema assert implicitly resolved and generates classes`() {
+    val apolloConfiguration = """
+      apollo {
+        service("api") {
+          generateKotlinModels = true
+        }
+      }
+    """.trimIndent()
+
+    withProject(
+        usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)
+    ) { projectDir ->
+      projectDir.child("src", "main", "graphql", "com").deleteRecursively()
+
+      val fixturesDir = TestUtils.fixturesDirectory()
+
+      val target = projectDir.child("src", "main", "graphql")
+      fixturesDir.child("sdl").copyRecursively(target = target, overwrite = true)
+
+      projectDir.child("src", "main", "graphql", "schema.json").delete()
+
+      executeTask("build", projectDir)
+
+      assertTrue(projectDir.generatedChild("main/api/FeedRepositoryQuery.kt").isFile)
+    }
+  }
+
+  @Test
+  fun `when SDL schema set explicitly assert generates classes`() {
+    val apolloConfiguration = """
+      apollo {
+        service("api") {
+          schemaPath = "schema.sdl"
+          generateKotlinModels = true
+        }
+      }
+    """.trimIndent()
+
+    withProject(
+        usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)
+    ) { projectDir ->
+      projectDir.child("src", "main", "graphql", "com").deleteRecursively()
+
+      val fixturesDir = TestUtils.fixturesDirectory()
+
+      val target = projectDir.child("src", "main", "graphql")
+      fixturesDir.child("sdl").copyRecursively(target = target, overwrite = true)
+
+      executeTask("build", projectDir)
+
+      assertTrue(projectDir.generatedChild("main/api/FeedRepositoryQuery.kt").isFile)
+    }
+  }
+
+  @Test
+  fun `when SDL and introspection schema not set explicitly assert build fails`() {
+    val apolloConfiguration = """
+      apollo {
+        service("api") {
+          generateKotlinModels = true
+        }
+      }
+    """.trimIndent()
+
+    withProject(
+        usesKotlinDsl = false,
+        apolloConfiguration = apolloConfiguration,
+        plugins = listOf(TestUtils.javaPlugin, TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin)
+    ) { projectDir ->
+      projectDir.child("src", "main", "graphql", "com").deleteRecursively()
+
+      val fixturesDir = TestUtils.fixturesDirectory()
+
+      val target = projectDir.child("src", "main", "graphql")
+      fixturesDir.child("sdl").copyRecursively(target = target, overwrite = true)
+
+      try {
+        executeTask("build", projectDir)
+        fail("expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        MatcherAssert.assertThat(
+            e.message,
+            CoreMatchers.containsString("ApolloGraphQL: By default only one schema.[json | sdl] file is supported.")
+        )
+      }
+    }
+  }
+}

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SchemaResolutionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/SchemaResolutionTests.kt
@@ -38,7 +38,7 @@ class SchemaResolutionTests {
 
       projectDir.child("src", "main", "graphql", "schema.json").delete()
 
-      executeTask("build", projectDir)
+      executeTask("generateApolloSources", projectDir)
 
       assertTrue(projectDir.generatedChild("main/api/FeedRepositoryQuery.kt").isFile)
     }
@@ -67,7 +67,7 @@ class SchemaResolutionTests {
       val target = projectDir.child("src", "main", "graphql")
       fixturesDir.child("sdl").copyRecursively(target = target, overwrite = true)
 
-      executeTask("build", projectDir)
+      executeTask("generateApolloSources", projectDir)
 
       assertTrue(projectDir.generatedChild("main/api/FeedRepositoryQuery.kt").isFile)
     }
@@ -96,7 +96,7 @@ class SchemaResolutionTests {
       fixturesDir.child("sdl").copyRecursively(target = target, overwrite = true)
 
       try {
-        executeTask("build", projectDir)
+        executeTask("generateApolloSources", projectDir)
         fail("expected to fail")
       } catch (e: UnexpectedBuildFailure) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Final PR to enable SDL schema support

- Resolve and call schema parser from schema file extension.
- Update implicit schema resolution to support `sdl` extension
- Add hardcoded built in scalar types into SDL schema to be more aligned with introspection query result.

Closes https://github.com/apollographql/apollo-android/issues/2261