### PR TITLE
Allow calls to WebSocketSubscriptionTransport#send when not connected.

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransport.java
@@ -52,7 +52,8 @@ public final class WebSocketSubscriptionTransport implements SubscriptionTranspo
   public void send(OperationClientMessage message) {
     WebSocket socket = webSocket.get();
     if (socket == null) {
-      throw new IllegalStateException("Not connected");
+      callback.onFailure(new IllegalStateException("Send attempted on closed connection"));
+      return;
     }
     socket.send(message.toJsonString());
   }


### PR DESCRIPTION
Failures from the transport are reported via the dispatcher, and are not synchronous, so it is possible (and quite common) for callers to attempt to send messages after the transport has moved into an errored or closed state, but before the subscription manager has received the message that the transport is closed.

I realize that `onFailure()` is probably not the right callback here. Other options are:

 * Fail silently -- I don't see any issues with this?
 * Return boolean from `send` that tells the caller whether the send was successful
 * Change the failure/close message passing to be synchronous up to the subscription manager
