### PR TITLE
[Runtime] add `ApolloClient.autoPersistedOperationsInterceptorFactory`

### DIFF
--- a/apollo-api/api.txt
+++ b/apollo-api/api.txt
@@ -178,6 +178,7 @@ package com.apollographql.apollo.api {
   }
 
   public abstract interface Operation<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> {
+    method public abstract error.NonExistentClass composeRequestBody(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
     method public abstract error.NonExistentClass composeRequestBody(com.apollographql.apollo.api.ScalarTypeAdapters);
     method public abstract error.NonExistentClass composeRequestBody();
     method public abstract com.apollographql.apollo.api.OperationName name();
@@ -220,7 +221,6 @@ package com.apollographql.apollo.api {
   }
 
   public abstract interface Query<D extends com.apollographql.apollo.api.Operation.Data, T, V extends com.apollographql.apollo.api.Operation.Variables> implements com.apollographql.apollo.api.Operation {
-    method public abstract error.NonExistentClass composeRequestBody(error.NonExistentClass, error.NonExistentClass, com.apollographql.apollo.api.ScalarTypeAdapters);
   }
 
   public final class Response<T> {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
@@ -74,6 +74,36 @@ interface Operation<D : Operation.Data, T, V : Operation.Variables> {
   fun parse(byteString: ByteString): Response<T>
 
   /**
+   * Composes POST JSON-encoded request body to be sent to the GraphQL server.
+   *
+   * In case when [autoPersistQueries] is set to `true` special `extension` attributes, required by query auto persistence,
+   * will be encoded along with regular GraphQL request body. If query was previously persisted on the GraphQL server
+   * set [withQueryDocument] to `false` to skip query document be sent in the request.
+   *
+   * Optional [scalarTypeAdapters] must be provided in case when this operation defines variables with custom GraphQL scalar type.
+   *
+   * *Example*:
+   * ```
+   * {
+   *    "query": "query TestQuery($episode: Episode) { hero(episode: $episode) { name } }",
+   *    "operationName": "TestQuery",
+   *    "variables": { "episode": "JEDI" }
+   *    "extensions": {
+   *      "persistedQuery": {
+   *        "version": 1,
+   *        "sha256Hash": "32637895609e6c51a2593f5cfb49244fd79358d327ff670b3e930e024c3db8f6"
+   *      }
+   *    }
+   * }
+   * ```
+   */
+  fun composeRequestBody(
+      autoPersistQueries: Boolean,
+      withQueryDocument: Boolean,
+      scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString
+
+  /**
    * Composes POST JSON-encoded request body with provided [scalarTypeAdapters] to be sent to the GraphQL server.
    *
    * *Example*:

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
@@ -5,34 +5,4 @@ import okio.ByteString
 /**
  * Represents a GraphQL query that will be sent to the server.
  */
-interface Query<D : Operation.Data, T, V : Operation.Variables> : Operation<D, T, V> {
-  /**
-   * Composes POST JSON-encoded request body to be sent to the GraphQL server.
-   *
-   * In case when [autoPersistQueries] is set to `true` special `extension` attributes, required by query auto persistence,
-   * will be encoded along with regular GraphQL request body. If query was previously persisted on the GraphQL server
-   * set [withQueryDocument] to `false` to skip query document be sent in the request.
-   *
-   * Optional [scalarTypeAdapters] must be provided in case when this operation defines variables with custom GraphQL scalar type.
-   *
-   * *Example*:
-   * ```
-   * {
-   *    "query": "query TestQuery($episode: Episode) { hero(episode: $episode) { name } }",
-   *    "operationName": "TestQuery",
-   *    "variables": { "episode": "JEDI" }
-   *    "extensions": {
-   *      "persistedQuery": {
-   *        "version": 1,
-   *        "sha256Hash": "32637895609e6c51a2593f5cfb49244fd79358d327ff670b3e930e024c3db8f6"
-   *      }
-   *    }
-   * }
-   * ```
-   */
-  fun composeRequestBody(
-      autoPersistQueries: Boolean,
-      withQueryDocument: Boolean,
-      scalarTypeAdapters: ScalarTypeAdapters
-  ): ByteString
-}
+interface Query<D : Operation.Data, T, V : Operation.Variables> : Operation<D, T, V>

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
@@ -23,4 +23,5 @@ val EMPTY_OPERATION: Operation<*, *, *> = object : Operation<Operation.Data, Any
   override fun parse(byteString: ByteString, scalarTypeAdapters: ScalarTypeAdapters) = throw UnsupportedOperationException()
   override fun composeRequestBody() = throw UnsupportedOperationException()
   override fun composeRequestBody(scalarTypeAdapters: ScalarTypeAdapters) = throw UnsupportedOperationException()
+  override fun composeRequestBody(autoPersistQueries: Boolean, withQueryDocument: Boolean, scalarTypeAdapters: ScalarTypeAdapters) = throw UnsupportedOperationException()
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/OperationTypeSpecBuilder.kt
@@ -56,9 +56,7 @@ class OperationTypeSpecBuilder(
         .addMethod(parseByteStringMethodWithDefaultScalarTypeAdapters(context))
         .addMethod(composeRequestBody())
         .addMethod(composeRequestBodyWithDefaultScalarTypeAdapters())
-        .applyIf(operation.isQuery()) {
-          addMethod(composeRequestBodyForQuery())
-        }
+        .addMethod(composeRequestBodyForQuery())
         .build()
         .flatten(excludeTypeNames = listOf(
             VISITOR_CLASSNAME,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -106,9 +106,7 @@ internal fun OperationType.typeSpec(targetPackage: String, generateAsInternal: B
     .addFunction(parseByteStringFunSpec())
     .addFunction(composeRequestBodyFunSpec())
     .addFunction(composeRequestBodyWithDefaultAdaptersFunSpec())
-    .applyIf(type == OperationType.Type.QUERY) {
-      addFunction(composeRequestBodyFunSpecForQuery())
-    }
+    .addFunction(composeRequestBodyFunSpecForQuery())
     .addTypes(nestedObjects.map { (ref, type) ->
       if (ref == data) {
         type.toOperationDataTypeSpec(name = data.name, generateAsInternal = generateAsInternal)

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.java
@@ -139,6 +139,13 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
   }
 
+  @Override
+  @NotNull
+  public ByteString composeRequestBody(final boolean autoPersistQueries,
+      final boolean withQueryDocument, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
+  }
+
   public static final class Builder {
     private @NotNull Episode ep;
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -23,6 +23,7 @@ import com.apollographql.apollo.api.internal.Throws
 import com.example.hero_with_review.type.Episode
 import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -85,6 +86,17 @@ data class TestQuery(
     autoPersistQueries = false,
     withQueryDocument = true,
     scalarTypeAdapters = DEFAULT
+  )
+
+  override fun composeRequestBody(
+    autoPersistQueries: Boolean,
+    withQueryDocument: Boolean,
+    scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString = OperationRequestBodyComposer.compose(
+    operation = this,
+    autoPersistQueries = autoPersistQueries,
+    withQueryDocument = withQueryDocument,
+    scalarTypeAdapters = scalarTypeAdapters
   )
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.java
@@ -141,6 +141,13 @@ public final class TestQuery implements Mutation<TestQuery.Data, Optional<TestQu
     return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
   }
 
+  @Override
+  @NotNull
+  public ByteString composeRequestBody(final boolean autoPersistQueries,
+      final boolean withQueryDocument, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
+  }
+
   public static final class Builder {
     private @NotNull Episode ep;
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -24,6 +24,7 @@ import com.example.input_object_type.type.Episode
 import com.example.input_object_type.type.ReviewInput
 import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -89,6 +90,17 @@ data class TestQuery(
     autoPersistQueries = false,
     withQueryDocument = true,
     scalarTypeAdapters = DEFAULT
+  )
+
+  override fun composeRequestBody(
+    autoPersistQueries: Boolean,
+    withQueryDocument: Boolean,
+    scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString = OperationRequestBodyComposer.compose(
+    operation = this,
+    autoPersistQueries = autoPersistQueries,
+    withQueryDocument = withQueryDocument,
+    scalarTypeAdapters = scalarTypeAdapters
   )
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -151,6 +151,13 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
   }
 
+  @Override
+  @NotNull
+  public ByteString composeRequestBody(final boolean autoPersistQueries,
+      final boolean withQueryDocument, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
+  }
+
   public static final class Builder {
     private @NotNull Episode ep;
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -26,6 +26,7 @@ import com.example.mutation_create_review.type.ReviewInput
 import java.util.Date
 import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -92,6 +93,17 @@ internal data class CreateReviewForEpisode(
     autoPersistQueries = false,
     withQueryDocument = true,
     scalarTypeAdapters = DEFAULT
+  )
+
+  override fun composeRequestBody(
+    autoPersistQueries: Boolean,
+    withQueryDocument: Boolean,
+    scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString = OperationRequestBodyComposer.compose(
+    operation = this,
+    autoPersistQueries = autoPersistQueries,
+    withQueryDocument = withQueryDocument,
+    scalarTypeAdapters = scalarTypeAdapters
   )
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.java
@@ -141,6 +141,13 @@ public final class CreateReviewForEpisodeMutation implements Mutation<CreateRevi
     return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
   }
 
+  @Override
+  @NotNull
+  public ByteString composeRequestBody(final boolean autoPersistQueries,
+      final boolean withQueryDocument, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
+  }
+
   public static final class Builder {
     private @NotNull Episode ep;
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -24,6 +24,7 @@ import com.example.mutation_create_review_semantic_naming.type.Episode
 import com.example.mutation_create_review_semantic_naming.type.ReviewInput
 import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -90,6 +91,17 @@ data class CreateReviewForEpisodeMutation(
     autoPersistQueries = false,
     withQueryDocument = true,
     scalarTypeAdapters = DEFAULT
+  )
+
+  override fun composeRequestBody(
+    autoPersistQueries: Boolean,
+    withQueryDocument: Boolean,
+    scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString = OperationRequestBodyComposer.compose(
+    operation = this,
+    autoPersistQueries = autoPersistQueries,
+    withQueryDocument = withQueryDocument,
+    scalarTypeAdapters = scalarTypeAdapters
   )
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.java
@@ -138,6 +138,13 @@ public final class TestSubscription implements Subscription<TestSubscription.Dat
     return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
   }
 
+  @Override
+  @NotNull
+  public ByteString composeRequestBody(final boolean autoPersistQueries,
+      final boolean withQueryDocument, @NotNull final ScalarTypeAdapters scalarTypeAdapters) {
+    return OperationRequestBodyComposer.compose(this, autoPersistQueries, withQueryDocument, scalarTypeAdapters);
+  }
+
   public static final class Builder {
     private @NotNull String repo;
 

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -22,6 +22,7 @@ import com.apollographql.apollo.api.internal.SimpleOperationResponseParser
 import com.apollographql.apollo.api.internal.Throws
 import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -84,6 +85,17 @@ data class TestSubscription(
     autoPersistQueries = false,
     withQueryDocument = true,
     scalarTypeAdapters = DEFAULT
+  )
+
+  override fun composeRequestBody(
+    autoPersistQueries: Boolean,
+    withQueryDocument: Boolean,
+    scalarTypeAdapters: ScalarTypeAdapters
+  ): ByteString = OperationRequestBodyComposer.compose(
+    operation = this,
+    autoPersistQueries = autoPersistQueries,
+    withQueryDocument = withQueryDocument,
+    scalarTypeAdapters = scalarTypeAdapters
   )
 
   /**

--- a/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockSubscription.kt
+++ b/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockSubscription.kt
@@ -13,6 +13,13 @@ import okio.ByteString.Companion.encodeUtf8
 
 internal class MockSubscription : Subscription<MockSubscription.Data, MockSubscription.Data, Operation.Variables> {
 
+  override fun composeRequestBody(
+      autoPersistQueries: Boolean,
+      withQueryDocument: Boolean,
+      scalarTypeAdapters: ScalarTypeAdapters): ByteString {
+    return composeRequestBody()
+  }
+
   override fun composeRequestBody(scalarTypeAdapters: ScalarTypeAdapters): ByteString {
     return composeRequestBody()
   }

--- a/apollo-runtime/api.txt
+++ b/apollo-runtime/api.txt
@@ -42,6 +42,7 @@ package com.apollographql.apollo {
     method public ApolloStore getApolloStore();
     method public List<ApolloInterceptorFactory> getApplicationInterceptorFactories();
     method public List<ApolloInterceptor> getApplicationInterceptors();
+    method public com.apollographql.apollo.interceptor.ApolloInterceptorFactory getAutoPersistedOperationsInterceptorFactory();
     method public CacheHeaders getDefaultCacheHeaders();
     method public HttpCache getHttpCache();
     method public ScalarTypeAdapters getScalarTypeAdapters();
@@ -78,6 +79,7 @@ package com.apollographql.apollo {
     method public com.apollographql.apollo.ApolloClient.Builder okHttpClient(OkHttpClient);
     method public com.apollographql.apollo.ApolloClient.Builder serverUrl(HttpUrl);
     method public com.apollographql.apollo.ApolloClient.Builder serverUrl(String);
+    method public com.apollographql.apollo.ApolloClient.Builder setAutoPersistedOperationsInterceptorFactory(com.apollographql.apollo.interceptor.ApolloInterceptorFactory);
     method public com.apollographql.apollo.ApolloClient.Builder subscriptionConnectionParams(com.apollographql.apollo.subscription.SubscriptionConnectionParams);
     method public com.apollographql.apollo.ApolloClient.Builder subscriptionConnectionParams(com.apollographql.apollo.subscription.SubscriptionConnectionParamsProvider);
     method public com.apollographql.apollo.ApolloClient.Builder subscriptionHeartbeatTimeout(long, TimeUnit);
@@ -236,6 +238,18 @@ package com.apollographql.apollo.http {
 
 package com.apollographql.apollo.interceptor {
 
+  public class ApolloAutoPersistedOperationInterceptor implements com.apollographql.apollo.interceptor.ApolloInterceptor {
+    ctor public ApolloAutoPersistedOperationInterceptor(ApolloLogger, boolean);
+    method public void dispose();
+    method public void interceptAsync(com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest, com.apollographql.apollo.interceptor.ApolloInterceptorChain, Executor, com.apollographql.apollo.interceptor.ApolloInterceptor.CallBack);
+  }
+
+  public static class ApolloAutoPersistedOperationInterceptor.Factory implements com.apollographql.apollo.interceptor.ApolloInterceptorFactory {
+    ctor public ApolloAutoPersistedOperationInterceptor.Factory(boolean, boolean, boolean);
+    ctor public ApolloAutoPersistedOperationInterceptor.Factory();
+    method public com.apollographql.apollo.interceptor.ApolloInterceptor newInterceptor(ApolloLogger, Operation<?, ?, ?>);
+  }
+
   public abstract interface ApolloInterceptor {
     method public abstract void dispose();
     method public abstract void interceptAsync(com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest, com.apollographql.apollo.interceptor.ApolloInterceptorChain, Executor, com.apollographql.apollo.interceptor.ApolloInterceptor.CallBack);
@@ -295,7 +309,7 @@ package com.apollographql.apollo.interceptor {
   }
 
   public abstract interface ApolloInterceptorFactory {
-    method public abstract com.apollographql.apollo.interceptor.ApolloInterceptor newInterceptor();
+    method public abstract com.apollographql.apollo.interceptor.ApolloInterceptor newInterceptor(error.NonExistentClass, error.NonExistentClass);
   }
 
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
@@ -77,7 +77,11 @@ public class ApolloAutoPersistedOperationInterceptor implements ApolloIntercepto
             logger.w("GraphQL server couldn't find Automatic Persisted Query for operation name: "
                 + request.operation.name().name() + " id: " + request.operation.operationId());
 
-            return Optional.of(request);
+            InterceptorRequest retryRequest = request.toBuilder()
+                .autoPersistQueries(true)
+                .sendQueryDocument(true)
+                .build();
+            return Optional.of(retryRequest);
           }
 
           if (isPersistedQueryNotSupported(response.getErrors())) {
@@ -109,15 +113,15 @@ public class ApolloAutoPersistedOperationInterceptor implements ApolloIntercepto
     return false;
   }
 
-  static class Factory implements ApolloInterceptorFactory {
+  public static class Factory implements ApolloInterceptorFactory {
 
     final boolean useHttpGet;
 
-    Factory(boolean useHttpGet) {
+    public Factory(boolean useHttpGet) {
       this.useHttpGet = useHttpGet;
     }
 
-    Factory() {
+    public Factory() {
       this(false);
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
@@ -1,7 +1,9 @@
 package com.apollographql.apollo.interceptor;
 
 import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.internal.ApolloLogger;
 import com.apollographql.apollo.api.internal.Function;
@@ -116,16 +118,26 @@ public class ApolloAutoPersistedOperationInterceptor implements ApolloIntercepto
   public static class Factory implements ApolloInterceptorFactory {
 
     final boolean useHttpGet;
+    final boolean persistQueries;
+    final boolean persistMutations;
 
-    public Factory(boolean useHttpGet) {
+    public Factory(boolean useHttpGet, boolean persistQueries, boolean persistMutations) {
       this.useHttpGet = useHttpGet;
+      this.persistQueries = persistQueries;
+      this.persistMutations = persistMutations;
     }
 
     public Factory() {
-      this(false);
+      this(false, true, true);
     }
 
     @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?, ?, ?> operation) {
+      if (operation instanceof Query && !persistQueries) {
+        return null;
+      }
+      if (operation instanceof Mutation && !persistMutations) {
+        return null;
+      }
       return new ApolloAutoPersistedOperationInterceptor(logger, useHttpGet);
     }
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
@@ -1,19 +1,19 @@
-package com.apollographql.apollo.internal.interceptor;
+package com.apollographql.apollo.interceptor;
 
 import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.internal.ApolloLogger;
 import com.apollographql.apollo.api.internal.Function;
 import com.apollographql.apollo.api.internal.Optional;
 import com.apollographql.apollo.exception.ApolloException;
-import com.apollographql.apollo.interceptor.ApolloInterceptor;
-import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.concurrent.Executor;
 
-public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
+public class ApolloAutoPersistedOperationInterceptor implements ApolloInterceptor {
   private static final String PROTOCOL_NEGOTIATION_ERROR_QUERY_NOT_FOUND = "PersistedQueryNotFound";
   private static final String PROTOCOL_NEGOTIATION_ERROR_NOT_SUPPORTED = "PersistedQueryNotSupported";
 
@@ -22,7 +22,7 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
 
   final boolean useHttpGetMethodForPersistedOperations;
 
-  public ApolloAutoPersistedQueryInterceptor(@NotNull ApolloLogger logger,
+  public ApolloAutoPersistedOperationInterceptor(@NotNull ApolloLogger logger,
                                              boolean useHttpGetMethodForPersistedOperations) {
     this.logger = logger;
     this.useHttpGetMethodForPersistedOperations = useHttpGetMethodForPersistedOperations;
@@ -107,5 +107,22 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
       }
     }
     return false;
+  }
+
+  static class Factory implements ApolloInterceptorFactory {
+
+    final boolean useHttpGet;
+
+    Factory(boolean useHttpGet) {
+      this.useHttpGet = useHttpGet;
+    }
+
+    Factory() {
+      this(false);
+    }
+
+    @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?, ?, ?> operation) {
+      return new ApolloAutoPersistedOperationInterceptor(logger, useHttpGet);
+    }
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
@@ -1,5 +1,16 @@
 package com.apollographql.apollo.interceptor
 
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.internal.ApolloLogger
+
 interface ApolloInterceptorFactory {
-  fun newInterceptor(): ApolloInterceptor
+  /**
+   * creates a new interceptor for the given operation
+   *
+   * @param logger: a logger to output debug information
+   * @param operation: the operation
+   *
+   * @return the interceptor or null if no interceptor is needed for this operation
+   */
+  fun newInterceptor(logger: ApolloLogger, operation: Operation<*, *, *>): ApolloInterceptor?
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
@@ -54,6 +54,7 @@ final class QueryReFetcher {
           .logger(builder.logger)
           .applicationInterceptors(builder.applicationInterceptors)
           .applicationInterceptorFactories(builder.applicationInterceptorFactories)
+          .autoPersistedOperationsInterceptorFactory(builder.autoPersistedOperationsInterceptorFactory)
           .tracker(builder.callTracker)
           .dispatcher(builder.dispatcher)
           .build());
@@ -126,6 +127,7 @@ final class QueryReFetcher {
     ApolloLogger logger;
     List<ApolloInterceptor> applicationInterceptors;
     List<ApolloInterceptorFactory> applicationInterceptorFactories;
+    ApolloInterceptorFactory autoPersistedOperationsInterceptorFactory;
     ApolloCallTracker callTracker;
 
     Builder queries(List<Query> queries) {
@@ -180,6 +182,11 @@ final class QueryReFetcher {
 
     Builder applicationInterceptorFactories(List<ApolloInterceptorFactory> applicationInterceptorFactories) {
       this.applicationInterceptorFactories = applicationInterceptorFactories;
+      return this;
+    }
+
+    Builder autoPersistedOperationsInterceptorFactory(ApolloInterceptorFactory interceptorFactories) {
+      this.autoPersistedOperationsInterceptorFactory = interceptorFactories;
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -385,7 +385,10 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     List<ApolloInterceptor> interceptors = new ArrayList<>();
 
     for (ApolloInterceptorFactory factory : applicationInterceptorFactories) {
-      interceptors.add(factory.newInterceptor());
+      ApolloInterceptor interceptor = factory.newInterceptor(logger, operation);
+      if (interceptor != null) {
+        interceptors.add(interceptor);
+      }
     }
     interceptors.addAll(applicationInterceptors);
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -23,7 +23,7 @@ import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import com.apollographql.apollo.interceptor.ApolloInterceptorFactory;
-import com.apollographql.apollo.internal.interceptor.ApolloAutoPersistedQueryInterceptor;
+import com.apollographql.apollo.interceptor.ApolloAutoPersistedOperationInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloCacheInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloParseInterceptor;
 import com.apollographql.apollo.internal.interceptor.ApolloServerInterceptor;
@@ -401,7 +401,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         writeToNormalizedCacheAsynchronously)
     );
     if (operation instanceof Query && enableAutoPersistedQueries) {
-      interceptors.add(new ApolloAutoPersistedQueryInterceptor(logger, useHttpGetMethodForPersistedQueries));
+      interceptors.add(new ApolloAutoPersistedOperationInterceptor(logger, useHttpGetMethodForPersistedQueries));
     }
     interceptors.add(new ApolloParseInterceptor(httpCache, apolloStore.networkResponseNormalizer(), responseFieldMapper,
         scalarTypeAdapters, logger));

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -149,7 +149,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .fetchFromCache(false)
         .optimisticUpdates(optimisticUpdates)
         .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
-        .autoPersistQueries(enableAutoPersistedQueries)
         .build();
     interceptorChain.proceedAsync(request, dispatcher, interceptorCallbackProxy());
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedQueryInterceptor.java
@@ -20,12 +20,12 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
   private final ApolloLogger logger;
   private volatile boolean disposed;
 
-  final boolean useHttpGetMethodForPersistedQueries;
+  final boolean useHttpGetMethodForPersistedOperations;
 
   public ApolloAutoPersistedQueryInterceptor(@NotNull ApolloLogger logger,
-                                             boolean useHttpGetMethodForPersistedQueries) {
+                                             boolean useHttpGetMethodForPersistedOperations) {
     this.logger = logger;
-    this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries;
+    this.useHttpGetMethodForPersistedOperations = useHttpGetMethodForPersistedOperations;
   }
 
   @Override
@@ -35,7 +35,7 @@ public class ApolloAutoPersistedQueryInterceptor implements ApolloInterceptor {
     InterceptorRequest newRequest = request.toBuilder()
             .sendQueryDocument(false)
             .autoPersistQueries(true)
-            .useHttpGetMethodForQueries(request.useHttpGetMethodForQueries || useHttpGetMethodForPersistedQueries)
+            .useHttpGetMethodForQueries(request.useHttpGetMethodForQueries || useHttpGetMethodForPersistedOperations)
             .build();
     chain.proceedAsync(newRequest, dispatcher, new CallBack() {
       @Override public void onResponse(@NotNull InterceptorResponse response) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.java
@@ -209,11 +209,7 @@ public final class ApolloServerInterceptor implements ApolloInterceptor {
 
   static ByteString httpPostRequestBody(Operation operation, ScalarTypeAdapters scalarTypeAdapters,
       boolean writeQueryDocument, boolean autoPersistQueries) throws IOException {
-    if (operation instanceof Query) {
-      return ((Query) operation).composeRequestBody(autoPersistQueries, writeQueryDocument, scalarTypeAdapters);
-    } else {
-      return operation.composeRequestBody(scalarTypeAdapters);
-    }
+    return operation.composeRequestBody(autoPersistQueries, writeQueryDocument, scalarTypeAdapters);
   }
 
   static HttpUrl httpGetUrl(HttpUrl serverUrl, Operation operation,

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.internal.ApolloLogger;
 import com.apollographql.apollo.api.internal.ResponseFieldMapper;
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller;
 import com.apollographql.apollo.cache.normalized.Record;
+import com.apollographql.apollo.interceptor.ApolloAutoPersistedOperationInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptor;
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain;
 import okhttp3.MediaType;
@@ -37,12 +38,12 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class ApolloAutoPersistedQueryInterceptorTest {
-  private ApolloAutoPersistedQueryInterceptor interceptor =
-      new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(null), false);
+public class ApolloAutoPersistedOperationInterceptorTest {
+  private ApolloAutoPersistedOperationInterceptor interceptor =
+      new ApolloAutoPersistedOperationInterceptor(new ApolloLogger(null), false);
 
-  private ApolloAutoPersistedQueryInterceptor interceptorWithGetMethod =
-      new ApolloAutoPersistedQueryInterceptor(new ApolloLogger(null), true);
+  private ApolloAutoPersistedOperationInterceptor interceptorWithGetMethod =
+      new ApolloAutoPersistedOperationInterceptor(new ApolloLogger(null), true);
 
   private ApolloInterceptor.InterceptorRequest request = ApolloInterceptor.InterceptorRequest.builder(new MockOperation())
       .autoPersistQueries(true)

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
@@ -332,6 +332,13 @@ public class ApolloAutoPersistedOperationInterceptorTest {
       throw new UnsupportedOperationException();
     }
 
+    @NotNull @Override public ByteString composeRequestBody(
+        boolean autoPersistQueries,
+        boolean withQueryDocument,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
+    }
+
     @NotNull @Override public ByteString composeRequestBody(@NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
@@ -222,6 +222,13 @@ public class SubscriptionAutoPersistTest {
       throw new UnsupportedOperationException();
     }
 
+    @NotNull @Override public ByteString composeRequestBody(
+        boolean autoPersistQueries,
+        boolean withQueryDocument,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
+    }
+
     @NotNull @Override public ByteString composeRequestBody(@NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.java
@@ -460,6 +460,13 @@ public class SubscriptionManagerTest {
       throw new UnsupportedOperationException();
     }
 
+    @NotNull @Override public ByteString composeRequestBody(
+        boolean autoPersistQueries,
+        boolean withQueryDocument,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
+    }
+
     @NotNull @Override public ByteString composeRequestBody(@NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.java
@@ -276,6 +276,13 @@ public class WebSocketSubscriptionTransportMessageTest {
       throw new UnsupportedOperationException();
     }
 
+    @NotNull @Override public ByteString composeRequestBody(
+        boolean autoPersistQueries,
+        boolean withQueryDocument,
+        @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+      throw new UnsupportedOperationException();
+    }
+
     @NotNull @Override public ByteString composeRequestBody(@NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -10,7 +10,7 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 # check that the public API did not change with Metalava
 # apollo-compiler is for now considered an internal artifact consumed by the Gradle plugin so we allow API changes there.
 # apollo-runtime-kotlin is still under development. Include the check once it is stable enough.
-./gradlew checkMetalava -x apollo-compiler:checkMetalava -x apollo-runtime-kotlin:checkMetalava --parallel
+./gradlew checkMetalava -x apollo-compiler:checkMetalava -x apollo-runtime-kotlin:checkMetalava
 
 ./gradlew publishIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET" --parallel
 # this is a separate task because sonatype does not support --parallel


### PR DESCRIPTION
closes #2330 

This PR allows to override the APQ (Auto Persisted Queries) interceptor and also enables APQs for mutations. I'm not sure if there was a specific reason to disable APQs for mutations. I tested against https://apollo-fullstack-tutorial.herokuapp.com/ and it's working well but maybe there is something else?

`ApolloClient.Builder.setAutoPersistedOperationsInterceptorFactory()` now takes precedence over `enableAutoPersistedQueries`. This allows to keep the existing behavior. There is one breaking change: the `ApolloInterceptorFactory` signature changes from 

```kotlin
fun newInterceptor(): ApolloInterceptor
```  

to 

```kotlin
fun newInterceptor(logger: ApolloLogger, operation: Operation<*, *, *>): Operation?
```

Since `ApolloInterceptorFactory` is pretty new and it's mainly adding new parameters, I'm hoping this change will be mostly pain-free.