### PR TITLE
[Performance] Batch normalized sql cache reads

### DIFF
--- a/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/CacheHeadersTest.java
@@ -53,7 +53,7 @@ public class CacheHeadersTest {
       }
 
       @NotNull @Override
-      protected Set<String> performMerge(@NotNull Record apolloRecord, @NotNull CacheHeaders cacheHeaders) {
+      protected Set<String> performMerge(@NotNull Record apolloRecord, @Nullable Record oldRecord, @NotNull CacheHeaders cacheHeaders) {
         return emptySet();
       }
     };
@@ -100,7 +100,7 @@ public class CacheHeadersTest {
       }
 
       @NotNull @Override
-      protected Set<String> performMerge(@NotNull Record apolloRecord, @NotNull CacheHeaders cacheHeaders) {
+      protected Set<String> performMerge(@NotNull Record apolloRecord, @Nullable Record oldRecord, @NotNull CacheHeaders cacheHeaders) {
         return emptySet();
       }
     };

--- a/apollo-integration/src/test/java/com/apollographql/apollo/internal/ApolloStoreTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/internal/ApolloStoreTest.java
@@ -42,7 +42,7 @@ public class ApolloStoreTest {
           }
 
           @NotNull @Override
-          protected Set<String> performMerge(@NotNull Record apolloRecord, @NotNull CacheHeaders cacheHeaders) {
+          protected Set<String> performMerge(@NotNull Record apolloRecord, @Nullable Record oldRecord, @NotNull CacheHeaders cacheHeaders) {
             return emptySet();
           }
         },

--- a/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
+++ b/apollo-normalized-cache-sqlite/src/commonMain/sqldelight/com/apollographql/apollo/cache/normalized/sql/cache.sq
@@ -9,6 +9,9 @@ CREATE INDEX idx_records_key ON records(key);
 recordForKey:
 SELECT key, record FROM records WHERE key=?;
 
+recordsForKeys:
+SELECT key, record FROM records WHERE key IN ?;
+
 insert:
 INSERT INTO records (key, record) VALUES (?,?);
 
@@ -17,6 +20,9 @@ UPDATE records SET record=:record WHERE key=:key;
 
 delete:
 DELETE FROM records WHERE key=?;
+
+deleteRecords:
+DELETE FROM records WHERE key IN ?;
 
 changes:
 SELECT changes();

--- a/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class SqlNormalizedCacheTest {
 
@@ -104,6 +105,19 @@ class SqlNormalizedCacheTest {
     val nullRecord = cache.loadRecord(STANDARD_KEY, CacheHeaders.builder()
         .addHeader(ApolloCacheHeaders.EVICT_AFTER_READ, "true").build())
     assertNull(nullRecord)
+  }
+
+  @Test
+  fun testHeader_evictAfterBatchRead() {
+    createRecord(STANDARD_KEY)
+    createRecord(QUERY_ROOT_KEY)
+    val selectionSet = setOf(STANDARD_KEY, QUERY_ROOT_KEY)
+    val records = cache.loadRecords(selectionSet, CacheHeaders.builder()
+        .addHeader(ApolloCacheHeaders.EVICT_AFTER_READ, "true").build())
+    assertEquals(records.size, 2)
+    val emptyRecords = cache.loadRecords(selectionSet, CacheHeaders.builder()
+        .addHeader(ApolloCacheHeaders.EVICT_AFTER_READ, "true").build())
+    assertTrue(emptyRecords.isEmpty())
   }
 
   @Test

--- a/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -40,6 +40,16 @@ class SqlNormalizedCacheTest {
   }
 
   @Test
+  fun testMultipleRecordSelection() {
+    createRecord(STANDARD_KEY)
+    createRecord(QUERY_ROOT_KEY)
+    val selectionKeys = setOf(STANDARD_KEY, QUERY_ROOT_KEY)
+    val records = cache.selectRecordsForKey(selectionKeys)
+    val selectedKeys = records.map { it.key }.toSet()
+    assertEquals(selectionKeys, selectedKeys)
+  }
+
+  @Test
   fun testRecordSelection_root() {
     createRecord(QUERY_ROOT_KEY)
     val record = requireNotNull(cache.selectRecordForKey(QUERY_ROOT_KEY))

--- a/apollo-normalized-cache/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.kt
+++ b/apollo-normalized-cache/src/main/java/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.kt
@@ -79,8 +79,7 @@ class LruNormalizedCache internal constructor(evictionPolicy: EvictionPolicy) : 
     lruCache.invalidateAll()
   }
 
-  override fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String> {
-    val oldRecord = lruCache.getIfPresent(apolloRecord.key)
+  override fun performMerge(apolloRecord: Record, oldRecord: Record?, cacheHeaders: CacheHeaders): Set<String> {
     return if (oldRecord == null) {
       lruCache.put(apolloRecord.key, apolloRecord)
       apolloRecord.keys()


### PR DESCRIPTION
Continued work from: https://github.com/apollographql/apollo-android/issues/2402

Batches all reads from the sql normalized cache in a small number of operations (there is a limit to 999 arguments) vs 1 operation per record.

Using the same profile set-up in that example, this change improves performance by ~300% i.e. 100ms for 1000 record response down from 300ms on Pixel 4.

The more efficient read had to be implemented OptimisticCache as well, as it calls through a read on the `nextCache` -- this is unfortunate as it actually means we read all records twice on the normal response path. Optimizing this would be a larger refactor. (But chaining an in-memory cache before the sql cache is a good way to mitigate impact of this double read).

**note breaking change in NormalizedCache**
```
protected abstract fun performMerge(apolloRecord: Record, cacheHeaders: CacheHeaders): Set<String>
```

```
protected abstract fun performMerge(apolloRecord: Record, oldRecord: Record?, cacheHeaders: CacheHeaders): Set<String>
```