### PR TITLE
[Build] unbreak the generation of `com.apollo.compiler.VERSION`

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -25,23 +25,33 @@ dependencies {
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.truth"))
 }
 
-tasks.register("pluginVersion") {
-  val outputDir = file("src/generated/kotlin")
+abstract class GeneratePluginVersion : DefaultTask() {
+  @get:org.gradle.api.tasks.Input
+  abstract val version: Property<String>
 
-  inputs.property("version", version)
-  outputs.dir(outputDir)
+  @get:org.gradle.api.tasks.OutputFile
+  abstract val outputFile: RegularFileProperty
 
-  doLast {
-    val versionFile = file("$outputDir/com/apollographql/android/Version.kt")
+  @org.gradle.api.tasks.TaskAction
+  fun taskAction() {
+    val versionFile = outputFile.asFile.get()
     versionFile.parentFile.mkdirs()
     versionFile.writeText("""// Generated file. Do not edit!
-package com.apollographql.android
+package com.apollographql.apollo.compiler
 val VERSION = "${project.version}"
 """)
   }
 }
 
-tasks.getByName("compileKotlin").dependsOn("pluginVersion")
+val pluginVersionTaskProvider = tasks.register("pluginVersion", GeneratePluginVersion::class.java) {
+  outputFile.set(project.layout.buildDirectory.file("generated/kotlin/com/apollographql/apollo/compiler/Version.kt"))
+  version.set(project.version.toString())
+}
+
+tasks.withType(KotlinCompile::class.java) {
+  val versionFileProvider = pluginVersionTaskProvider.flatMap { it.outputFile }
+  source(versionFileProvider)
+}
 
 tasks.withType<Checkstyle> {
   exclude("**com/apollographql/apollo/compiler/parser/antlr/**")

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -16,13 +16,6 @@ open class ApolloPlugin : Plugin<Project> {
     const val MIN_GRADLE_VERSION = "6.0"
 
     val Project.isKotlinMultiplatform get() = pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
-    val Project.isKotlin
-      get() = when {
-        pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform") -> true
-        pluginManager.hasPlugin("org.jetbrains.kotlin.jvm") -> true
-        pluginManager.hasPlugin("org.jetbrains.kotlin.android") -> true
-        else -> false
-      }
 
     private fun registerCompilationUnits(project: Project, apolloExtension: DefaultApolloExtension, checkVersionsTask: TaskProvider<Task>) {
       val androidExtension = project.extensions.findByName("android")

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -24,37 +24,6 @@ open class ApolloPlugin : Plugin<Project> {
         else -> false
       }
 
-    private fun useService(project: Project, schemaFilePath: String?, outputPackageName: String? = null, exclude: String? = null): String {
-
-      var ret = """
-      |Please use a service instead:
-      |apollo {
-      |  service("github") {
-      """.trimMargin()
-
-      if (schemaFilePath != null) {
-        val match = Regex("src/.*/graphql/(.*)").matchEntire(schemaFilePath)
-        val schemaPath = if (match != null) {
-          match.groupValues[1]
-        } else {
-          project.file(schemaFilePath).absolutePath
-        }
-        ret += "\n    schemaPath = \"$schemaPath\""
-      }
-      if (outputPackageName != null) {
-        ret += "\n    rootPackageName = \"$outputPackageName\""
-      }
-      if (exclude != null) {
-        ret += "\n    exclude = $exclude"
-      }
-      ret += """
-      |
-      |  }
-      |}
-    """.trimMargin()
-      return ret
-    }
-
     private fun registerCompilationUnits(project: Project, apolloExtension: DefaultApolloExtension, checkVersionsTask: TaskProvider<Task>) {
       val androidExtension = project.extensions.findByName("android")
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -16,6 +16,13 @@ open class ApolloPlugin : Plugin<Project> {
     const val MIN_GRADLE_VERSION = "6.0"
 
     val Project.isKotlinMultiplatform get() = pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
+    val Project.isKotlin
+      get() = when {
+        pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform") -> true
+        pluginManager.hasPlugin("org.jetbrains.kotlin.jvm") -> true
+        pluginManager.hasPlugin("org.jetbrains.kotlin.android") -> true
+        else -> false
+      }
 
     private fun useService(project: Project, schemaFilePath: String?, outputPackageName: String? = null, exclude: String? = null): String {
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
+import com.apollographql.apollo.gradle.internal.ApolloPlugin.Companion.isKotlin
 import com.apollographql.apollo.gradle.internal.ApolloPlugin.Companion.isKotlinMultiplatform
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
@@ -79,7 +80,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
 
   fun generateKotlinModels(): Boolean = when {
     project.isKotlinMultiplatform -> true
-    else -> generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(false)
+    else -> generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(project.isKotlin)
   }
 
   companion object {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.gradle.api.CompilationUnit
 import com.apollographql.apollo.gradle.api.CompilerParams
-import com.apollographql.apollo.gradle.internal.ApolloPlugin.Companion.isKotlin
 import com.apollographql.apollo.gradle.internal.ApolloPlugin.Companion.isKotlinMultiplatform
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -80,7 +80,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
 
   fun generateKotlinModels(): Boolean = when {
     project.isKotlinMultiplatform -> true
-    else -> generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(project.isKotlin)
+    else -> generateKotlinModels.orElse(service.generateKotlinModels).orElse(apolloExtension.generateKotlinModels).getOrElse(false)
   }
 
   companion object {


### PR DESCRIPTION
~Supersedes https://github.com/apollographql/apollo-android/pull/2399~

~The aim of this pull request is to remove the~

```
apollo {
  generateKotlinModels.set(true)
}
```

~If the Kotlin plugin is applied, the Apollo plugin will default to generating Kotlin models.~

This pull request fixes generating the version source file.