### PR TITLE
[Kotlin Runtime] do not close the Websocket too early

### DIFF
--- a/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/ws/ApolloWebSocket.kt
+++ b/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/ws/ApolloWebSocket.kt
@@ -79,14 +79,10 @@ actual class ApolloWebSocketFactory(
       }
     })
 
-    try {
-      return WebSocketConnectionImpl(
-          webSocket = webSocketConnectionDeferred.await(),
-          messageChannel = messageChannel
-      )
-    } finally {
-      webSocket.cancel()
-    }
+    return WebSocketConnectionImpl(
+        webSocket = webSocketConnectionDeferred.await(),
+        messageChannel = messageChannel
+    )
   }
 }
 


### PR DESCRIPTION
While working on the [Kommentaire App](https://github.com/kommentaire/kommentaire-app), I realised the websocket was closed too early. This PR fixes it. 

Subscriptions now work on both iOS and Android. 

On a side note, the Kommentaire organisation also has a [kommentaire-server](https://github.com/kommentaire/kommentaire-server) repo written in Kotlin by @aaudelin which is very useful for prototyping/debugging.