### PR TITLE
[Publication] Fix packaging of apollo-normalized-cache

### DIFF
--- a/apollo-normalized-cache/gradle.properties
+++ b/apollo-normalized-cache/gradle.properties
@@ -1,4 +1,3 @@
 POM_ARTIFACT_ID=apollo-normalized-cache
 POM_NAME=Apollo GraphQL Normalized Cache APIs
 POM_DESCRIPTION=Apollo GraphQL Normalized Cache APIs
-POM_PACKAGING=pom

--- a/apollo-normalized-cache/gradle.properties
+++ b/apollo-normalized-cache/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=apollo-normalized-cache
 POM_NAME=Apollo GraphQL Normalized Cache APIs
 POM_DESCRIPTION=Apollo GraphQL Normalized Cache APIs
-POM_PACKAGING=jar
+POM_PACKAGING=pom


### PR DESCRIPTION
Using a `jar` packaging confuses Gradle when artifacts are deployed in `mavenLocal`. (Somehow it works with OSS snapshots). 
Use a `pom` packaging instead since `apollo-normalized-cache` does not contain the actual jar anymore. (It is in `apollo-normalized-cache-jvm`)