### PR TITLE
[Runtime] add more documentation about ApolloCall deprecated methods

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -35,6 +35,8 @@ public interface ApolloCall<T> extends Cancelable {
    * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
    * be configured with this headers, and will be accessible from the {@link ResponseFetcher} used for this call.
    *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
+   *
    * @param cacheHeaders the {@link CacheHeaders} that will be passed with records generated from this request to {@link
    *                     com.apollographql.apollo.cache.normalized.NormalizedCache}. Standardized cache headers are
    *                     defined in {@link ApolloCacheHeaders}.
@@ -44,6 +46,8 @@ public interface ApolloCall<T> extends Cancelable {
 
   /**
    * Creates a new, identical call to this one which can be enqueued or executed even if this call has already been.
+   *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
    *
    * @return The cloned ApolloCall object.
    */

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -42,6 +42,8 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
   /**
    * Sets the {@link ResponseFetcher} strategy for an ApolloCall object.
    *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
+   *
    * @param fetcher the {@link ResponseFetcher} to use.
    * @return The ApolloCall object with the provided CacheControl strategy
    */
@@ -51,6 +53,8 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
    * it is issued. These headers will be applied after any headers applied by application-level interceptors
    * and will override those if necessary.
+   *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
    *
    * @param requestHeaders The {@link RequestHeaders} to use for this request.
    * @return The ApolloCall object with the provided {@link RequestHeaders}.


### PR DESCRIPTION
minor edits to javadoc to point to the replacement of deprecated methods. It would be nice if there was an equivalent of the Kotlin deprecated `message`  but I haven't found anything.