### PR TITLE
[apollo-api] prefix Boolean Kotlin properties with `is` for better java interop

### DIFF
--- a/apollo-api/api.txt
+++ b/apollo-api/api.txt
@@ -250,9 +250,11 @@ package com.apollographql.apollo.api {
     method public com.apollographql.apollo.api.Operation<?, ?, ?> getOperation();
     method public error.NonExistentClass hasErrors();
     method public error.NonExistentClass hashCode();
+    method public error.NonExistentClass isFromCache();
     method public com.apollographql.apollo.api.Operation<?, ?, ?> operation();
     method public com.apollographql.apollo.api.Response.Builder<T> toBuilder();
     method public java.lang.String toString();
+    property public final error.NonExistentClass fromCache;
     field public static final com.apollographql.apollo.api.Response.Companion Companion;
   }
 
@@ -296,7 +298,9 @@ package com.apollographql.apollo.api {
     method public error.NonExistentClass getVariableName();
     method public error.NonExistentClass hashCode();
     method public error.NonExistentClass inverted();
+    method public error.NonExistentClass isInverted();
     method public error.NonExistentClass variableName();
+    property public final error.NonExistentClass inverted;
   }
 
   public static final class ResponseField.Companion {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
@@ -31,7 +31,7 @@ data class Response<T>(
     /**
      * Indicates if response is resolved from the cache.
      */
-    val fromCache: Boolean = false,
+    val isFromCache: Boolean = false,
 
     /**
      * Extensions of GraphQL protocol, arbitrary map of key [String] / value [Any] sent by server along with the response.
@@ -49,7 +49,7 @@ data class Response<T>(
       data = builder.data,
       errors = builder.errors,
       dependentKeys = builder.dependentKeys.orEmpty(),
-      fromCache = builder.fromCache,
+      isFromCache = builder.fromCache,
       extensions = builder.extensions.orEmpty(),
       executionContext = builder.executionContext
   )
@@ -72,10 +72,13 @@ data class Response<T>(
 
   fun hasErrors(): Boolean = !errors.isNullOrEmpty()
 
-  @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "fromCache"))
+  @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "isFromCache"))
   fun fromCache(): Boolean {
-    return fromCache
+    return isFromCache
   }
+
+  @Deprecated(message = "Use isFromCache Instead", replaceWith = ReplaceWith(expression = "isFromCache"))
+  val fromCache = isFromCache
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "extensions"))
   fun extensions(): Map<String, Any?> {
@@ -86,7 +89,7 @@ data class Response<T>(
       .data(data)
       .errors(errors)
       .dependentKeys(dependentKeys)
-      .fromCache(fromCache)
+      .fromCache(isFromCache)
       .extensions(extensions)
       .executionContext(executionContext)
 
@@ -98,7 +101,7 @@ data class Response<T>(
     if (data != other.data) return false
     if (errors != other.errors) return false
     if (dependentKeys != other.dependentKeys) return false
-    if (fromCache != other.fromCache) return false
+    if (isFromCache != other.isFromCache) return false
     if (extensions != other.extensions) return false
     if (executionContext != other.executionContext) return false
 
@@ -110,7 +113,7 @@ data class Response<T>(
     result = 31 * result + (data?.hashCode() ?: 0)
     result = 31 * result + (errors?.hashCode() ?: 0)
     result = 31 * result + dependentKeys.hashCode()
-    result = 31 * result + fromCache.hashCode()
+    result = 31 * result + isFromCache.hashCode()
     result = 31 * result + extensions.hashCode()
     return result
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ResponseField.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ResponseField.kt
@@ -200,31 +200,34 @@ open class ResponseField internal constructor(
    */
   class BooleanCondition internal constructor(
       val variableName: String,
-      val inverted: Boolean
+      val isInverted: Boolean
   ) : Condition() {
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "variableName"))
     fun variableName(): String {
       return variableName
     }
 
-    @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "inverted"))
+    @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "isInverted"))
     fun inverted(): Boolean {
-      return inverted
+      return isInverted
     }
+
+    @Deprecated(message = "Use isInverted instead", replaceWith = ReplaceWith(expression = "isInverted"))
+    val inverted = isInverted
 
     override fun equals(other: Any?): Boolean {
       if (this === other) return true
       if (other !is BooleanCondition) return false
 
       if (variableName != other.variableName) return false
-      if (inverted != other.inverted) return false
+      if (isInverted != other.isInverted) return false
 
       return true
     }
 
     override fun hashCode(): Int {
       var result = variableName.hashCode()
-      result = 31 * result + inverted.hashCode()
+      result = 31 * result + isInverted.hashCode()
       return result
     }
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
@@ -130,7 +130,7 @@ class SimpleResponseReader private constructor(
     for (condition in field.conditions) {
       if (condition is ResponseField.BooleanCondition) {
         val conditionValue = variableValues[condition.variableName] as Boolean
-        if (condition.inverted) {
+        if (condition.isInverted) {
           // means it's a skip directive
           if (conditionValue) {
             return true

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
@@ -201,7 +201,7 @@ class RealResponseReader<R>(
     for (condition in field.conditions) {
       if (condition is ResponseField.BooleanCondition) {
         val conditionValue = variableValues[condition.variableName] as Boolean?
-        if (condition.inverted) {
+        if (condition.isInverted) {
           // means it's a skip directive
           if (conditionValue == true) {
             return true

--- a/buildSrc/src/main/kotlin/ApiCompatibility.kt
+++ b/buildSrc/src/main/kotlin/ApiCompatibility.kt
@@ -11,8 +11,21 @@ object ApiCompatibility {
     }
 
     project.subprojects {
-      it.configureJapiCmp()
-      it.configureMetalava(downloadMetalavaJar)
+      when(it.name) {
+        "apollo-compiler" -> {
+          // apollo-compiler is for now considered an internal artifact consumed by the Gradle plugin so we allow API changes there.
+          return@subprojects
+        }
+        "apollo-runtime-kotlin" -> {
+          // apollo-runtime-kotlin is still under development. Include the check once it is stable enough.
+          return@subprojects
+        }
+        else -> {
+          it.configureJapiCmp()
+          it.configureMetalava(downloadMetalavaJar)
+
+        }
+      }
     }
   }
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -8,9 +8,7 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 ./gradlew clean build --stacktrace --max-workers=2
 ./gradlew -p composite build
 # check that the public API did not change with Metalava
-# apollo-compiler is for now considered an internal artifact consumed by the Gradle plugin so we allow API changes there.
-# apollo-runtime-kotlin is still under development. Include the check once it is stable enough.
-./gradlew checkMetalava -x apollo-compiler:checkMetalava -x apollo-runtime-kotlin:checkMetalava
+./gradlew checkMetalava
 
 ./gradlew publishIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET" --parallel
 # this is a separate task because sonatype does not support --parallel


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/pull/2467#issuecomment-663872203. 

When using Java, it's better to have 

```java
response.isFromCache()
```

than 

```java
response.getFromCache()
```