### PR TITLE
Introduce new codegen AST (frontend) to support fragment as interfaces

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/CodeGenerationAst.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/CodeGenerationAst.kt
@@ -1,0 +1,175 @@
+package com.apollographql.apollo.compiler.next.ast
+
+internal typealias ObjectTypeContainer = Map<CodeGenerationAst.TypeRef, CodeGenerationAst.ObjectType>
+
+internal data class CodeGenerationAst(
+    val operationTypes: List<OperationType>,
+    val fragmentTypes: List<FragmentType>,
+    val inputTypes: List<InputType>,
+    val enumTypes: List<EnumType>
+) {
+
+  data class OperationType(
+      val name: String,
+      val type: Type,
+      val operationName: String,
+      val description: String,
+      val operationId: String,
+      val queryDocument: String,
+      val variables: List<InputField>,
+      val dataType: OperationDataType,
+      val filePath: String
+  ) {
+    enum class Type {
+      QUERY, MUTATION, SUBSCRIPTION
+    }
+  }
+
+  data class OperationDataType(
+      val rootType: TypeRef,
+      val nestedTypes: ObjectTypeContainer
+  )
+
+  data class FragmentType(
+      val rootType: TypeRef,
+      val nestedTypes: ObjectTypeContainer
+  )
+
+  data class ObjectType(
+      val name: String,
+      val description: String,
+      val deprecated: Boolean,
+      val deprecationReason: String,
+      val abstract: Boolean,
+      val fields: List<Field>,
+      val implements: Set<TypeRef>
+  )
+
+  data class Field(
+      val name: String,
+      val responseName: String,
+      val type: FieldType,
+      val description: String,
+      val deprecated: Boolean,
+      val deprecationReason: String,
+      val arguments: Map<String, Any?>,
+      val conditions: Set<Condition>,
+      val override: Boolean
+  ) {
+    sealed class Condition {
+      data class Directive(val variableName: String, val inverted: Boolean) : Condition()
+    }
+  }
+
+  data class InputType(
+      val name: String,
+      val description: String,
+      val deprecated: Boolean,
+      val deprecationReason: String,
+      val fields: List<InputField>
+  )
+
+  data class InputField(
+      val name: String,
+      val schemaName: String,
+      val deprecated: Boolean,
+      val deprecationReason: String,
+      val type: FieldType,
+      val description: String,
+      val defaultValue: Any?
+  )
+
+  data class EnumType(
+      val name: String,
+      val description: String,
+      val consts: List<EnumConst>
+  )
+
+  data class EnumConst(
+      val constName: String,
+      val value: String,
+      val description: String,
+      val isDeprecated: Boolean,
+      val deprecationReason: String
+  )
+
+  sealed class FieldType {
+    abstract val nullable: Boolean
+
+    fun nonNullable(): FieldType {
+      return when (this) {
+        is Scalar.ID -> copy(nullable = false)
+        is Scalar.String -> copy(nullable = false)
+        is Scalar.Int -> copy(nullable = false)
+        is Scalar.Boolean -> copy(nullable = false)
+        is Scalar.Float -> copy(nullable = false)
+        is Scalar.Enum -> copy(nullable = false)
+        is Scalar.Custom -> copy(nullable = false)
+        is Object -> copy(nullable = false)
+        is Array -> copy(nullable = false)
+        is Fragment -> copy(nullable = false)
+      }
+    }
+
+    fun nullable(): FieldType {
+      return when (this) {
+        is Scalar.ID -> copy(nullable = true)
+        is Scalar.String -> copy(nullable = true)
+        is Scalar.Int -> copy(nullable = true)
+        is Scalar.Boolean -> copy(nullable = true)
+        is Scalar.Float -> copy(nullable = true)
+        is Scalar.Enum -> copy(nullable = true)
+        is Scalar.Custom -> copy(nullable = true)
+        is Object -> copy(nullable = true)
+        is Array -> copy(nullable = true)
+        is Fragment -> copy(nullable = true)
+      }
+    }
+
+    sealed class Scalar : FieldType() {
+      data class ID(override val nullable: kotlin.Boolean) : Scalar()
+
+      data class String(override val nullable: kotlin.Boolean) : Scalar()
+
+      data class Int(override val nullable: kotlin.Boolean) : Scalar()
+
+      data class Boolean(override val nullable: kotlin.Boolean) : Scalar()
+
+      data class Float(override val nullable: kotlin.Boolean) : Scalar()
+
+      data class Enum(
+          override val nullable: kotlin.Boolean,
+          val typeRef: TypeRef
+      ) : Scalar()
+
+      data class Custom(
+          override val nullable: kotlin.Boolean,
+          val schemaType: kotlin.String,
+          val type: kotlin.String
+      ) : Scalar()
+    }
+
+    data class Object(
+        override val nullable: Boolean,
+        val typeRef: TypeRef
+    ) : FieldType()
+
+    data class Array(
+        override val nullable: Boolean,
+        val rawType: FieldType
+    ) : FieldType()
+
+    data class Fragment(
+        override val nullable: Boolean,
+        val rawType: TypeRef,
+        val defaultType: TypeRef,
+        val possibleTypes: Map<String, TypeRef>
+    ) : FieldType()
+  }
+
+  data class TypeRef(
+      val name: String,
+      val packageName: String = "",
+      val enclosingType: TypeRef? = null
+  )
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/CodeGenerationAstBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/CodeGenerationAstBuilder.kt
@@ -1,0 +1,286 @@
+package com.apollographql.apollo.compiler.next.ast
+
+import com.apollographql.apollo.api.internal.QueryDocumentMinifier
+import com.apollographql.apollo.compiler.OperationIdGenerator
+import com.apollographql.apollo.compiler.ast.CustomTypes
+import com.apollographql.apollo.compiler.escapeKotlinReservedWord
+import com.apollographql.apollo.compiler.ir.CodeGenerationIR
+import com.apollographql.apollo.compiler.ir.Operation
+import com.apollographql.apollo.compiler.ir.TypeDeclaration
+import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
+import com.apollographql.apollo.compiler.parser.introspection.resolveType
+import com.apollographql.apollo.compiler.ir.Fragment as IrFragment
+
+internal fun CodeGenerationIR.buildCodeGenerationAst(
+    schema: IntrospectionSchema,
+    customTypeMap: CustomTypes,
+    typesPackageName: String,
+    fragmentsPackage: String,
+    useSemanticNaming: Boolean,
+    operationIdGenerator: OperationIdGenerator
+): CodeGenerationAst {
+  return CodeGenerationAstBuilder(
+      schema = schema,
+      customTypeMap = customTypeMap,
+      typesPackageName = typesPackageName,
+      fragmentsPackage = fragmentsPackage,
+      useSemanticNaming = useSemanticNaming,
+      operationIdGenerator = operationIdGenerator
+  ).build(this)
+}
+
+private class CodeGenerationAstBuilder(
+    private val schema: IntrospectionSchema,
+    private val customTypeMap: CustomTypes,
+    private val typesPackageName: String,
+    private val fragmentsPackage: String,
+    private val useSemanticNaming: Boolean,
+    private val operationIdGenerator: OperationIdGenerator
+) {
+
+  fun build(ir: CodeGenerationIR): CodeGenerationAst {
+    val enums = ir.typesUsed
+        .filter { typeUsed -> typeUsed.kind == TypeDeclaration.KIND_ENUM }
+        .map { type -> type.buildEnumType() }
+
+    val inputTypes = ir.typesUsed
+        .filter { typeUsed -> typeUsed.kind == TypeDeclaration.KIND_INPUT_OBJECT_TYPE }
+        .map { type ->
+          type.buildInputType(
+              schema = schema,
+              typesPackageName = typesPackageName,
+              customTypeMap = customTypeMap
+          )
+        }
+
+    val fragmentTypes = ir.fragments.map { fragment ->
+      fragment.buildFragmentType(ir.fragments)
+    }
+
+    val operations = ir.operations.map { operation ->
+      operation.buildOperationType(
+          irFragments = ir.fragments,
+          fragmentTypes = fragmentTypes
+      )
+    }
+
+    return CodeGenerationAst(
+        operationTypes = operations,
+        fragmentTypes = fragmentTypes,
+        inputTypes = inputTypes,
+        enumTypes = enums
+    )
+  }
+
+  private fun TypeDeclaration.buildEnumType() = CodeGenerationAst.EnumType(
+      name = name.capitalize().escapeKotlinReservedWord(),
+      description = description,
+      consts = values.map { value ->
+        CodeGenerationAst.EnumConst(
+            constName = value.name.toUpperCase().escapeKotlinReservedWord(),
+            value = value.name,
+            description = value.description,
+            isDeprecated = value.isDeprecated,
+            deprecationReason = value.deprecationReason
+        )
+      }
+  )
+
+  private fun TypeDeclaration.buildInputType(
+      schema: IntrospectionSchema,
+      typesPackageName: String,
+      customTypeMap: CustomTypes
+  ): CodeGenerationAst.InputType {
+    return CodeGenerationAst.InputType(
+        name = name.capitalize().escapeKotlinReservedWord(),
+        description = description,
+        deprecated = false,
+        deprecationReason = "",
+        fields = fields.map { field ->
+          val fieldType = resolveInputFieldType(
+              schemaTypeRef = schema.resolveType(schema.resolveType(name)).resolveInputField(field.name).type,
+              typesPackageName = typesPackageName,
+              customTypeMap = customTypeMap
+          )
+          CodeGenerationAst.InputField(
+              name = field.name.decapitalize().escapeKotlinReservedWord(),
+              schemaName = field.name,
+              deprecated = false,
+              deprecationReason = "",
+              type = fieldType,
+              description = field.description,
+              defaultValue = if (fieldType is CodeGenerationAst.FieldType.Scalar.Custom) null else field.defaultValue
+          )
+        }
+    )
+  }
+
+  private fun Operation.buildOperationType(
+      irFragments: List<IrFragment>,
+      fragmentTypes: List<CodeGenerationAst.FragmentType>
+  ): CodeGenerationAst.OperationType {
+    val operationType = when {
+      isQuery() -> CodeGenerationAst.OperationType.Type.QUERY
+      isMutation() -> CodeGenerationAst.OperationType.Type.MUTATION
+      isSubscription() -> CodeGenerationAst.OperationType.Type.SUBSCRIPTION
+      else -> throw IllegalArgumentException("Unsupported GraphQL operation type: $operationType")
+    }
+    val operationDataType = buildOperationDataType(
+        irFragments = irFragments,
+        fragmentTypes = fragmentTypes
+    )
+    val operationId = operationIdGenerator.apply(QueryDocumentMinifier.minify(sourceWithFragments), filePath)
+    val operationClassName = normalizedOperationName(useSemanticNaming).capitalize()
+    return CodeGenerationAst.OperationType(
+        name = operationClassName,
+        type = operationType,
+        operationName = operationName,
+        description = description,
+        operationId = operationId,
+        queryDocument = sourceWithFragments,
+        variables = variables.map { variable ->
+          val fieldType = resolveInputFieldType(
+              schemaTypeRef = variable.type.toIntrospectionTypeRef(schema),
+              typesPackageName = typesPackageName,
+              customTypeMap = customTypeMap
+          )
+          CodeGenerationAst.InputField(
+              name = variable.name.decapitalize().escapeKotlinReservedWord(),
+              schemaName = variable.name,
+              deprecated = false,
+              deprecationReason = "",
+              type = fieldType,
+              description = "",
+              defaultValue = null
+          )
+        },
+        dataType = operationDataType,
+        filePath = filePath
+    )
+  }
+
+  private fun IntrospectionSchema.Type.resolveInputField(name: String): IntrospectionSchema.InputField {
+    return (this as? IntrospectionSchema.Type.InputObject)?.inputFields?.find { field -> field.name == name }
+        ?: throw IllegalArgumentException("Failed to resolve input field `$name` on type `${this.name}`")
+  }
+
+  private fun String.toIntrospectionTypeRef(schema: IntrospectionSchema): IntrospectionSchema.TypeRef {
+    return when {
+      endsWith("!") -> IntrospectionSchema.TypeRef(
+          kind = IntrospectionSchema.Kind.NON_NULL,
+          ofType = removeSuffix("!").toIntrospectionTypeRef(schema)
+      )
+
+      startsWith("[") && endsWith("]") -> IntrospectionSchema.TypeRef(
+          kind = IntrospectionSchema.Kind.LIST,
+          ofType = removeSuffix("!").toIntrospectionTypeRef(schema)
+      )
+
+      else -> schema.resolveType(this)
+    }
+  }
+
+  private fun resolveInputFieldType(
+      schemaTypeRef: IntrospectionSchema.TypeRef,
+      typesPackageName: String,
+      customTypeMap: CustomTypes
+  ): CodeGenerationAst.FieldType {
+    return when (schemaTypeRef.kind) {
+      IntrospectionSchema.Kind.ENUM -> CodeGenerationAst.FieldType.Scalar.Enum(
+          nullable = true,
+          typeRef = CodeGenerationAst.TypeRef(
+              name = schemaTypeRef.name!!.capitalize().escapeKotlinReservedWord(),
+              packageName = typesPackageName
+          )
+      )
+
+      IntrospectionSchema.Kind.SCALAR -> {
+        when (schemaTypeRef.name!!.toUpperCase()) {
+          "STRING" -> CodeGenerationAst.FieldType.Scalar.String(nullable = true)
+          "INT" -> CodeGenerationAst.FieldType.Scalar.Int(nullable = true)
+          "BOOLEAN" -> CodeGenerationAst.FieldType.Scalar.Boolean(nullable = true)
+          "FLOAT" -> CodeGenerationAst.FieldType.Scalar.Float(nullable = true)
+          else -> CodeGenerationAst.FieldType.Scalar.Custom(
+              nullable = true,
+              schemaType = schemaTypeRef.name,
+              type = customTypeMap[schemaTypeRef.name]!!
+          )
+        }
+      }
+
+      IntrospectionSchema.Kind.NON_NULL -> resolveInputFieldType(
+          schemaTypeRef = schemaTypeRef.ofType!!,
+          typesPackageName = typesPackageName,
+          customTypeMap = customTypeMap
+      ).nonNullable()
+
+      IntrospectionSchema.Kind.LIST -> CodeGenerationAst.FieldType.Array(
+          nullable = true,
+          rawType = resolveInputFieldType(
+              schemaTypeRef = schemaTypeRef.ofType!!,
+              typesPackageName = typesPackageName,
+              customTypeMap = customTypeMap
+          )
+      )
+
+      else -> throw IllegalArgumentException(
+          "Unsupported input field type `$schemaTypeRef`"
+      )
+    }
+  }
+
+  private fun Operation.buildOperationDataType(
+      irFragments: List<IrFragment>,
+      fragmentTypes: List<CodeGenerationAst.FragmentType>
+  ): CodeGenerationAst.OperationDataType {
+    val operationSchemaType = when {
+      isQuery() -> schema.resolveType(schema.resolveType(schema.queryType))
+
+      isMutation() -> schema.resolveType(schema.resolveType(schema.mutationType))
+
+      isSubscription() -> schema.resolveType(schema.resolveType(schema.subscriptionType))
+
+      else -> throw IllegalArgumentException("Unsupported GraphQL operation type: `$operationType`")
+    }
+    val nestedTypeContainer = ObjectTypeContainerBuilder(packageName = "")
+
+    val rootType = nestedTypeContainer.registerObjectType(typeName = "Data", enclosingType = null) { typeRef ->
+      buildObjectType(
+          typeRef = typeRef,
+          schemaType = operationSchemaType,
+          fields = fields,
+          schema = schema,
+          customTypeMap = customTypeMap,
+          typesPackageName = typesPackageName,
+          fragmentsPackage = fragmentsPackage,
+          irFragments = irFragments,
+          nestedTypeContainer = nestedTypeContainer
+      )
+    }
+    return CodeGenerationAst.OperationDataType(
+        rootType = rootType,
+        nestedTypes = nestedTypeContainer.typeContainer.patchTypeHierarchy(rootType, fragmentTypes)
+    )
+  }
+
+  private fun IrFragment.buildFragmentType(irFragments: List<IrFragment>): CodeGenerationAst.FragmentType {
+    val nestedTypeContainer = ObjectTypeContainerBuilder(packageName = fragmentsPackage)
+    val rootType = nestedTypeContainer.registerObjectType(typeName = fragmentName, enclosingType = null) { typeRef ->
+      buildInterfaceType(
+          typeRef = typeRef,
+          schemaType = schema.resolveType(schema.resolveType(typeCondition)),
+          fields = fields,
+          schema = schema,
+          customTypeMap = customTypeMap,
+          typesPackageName = typesPackageName,
+          fragmentsPackage = fragmentsPackage,
+          irFragments = irFragments,
+          nestedTypeContainer = nestedTypeContainer
+      )
+    }
+    return CodeGenerationAst.FragmentType(
+        rootType = rootType,
+        nestedTypes = nestedTypeContainer.typeContainer
+    )
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeBuilder.kt
@@ -1,0 +1,470 @@
+package com.apollographql.apollo.compiler.next.ast
+
+import com.apollographql.apollo.compiler.ast.CustomTypes
+import com.apollographql.apollo.compiler.escapeKotlinReservedWord
+import com.apollographql.apollo.compiler.ir.Condition
+import com.apollographql.apollo.compiler.ir.Field
+import com.apollographql.apollo.compiler.ir.FragmentRef
+import com.apollographql.apollo.compiler.ir.InlineFragment
+import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
+import com.apollographql.apollo.compiler.parser.introspection.resolveType
+import com.apollographql.apollo.compiler.singularize
+import com.apollographql.apollo.compiler.ir.Fragment as IrFragment
+
+internal fun buildInterfaceType(
+    typeRef: CodeGenerationAst.TypeRef,
+    schemaType: IntrospectionSchema.Type,
+    fields: List<Field>,
+    schema: IntrospectionSchema,
+    customTypeMap: CustomTypes,
+    typesPackageName: String,
+    fragmentsPackage: String,
+    irFragments: List<IrFragment>,
+    nestedTypeContainer: ObjectTypeContainerBuilder
+): CodeGenerationAst.ObjectType {
+  return ObjectTypeBuilder(
+      schema = schema,
+      customTypeMap = customTypeMap,
+      typesPackageName = typesPackageName,
+      fragmentsPackage = fragmentsPackage,
+      irFragments = irFragments.associateBy { it.fragmentName },
+      nestedTypeContainer = nestedTypeContainer,
+      enclosingType = typeRef
+  ).buildObjectType(
+      typeRef = typeRef,
+      schemaType = schemaType,
+      fields = fields,
+      abstract = true
+  )
+}
+
+internal fun buildObjectType(
+    typeRef: CodeGenerationAst.TypeRef,
+    schemaType: IntrospectionSchema.Type,
+    fields: List<Field>,
+    schema: IntrospectionSchema,
+    customTypeMap: CustomTypes,
+    typesPackageName: String,
+    fragmentsPackage: String,
+    irFragments: List<IrFragment>,
+    nestedTypeContainer: ObjectTypeContainerBuilder
+): CodeGenerationAst.ObjectType {
+  return ObjectTypeBuilder(
+      schema = schema,
+      customTypeMap = customTypeMap,
+      typesPackageName = typesPackageName,
+      fragmentsPackage = fragmentsPackage,
+      irFragments = irFragments.associateBy { it.fragmentName },
+      nestedTypeContainer = nestedTypeContainer,
+      enclosingType = typeRef
+  ).buildObjectType(
+      typeRef = typeRef,
+      schemaType = schemaType,
+      fields = fields,
+      abstract = false
+  )
+}
+
+private class ObjectTypeBuilder(
+    private val schema: IntrospectionSchema,
+    private val customTypeMap: CustomTypes,
+    private val typesPackageName: String,
+    private val fragmentsPackage: String,
+    private val irFragments: Map<String, com.apollographql.apollo.compiler.ir.Fragment>,
+    private val nestedTypeContainer: ObjectTypeContainerBuilder,
+    private val enclosingType: CodeGenerationAst.TypeRef
+) {
+
+  fun buildObjectType(
+      typeRef: CodeGenerationAst.TypeRef,
+      schemaType: IntrospectionSchema.Type,
+      fields: List<Field>,
+      abstract: Boolean
+  ): CodeGenerationAst.ObjectType {
+    return CodeGenerationAst.ObjectType(
+        name = typeRef.name,
+        description = schemaType.description ?: "",
+        deprecated = false,
+        deprecationReason = "",
+        abstract = abstract,
+        fields = fields.mapNotNull { field ->
+          // ignore any fields that don't belong to schemaType because they were merged during parsing inline fragments
+          // the way how this merge works is required by old codegen
+          buildField(
+              field = field,
+              schemaType = schemaType,
+              abstract = abstract
+          )
+        },
+        implements = emptySet()
+    )
+  }
+
+  private fun buildObjectType(
+      name: String,
+      schemaType: IntrospectionSchema.Type,
+      fields: List<Field>,
+      abstract: Boolean,
+      implements: List<CodeGenerationAst.TypeRef>,
+      singularizeName: Boolean = true
+  ): CodeGenerationAst.TypeRef {
+    return nestedTypeContainer.registerObjectType(
+        typeName = name,
+        enclosingType = enclosingType,
+        singularizeName = singularizeName
+    ) { typeRef ->
+      CodeGenerationAst.ObjectType(
+          name = typeRef.name,
+          description = schemaType.description ?: "",
+          deprecated = false,
+          deprecationReason = "",
+          abstract = abstract,
+          fields = fields.mapNotNull { field ->
+            // ignore any fields that don't belong to schemaType because they were merged during parsing inline fragments
+            // the way how this merge works is required by old codegen
+            buildField(
+                field = field,
+                schemaType = schemaType,
+                abstract = abstract
+            )
+          },
+          implements = implements.toSet()
+      )
+    }
+  }
+
+  private fun buildField(
+      field: Field,
+      schemaType: IntrospectionSchema.Type,
+      abstract: Boolean
+  ): CodeGenerationAst.Field? {
+    val schemaField = schemaType.resolveField(field.fieldName) ?: return null
+    return CodeGenerationAst.Field(
+        name = field.responseName.escapeKotlinReservedWord(),
+        responseName = field.responseName,
+        type = resolveFieldType(
+            field = field,
+            schemaTypeRef = schemaField.type,
+            abstract = abstract
+        ),
+        description = field.description,
+        deprecated = field.isDeprecated,
+        deprecationReason = field.deprecationReason,
+        arguments = field.args.associate { it.name to it.value },
+        conditions = field.normalizedConditions.toSet(),
+        override = false
+    )
+  }
+
+  private fun resolveFieldType(
+      field: Field,
+      schemaTypeRef: IntrospectionSchema.TypeRef,
+      abstract: Boolean,
+      singularizeName: Boolean = false
+  ): CodeGenerationAst.FieldType {
+    return when (schemaTypeRef.kind) {
+      IntrospectionSchema.Kind.ENUM -> CodeGenerationAst.FieldType.Scalar.Enum(
+          nullable = true,
+          typeRef = CodeGenerationAst.TypeRef(
+              name = schemaTypeRef.name!!.capitalize().escapeKotlinReservedWord(),
+              packageName = typesPackageName
+          )
+      )
+
+      IntrospectionSchema.Kind.INTERFACE,
+      IntrospectionSchema.Kind.OBJECT,
+      IntrospectionSchema.Kind.UNION -> {
+        if (field.inlineFragments.isEmpty()) {
+          val typeRef = buildObjectType(
+              name = field.responseName,
+              schemaType = schema.resolveType(schemaTypeRef),
+              fields = field.fields,
+              abstract = abstract,
+              implements = emptyList(),
+              singularizeName = singularizeName
+          )
+          CodeGenerationAst.FieldType.Object(
+              nullable = true,
+              typeRef = typeRef
+          )
+        } else {
+          field.resolveFragmentFieldType(
+              schemaTypeRef = schemaTypeRef,
+              singularizeName = singularizeName
+          )
+        }
+      }
+
+      IntrospectionSchema.Kind.SCALAR -> {
+        when (schemaTypeRef.name!!.toUpperCase()) {
+          "STRING" -> CodeGenerationAst.FieldType.Scalar.String(nullable = true)
+          "INT" -> CodeGenerationAst.FieldType.Scalar.Int(nullable = true)
+          "BOOLEAN" -> CodeGenerationAst.FieldType.Scalar.Boolean(nullable = true)
+          "FLOAT" -> CodeGenerationAst.FieldType.Scalar.Float(nullable = true)
+          else -> CodeGenerationAst.FieldType.Scalar.Custom(
+              nullable = true,
+              schemaType = schemaTypeRef.name,
+              type = requireNotNull(customTypeMap[schemaTypeRef.name]) {
+                "Missing type mapping for custom scalar`${schemaTypeRef.name}` GraphQL type. "
+              }
+          )
+        }
+      }
+
+      IntrospectionSchema.Kind.NON_NULL -> resolveFieldType(
+          field = field,
+          schemaTypeRef = schemaTypeRef.ofType!!,
+          abstract = abstract,
+          singularizeName = singularizeName
+      ).nonNullable()
+
+      IntrospectionSchema.Kind.LIST -> CodeGenerationAst.FieldType.Array(
+          nullable = true,
+          rawType = resolveFieldType(
+              field = field,
+              schemaTypeRef = schemaTypeRef.ofType!!,
+              abstract = abstract,
+              singularizeName = true
+          )
+      )
+
+      else -> throw IllegalArgumentException("Unsupported selection field type `$schemaTypeRef`")
+    }.let { type ->
+      if (field.isConditional && type !is CodeGenerationAst.FieldType.Fragment) type.nullable() else type
+    }
+  }
+
+  private fun List<Fragment>.buildFragmentFieldPossibleTypes(
+      parentType: CodeGenerationAst.TypeRef
+  ): Map<String, CodeGenerationAst.TypeRef> {
+    val (fragmentOnObjects, fragmentOnInterfaces) = partition { fragment ->
+      val typeConditionSchemaType = schema.resolveType(schema.resolveType(fragment.typeCondition))
+      typeConditionSchemaType.kind == IntrospectionSchema.Kind.OBJECT
+    }
+
+    // build interfaces for all fragments defined on non concrete types if needed
+    val fragmentOnInterfaceTypes = fragmentOnInterfaces.map { fragment ->
+      fragment to (fragment.interfaceType ?: buildObjectType(
+          name = fragment.typeCondition,
+          schemaType = schema.resolveType(schema.resolveType(fragment.typeCondition)),
+          fields = fragment.fields,
+          abstract = true,
+          implements = listOf(parentType)
+      ))
+    }.toMap()
+
+    val fragmentOnObjectsPossibleTypes = fragmentOnObjects.map { it.typeCondition }
+    val fragmentOnInterfacesPossibleTypes = fragmentOnInterfaces.flatMap { it.possibleTypes - fragmentOnObjectsPossibleTypes }
+
+    // for all fragments defined on non concrete types build implementation types
+    val fragmentImplementationTypes = fragmentOnInterfacesPossibleTypes
+        // for each possible type find all possible fragments defined on it
+        .map { possibleType -> possibleType to fragmentOnInterfaces.filter { fragment -> fragment.possibleTypes.contains(possibleType) } }
+        // group possible types by the same set of fragments
+        .fold(emptyMap<List<Fragment>, List<String>>()) { acc, (possibleType, fragment) ->
+          acc + (fragment to (acc[fragment]?.plus(possibleType) ?: listOf(possibleType)))
+        }
+        .flatMap { (fragments, possibleTypes) ->
+          // build implementation type for set of fragments
+          val implementationType = fragments.buildImplementationType(fragmentOnInterfaceTypes)
+          // associate each possible type with implementation type
+          possibleTypes.map { it to implementationType }
+        }
+        .toMap()
+
+    // build object types for all fragments defined on concrete types
+    val fragmentOnObjectTypes = fragmentOnObjects.map { fragment ->
+      fragment.typeCondition to buildObjectType(
+          name = fragment.interfaceType?.name?.let { "${it}Impl" } ?: fragment.typeCondition,
+          schemaType = schema.resolveType(schema.resolveType(fragment.typeCondition)),
+          fields = fragment.fields,
+          abstract = false,
+          implements = fragmentOnInterfaceTypes
+              .filter { (fragmentOnInterface, _) -> fragmentOnInterface.possibleTypes.contains(fragment.typeCondition) }
+              .map { (_, superInterfaceTypeRef) -> superInterfaceTypeRef }
+              .plus(parentType)
+              .plus(listOfNotNull(fragment.interfaceType))
+      )
+    }
+
+    return fragmentImplementationTypes + fragmentOnObjectTypes
+  }
+
+  private fun List<Fragment>.buildImplementationType(
+      fragmentInterfaceTypes: Map<Fragment, CodeGenerationAst.TypeRef>
+  ): CodeGenerationAst.TypeRef {
+    val typeName = joinToString(separator = "", postfix = "Impl") { fragment ->
+      fragment.interfaceType?.name ?: fragment.typeCondition.capitalize().singularize()
+    }
+    return nestedTypeContainer.registerObjectType(
+        typeName = typeName,
+        enclosingType = enclosingType
+    ) { typeRef ->
+      // collect fields from all fragments
+      val fields = this
+          .flatMap { fragment ->
+            fragment.fields.mapNotNull { field ->
+              buildField(
+                  field = field,
+                  schemaType = schema.resolveType(schema.resolveType(fragment.typeCondition)),
+                  abstract = false
+              )
+            }.map { fragment to it }
+          }
+          // check that fields with the same name don't clash
+          .fold(emptyMap<String, Pair<Fragment, CodeGenerationAst.Field>>()) { acc, (fragment, field) ->
+            when (val existingFragmentField = acc[field.name]) {
+              null -> acc + (field.name to (fragment to field))
+              else -> {
+                check(existingFragmentField.second.type == field.type) {
+                  "Can't mix `${field.name}` field's types " +
+                      "`${existingFragmentField.second.type}` defined on `${existingFragmentField.first.typeCondition}` fragment " +
+                      "and `${field.type}` defined on `${fragment.typeCondition}` fragment." +
+                      "Use field alias instead."
+                }
+
+                check(existingFragmentField.second.conditions == field.conditions) {
+                  "Can't mix `${field.name}` field's conditions " +
+                      "`${existingFragmentField.second.conditions}` defined on `${existingFragmentField.first.typeCondition}` fragment " +
+                      "and `${field.conditions}` defined on `${fragment.typeCondition}` fragment." +
+                      "Use field alias instead."
+                }
+
+                check(existingFragmentField.second.arguments == field.arguments) {
+                  "Can't mix `${field.name}` field's arguments " +
+                      "`${existingFragmentField.second.arguments}` defined on `${existingFragmentField.first.typeCondition}` fragment " +
+                      "and `${field.arguments}` defined on `${fragment.typeCondition}` fragment." +
+                      "Use field alias instead."
+                }
+
+                acc
+              }
+            }
+          }
+          .values
+          .map { (_, field) -> field }
+      CodeGenerationAst.ObjectType(
+          name = typeRef.name,
+          description = "",
+          deprecated = false,
+          deprecationReason = "",
+          abstract = false,
+          fields = fields,
+          implements = mapNotNull { fragment -> fragmentInterfaceTypes[fragment] }.toSet()
+      )
+    }
+  }
+
+  private fun Field.resolveFragmentFieldType(
+      schemaTypeRef: IntrospectionSchema.TypeRef,
+      singularizeName: Boolean
+  ): CodeGenerationAst.FieldType.Fragment {
+    val parentType = buildObjectType(
+        name = responseName,
+        schemaType = schema.resolveType(schemaTypeRef),
+        fields = fields,
+        abstract = true,
+        implements = emptyList(),
+        singularizeName = singularizeName
+    )
+    val defaultImplType = buildObjectType(
+        name = "${responseName.singularize()}Impl",
+        schemaType = schema.resolveType(schemaTypeRef),
+        fields = fields,
+        abstract = false,
+        implements = listOf(parentType),
+        singularizeName = singularizeName
+    )
+    val fragments = inlineFragments.toFragments()
+    return CodeGenerationAst.FieldType.Fragment(
+        nullable = false,
+        defaultType = defaultImplType,
+        rawType = parentType,
+        possibleTypes = fragments.buildFragmentFieldPossibleTypes(parentType)
+    )
+  }
+
+  private fun IntrospectionSchema.Type.fields(): List<IntrospectionSchema.Field> {
+    return when (this) {
+      is IntrospectionSchema.Type.Object -> fields
+      is IntrospectionSchema.Type.Interface -> fields
+      is IntrospectionSchema.Type.Union -> fields
+      else -> emptyList()
+    } ?: emptyList()
+  }
+
+  private fun IntrospectionSchema.Type.resolveField(name: String): IntrospectionSchema.Field? {
+    if (name == "__typename") {
+      return IntrospectionSchema.Field(
+          name = "__typename",
+          description = null,
+          isDeprecated = false,
+          deprecationReason = null,
+          type = IntrospectionSchema.TypeRef(
+              kind = IntrospectionSchema.Kind.SCALAR,
+              name = "String"
+          )
+      )
+    }
+    return fields().find { field -> field.name == name }
+  }
+
+  private val Field.normalizedConditions: List<CodeGenerationAst.Field.Condition>
+    get() {
+      return if (isConditional) {
+        conditions.filter { it.kind == Condition.Kind.BOOLEAN.rawValue }.map {
+          CodeGenerationAst.Field.Condition.Directive(
+              variableName = it.variableName,
+              inverted = it.inverted
+          )
+        }
+      } else {
+        emptyList()
+      }
+    }
+
+  private fun List<InlineFragment>.toFragments(): List<Fragment> {
+    return if (isEmpty()) {
+      emptyList()
+    } else {
+      flatMap { fragment ->
+        listOf(
+            Fragment(
+                typeCondition = fragment.typeCondition,
+                possibleTypes = fragment.possibleTypes,
+                description = fragment.description,
+                fields = fragment.fields,
+                fragments = fragment.fragments,
+                interfaceType = null
+            )
+        ) + fragment.fragments.map { it.toFragment() }
+      } + flatMap { it.inlineFragments }.toFragments()
+    }
+  }
+
+  private fun FragmentRef.toFragment(): Fragment {
+    val fragment = requireNotNull(irFragments[name]) {
+      "Unknown fragment `${name}` reference"
+    }
+    return Fragment(
+        typeCondition = fragment.typeCondition,
+        possibleTypes = fragment.possibleTypes,
+        description = fragment.description,
+        fields = fragment.fields,
+        fragments = fragment.fragmentRefs,
+        interfaceType = CodeGenerationAst.TypeRef(
+            name = fragment.fragmentName.capitalize().escapeKotlinReservedWord(),
+            packageName = fragmentsPackage
+        )
+    )
+  }
+
+  private data class Fragment(
+      val typeCondition: String,
+      val possibleTypes: List<String>,
+      val description: String,
+      val fields: List<Field>,
+      val fragments: List<FragmentRef>,
+      val interfaceType: CodeGenerationAst.TypeRef?
+  )
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeContainerBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeContainerBuilder.kt
@@ -1,0 +1,57 @@
+package com.apollographql.apollo.compiler.next.ast
+
+import com.apollographql.apollo.compiler.escapeKotlinReservedWord
+import com.apollographql.apollo.compiler.singularize
+
+internal class ObjectTypeContainerBuilder(private val packageName: String) {
+
+  private val usedTypeNames = HashSet<String>()
+  private val container = LinkedHashMap<CodeGenerationAst.TypeRef, CodeGenerationAst.ObjectType>()
+
+  val typeContainer: ObjectTypeContainer
+    get() = container
+
+  inline fun registerObjectType(
+      typeName: String,
+      enclosingType: CodeGenerationAst.TypeRef?,
+      singularizeName: Boolean = false,
+      builder: (typeRef: CodeGenerationAst.TypeRef) -> CodeGenerationAst.ObjectType
+  ): CodeGenerationAst.TypeRef {
+    val normalizedTypeName = normalizeTypeName(
+        typeName = typeName,
+        singularizeName = singularizeName
+    )
+    usedTypeNames.add(normalizedTypeName)
+
+    val objectTypeRef = CodeGenerationAst.TypeRef(
+        name = normalizedTypeName,
+        packageName = packageName,
+        enclosingType = enclosingType
+    )
+    container[objectTypeRef] = builder(objectTypeRef)
+
+    return objectTypeRef
+  }
+
+  private fun normalizeTypeName(typeName: String, singularizeName: Boolean): String {
+    val normalizedClassName = typeName.escapeKotlinReservedWord().let { originalClassName ->
+      var className = originalClassName
+      while (className.first() == '_') {
+        className = className.removeRange(0, 1)
+      }
+      "_".repeat(originalClassName.length - className.length) + className.capitalize()
+    }
+    return usedTypeNames.generateUniqueTypeName(
+        typeName = normalizedClassName.let { if (singularizeName) it.singularize() else it }
+    )
+  }
+
+  private fun Set<String>.generateUniqueTypeName(typeName: String): String {
+    var index = 0
+    var uniqueTypeName = typeName
+    while (find { it.toLowerCase() == uniqueTypeName.toLowerCase() } != null) {
+      uniqueTypeName = "$typeName${++index}"
+    }
+    return uniqueTypeName
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeHierarchyPatcher.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/next/ast/ObjectTypeHierarchyPatcher.kt
@@ -1,0 +1,181 @@
+package com.apollographql.apollo.compiler.next.ast
+
+internal fun ObjectTypeContainer.patchTypeHierarchy(
+    rootType: CodeGenerationAst.TypeRef,
+    fragmentTypes: List<CodeGenerationAst.FragmentType>
+): ObjectTypeContainer {
+  val fragmentTypeContainer = fragmentTypes.fold(emptyMap<CodeGenerationAst.TypeRef, CodeGenerationAst.ObjectType>()) { acc, fragmentType ->
+    acc + fragmentType.nestedTypes
+  }
+  return TypeHierarchyPatcher(this + fragmentTypeContainer)
+      .patch(rootType)
+      .minus(fragmentTypeContainer.keys)
+}
+
+private class TypeHierarchyPatcher(typeContainer: ObjectTypeContainer) {
+  private val patchedTypeContainer = typeContainer.toMutableMap()
+
+  fun patch(rootType: CodeGenerationAst.TypeRef): Map<CodeGenerationAst.TypeRef, CodeGenerationAst.ObjectType> {
+    rootType.patch()
+    return patchedTypeContainer
+  }
+
+  private fun CodeGenerationAst.TypeRef.patch() {
+    val type = requireNotNull(patchedTypeContainer[this]) {
+      "Can't resolve type, unknown type reference `$this`"
+    }
+
+    type.implements.forEach { parentType -> parentType.patch() }
+
+    val parentTypeFields = type.implements
+        .flatMap { parentType -> (patchedTypeContainer[parentType] as CodeGenerationAst.ObjectType).fields }
+
+    val patchedFields = type.fields.map { field ->
+      if (field.type.nullable) {
+        val nonNullableParentField = parentTypeFields.find { parentField ->
+          parentField.name == field.name && !parentField.type.nullable
+        }
+        check(nonNullableParentField == null) {
+          "Nullable field `${field.responseName}` of type `${field.type}` defined on object `${name}` is not a subtype of non nullable " +
+              "overridden field. Please use field alias instead."
+        }
+      }
+
+      if (field.override) {
+        field
+      } else {
+        field.copy(override = parentTypeFields.find { parentField -> parentField.name == field.name } != null)
+      }
+    }
+
+    patchedTypeContainer[this] = type.copy(fields = patchedFields)
+
+    patchedFields.forEach { field ->
+      val parentFieldTypes = parentTypeFields.mapNotNull { parentField ->
+        parentField.takeIf { it.name == field.name }?.type
+      }
+      when {
+        parentFieldTypes.isEmpty() -> field.type.patch()
+        else -> field.type.patch(parentFieldTypes)
+      }
+    }
+  }
+
+  private fun CodeGenerationAst.FieldType.patch() {
+    when (this) {
+      is CodeGenerationAst.FieldType.Object -> {
+        typeRef.patch()
+      }
+
+      is CodeGenerationAst.FieldType.Array -> {
+        rawType.patch()
+      }
+
+      is CodeGenerationAst.FieldType.Fragment -> {
+        defaultType.patch()
+        possibleTypes.values.forEach { type -> type.patch() }
+      }
+    }
+  }
+
+  private fun CodeGenerationAst.FieldType.patch(parentFieldTypes: List<CodeGenerationAst.FieldType>) {
+    when (this) {
+      is CodeGenerationAst.FieldType.Object -> {
+        parentFieldTypes.forEach { parentFieldType ->
+          if (parentFieldType is CodeGenerationAst.FieldType.Object) {
+            patch(parentFieldType)
+          } else if (parentFieldType is CodeGenerationAst.FieldType.Fragment) {
+            patch(parentFieldType)
+          }
+        }
+      }
+
+      is CodeGenerationAst.FieldType.Array -> {
+        parentFieldTypes.forEach { parentFieldType ->
+          patch(parentFieldType as CodeGenerationAst.FieldType.Array)
+        }
+      }
+
+      is CodeGenerationAst.FieldType.Fragment -> {
+        parentFieldTypes.forEach { parentFieldType ->
+          if (parentFieldType is CodeGenerationAst.FieldType.Object) {
+            patch(parentFieldType)
+          } else if (parentFieldType is CodeGenerationAst.FieldType.Fragment) {
+            patch(parentFieldType)
+          }
+        }
+      }
+    }
+  }
+
+  private fun CodeGenerationAst.FieldType.Object.patch(
+      parentFieldType: CodeGenerationAst.FieldType.Object
+  ) {
+    patchedTypeContainer[typeRef] = with(patchedTypeContainer[typeRef] as CodeGenerationAst.ObjectType) {
+      copy(implements = implements + parentFieldType.typeRef)
+    }
+    typeRef.patch()
+  }
+
+  private fun CodeGenerationAst.FieldType.Object.patch(
+      parentFieldType: CodeGenerationAst.FieldType.Fragment
+  ) {
+    patchedTypeContainer[typeRef] = with(patchedTypeContainer[typeRef] as CodeGenerationAst.ObjectType) {
+      copy(implements = implements + parentFieldType.rawType)
+    }
+    typeRef.patch()
+  }
+
+  private fun CodeGenerationAst.FieldType.Fragment.patch(
+      parentFieldType: CodeGenerationAst.FieldType.Object
+  ) {
+    patchedTypeContainer[defaultType] = with(patchedTypeContainer[defaultType] as CodeGenerationAst.ObjectType) {
+      copy(implements = implements + parentFieldType.typeRef)
+    }
+    defaultType.patch()
+
+    possibleTypes.values.forEach { typeRef ->
+      patchedTypeContainer[typeRef] = with(patchedTypeContainer[typeRef] as CodeGenerationAst.ObjectType) {
+        copy(implements = implements + parentFieldType.typeRef)
+      }
+      typeRef.patch()
+    }
+  }
+
+  private fun CodeGenerationAst.FieldType.Fragment.patch(
+      parentFieldType: CodeGenerationAst.FieldType.Fragment
+  ) {
+    patchedTypeContainer[defaultType] = with(patchedTypeContainer[defaultType] as CodeGenerationAst.ObjectType) {
+      copy(implements = implements + parentFieldType.rawType)
+    }
+    defaultType.patch()
+
+    possibleTypes.values.forEach { typeRef ->
+      patchedTypeContainer[typeRef] = with(patchedTypeContainer[typeRef] as CodeGenerationAst.ObjectType) {
+        copy(implements = implements + parentFieldType.rawType)
+      }
+      typeRef.patch()
+    }
+  }
+
+  private fun CodeGenerationAst.FieldType.Array.patch(
+      parentFieldType: CodeGenerationAst.FieldType.Array
+  ) {
+    when (rawType) {
+      is CodeGenerationAst.FieldType.Object -> {
+        if (parentFieldType.rawType is CodeGenerationAst.FieldType.Object) {
+          rawType.patch(
+              parentFieldType = parentFieldType.rawType
+          )
+        } else if (parentFieldType.rawType is CodeGenerationAst.FieldType.Fragment) {
+          rawType.patch(
+              parentFieldType = parentFieldType.rawType
+          )
+        }
+      }
+      is CodeGenerationAst.FieldType.Array -> rawType.patch(
+          parentFieldType = parentFieldType.rawType as CodeGenerationAst.FieldType.Array
+      )
+    }
+  }
+}


### PR DESCRIPTION
Introduce new codegen AST to make it possible generate named / inline fragments as interfaces, following the similar approach described by Airbnb.

This is the first phase (we can call it as frontend) of new codegen, build AST structure that very closely represents Kotlin / JVM code to be generated.

Next phase (backend) is actually take AST and transform it to the Kotlin / JVM code.

There are no tests yet as this is just a first step of new codegen, tests will be added with next PR for backend.