### PR TITLE
Add JS target to `apollo-api` module

### DIFF
--- a/apollo-api/build.gradle.kts
+++ b/apollo-api/build.gradle.kts
@@ -24,6 +24,8 @@ kotlin {
     withJava()
   }
 
+  js().browser()
+
   sourceSets {
     val commonMain by getting {
       dependencies {
@@ -47,6 +49,14 @@ kotlin {
       dependsOn(iosMain)
     }
 
+    val jsMain by getting {
+      dependsOn(commonMain)
+      dependencies {
+        implementation(kotlin("stdlib-js"))
+        implementation("com.ionspin.kotlin:bignum-js:0.1.5")
+      }
+    }
+
     val commonTest by getting {
       dependencies {
         implementation(kotlin("test-common"))
@@ -60,6 +70,14 @@ kotlin {
         implementation(kotlin("test-junit"))
         implementation(groovy.util.Eval.x(project, "x.dep.truth"))
         implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+      }
+    }
+
+    val jsTest by getting {
+      dependsOn(jsMain)
+
+      dependencies {
+        implementation(kotlin("test-js"))
       }
     }
   }

--- a/apollo-api/build.gradle.kts
+++ b/apollo-api/build.gradle.kts
@@ -52,7 +52,7 @@ kotlin {
     val jsMain by getting {
       dependencies {
         implementation(kotlin("stdlib-js"))
-        implementation(groovy.util.Eval.x(project, "x.dep.bignum"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kbignum"))
       }
     }
 
@@ -90,17 +90,17 @@ tasks.create("jsPatch") {
   doLast {
     val kotlinJs = File(rootProject.buildDir, "js/packages_imported/kotlin/1.3.72/kotlin.js")
 
-    val patch = "package\$kotlin.Number = Number;"
+    val patch = "package\$kotlin.Number = Number; _.isNumber = function (a) { return typeof a == 'number' || a instanceof Kotlin.Long || a.constructor.name == 'BigDecimal'; };"
     val applyAfter = "var package\$kotlin = _.kotlin || (_.kotlin = {});"
     val fileContent = kotlinJs.readText()
 
     if (patch !in fileContent) {
-      kotlinJs.writeText(fileContent.replace(applyAfter, "$applyAfter\n\t$patch\n"))
+      kotlinJs.writeText(fileContent.replace(applyAfter, "$applyAfter\n\t\t$patch\n"))
     }
   }
 }
 
-tasks.named("jsBrowserTest").configure {
+tasks.named("jsBrowserTest") {
   setDependsOn(listOf("jsPatch"))
 }
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo.api
 
+import kotlin.js.JsName
+
 /**
  * Represents an error response returned from the GraphQL server
  */
@@ -24,18 +26,21 @@ class Error(
    * Returns server error message.
    */
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "message"))
+  @JsName("message_deprecated")
   fun message(): String? = message
 
   /**
    * Returns the location of the error in the GraphQL operation.
    */
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "locations"))
+  @JsName("locations_deprecated")
   fun locations(): List<Location> = locations
 
   /**
    * Returns custom attributes associated with this error
    */
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "customAttributes"))
+  @JsName("customAttributes_deprecated")
   fun customAttributes(): Map<String, Any?> = customAttributes
 
   override fun equals(other: Any?): Boolean {
@@ -76,12 +81,14 @@ class Error(
      * Returns the line number of the error location.
      */
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "line"))
+    @JsName("line_deprecated")
     fun line(): Long = line
 
     /**
      * Returns the column number of the error location.
      */
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "column"))
+    @JsName("column_deprecated")
     fun column(): Long = column
 
     override fun equals(other: Any?): Boolean {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api
 
+import kotlin.js.JsName
 import kotlin.jvm.JvmStatic
 
 /**
@@ -55,17 +56,21 @@ data class Response<T>(
   )
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "operation"))
+  @JsName("operation_deprecated")
   fun operation(): Operation<*, *, *> {
     return operation
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "data"))
+  @JsName("data_deprecated")
   fun data(): T? = data
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "errors"))
+  @JsName("errors_deprecated")
   fun errors(): List<Error>? = errors
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "dependentKeys"))
+  @JsName("dependentKeys_deprecated")
   fun dependentKeys(): Set<String> {
     return dependentKeys
   }
@@ -73,11 +78,13 @@ data class Response<T>(
   fun hasErrors(): Boolean = !errors.isNullOrEmpty()
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "fromCache"))
+  @JsName("fromCache_deprecated")
   fun fromCache(): Boolean {
     return fromCache
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "extensions"))
+  @JsName("extensions_deprecated")
   fun extensions(): Map<String, Any?> {
     return extensions
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ResponseField.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ResponseField.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api
 
+import kotlin.js.JsName
 import kotlin.jvm.JvmStatic
 
 /**
@@ -22,31 +23,37 @@ open class ResponseField internal constructor(
 ) {
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "type"))
+  @JsName("type_deprecated")
   fun type(): Type {
     return type
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "responseName"))
+  @JsName("responseName_deprecated")
   fun responseName(): String {
     return responseName
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "fieldName"))
+  @JsName("fieldName_deprecated")
   fun fieldName(): String {
     return fieldName
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "arguments"))
+  @JsName("arguments_deprecated")
   fun arguments(): Map<String, Any?> {
     return arguments
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "optional"))
+  @JsName("optional_deprecated")
   fun optional(): Boolean {
     return optional
   }
 
   @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "conditions"))
+  @JsName("conditions_deprecated")
   fun conditions(): List<Condition> {
     return conditions
   }
@@ -126,6 +133,7 @@ open class ResponseField internal constructor(
   ) {
 
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "scalarType"))
+    @JsName("scalarType_deprecated")
     fun scalarType(): ScalarType {
       return scalarType
     }
@@ -177,6 +185,7 @@ open class ResponseField internal constructor(
       val typeNames: List<String>
   ) : Condition() {
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "typeNames"))
+    @JsName("typeNames_deprecated")
     fun typeNames(): List<String> {
       return typeNames
     }
@@ -203,11 +212,13 @@ open class ResponseField internal constructor(
       val inverted: Boolean
   ) : Condition() {
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "variableName"))
+    @JsName("variableName_deprecated")
     fun variableName(): String {
       return variableName
     }
 
     @Deprecated(message = "Use property instead", replaceWith = ReplaceWith(expression = "inverted"))
+    @JsName("inverted_deprecated")
     fun inverted(): Boolean {
       return inverted
     }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo.api.internal
+
+import kotlin.reflect.KClass
+
+expect val KClass<*>.qualifiedName2: String?

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/BigDecimalTest.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/BigDecimalTest.kt
@@ -1,0 +1,71 @@
+package com.apollographql.apollo.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BigDecimalTest {
+
+  @Test
+  fun add() {
+    assertEquals(2.0, BigDecimal(1).add(BigDecimal(1)).toDouble())
+    assertEquals(4.25, BigDecimal(2.5).add(BigDecimal(1.75)).toDouble())
+  }
+
+  @Test
+  fun subtract() {
+    assertEquals(0.0, BigDecimal(1).subtract(BigDecimal(1)).toDouble())
+    assertEquals(0.75, BigDecimal(2.5).subtract(BigDecimal(1.75)).toDouble())
+  }
+
+  @Test
+  fun multiply() {
+    assertEquals(1.0, BigDecimal(1).multiply(BigDecimal(1)).toDouble())
+    assertEquals(4.375, BigDecimal(2.5).multiply(BigDecimal(1.75)).toDouble())
+  }
+
+  @Test
+  fun divide() {
+    assertEquals(2.0, BigDecimal(4.0).divide(BigDecimal(2.0)).toDouble())
+    assertEquals(2.5, BigDecimal(5.0).divide(BigDecimal(2.0)).toDouble())
+  }
+
+  @Test
+  fun negate() {
+    assertEquals(BigDecimal(-1), BigDecimal(1).negate())
+    assertEquals(BigDecimal(1), BigDecimal(-1).negate())
+  }
+
+  @Test
+  fun signum() {
+    assertEquals(0, BigDecimal(0).signum())
+    assertEquals(-1, BigDecimal(-1).signum())
+    assertEquals(-1, BigDecimal(-1).signum())
+  }
+
+  // From kotlin.Number
+
+  @Test
+  fun toInt() {
+    assertEquals(1, BigDecimal(1).toInt())
+    assertEquals(-1, BigDecimal(-1).toInt())
+  }
+
+  @Test
+  fun toLong() {
+    assertEquals(1L, BigDecimal(1).toLong())
+    assertEquals(-1L, BigDecimal(-1).toLong())
+  }
+
+  @Test
+  fun toDouble() {
+    assertEquals(1.0, BigDecimal(1.0).toDouble())
+    assertEquals(-1.0, BigDecimal(-1.0).toDouble())
+  }
+
+  @Test
+  fun is_a_Number() {
+    // Fails in JS without the patch in `Kotlin.isNumber`
+    assertTrue { BigDecimal(1) is Number }
+  }
+}

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/ReflectionTest.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/ReflectionTest.kt
@@ -1,0 +1,26 @@
+package com.apollographql.apollo.api.internal
+
+import com.apollographql.apollo.api.BigDecimal
+import com.apollographql.apollo.api.FileUpload
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReflectionTest {
+  @Test
+  fun qualifiedName2_mapping() {
+    assertEquals("kotlin.String", String::class.qualifiedName2 )
+    assertEquals("kotlin.Char", Char::class.qualifiedName2 )
+    assertEquals("kotlin.Boolean", Boolean::class.qualifiedName2 )
+    assertEquals("kotlin.Byte", Byte::class.qualifiedName2 )
+    assertEquals("kotlin.Short", Short::class.qualifiedName2 )
+    assertEquals("kotlin.Int", Int::class.qualifiedName2 )
+    assertEquals("kotlin.Long", Long::class.qualifiedName2 )
+    assertEquals("kotlin.Float", Float::class.qualifiedName2 )
+    assertEquals("kotlin.Double", Double::class.qualifiedName2 )
+    assertEquals("kotlin.collections.List", List::class.qualifiedName2 )
+    assertEquals("kotlin.collections.Map", Map::class.qualifiedName2 )
+    assertTrue { BigDecimal::class.qualifiedName2  in listOf("java.math.BigDecimal", "com.apollographql.apollo.api.BigDecimal") }
+    assertEquals("com.apollographql.apollo.api.FileUpload", FileUpload::class.qualifiedName2 )
+  }
+}

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReaderTest.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReaderTest.kt
@@ -170,7 +170,7 @@ class SimpleResponseReaderTest {
       }
 
       override fun className(): String {
-        return Map::class.qualifiedName!!
+        return Map::class.qualifiedName2!!
       }
     }
     val successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
@@ -205,7 +205,7 @@ class SimpleResponseReaderTest {
       }
 
       override fun className(): String {
-        return List::class.qualifiedName!!
+        return List::class.qualifiedName2!!
       }
     }
     val successField = ResponseField.forCustomType("successFieldResponseName", "successFieldName", null,
@@ -534,7 +534,7 @@ class SimpleResponseReaderTest {
         }
 
         override fun className(): String {
-          return clazz.qualifiedName!!
+          return clazz.qualifiedName2!!
         }
       }
     }
@@ -545,7 +545,7 @@ class SimpleResponseReaderTest {
       }
 
       override fun className(): String {
-        return String::class.qualifiedName!!
+        return String::class.qualifiedName2!!
       }
     }
   }

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/internal/json/InputFieldJsonWriterTest.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.ScalarType
 import com.apollographql.apollo.api.ScalarTypeAdapters
 import com.apollographql.apollo.api.internal.InputFieldMarshaller
 import com.apollographql.apollo.api.internal.InputFieldWriter
+import com.apollographql.apollo.api.internal.qualifiedName2
 import okio.Buffer
 import kotlin.reflect.KClass
 import kotlin.test.Test
@@ -194,7 +195,7 @@ class InputFieldJsonWriterTest {
     }
 
     override fun className(): String {
-      return clazz.qualifiedName!!
+      return clazz.qualifiedName2!!
     }
   }
 

--- a/apollo-api/src/iosMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
+++ b/apollo-api/src/iosMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo.api.internal
+
+import kotlin.reflect.KClass
+
+actual val KClass<*>.qualifiedName2: String?
+  get() = qualifiedName

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/BigDecimal.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/BigDecimal.kt
@@ -1,0 +1,60 @@
+package com.apollographql.apollo.api
+
+import com.soywiz.kbignum.BigInt
+import com.soywiz.kbignum.BigNum
+
+@ExperimentalUnsignedTypes
+actual class BigDecimal(private val raw: BigNum) : Number(), Comparable<BigDecimal> {
+
+  actual constructor(strVal: String) : this(BigNum(strVal))
+
+  actual constructor(doubleVal: Double) : this(BigNum(doubleVal.toString().let { str -> if ("." in str) str else "$str.0" }))
+
+  actual constructor(intVal: Int) : this(BigNum(BigInt(intVal), 0))
+
+  actual constructor(longVal: Long) : this(BigNum(BigInt(longVal), 0))
+
+  actual fun add(augend: BigDecimal): BigDecimal = BigDecimal(this.raw + augend.raw)
+
+  actual fun subtract(subtrahend: BigDecimal): BigDecimal = BigDecimal(this.raw - subtrahend.raw)
+
+  actual fun multiply(multiplicand: BigDecimal): BigDecimal = BigDecimal(this.raw * multiplicand.raw)
+
+  actual fun divide(divisor: BigDecimal): BigDecimal = BigDecimal(this.raw / divisor.raw)
+
+  actual fun negate(): BigDecimal = BigDecimal(this.raw * rawMinusOne)
+
+  actual fun signum(): Int =
+    when {
+      this.raw.int.isNegative -> -1
+      this.raw.int.isPositive -> 1
+      else -> 0
+    }
+
+  override fun equals(other: Any?): Boolean = this.raw == (other as? BigDecimal)?.raw
+
+  override fun hashCode(): Int = this.raw.hashCode()
+
+  override fun compareTo(other: BigDecimal): Int = this.raw.compareTo(other.raw)
+
+  override fun toString(): String = this.raw.toString()
+
+  override fun toChar(): Char = toInt().toChar()
+
+  override fun toByte(): Byte = toInt().toByte()
+
+  override fun toShort(): Short = toInt().toShort()
+
+  override fun toInt(): Int = toDouble().toInt()
+
+  override fun toLong(): Long = toDouble().toLong()
+
+  override fun toFloat(): Float = toDouble().toFloat()
+
+  override fun toDouble(): Double = this.raw.toString().toDouble()
+
+  companion object {
+    private val rawMinusOne = BigNum("-1")
+  }
+}
+

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/Reflection.kt
@@ -1,0 +1,21 @@
+package com.apollographql.apollo.api.internal
+
+import kotlin.reflect.KClass
+
+actual val KClass<*>.qualifiedName2: String?
+  get() = when (simpleName) {
+    "String" -> "kotlin.String"
+    "BoxedChar" -> "kotlin.Char"
+    "Boolean" -> "kotlin.Boolean"
+    "Byte" -> "kotlin.Byte"
+    "Short" -> "kotlin.Short"
+    "Int" -> "kotlin.Int"
+    "Long" -> "kotlin.Long"
+    "Float" -> "kotlin.Float"
+    "Double" -> "kotlin.Double"
+    "List" -> "kotlin.collections.List"
+    "Map" -> "kotlin.collections.Map"
+    "BigDecimal" -> "com.apollographql.apollo.api.BigDecimal"
+    "FileUpload" -> "com.apollographql.apollo.api.FileUpload"
+    else -> simpleName
+  }

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/Throws.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/Throws.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo.api.internal
+
+import kotlin.reflect.KClass
+
+actual annotation class Throws actual constructor(actual vararg val exceptionClasses: KClass<out Throwable>)

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/json/Closeable.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/json/Closeable.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo.api.internal.json
+
+actual interface Closeable {
+  actual fun close()
+}

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/json/Flushable.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo/api/internal/json/Flushable.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo.api.internal.json
+
+actual interface Flushable {
+  actual fun flush()
+}

--- a/apollo-api/src/jvmMain/java/com/apollographql/apollo/api/internal/Reflection.kt
+++ b/apollo-api/src/jvmMain/java/com/apollographql/apollo/api/internal/Reflection.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo.api.internal
+
+import kotlin.reflect.KClass
+
+actual val KClass<*>.qualifiedName2: String?
+  get() = qualifiedName

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -104,7 +104,7 @@ ext.dep = [
     ],
     truth                 : "com.google.truth:truth:$versions.truth",
     uuid                  : "com.benasher44:uuid:0.1.0",
-    bignum                : "com.ionspin.kotlin:bignum-js:0.1.5",
+    kbignum               : "com.soywiz.korlibs.kbignum:kbignum-js:1.10.2",
 ]
 ext.androidConfig = [
     compileSdkVersion: 28,

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -104,6 +104,7 @@ ext.dep = [
     ],
     truth                 : "com.google.truth:truth:$versions.truth",
     uuid                  : "com.benasher44:uuid:0.1.0",
+    bignum                : "com.ionspin.kotlin:bignum-js:0.1.5",
 ]
 ext.androidConfig = [
     compileSdkVersion: 28,


### PR DESCRIPTION
- First attempt to bring JS support in Kotlin Multiplatform.
- One test is still failing due to some bugs in `Kolin.Number` in JS, I fixed some, and I'm still working on it, but I wanted to have early feedback.
- Maybe the PR shouldn't be merged in `master`, but in some kind of epic/feature branch, like `js-support`