### PR TITLE
[Runtime] Parameter writeToCacheAsynchronously is not taken into account in RealApolloCall

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -125,9 +125,9 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     useHttpGetMethodForQueries = builder.useHttpGetMethodForQueries;
     enableAutoPersistedQueries = builder.enableAutoPersistedQueries;
     useHttpGetMethodForPersistedQueries = builder.useHttpGetMethodForPersistedQueries;
-    interceptorChain = prepareInterceptorChain(operation);
     optimisticUpdates = builder.optimisticUpdates;
     writeToNormalizedCacheAsynchronously = builder.writeToNormalizedCacheAsynchronously;
+    interceptorChain = prepareInterceptorChain(operation);
   }
 
   @Override public void enqueue(@Nullable final Callback<T> responseCallback) {


### PR DESCRIPTION
Fixes #2483 

**Summary**
When building ApolloClient's normalized cache, a parameter called writeToCacheAsynchronously is available.
Unfortunately, the underlying usage of this boolean in RealApolloCall line 130 succeeds the preparation of the interceptor chain, thus the boolean at line 128 is always false. This results in the ApolloCacheInterceptor always receiving false for writeToCacheAsynchronously.

**Description**
The fix is simple, in RealApolloCall the current line 128 needs to go to line 130 so prepareInterceptorChain() is the last operation in the constructor.