### PR TITLE
[Plugin] better error message for multiple schemas

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -100,17 +100,20 @@ abstract class DefaultCompilationUnit @Inject constructor(
     }
 
     private fun multipleSchemaError(project: Project, schemaList: List<File>): String {
-      val services = schemaList.joinToString("\n") {
-        val name = it.parentFile.name
-        """|
-          |  service("$name") {
-          |    sourceFolder.set("com/$name)"
-          |    rootPackageName.set("com.$name)
+      val services = """|
+          |  service("service1") {
+          |    sourceFolder.set("com/service1)"
+          |    rootPackageName.set("com.service1)
+          |  }
+          |  
+          |  service("service2") {
+          |    sourceFolder.set("com/service2)"
+          |    rootPackageName.set("com.service2)
           |  }
         """.trimMargin()
-      }
       return "ApolloGraphQL: By default only one schema.[json | sdl] file is supported.\n" +
-          "Please use multiple services instead:\napollo {\n$services\n}"
+          "Please use multiple services instead:\napollo {\n$services\n}" +
+          "See https://www.apollographql.com/docs/android/essentials/plugin-configuration/#apolloextension-services-and-compilationunit for more details."
     }
 
     fun resolveDirectories(project: Project, sourceFolderProvider: Provider<String>, sourceSetNames: List<String>): List<String> {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -99,11 +99,13 @@ abstract class DefaultCompilationUnit @Inject constructor(
       }
     }
 
-    private fun multipleSchemaError(schemaList: List<File>): String {
+    private fun multipleSchemaError(project: Project, schemaList: List<File>): String {
       val services = schemaList.joinToString("\n") {
+        val name = it.parentFile.name
         """|
-          |  service("${it.parentFile.name}") {
-          |    sourceFolder = "${it.parentFile.normalize().absolutePath}"
+          |  service("$name") {
+          |    sourceFolder.set("com/$name)"
+          |    rootPackageName.set("com.$name)
           |  }
         """.trimMargin()
       }
@@ -152,7 +154,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
         }
 
         require(candidates.size <= 1) {
-          multipleSchemaError(candidates)
+          multipleSchemaError(project, candidates)
         }
 
         require(candidates.size == 1) {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultCompilationUnit.kt
@@ -99,7 +99,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
       }
     }
 
-    private fun multipleSchemaError(project: Project, schemaList: List<File>): String {
+    private fun multipleSchemaError(): String {
       val services = """|
           |  service("service1") {
           |    sourceFolder.set("com/service1)"
@@ -157,7 +157,7 @@ abstract class DefaultCompilationUnit @Inject constructor(
         }
 
         require(candidates.size <= 1) {
-          multipleSchemaError(project, candidates)
+          multipleSchemaError()
         }
 
         require(candidates.size == 1) {


### PR DESCRIPTION
* do not put absolute paths in the error message
* add a rootPackageName
* use `.set` instead of `=` as it works for both Groovy and Kotlin build scripts

**before**
```
  ApolloGraphQL: By default only one schema.[json | sdl] file is supported.
  Please use multiple services instead:
  apollo {
  
    service("github") {
      sourceFolder = "/Users/mbonnin/git/apollo-android-samples/multiple-services/src/main/graphql/com/github"
    }
  
    service("fullstack") {
      sourceFolder = "/Users/mbonnin/git/apollo-android-samples/multiple-services/src/main/graphql/com/apollographql/fullstack"
    }
  }
```

**after**
```
  ApolloGraphQL: By default only one schema.[json | sdl] file is supported.
  Please use multiple services instead:
  apollo {
  
    service("service1") {
      sourceFolder.set("com/service1)"
      rootPackageName.set("com.service1)
    }
  
    service("service2") {
      sourceFolder.set("com/service2)"
      rootPackageName.set("com.service2)
    }
  }
```