### PR TITLE
[Parser] allow `defaultValue="null"` for non-string scalar types

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
@@ -732,9 +732,9 @@ class GraphQLDocumentParser(val schema: IntrospectionSchema, private val package
     return when (type.kind) {
       IntrospectionSchema.Kind.SCALAR -> {
         when (ScalarType.forName(type.name ?: "")) {
-          ScalarType.INT -> toString().trim().toInt()
-          ScalarType.BOOLEAN -> toString().trim().toBoolean()
-          ScalarType.FLOAT -> toString().trim().toDouble()
+          ScalarType.INT -> toString().trim().takeIf { it != "null" }?.toInt()
+          ScalarType.BOOLEAN -> toString().trim().takeIf { it != "null" }?.toBoolean()
+          ScalarType.FLOAT -> toString().trim().takeIf { it != "null" }?.toDouble()
           else -> toString()
         }
       }


### PR DESCRIPTION
Some servers put `"null"` in the `defaultValue` for `Int`, `Float`, `Boolean` types while we expect `null`. Be more robust to that. 

We could make it a configuration option but I don't think there are any valid use cases for `"null"` to not represent and actual null

exemple schema that reproduces this with the Apollo Server:

```
  input ReviewInput {
    stars: Int = null
  }

  type Mutation {
    review(input: ReviewInput): String
  }

```

closes #2450