### PR TITLE
Fix SNAPSHOT version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.apollographql.apollo
-VERSION_NAME=3.0.0-alpha01
+VERSION_NAME=2.2.4-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-android/
 POM_SCM_URL=https://github.com/apollographql/apollo-android/

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ def versions = [
     minAndroidPlugin      : '3.4.2',
     androidPlugin         : '3.6.2',
     androidxSqlite        : '2.1.0',
-    apollo                : '3.0.0-alpha01', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
+    apollo                : '2.2.4-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',
     cache                 : '2.0.2',
     compiletesting        : '0.15',


### PR DESCRIPTION
restore `2.2.4-SNAPSHOT` version. 

Changing the base of https://github.com/apollographql/apollo-android/pull/2473/ also obviously took the commits from dev-3.x 🤦 . I'll avoid changing the base in future pull requests....