### PR TITLE
[Runtime] add missing @Deprecated and `toBuilder` for ApolloMutationCall

### DIFF
--- a/apollo-runtime/api.txt
+++ b/apollo-runtime/api.txt
@@ -100,6 +100,7 @@ package com.apollographql.apollo {
     method public abstract com.apollographql.apollo.ApolloMutationCall<T> refetchQueries(OperationName...);
     method public abstract com.apollographql.apollo.ApolloMutationCall<T> refetchQueries(Query...);
     method public abstract com.apollographql.apollo.ApolloMutationCall<T> requestHeaders(com.apollographql.apollo.request.RequestHeaders);
+    method public abstract com.apollographql.apollo.ApolloMutationCall.Builder<T> toBuilder();
   }
 
   public static abstract interface ApolloMutationCall.Builder<T> implements com.apollographql.apollo.ApolloCall.Builder {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -56,6 +56,8 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
 
   @Deprecated @NotNull @Override ApolloMutationCall<T> clone();
 
+  @NotNull @Override ApolloMutationCall.Builder<T> toBuilder();
+
   interface Builder<T> extends ApolloCall.Builder<T> {
     @NotNull @Override ApolloMutationCall<T> build();
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.api.Mutation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.cache.CacheHeaders;
+import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.apollographql.apollo.request.RequestHeaders;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,7 +15,18 @@ import java.util.List;
  */
 public interface ApolloMutationCall<T> extends ApolloCall<T> {
 
-  @NotNull @Override ApolloMutationCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+  /**
+   * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
+   * be configured with this headers, and will be accessible from the {@link ResponseFetcher} used for this call.
+   *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
+   *
+   * @param cacheHeaders the {@link CacheHeaders} that will be passed with records generated from this request to {@link
+   *                     com.apollographql.apollo.cache.normalized.NormalizedCache}. Standardized cache headers are
+   *                     defined in {@link com.apollographql.apollo.cache.ApolloCacheHeaders}.
+   * @return The ApolloCall object with the provided {@link CacheHeaders}.
+   */
+  @Deprecated @NotNull @Override ApolloMutationCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
   /**
    * <p>Sets a list of {@link ApolloQueryWatcher} query names to be re-fetched once this mutation completed.</p>
@@ -22,7 +34,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param operationNames array of {@link OperationName} query names to be re-fetched
    * @return {@link ApolloMutationCall} that will trigger re-fetching provided queries
    */
-  @NotNull ApolloMutationCall<T> refetchQueries(@NotNull OperationName... operationNames);
+  @Deprecated @NotNull ApolloMutationCall<T> refetchQueries(@NotNull OperationName... operationNames);
 
   /**
    * <p>Sets a list of {@link Query} to be re-fetched once this mutation completed.</p>
@@ -30,7 +42,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param queries array of {@link Query} to be re-fetched
    * @return {@link ApolloMutationCall} that will trigger re-fetching provided queries
    */
-  @NotNull ApolloMutationCall<T> refetchQueries(@NotNull Query... queries);
+  @Deprecated @NotNull ApolloMutationCall<T> refetchQueries(@NotNull Query... queries);
 
   /**
    * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
@@ -40,9 +52,9 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param requestHeaders The {@link RequestHeaders} to use for this request.
    * @return The ApolloCall object with the provided {@link RequestHeaders}.
    */
-  @NotNull ApolloMutationCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+  @Deprecated @NotNull ApolloMutationCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
-  @NotNull @Override ApolloMutationCall<T> clone();
+  @Deprecated @NotNull @Override ApolloMutationCall<T> clone();
 
   interface Builder<T> extends ApolloCall.Builder<T> {
     @NotNull @Override ApolloMutationCall<T> build();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -23,21 +23,25 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
   /**
    * Sets the http cache policy for response/request cache.
    *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
+   *
    * @param httpCachePolicy {@link HttpCachePolicy.Policy} to set
    * @return {@link ApolloQueryCall} with the provided {@link HttpCachePolicy.Policy}
    */
-  @NotNull ApolloQueryCall<T> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
+  @Deprecated @NotNull ApolloQueryCall<T> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
 
   /**
    * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
    * be configured with this headers, and will be accessible from the {@link ResponseFetcher} used for this call.
+   *
+   * Deprecated, use {@link #toBuilder()} to mutate the ApolloCall
    *
    * @param cacheHeaders the {@link CacheHeaders} that will be passed with records generated from this request to {@link
    *                     com.apollographql.apollo.cache.normalized.NormalizedCache}. Standardized cache headers are
    *                     defined in {@link com.apollographql.apollo.cache.ApolloCacheHeaders}.
    * @return The ApolloCall object with the provided {@link CacheHeaders}.
    */
-  @NotNull @Override ApolloQueryCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+  @Deprecated @NotNull @Override ApolloQueryCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
   /**
    * Sets the {@link ResponseFetcher} strategy for an ApolloCall object.
@@ -61,7 +65,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    */
   @Deprecated @NotNull ApolloQueryCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
-  @NotNull @Override ApolloQueryCall<T> clone();
+  @Deprecated @NotNull @Override ApolloQueryCall<T> clone();
 
   @NotNull @Override Builder<T> toBuilder();
 


### PR DESCRIPTION
This PR adds the `Deprecated` annotation on `ApolloMutationCall` so that it is consistent with `ApolloQueryCall`.


See https://github.com/apollographql/apollo-android/issues/2500#issuecomment-669092437

See also https://github.com/apollographql/apollo-android/issues/2430 for the original issue why deprecation was needed.