### PR TITLE
[Normalized Cache] bump SqlDelight version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ def versions = [
     rxjava                : '2.0.5',
     rxjava3               : '3.0.4',
     rxandroid             : '2.0.1',
-    sqldelight            : '1.3.0',
+    sqldelight            : '1.4.0',
     testRunner            : '0.5',
     truth                 : '0.30'
 ]


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/issues/2504

SqlDelight 1.4.0 introduced an incompatible change with 1.3.0. Bumping the version at least gives a path forward. It doesn't solve issues if another dependency is compiled against 1.3.0 but if all dependencies update to 1.4.0, the problem should disappear.
