### PR TITLE
Kotlin 1.4-M3 branch

### DIFF
--- a/apollo-idling-resource/build.gradle.kts
+++ b/apollo-idling-resource/build.gradle.kts
@@ -1,14 +1,10 @@
 import com.android.build.gradle.BaseExtension
 
-buildscript {
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
-  }
+plugins {
+  id("com.android.library")
 }
 
-apply(plugin = "com.android.library")
-
-extensions.findByType(BaseExtension::class.java)!!.apply {
+android {
   compileSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.compileSdkVersion").toString().toInt())
 
   lintOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,7 @@ subprojects {
 
   repositories {
     google()
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
-    //maven { url = uri("https://plugins.gradle.org/m2/") }
+    mavenCentral()
     maven {
       url = uri("https://dl.bintray.com/kotlin/kotlin-eap")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,14 +14,6 @@ subprojects {
     from(rootProject.file("gradle/dependencies.gradle"))
   }
 
-  buildscript {
-    repositories {
-      maven { url = uri("https://plugins.gradle.org/m2/") }
-      maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
-      google()
-    }
-  }
-
   plugins.withType(com.android.build.gradle.BasePlugin::class.java) {
     (project.extensions.getByName("android") as com.android.build.gradle.BaseExtension).compileOptions {
       sourceCompatibility = JavaVersion.VERSION_1_8
@@ -53,10 +45,12 @@ subprojects {
   this.apply(plugin = "signing")
 
   repositories {
-    maven { url = uri("https://plugins.gradle.org/m2/") }
-    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
     google()
-    maven { url = uri("https://jitpack.io") }
+    maven { url = uri("https://oss.sonatype.org/content/repositories/snapshots") }
+    //maven { url = uri("https://plugins.gradle.org/m2/") }
+    maven {
+      url = uri("https://dl.bintray.com/kotlin/kotlin-eap")
+    }
   }
 
   group = property("GROUP")!!

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,16 +1,29 @@
-plugins {
-  kotlin("jvm") version "1.3.72"
+buildscript {
+  repositories {
+    mavenCentral()
+    maven {
+      url = uri("https://dl.bintray.com/kotlin/kotlin-eap")
+    }
+  }
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4-M3")
+  }
 }
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
 
 project.apply {
   from(file("../gradle/dependencies.gradle"))
 }
 
 repositories {
-  maven { url = uri("https://plugins.gradle.org/m2/") }
+  gradlePluginPortal()
   google()
   jcenter()
   mavenCentral()
+  maven {
+    url = uri("https://dl.bintray.com/kotlin/kotlin-eap")
+  }
 }
 
 dependencies {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ def versions = [
     javaPoet              : '1.9.0',
     jetbrainsAnnotations  : '13.0',
     junit                 : '4.12',
-    kotlin                : '1.3.72',
+    kotlin                : '1.4-M3',
     kotlinCoroutines      : '1.3.5',
     kotlinPoet            : '1.5.0',
     mockito               : '1.9.5',


### PR DESCRIPTION
A branch for compiling against Kotlin 1.4, see #2503. Currently fails because okio is not compiled with 1.4 yet:

```
w: Skipping "/Users/mbonnin/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio-iosarm64/2.7.0/146bfce67666891873395f363bb85ddfbc233afd/okio.klib" as it is a pre 1.4 library
e: Could not find "/Users/mbonnin/.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio-iosarm64/2.7.0/146bfce67666891873395f363bb85ddfbc233afd/okio.klib" in [/Users/mbonnin/git/apollo-android, /Users/mbonnin/.konan/klib, /Users/mbonnin/.konan/kotlin-native-prebuilt-macos-1.4-M3/klib/common, /Users/mbonnin/.konan/kotlin-native-prebuilt-macos-1.4-M3/klib/platform/ios_arm64].
```

Also cleanup the repositories. We somehow had snapshot repositories enabled.