### PR TITLE
[Kotlin Runtime] do not use Java8 forEach

### DIFF
--- a/apollo-runtime-kotlin/build.gradle.kts
+++ b/apollo-runtime-kotlin/build.gradle.kts
@@ -20,9 +20,7 @@ kotlin {
     }
   }
 
-  jvm {
-    withJava()
-  }
+  jvm()
 
   sourceSets {
     val commonMain by getting {

--- a/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
+++ b/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
@@ -171,8 +171,8 @@ actual class ApolloHttpNetworkTransport(
         .url(serverUrl)
         .headers(headers)
         .apply {
-          httpExecutionContext?.headers?.forEach { name, value ->
-            header(name = name, value = value)
+          httpExecutionContext?.headers?.entries?.forEach {
+            header(name = it.key, value = it.value)
           }
         }
         .post(requestBody)

--- a/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
+++ b/apollo-runtime-kotlin/src/jvmMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
@@ -171,8 +171,8 @@ actual class ApolloHttpNetworkTransport(
         .url(serverUrl)
         .headers(headers)
         .apply {
-          httpExecutionContext?.headers?.entries?.forEach {
-            header(name = it.key, value = it.value)
+          httpExecutionContext?.headers?.forEach { (name, value) ->
+            header(name = name, value = value)
           }
         }
         .post(requestBody)


### PR DESCRIPTION
Do not use `Map.forEach {}`, it doesn't work on some old Android devices without desugaring

fixes https://github.com/apollographql/apollo-android/issues/2516

I'm wondering whether we can:
1. force users to desugar
or
2. break at compile time for Java8 API usages. 