### PR TITLE
[SQLNormalizedCache] fix watcher not called on initial cache write

### DIFF
--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   add("implementation", "com.apollographql.apollo:apollo-rx3-support")
   add("implementation", "com.apollographql.apollo:apollo-coroutines-support")
   add("implementation", "com.apollographql.apollo:apollo-http-cache")
+  add("implementation", "com.apollographql.apollo:apollo-normalized-cache-sqlite")
   add("implementation", "com.apollographql.apollo:apollo-compiler")
 
   add("testImplementation", kotlin("test-junit"))
@@ -50,6 +51,12 @@ configure<ApolloExtension> {
   service("performance") {
     sourceFolder.set("com/apollographql/apollo/integration/performance")
     rootPackageName.set("com.apollographql.apollo.integration.performance")
+  }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
   }
 }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
@@ -68,7 +68,7 @@ class SqliteNormalizedCacheTest {
       Truth.assertThat(responses[0].isFromCache).isEqualTo(false)
 
       withTimeout(1000) {
-        while(watchedResponses.isEmpty()) {
+        while(watchedResponses.size < 2) {
           delay(100)
         }
         Truth.assertThat(watchedResponses.size).isEqualTo(2)

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
@@ -1,0 +1,82 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.Utils.mockResponse
+import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.api.internal.OperationRequestBodyComposer
+import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo.coroutines.toDeferred
+import com.apollographql.apollo.coroutines.toFlow
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers
+import com.apollographql.apollo.fetcher.ResponseFetcher
+import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery
+import com.apollographql.apollo.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo.integration.normalizer.type.Episode
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SqliteNormalizedCacheTest {
+  private lateinit var apolloClient: ApolloClient
+
+  @get:Rule
+  val server = MockWebServer()
+
+  @Before
+  @Throws(IOException::class)
+  fun setUp() {
+    val cache = SqlNormalizedCacheFactory("jdbc:sqlite:")
+    apolloClient = ApolloClient.builder()
+        .serverUrl(server.url("/"))
+        .normalizedCache(cache)
+        .build()
+  }
+
+  @Test
+  fun `populating the cache triggers the watcher`() {
+    println("HERE")
+    runBlocking {
+      val query = EpisodeHeroNameQuery.builder().episode(Episode.EMPIRE).build()
+      server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"))
+
+      val watchedResponses = mutableListOf<Response<EpisodeHeroNameQuery.Data>>()
+
+      val deferred = async {
+        apolloClient.query(query)
+            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
+            .watcher()
+            .toFlow()
+            .collect {
+              watchedResponses.add(it)
+            }
+      }
+
+      val responses = apolloClient.query(query).toFlow().toList()
+
+      Truth.assertThat(responses.size).isEqualTo(1)
+      Truth.assertThat(responses[0].isFromCache).isEqualTo(false)
+
+      withTimeout(1000) {
+        while(watchedResponses.isEmpty()) {
+          delay(100)
+        }
+        Truth.assertThat(watchedResponses.size).isEqualTo(2)
+        Truth.assertThat(watchedResponses[0].data).isEqualTo(null)
+        Truth.assertThat(watchedResponses[1].data?.hero()?.name()).isEqualTo("R2-D2")
+        Truth.assertThat(watchedResponses[1].isFromCache).isEqualTo(true)
+      }
+      deferred.cancel()
+    }
+  }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
@@ -45,7 +45,6 @@ class SqliteNormalizedCacheTest {
 
   @Test
   fun `populating the cache triggers the watcher`() {
-    println("HERE")
     runBlocking {
       val query = EpisodeHeroNameQuery.builder().episode(Episode.EMPIRE).build()
       server.enqueue(mockResponse("EpisodeHeroNameResponseWithId.json"))

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCache.kt
@@ -65,7 +65,7 @@ class SqlNormalizedCache internal constructor(
   override fun performMerge(apolloRecord: Record, oldRecord: Record?, cacheHeaders: CacheHeaders): Set<String> {
     return if (oldRecord == null) {
       cacheQueries.insert(key = apolloRecord.key, record = recordFieldAdapter.toJson(apolloRecord.fields))
-      emptySet()
+      apolloRecord.keys()
     } else {
       oldRecord.mergeWith(apolloRecord).also {
         if (it.isNotEmpty()) {

--- a/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -130,11 +130,12 @@ class SqlNormalizedCacheTest {
 
   @Test
   fun testRecordMerge_noOldRecord() {
-    cache.merge(Record.builder(STANDARD_KEY)
+    val changedKeys = cache.merge(Record.builder(STANDARD_KEY)
         .addField("fieldKey", "valueUpdated")
         .addField("newFieldKey", true).build(), CacheHeaders.NONE)
     val record = cache.selectRecordForKey(STANDARD_KEY)
     assertNotNull(record)
+    assertEquals(expected = setOf("$STANDARD_KEY.fieldKey", "$STANDARD_KEY.newFieldKey"), actual = changedKeys)
     assertEquals(expected = "valueUpdated", actual = record.fields["fieldKey"])
     assertEquals(expected = true, actual = record.fields["newFieldKey"])
   }


### PR DESCRIPTION
When no record was present in the cache, return all changed keys. 

fixes #2537