### PR TITLE
[Plugin] allow running the plugin on Gradle 5.6

### DIFF
--- a/apollo-gradle-plugin/api.txt
+++ b/apollo-gradle-plugin/api.txt
@@ -1,8 +1,10 @@
 package com.apollographql.apollo.gradle.api {
 
   public abstract interface ApolloExtension implements com.apollographql.apollo.gradle.api.CompilerParams {
+    method public abstract error.NonExistentClass getRelaxGradleVersionCheck();
     method public abstract void onCompilationUnit(error.NonExistentClass);
     method public abstract void service(error.NonExistentClass, error.NonExistentClass);
+    property public abstract error.NonExistentClass relaxGradleVersionCheck;
   }
 
   public abstract interface CompilationUnit implements com.apollographql.apollo.gradle.api.CompilerParams {

--- a/apollo-gradle-plugin/api.txt
+++ b/apollo-gradle-plugin/api.txt
@@ -1,10 +1,8 @@
 package com.apollographql.apollo.gradle.api {
 
   public abstract interface ApolloExtension implements com.apollographql.apollo.gradle.api.CompilerParams {
-    method public abstract error.NonExistentClass getRelaxGradleVersionCheck();
     method public abstract void onCompilationUnit(error.NonExistentClass);
     method public abstract void service(error.NonExistentClass, error.NonExistentClass);
-    property public abstract error.NonExistentClass relaxGradleVersionCheck;
   }
 
   public abstract interface CompilationUnit implements com.apollographql.apollo.gradle.api.CompilerParams {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -38,6 +38,4 @@ interface ApolloExtension: CompilerParams {
    * @param action: the configure action for the [CompilationUnit]
    */
   fun onCompilationUnit(action: Action<CompilationUnit>)
-
-  val relaxGradleVersionCheck: Property<Boolean>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -39,8 +39,5 @@ interface ApolloExtension: CompilerParams {
    */
   fun onCompilationUnit(action: Action<CompilationUnit>)
 
-  /**
-   * The gradle plugin works with Gradle 5.6
-   */
   val relaxGradleVersionCheck: Property<Boolean>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -39,4 +39,5 @@ interface ApolloExtension: CompilerParams {
    */
   fun onCompilationUnit(action: Action<CompilationUnit>)
 
+  val skipGradleVersionCheck: Property<Boolean>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -39,5 +39,8 @@ interface ApolloExtension: CompilerParams {
    */
   fun onCompilationUnit(action: Action<CompilationUnit>)
 
-  val skipGradleVersionCheck: Property<Boolean>
+  /**
+   * The gradle plugin works with Gradle 5.6
+   */
+  val relaxGradleVersionCheck: Property<Boolean>
 }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -18,10 +18,7 @@ import java.net.URLDecoder
 open class ApolloPlugin : Plugin<Project> {
   companion object {
     const val TASK_GROUP = "apollo"
-    const val MIN_GRADLE_VERSION = "6.0"
-    // the plugin should work with 5.6 although it's largely untested
-    // anything below 5.6 will not work due to missing Property APIs such as org.gradle.api.provider.Property.orElse
-    const val MIN_GRADLE_VERSION_RELAXED = "5.6"
+    const val MIN_GRADLE_VERSION = "5.6"
 
     val Project.isKotlinMultiplatform get() = pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
 
@@ -264,14 +261,14 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   override fun apply(project: Project) {
+    require(GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
+      "apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"
+    }
+
     val apolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project) as DefaultApolloExtension
 
     // the extension block has not been evaluated yet, register a callback once the project has been evaluated
     project.afterEvaluate {
-      require(apolloExtension.relaxGradleVersionCheck.getOrElse(false) && GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION_RELAXED)) >= 0
-          || GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
-        "apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"
-      }
 
       afterEvaluate(it, apolloExtension)
     }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -19,6 +19,9 @@ open class ApolloPlugin : Plugin<Project> {
   companion object {
     const val TASK_GROUP = "apollo"
     const val MIN_GRADLE_VERSION = "6.0"
+    // the plugin should work with 5.6 although it's largely untested
+    // anything below 5.6 will not work due to missing Property APIs such as org.gradle.api.provider.Property.orElse
+    const val MIN_GRADLE_VERSION_RELAXED = "5.6"
 
     val Project.isKotlinMultiplatform get() = pluginManager.hasPlugin("org.jetbrains.kotlin.multiplatform")
 
@@ -265,7 +268,8 @@ open class ApolloPlugin : Plugin<Project> {
 
     // the extension block has not been evaluated yet, register a callback once the project has been evaluated
     project.afterEvaluate {
-      require(apolloExtension.skipGradleVersionCheck.getOrElse(false) || GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
+      require(apolloExtension.relaxGradleVersionCheck.getOrElse(false) && GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION_RELAXED)) >= 0
+          || GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
         "apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"
       }
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -261,14 +261,14 @@ open class ApolloPlugin : Plugin<Project> {
   }
 
   override fun apply(project: Project) {
-    require(GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
-      "apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"
-    }
-
     val apolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project) as DefaultApolloExtension
 
     // the extension block has not been evaluated yet, register a callback once the project has been evaluated
     project.afterEvaluate {
+      require(apolloExtension.skipGradleVersionCheck.getOrElse(false) || GradleVersion.current().compareTo(GradleVersion.version(MIN_GRADLE_VERSION)) >= 0) {
+        "apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"
+      }
+
       afterEvaluate(it, apolloExtension)
     }
   }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo.gradle.api.CompilerParams
 import org.gradle.api.Action
 import org.gradle.api.Project
 
-open class DefaultApolloExtension(val project: Project)
+abstract class DefaultApolloExtension(val project: Project)
   : CompilerParams by project.objects.newInstance(DefaultCompilerParams::class.java)
     , ApolloExtension {
   /**

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleVersionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleVersionTests.kt
@@ -28,7 +28,7 @@ class GradleVersionTests  {
     TestUtils.withSimpleProject { dir ->
       var exception: Exception? = null
       try {
-        TestUtils.executeGradleWithVersion(dir, "5.6","generateApolloSources")
+        TestUtils.executeGradleWithVersion(dir, "5.4","generateApolloSources")
       } catch (e: UnexpectedBuildFailure) {
         exception = e
         Assert.assertThat(e.message, CoreMatchers.containsString("apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater"))

--- a/docs/source/essentials/migration.mdx
+++ b/docs/source/essentials/migration.mdx
@@ -22,8 +22,7 @@ Side effect changes of Kotlin migration:
 - Classes and functions are `final` unless they are intentionally marked as `open`
 - Kotlin-stdlib is added as a transitive dependency
 - Jvm target version is now 1.8. See the [Android Developer website](https://developer.android.com/studio/write/java8-support#supported_features) for details on how to enable it in yout project.
-- Gradle 6.x recommended. In 5.x, Gradle Metadata needs to be enabled by putting this into settings.gradle `enableFeaturePreview("GRADLE_METADATA")`
-                                
+
 ### Okio migration
 
 Okio has been updated to [2.4.3](https://github.com/square/okio/blob/master/CHANGELOG.md#version-230) for Kotlin multiplatform.


### PR DESCRIPTION
Add `ApolloExtension.relaxGradleVersionCheck` as a workaround for users stuck on Gradle 5.6. Anything lower than Gradle 5.6 will not work because the plugin is using some 5.6 Provider APIs like `Provider.orElse`

Fixes #2536 