### PR TITLE
Bump kotlin compile testing

### DIFF
--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -103,7 +103,7 @@ class CodeGenTest(private val folder: File) {
         sources = kotlinFiles
 
         val expectedWarnings = folder.name in listOf("deprecation", "custom_scalar_type_warnings", "arguments_complex", "arguments_simple")
-        allWarningsAsErrors = false // TODO: enable again when kotlin-test-compile targets Kotlin 1.4 (was expectedWarnings.not())
+        allWarningsAsErrors = expectedWarnings.not()
         inheritClassPath = true
         messageOutputStream = System.out // see diagnostics in real time
       }.compile()

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ ext.dep = [
         api    : "com.apollographql.apollo:apollo-api:$versions.apollo",
     ],
     compiletesting        : "com.google.testing.compile:compile-testing:$versions.compiletesting",
-    kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.9",
+    kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.10",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
     vanniktechPlugin      : "com.vanniktech:gradle-maven-publish-plugin:0.11.1",


### PR DESCRIPTION
kotlin-compile-testing is now ready for 1.4: https://github.com/tschuchortdev/kotlin-compile-testing/releases/tag/1.2.10