### PR TITLE
Kotlin Multiplatform Mobile integration for iOS targer

### DIFF
--- a/composite/gradle.properties
+++ b/composite/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
+
+xcodeproj=../samples/multiplatform/kmp-ios-app/kmp-ios-app.xcodeproj


### PR DESCRIPTION
Put the location of the .xcodeproj file for Kotlin Multiplatform Mobile integration in Android Studio.

Once you Gradle Sync, you will have the following run configuration. I hit the run button and everything worked as expected. 

Note: You of-course need to run `./gradlew multiplatform:kmp-lib-sample:copyFramework` manually. Maybe we can automate that. 

<img width="524" alt="Screen Shot 2020-08-31 at 19 30 02" src="https://user-images.githubusercontent.com/763339/91749407-b5d3e600-ebc1-11ea-8032-8c4f18ee1723.png">
