### PR TITLE
Compile Kotlin against stdlib 1.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ subprojects {
 
   tasks.withType<KotlinCompile> {
     kotlinOptions {
+      // Gradle forces 1.3.72 for the time being so compile against 1.3 stdlib for the time being
+      // See https://issuetracker.google.com/issues/166582569
+      apiVersion = "1.3"
       jvmTarget = JavaVersion.VERSION_1_8.toString()
       freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }


### PR DESCRIPTION
Since Gradle forces stdlib 1.3.72, it should be safer to add the `apiVersion = "1.3"` compiler option to tell the Kotlin compiler to not use anything in the 1.4 stdlib. It looks like it's already the case but this option makes it explicit.

See https://issuetracker.google.com/issues/166468915 
and https://issuetracker.google.com/issues/166582569