### PR TITLE
[Sdl] Fix a scalar definition after a union defintion

### DIFF
--- a/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphSDL.g4
+++ b/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphSDL.g4
@@ -86,12 +86,7 @@ unionTypeDefinition
   ;
 
 unionMemberTypes
-  : '=' unionMemberType*
-  ;
-
-unionMemberType
-  : '|'? namedType
-  ;
+  : '=' '|'?  namedType ('|'namedType)* ;
 
 scalarTypeDefinition
   : description? SCALAR name directives?

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -11,6 +11,8 @@ import com.apollographql.apollo.compiler.ir.TypeDeclaration.Companion.KIND_ENUM
 import com.apollographql.apollo.compiler.ir.TypeDeclaration.Companion.KIND_INPUT_OBJECT_TYPE
 import com.apollographql.apollo.compiler.operationoutput.OperationDescriptor
 import com.apollographql.apollo.compiler.operationoutput.toJson
+import com.apollographql.apollo.compiler.parser.error.DocumentParseException
+import com.apollographql.apollo.compiler.parser.error.ParseException
 import com.apollographql.apollo.compiler.parser.graphql.GraphQLDocumentParser
 import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
 import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema.Companion.toIntrospectionSchema
@@ -242,7 +244,11 @@ class GraphQLCompiler {
         val introspectionSchema = if (schemaFile.extension == "json") {
           IntrospectionSchema(schemaFile)
         } else {
-          GraphSdlSchema(schemaFile).toIntrospectionSchema()
+          try {
+            GraphSdlSchema(schemaFile).toIntrospectionSchema()
+          } catch (e: ParseException) {
+            throw DocumentParseException(e, schemaFile.absolutePath)
+          }
         }
 
         val packageName = try {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSDLSchemaParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSDLSchemaParser.kt
@@ -166,7 +166,7 @@ internal object GraphSDLSchemaParser {
         name = name().text,
         description = description().parse(),
         directives = directives().parse(),
-        typeRefs = unionMemberTypes()?.unionMemberType()?.map { it.namedType().parse() } ?: emptyList()
+        typeRefs = unionMemberTypes()?.namedType()?.map { it.parse() } ?: emptyList()
     )
   }
 

--- a/apollo-compiler/src/test/sdl/schema.json
+++ b/apollo-compiler/src/test/sdl/schema.json
@@ -730,7 +730,7 @@
         {
           "kind": "SCALAR",
           "name": "URL",
-          "description": "URL for testing",
+          "description": "",
           "fields": null,
           "inputFields": null,
           "interfaces": null,

--- a/apollo-compiler/src/test/sdl/schema.sdl
+++ b/apollo-compiler/src/test/sdl/schema.sdl
@@ -394,6 +394,9 @@ input ReviewRefInput {
 
 union SearchResult = Human | Droid | Starship
 
+#URL for testing
+scalar URL
+
 type Starship {
   coordinates: [[Float!]!]
 
@@ -416,9 +419,6 @@ type Tree {
 
 """UnsupportedType for testing"""
 scalar UnsupportedType
-
-"""URL for testing"""
-scalar URL
 
 schema {
   query: Query


### PR DESCRIPTION
Fixes #2558 

~Don't merge this branch yet, I made it against the multi-module branch which contains changes to where the SDL parser is invoked. I'll rebase once multi-module is merged.~
Edit: it's rebased