### PR TITLE
bump sql delight version to 1.4.3

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -22,7 +22,7 @@ def versions = [
     rxjava                : '2.0.5',
     rxjava3               : '3.0.4',
     rxandroid             : '2.0.1',
-    sqldelight            : '1.4.1',
+    sqldelight            : '1.4.3',
     testRunner            : '0.5',
     truth                 : '0.30'
 ]


### PR DESCRIPTION
Bump SQLDelight version to 1.4.3: https://github.com/cashapp/sqldelight/releases/tag/1.4.3

1.4.3 has an important fix in the IDE plugin. I'm not sure how coupled the IDE plugin and runtime are but it's best to stay up to date there.