### PR TITLE
Deprecate toDeferred and toJob in favor of await.

### DIFF
--- a/apollo-coroutines-support/api.txt
+++ b/apollo-coroutines-support/api.txt
@@ -2,6 +2,8 @@ package com.apollographql.apollo.coroutines {
 
   public final class CoroutinesExtensionsKt {
     ctor public CoroutinesExtensionsKt();
+    method public static suspend <T> java.lang.Object await(error.NonExistentClass, java.lang.Object);
+    method public static suspend java.lang.Object await(error.NonExistentClass, java.lang.Object);
     method public static <T> error.NonExistentClass toDeferred(error.NonExistentClass);
     method public static <T> error.NonExistentClass toFlow(error.NonExistentClass);
     method public static <T> error.NonExistentClass toFlow(error.NonExistentClass);

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SqliteNormalizedCacheTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo.Utils.mockResponse
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.api.internal.OperationRequestBodyComposer
 import com.apollographql.apollo.cache.normalized.sql.SqlNormalizedCacheFactory
-import com.apollographql.apollo.coroutines.toDeferred
 import com.apollographql.apollo.coroutines.toFlow
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers
 import com.apollographql.apollo.fetcher.ResponseFetcher

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.kotlinsample.data
 
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.coroutines.toDeferred
+import com.apollographql.apollo.coroutines.await
 import com.apollographql.apollo.kotlinsample.GithubRepositoriesQuery
 import com.apollographql.apollo.kotlinsample.GithubRepositoryCommitsQuery
 import com.apollographql.apollo.kotlinsample.GithubRepositoryDetailQuery
@@ -30,7 +30,7 @@ class ApolloCoroutinesService(
 
     job = CoroutineScope(processContext).launch {
       try {
-        val response = apolloClient.query(repositoriesQuery).toDeferred().await()
+        val response = apolloClient.query(repositoriesQuery).await()
         withContext(resultContext) {
           repositoriesSubject.onNext(mapRepositoriesResponseToRepositories(response))
         }
@@ -48,7 +48,7 @@ class ApolloCoroutinesService(
 
     job = CoroutineScope(processContext).launch {
       try {
-        val response = apolloClient.query(repositoryDetailQuery).toDeferred().await()
+        val response = apolloClient.query(repositoryDetailQuery).await()
 
         withContext(resultContext) {
           repositoryDetailSubject.onNext(response)
@@ -66,7 +66,7 @@ class ApolloCoroutinesService(
 
     job = CoroutineScope(processContext).launch {
       try {
-        val response = apolloClient.query(commitsQuery).toDeferred().await()
+        val response = apolloClient.query(commitsQuery).await()
         val headCommit = response.data?.viewer?.repository?.ref?.target?.asCommit
         val commits = headCommit?.history?.edges?.filterNotNull().orEmpty()
 


### PR DESCRIPTION
Closes #2571

I've removed the `toDeferred` and `toJob` APIs since they weren't respecting structured concurrency properly. I've introduced new `await` calls as discussed in the ticket.

~~I wanted to provide some tests, but I found out the necessary infrastructure isn't there yet, and it's out of scope of this PR.~~
EDIT: Found where the tests are, will add a few of them.