### PR TITLE
[Plugin] Add an option to fail on deprecated usages

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -63,7 +63,7 @@ class GraphQLCompiler(val logger: Logger = NoOpLogger) {
         // antlr is 0-indexed but IntelliJ is 1-indexed. Add 1 so that clicking the link will land on the correct location
         val column = it.sourceLocation.position + 1
         // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-        logger.warning("w: ${it.filePath}:${it.sourceLocation.line}:${column}: ApolloGraphQL: Use of deprecated field '${it.field.responseName}'")
+        logger.warning("w: ${it.filePath}:${it.sourceLocation.line}:${column}: ApolloGraphQL: Use of deprecated field '${it.field.fieldName}'")
       }
       if (args.failOnWarnings && deprecatedUsages.isNotEmpty()) {
         throw IllegalStateException("ApolloGraphQL: Warnings found and 'failOnWarnings' is true, aborting.")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -60,7 +60,10 @@ class GraphQLCompiler(val logger: Logger = NoOpLogger) {
     if (args.warnOnDeprecatedUsages) {
       val deprecatedUsages = parseResult.collectDeprecatedUsages()
       deprecatedUsages.forEach {
-        logger.warning("w: ${it.filePath}:${it.sourceLocation.line}:${it.sourceLocation.position}: ApolloGraphQL: Use of deprecated field '${it.field.responseName}'")
+        // antlr is 0-indexed but IntelliJ is 1-indexed. Add 1 so that clicking the link will land on the correct location
+        val column = it.sourceLocation.position + 1
+        // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
+        logger.warning("w: ${it.filePath}:${it.sourceLocation.line}:${column}: ApolloGraphQL: Use of deprecated field '${it.field.responseName}'")
       }
       if (args.failOnWarnings && deprecatedUsages.isNotEmpty()) {
         throw IllegalStateException("ApolloGraphQL: Warnings found and 'failOnWarnings' is true, aborting.")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Argument.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Argument.kt
@@ -5,7 +5,17 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class Argument(
     val name: String,
+    /**
+     * The value of the argument
+     * - Input objects will be represented as Maps
+     * - Built-in scalars as their primitive type
+     * - Variables as a map: {"kind": "Variable", "variableName": name}
+     */
     val value: Any?,
+    /**
+     * The type of the argument as it would appear in a query
+     * For an example: String, [String!]!, SomeInputObject, SomeEnum
+     */
     val type: String,
     val sourceLocation: SourceLocation
 ) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
@@ -30,9 +30,10 @@ import org.antlr.v4.runtime.atn.PredictionMode
 import java.io.File
 import java.io.IOException
 
-class GraphQLDocumentParser(val schema: IntrospectionSchema,
-                            private val packageNameProvider: PackageNameProvider
-) {
+class GraphQLDocumentParser(
+    private val schema: IntrospectionSchema,
+    private val packageNameProvider: PackageNameProvider,
+    ) {
   fun parse(graphQLFiles: Collection<File>): DocumentParseResult {
     return graphQLFiles.fold(DocumentParseResult()) { acc, graphQLFile ->
       val result = graphQLFile.parse()

--- a/apollo-gradle-plugin/api.txt
+++ b/apollo-gradle-plugin/api.txt
@@ -37,6 +37,7 @@ package com.apollographql.apollo.gradle.api {
   public abstract interface CompilerParams {
     method public abstract error.NonExistentClass getAlwaysGenerateTypesMatching();
     method public abstract error.NonExistentClass getCustomTypeMapping();
+    method public abstract error.NonExistentClass getFailOnWarnings();
     method public abstract error.NonExistentClass getGenerateApolloMetadata();
     method public abstract error.NonExistentClass getGenerateAsInternal();
     method public abstract error.NonExistentClass getGenerateKotlinModels();
@@ -53,8 +54,10 @@ package com.apollographql.apollo.gradle.api {
     method public abstract error.NonExistentClass getSuppressRawTypesWarning();
     method public abstract error.NonExistentClass getUseJavaBeansSemanticNaming();
     method public abstract error.NonExistentClass getUseSemanticNaming();
+    method public abstract error.NonExistentClass getWarnOnDeprecatedUsages();
     property public abstract error.NonExistentClass alwaysGenerateTypesMatching;
     property public abstract error.NonExistentClass customTypeMapping;
+    property public abstract error.NonExistentClass failOnWarnings;
     property public abstract error.NonExistentClass generateApolloMetadata;
     property public abstract error.NonExistentClass generateAsInternal;
     property public abstract error.NonExistentClass generateKotlinModels;
@@ -71,6 +74,7 @@ package com.apollographql.apollo.gradle.api {
     property public abstract error.NonExistentClass suppressRawTypesWarning;
     property public abstract error.NonExistentClass useJavaBeansSemanticNaming;
     property public abstract error.NonExistentClass useSemanticNaming;
+    property public abstract error.NonExistentClass warnOnDeprecatedUsages;
   }
 
   public abstract interface Introspection {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/CompilerParams.kt
@@ -25,6 +25,20 @@ interface CompilerParams {
   val generateKotlinModels: Property<Boolean>
 
   /**
+   * Warn if using a deprecated field
+   *
+   * Default value: true
+   */
+  val warnOnDeprecatedUsages: Property<Boolean>
+
+  /**
+   * Fail the build if there are warnings. This is not named `allWarningAsErrors` to avoid nameclashes with the Kotlin options
+   *
+   * Default value: false
+   */
+  val failOnWarnings: Property<Boolean>
+
+  /**
    * Whether to generate operationOutput.json. operationOutput.json contains information such as
    * operation id, name and complete source sent to the server. This can be used to upload
    * a query's exact content to a server that doesn't support automatic persisted queries.

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -97,6 +97,9 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   @get:Optional
   abstract val generateKotlinModels: Property<Boolean>
 
+  abstract val warnOnDeprecatedUsages: Property<Boolean>
+  abstract val failOnWarnings: Property<Boolean>
+
   @get:Input
   @get:Optional
   abstract val generateVisitorForPolymorphicDatatypes: Property<Boolean>
@@ -151,13 +154,22 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         useJavaBeansSemanticNaming = useJavaBeansSemanticNaming.getOrElse(false),
         suppressRawTypesWarning = suppressRawTypesWarning.getOrElse(false),
         generateKotlinModels = generateKotlinModels.getOrElse(false),
+        warnOnDeprecatedUsages = warnOnDeprecatedUsages.getOrElse(true),
+        failOnWarnings = failOnWarnings.getOrElse(false),
         generateVisitorForPolymorphicDatatypes = generateVisitorForPolymorphicDatatypes.getOrElse(false),
         generateAsInternal = generateAsInternal.getOrElse(false),
         kotlinMultiPlatformProject = kotlinMultiPlatformProject.getOrElse(false),
-        enumAsSealedClassPatternFilters = sealedClassesForEnumsMatching.getOrElse(emptyList()).toSet()
+        enumAsSealedClassPatternFilters = sealedClassesForEnumsMatching.getOrElse(emptyList()).toSet(),
+
     )
 
-    GraphQLCompiler().write(args)
+    val logger = object :GraphQLCompiler.Logger {
+      override fun warning(message: String) {
+        logger.lifecycle(message)
+      }
+    }
+
+    GraphQLCompiler(logger).write(args)
   }
 
   private fun checkParameters() {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -97,7 +97,10 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   @get:Optional
   abstract val generateKotlinModels: Property<Boolean>
 
+  @get:Internal
   abstract val warnOnDeprecatedUsages: Property<Boolean>
+
+  @get:Internal
   abstract val failOnWarnings: Property<Boolean>
 
   @get:Input

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -187,6 +187,8 @@ open class ApolloPlugin : Plugin<Project> {
         task.useJavaBeansSemanticNaming.set(compilerParams.useJavaBeansSemanticNaming)
         task.suppressRawTypesWarning.set(compilerParams.suppressRawTypesWarning)
         task.generateKotlinModels.set(compilationUnit.generateKotlinModels())
+        task.warnOnDeprecatedUsages.set(compilerParams.warnOnDeprecatedUsages)
+        task.failOnWarnings.set(compilerParams.failOnWarnings)
         task.generateVisitorForPolymorphicDatatypes.set(compilerParams.generateVisitorForPolymorphicDatatypes)
         task.customTypeMapping.set(compilerParams.customTypeMapping)
         task.outputDir.apply {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/CompilerParamsExtensions.kt
@@ -29,6 +29,8 @@ fun CompilerParams.withFallback(objects: ObjectFactory, other: CompilerParams): 
   merge.sealedClassesForEnumsMatching.set(this.sealedClassesForEnumsMatching.orElse(other.sealedClassesForEnumsMatching))
   merge.generateApolloMetadata.set(this.generateApolloMetadata.orElse(other.generateApolloMetadata))
   merge.alwaysGenerateTypesMatching.set(this.alwaysGenerateTypesMatching.orElse(other.alwaysGenerateTypesMatching))
+  merge.warnOnDeprecatedUsages.set(this.warnOnDeprecatedUsages.orElse(other.warnOnDeprecatedUsages))
+  merge.failOnWarnings.set(this.failOnWarnings.orElse(other.failOnWarnings))
 
   return merge
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/DeprecationTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/DeprecationTests.kt
@@ -1,0 +1,53 @@
+package com.apollographql.apollo.gradle.test
+
+import com.apollographql.apollo.gradle.util.TestUtils
+import com.google.common.truth.Truth
+import junit.framework.Assert.fail
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class DeprecationTests {
+  @Test
+  fun `deprecation warnings are shown by default`() {
+    TestUtils.withTestProject("deprecationWarnings") { dir ->
+      val result = TestUtils.executeTask("generateMainServiceApolloSources", dir)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
+      Truth.assertThat(result.output).contains("operations.graphql:6:6: ApolloGraphQL: Use of deprecated field 'number'")
+      Truth.assertThat(result.output).contains("operations.graphql:3:4: ApolloGraphQL: Use of deprecated field 'name'")
+    }
+  }
+
+  @Test
+  fun `deprecation warnings can be silenced`() {
+    TestUtils.withTestProject("deprecationWarnings") { dir ->
+      File(dir, "build.gradle.kts").appendText("""
+        configure<ApolloExtension> {
+          warnOnDeprecatedUsages.set(false)
+        }
+      """.trimIndent())
+      val result = TestUtils.executeTask("generateMainServiceApolloSources", dir)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
+      Truth.assertThat(result.output).doesNotContain("ApolloGraphQL: Use of deprecated field")
+    }
+  }
+
+  @Test
+  fun `failOnWarnings works as expected`() {
+    TestUtils.withTestProject("deprecationWarnings") { dir ->
+      File(dir, "build.gradle.kts").appendText("""
+        configure<ApolloExtension> {
+          failOnWarnings.set(true)
+        }
+      """.trimIndent())
+      try {
+        TestUtils.executeTask("generateMainServiceApolloSources", dir)
+        fail("generateMainServiceApolloSources was expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        Truth.assertThat(e.message).contains("Warnings found and 'failOnWarnings' is true, aborting")
+      }
+    }
+  }
+}

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/DeprecationTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/DeprecationTests.kt
@@ -15,8 +15,8 @@ class DeprecationTests {
     TestUtils.withTestProject("deprecationWarnings") { dir ->
       val result = TestUtils.executeTask("generateMainServiceApolloSources", dir)
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateMainServiceApolloSources")!!.outcome)
-      Truth.assertThat(result.output).contains("operations.graphql:6:6: ApolloGraphQL: Use of deprecated field 'number'")
-      Truth.assertThat(result.output).contains("operations.graphql:3:4: ApolloGraphQL: Use of deprecated field 'name'")
+      Truth.assertThat(result.output).contains("operations.graphql:6:7: ApolloGraphQL: Use of deprecated field 'number'")
+      Truth.assertThat(result.output).contains("operations.graphql:3:5: ApolloGraphQL: Use of deprecated field 'name'")
     }
   }
 

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
@@ -1,0 +1,28 @@
+import com.apollographql.apollo.gradle.api.ApolloExtension
+
+buildscript {
+  apply(from = "../../../gradle/dependencies.gradle")
+
+  repositories {
+    jcenter()
+    maven {
+      url = uri("../../../build/localMaven")
+    }
+  }
+  dependencies {
+    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+  }
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+apply(plugin = "com.apollographql.apollo")
+
+repositories {
+  mavenCentral()
+  maven {
+    url = uri("../../../../build/localMaven")
+  }
+}
+
+

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/src/main/graphql/operations.graphql
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/src/main/graphql/operations.graphql
@@ -1,0 +1,10 @@
+query GetUser {
+  user {
+    name
+    address {
+      street
+      number
+      country
+    }
+  }
+}

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/src/main/graphql/schema.sdl
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/src/main/graphql/schema.sdl
@@ -1,0 +1,14 @@
+type Query {
+  user: User
+}
+
+type Address {
+  street: String!
+  number: Int! @deprecated(reason: "use something else")
+  country: String!
+}
+
+type User {
+  name: String! @deprecated
+  address: Address
+}

--- a/docs/source/essentials/normalized-cache.mdx
+++ b/docs/source/essentials/normalized-cache.mdx
@@ -215,7 +215,7 @@ val resolver: CacheKeyResolver = object : CacheKeyResolver() {
 
   override fun fromFieldArguments(field: ResponseField, variables: Operation.Variables): CacheKey {
     // Retrieve the id from the field arguments.
-    // In the example, this allows to know that `author(id: "author1")` will retrive `author1`
+    // In the example, this allows to know that `author(id: "author1")` will retrieve `author1`
     // That sounds straightforward but without this, the cache would have no way of finding the id before executing the request on the
     // network which is what we want to avoid
     return CacheKey.from(field.resolveArgument("id", variables) as String)

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ android.useAndroidX=true
 
 # https://github.com/gradle/gradle/issues/11412
 systemProp.org.gradle.internal.publish.checksums.insecure=true
+
+# silence the "multiplatform alpha" warning
+kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
Add 

```
apollo {
  warnOnDeprecatedUsages.set(true) // true by default
  failOnWarnings.set(true) // false by default
}
```

Fixes #2489 

Using the `w: $file: ($line, $column): $message` format, intelliJ will display it nicely in the "Run" panel:

![Screenshot 2020-09-14 at 11 57 09](https://user-images.githubusercontent.com/3974977/93073954-f896c300-f683-11ea-9fc7-bfa17909070d.png)

Somehow the warnings are not clickable in the "Run" panel but are in the build output, not really sure how to make IntelliJ pick them up. 

Also, this PR only checks deprecated fields usages. Checking for deprecated enums could be done too but that's more complex so will be done in a future PR.

Ping @kenyee, sorry it took so long, I wanted to get the multi-module PR in first to avoid too many conflicts.
