### PR TITLE
[Plugin] Allow to download SDL schemas

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/moshi.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/moshi.kt
@@ -74,3 +74,9 @@ inline fun <reified T> T.toJson(file: File) {
     return getJsonAdapter<T>().toJson(it, this)
   }
 }
+
+inline fun <reified T> T.toJson(file: File, indent: String) {
+  file.outputStream().sink().buffer().use {
+    return getJsonAdapter<T>().indent(indent).toJson(it, this)
+  }
+}

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
@@ -1,0 +1,208 @@
+package com.apollographql.apollo.compiler.parser.introspection
+
+import okio.Buffer
+import okio.BufferedSink
+import okio.buffer
+import okio.sink
+import java.io.File
+
+fun IntrospectionSchema.toSDL(file: File) {
+  file.sink().buffer().use {
+    toSDL(it)
+  }
+}
+
+fun IntrospectionSchema.toSDL(sink: BufferedSink) {
+  val builtinsTypes = setOf(
+      "Int", "Float", "String", "Boolean", "ID",
+      "__Directive", "__DirectiveLocation", "__EnumValue", "__Field", "__InputValue", "__Schema", "__Type", "__TypeKind"
+  )
+  val allInterfaces = types.values.filterIsInstance<IntrospectionSchema.Type.Interface>()
+  types.values.forEach {
+    if (builtinsTypes.contains(it.name)) {
+      // No need to include builtin types in SDL files
+      return@forEach
+    }
+    when (it) {
+      is IntrospectionSchema.Type.Scalar -> it.toSDL(sink)
+      is IntrospectionSchema.Type.Enum -> it.toSDL(sink)
+      is IntrospectionSchema.Type.InputObject -> it.toSDL(sink)
+      is IntrospectionSchema.Type.Interface -> it.toSDL(sink)
+      is IntrospectionSchema.Type.Object -> it.toSDL(sink, allInterfaces)
+      is IntrospectionSchema.Type.Union -> it.toSDL(sink)
+    }
+    // Add a newline as a separation
+    sink.writeUtf8("\n")
+  }
+  sink.writeUtf8("schema {\n")
+  sink.writeUtf8("  subscription: $subscriptionType\n")
+  sink.writeUtf8("  query: $queryType\n")
+  sink.writeUtf8("  mutation: $mutationType\n")
+  sink.writeUtf8("}\n")
+}
+
+private fun BufferedSink.writeDescription(description: String?, indent: String = "") {
+  if (!description.isNullOrBlank()) {
+    writeUtf8(
+"""${indent}${"\"\"\""}
+${indent}$description
+${indent}${"\"\"\""}
+"""
+    )
+  }
+}
+
+private fun BufferedSink.writeDeprecatedDirective(isDeprecated: Boolean, deprecationReason: String?) {
+  if (isDeprecated) {
+    writeUtf8(" @deprecated")
+    if (deprecationReason != null) {
+      writeUtf8("(reason: \"${deprecationReason}\")")
+    }
+  }
+}
+
+private fun IntrospectionSchema.Type.Scalar.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description)
+  sink.writeUtf8("scalar $name\n")
+}
+
+private fun IntrospectionSchema.Type.Enum.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description)
+  sink.writeUtf8("enum $name {\n")
+  enumValues.forEach {
+    it.toSDL(sink)
+    sink.writeUtf8("\n\n")
+  }
+  sink.writeUtf8("}\n")
+}
+
+private fun IntrospectionSchema.Type.Enum.Value.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description, "  ")
+  sink.writeUtf8("  $name")
+  sink.writeDeprecatedDirective(isDeprecated, deprecationReason)
+}
+
+private fun IntrospectionSchema.Type.InputObject.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description)
+  sink.writeUtf8("input $name {\n")
+  inputFields.forEach {
+    it.toSDL(sink)
+    sink.writeUtf8("\n\n")
+  }
+  sink.writeUtf8("}\n")
+}
+
+/**
+ * Writes the Json element returned by the Json parser as a GraphQL value
+ */
+private fun BufferedSink.writeValue(value: Any?) {
+  when(value) {
+    null -> writeUtf8("null")
+    is Long -> writeUtf8(value.toString())
+    is Double -> writeUtf8(value.toString())
+    is Boolean -> writeUtf8(value.toString())
+    is String -> writeUtf8("\"$value\"") // enums will fall in this case as there is no way to express an enum in Json
+    is List<*> -> {
+      writeUtf8("[")
+      value.forEachIndexed { index, item ->
+        writeValue(item)
+        if (index != value.size - 1) {
+          writeUtf8(", ")
+        }
+      }
+      writeUtf8("]")
+    }
+    is Map<*, *> -> {
+      writeUtf8("[")
+      value.entries.forEachIndexed {  index, entry ->
+        writeUtf8("${entry.key}: ")
+        writeValue(entry.value)
+        if (index != value.size - 1) {
+          writeUtf8(", ")
+        }
+      }
+      writeUtf8("]")
+    }
+  }
+}
+
+private fun IntrospectionSchema.InputField.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description, "  ")
+  sink.writeUtf8("  $name: ${type.asGraphQLType()}")
+  if (defaultValue != null) {
+    sink.writeUtf8(" = ")
+    sink.writeValue(defaultValue)
+  }
+  sink.writeDeprecatedDirective(isDeprecated, deprecationReason)
+  sink.writeUtf8("\n")
+}
+
+private fun IntrospectionSchema.Type.Interface.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description)
+  sink.writeUtf8("interface $name {\n")
+  fields?.forEach {
+    it.toSDL(sink)
+    sink.writeUtf8("\n\n")
+  }
+  sink.writeUtf8("}\n")
+}
+
+private fun IntrospectionSchema.Field.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description, "  ")
+  sink.writeUtf8("  $name")
+  if (args.isNotEmpty()) {
+    sink.writeUtf8("(")
+    args.forEach {arg ->
+      arg.toSDL(sink)
+    }
+    sink.writeUtf8(")")
+  }
+  sink.writeUtf8(": ${type.asGraphQLType()}")
+  sink.writeDeprecatedDirective(isDeprecated, deprecationReason)
+}
+
+private fun IntrospectionSchema.Field.Argument.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description, "  ")
+  sink.writeUtf8("  $name: ${type.asGraphQLType()}")
+  if (defaultValue != null) {
+    sink.writeUtf8(" = ")
+    sink.writeValue(defaultValue)
+  }
+  sink.writeDeprecatedDirective(isDeprecated, deprecationReason)
+}
+
+private fun IntrospectionSchema.Type.Object.toSDL(sink: BufferedSink, interfaces: List<IntrospectionSchema.Type.Interface>) {
+  sink.writeDescription(description, "")
+  sink.writeUtf8("type $name")
+  val implements = interfaces.filter {
+    it.possibleTypes?.map {
+      check(it.kind == IntrospectionSchema.Kind.OBJECT) {
+        "possibleType ${it.name} of interface $name is of type ${it.kind} and not OBJECT"
+      }
+      it.name
+    }?.contains(name) ?: false
+  }.map {
+    it.name
+  }
+
+  if (interfaces.isNotEmpty()) {
+    sink.writeUtf8(" implements ")
+    sink.writeUtf8(implements.joinToString(" & "))
+  }
+  sink.writeUtf8(" {\n")
+
+  fields?.forEach {
+    it.toSDL(sink)
+    sink.writeUtf8("\n\n")
+  }
+
+  sink.writeUtf8("}\n")
+}
+
+private fun IntrospectionSchema.Type.Union.toSDL(sink: BufferedSink) {
+  sink.writeDescription(description, "")
+  sink.writeUtf8("union $name = ")
+  sink.writeUtf8(possibleTypes!!.map { it.name }.joinToString(" | "))
+  sink.writeUtf8("\n")
+}
+

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
@@ -123,6 +123,7 @@ private fun BufferedSink.writeValue(value: Any?) {
       }
       writeUtf8("]")
     }
+    else -> throw IllegalStateException("ApolloGraphQL: Cannot write SDL value: $value")
   }
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
@@ -97,7 +97,8 @@ private fun IntrospectionSchema.Type.InputObject.toSDL(sink: BufferedSink) {
 private fun BufferedSink.writeValue(value: Any?) {
   when (value) {
     null -> writeUtf8("null")
-    is Long -> writeUtf8(value.toString())
+    is Int -> writeUtf8(value.toString()) // We get Ints coming from the SDL parsers
+    is Long -> writeUtf8(value.toString()) // And Longs coming from moshi, be robust to both
     is Double -> writeUtf8(value.toString())
     is Boolean -> writeUtf8(value.toString())
     is String -> writeUtf8("\"$value\"") // enums will fall in this case as there is no way to express an enum in Json

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
@@ -2,8 +2,11 @@ package com.apollographql.apollo.compiler
 
 import com.apollographql.apollo.compiler.parser.error.ParseException
 import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
+import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema.Companion.wrap
+import com.apollographql.apollo.compiler.parser.introspection.toSDL
 import com.apollographql.apollo.compiler.parser.sdl.GraphSdlSchema
 import com.apollographql.apollo.compiler.parser.sdl.toIntrospectionSchema
+import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.fail
@@ -61,5 +64,31 @@ class GraphSdlParseTest() {
     } catch (e: ParseException) {
       assertThat(e.message).contains("Object `Cat` cannot implement non-interface `Animal`")
     }
+  }
+
+  @Test
+  fun `writing SDL and parsing again yields identical schemas`() {
+    /**
+     * Things to watch out:
+     * - leading/trailing spaces in descriptions
+     * - defaultValue coercion
+     */
+    val initialSchema = IntrospectionSchema(File("src/test/sdl/schema.json")).normalize()
+    val sdlFile = File("build/sdl-test/schema.sdl")
+    sdlFile.parentFile.deleteRecursively()
+    sdlFile.parentFile.mkdirs()
+    initialSchema.toSDL(sdlFile)
+    val finalSchema = GraphSdlSchema(sdlFile).toIntrospectionSchema().normalize()
+
+    dumpSchemas(initialSchema, finalSchema)
+    assertEquals(initialSchema, finalSchema)
+  }
+
+  /**
+   * use to make easier diffs
+   */
+  private fun dumpSchemas(expected: IntrospectionSchema, actual: IntrospectionSchema) {
+    actual.wrap().toJson(File("build/sdl-test/actual.json"), "  ")
+    expected.wrap().toJson(File("build/sdl-test/expected.json"), "  ")
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
@@ -68,11 +68,6 @@ class GraphSdlParseTest() {
 
   @Test
   fun `writing SDL and parsing again yields identical schemas`() {
-    /**
-     * Things to watch out:
-     * - leading/trailing spaces in descriptions
-     * - defaultValue coercion
-     */
     val initialSchema = IntrospectionSchema(File("src/test/sdl/schema.json")).normalize()
     val sdlFile = File("build/sdl-test/schema.sdl")
     sdlFile.parentFile.deleteRecursively()

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo.gradle.internal
 
+import com.apollographql.apollo.compiler.parser.introspection.IntrospectionSchema
+import com.apollographql.apollo.compiler.parser.introspection.toSDL
 import com.squareup.moshi.JsonWriter
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.OkHttpClient
@@ -51,7 +53,14 @@ object SchemaDownloader {
     }
 
     schema.parentFile?.mkdirs()
-    schema.writeText(response.body!!.string())
+
+    response.body.use { responseBody ->
+      if (schema.extension.toLowerCase() == "json") {
+        schema.writeText(responseBody!!.string())
+      } else {
+        IntrospectionSchema(responseBody!!.byteStream()).toSDL(schema)
+      }
+    }
   }
 
   val introspectionQuery = """


### PR DESCRIPTION
closes #2582 

Initial support for downloading SDL schemas from an introspection endpoint.

The code generator is relatively barebones, maybe we could make it smarter to handle better indentation, line breaks, etc...

Usage:

```
#the plugin will detect the `.sdl` extension and convert on the fly if that's the case
./gradlew downloadApolloSchema 
     --endpoint=https://apollo-fullstack-tutorial.herokuapp.com/graphql 
     --schema=src/main/graphql/com/library/schema.sdl 
```