### PR TITLE
Hopefully make publication less flaky

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -188,7 +190,7 @@ fun Project.configurePublishing() {
 
       maven {
         name = "bintray"
-        url = uri("https://api.bintray.com/maven/apollographql/android/apollo/;publish=1;override=1")
+        url = uri("https://api.bintray.com/maven/apollographql/android/apollo/")
         credentials {
           username = System.getenv("BINTRAY_USER")
           password = System.getenv("BINTRAY_API_KEY")
@@ -304,7 +306,7 @@ tasks.register("publishSnapshotsIfNeeded") {
 }
 
 
-tasks.register("closeAndReleaseRepository") {
+tasks.register("sonatypeCloseAndReleaseRepository") {
   doLast {
     com.vanniktech.maven.publish.nexus.Nexus(
         username = System.getenv("SONATYPE_NEXUS_USERNAME"),
@@ -312,5 +314,22 @@ tasks.register("closeAndReleaseRepository") {
         baseUrl = "https://oss.sonatype.org/service/local/",
         groupId = "com.apollographql"
     ).closeAndReleaseRepository()
+  }
+}
+
+tasks.register("bintrayPublish") {
+  doLast {
+    val response = "{\"publish_wait_for_secs\": -1}".toRequestBody("application/json".toMediaType()).let {
+      okhttp3.Request.Builder()
+          .post(it)
+          .url("https://api.bintray.com//content/apollographql/android/apollo/$version/publish")
+          .build()
+    }.let {
+      okhttp3.OkHttpClient().newCall(it).execute()
+    }
+
+    check(response.isSuccessful) {
+      "Cannot publish to bintray: ${response.code}"
+    }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -190,7 +190,7 @@ fun Project.configurePublishing() {
 
       maven {
         name = "bintray"
-        url = uri("https://api.bintray.com/maven/apollographql/android/apollo/")
+        url = uri("https://api.bintray.com/maven/apollographql/android/apollo/;override=1")
         credentials {
           username = System.getenv("BINTRAY_USER")
           password = System.getenv("BINTRAY_API_KEY")
@@ -319,17 +319,17 @@ tasks.register("sonatypeCloseAndReleaseRepository") {
 
 tasks.register("bintrayPublish") {
   doLast {
-    val response = "{\"publish_wait_for_secs\": -1}".toRequestBody("application/json".toMediaType()).let {
+    "{\"publish_wait_for_secs\": -1}".toRequestBody("application/json".toMediaType()).let {
       okhttp3.Request.Builder()
           .post(it)
           .url("https://api.bintray.com//content/apollographql/android/apollo/$version/publish")
           .build()
     }.let {
       okhttp3.OkHttpClient().newCall(it).execute()
-    }
-
-    check(response.isSuccessful) {
-      "Cannot publish to bintray: ${response.code}"
+    }.use {
+      check(it.isSuccessful) {
+        "Cannot publish to bintray: ${it.code}"
+      }
     }
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,8 +1,10 @@
 # Jcenter
 ./gradlew publishAllPublicationsToBintrayRepository
+./gradlew bintrayPublish
 
 # Gradle Plugin Portal
 ./gradlew :apollo-gradle-plugin:publishPlugins -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET"
 
 # MavenCentral (go to https://oss.sonatype.org/ to close and release the repository after this is run)
 ./gradlew publishAllPublicationsToOssStagingRepository
+./gradlew sonatypeCloseAndReleaseRepository


### PR DESCRIPTION
Publish bintray artifacts all at once. This should fix 405/409 errors from bintray. 

I'll test that for the 2.3.2 release.

If it works well, and if we can remove the [Github Actions 443 errors](https://github.com/actions/virtual-environments/issues/1187#issuecomment-696195756), publishing from CI could be enabled again.