### PR TITLE
[Build] Fix a gradle warning

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
   compileOnly(gradleApi())
   compileOnly(dep("kotlin").dot("plugin"))
   compileOnly(dep("android").dot("minPlugin"))
+  // kotlin-reflect is transitively pulled by ythe android plugin, make it explicit so that it uses the same version as the rest of kotlin libs
+  compileOnly(dep("kotlin").dot("reflect"))
 
   api(project(":apollo-compiler"))
   implementation(project(":apollo-api")) // for QueryDocumentMinifier

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,13 +1,6 @@
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10")
-  }
+plugins {
+  id("org.jetbrains.kotlin.jvm").version("1.4.10")
 }
-
-apply(plugin = "org.jetbrains.kotlin.jvm")
 
 project.apply {
   from(file("../gradle/dependencies.gradle"))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -63,7 +63,8 @@ ext.dep = [
     kotlin                : [
         plugin             : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin",
         coroutines         : "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.kotlinCoroutines",
-        coroutinesAndroid  : "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlinCoroutines"
+        coroutinesAndroid  : "org.jetbrains.kotlinx:kotlinx-coroutines-android:$versions.kotlinCoroutines",
+        reflect            : "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
     ],
     mockito               : "org.mockito:mockito-all:$versions.mockito",
     moshi                 : [

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,6 @@ include("apollo-normalized-cache")
 include("apollo-normalized-cache-api")
 include("apollo-runtime-kotlin")
 
+include("apollo-idling-resource")
+include("apollo-normalized-cache-sqlite")
+include("apollo-android-support")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,3 @@ include("apollo-normalized-cache")
 include("apollo-normalized-cache-api")
 include("apollo-runtime-kotlin")
 
-include("apollo-idling-resource")
-include("apollo-normalized-cache-sqlite")
-include("apollo-android-support")


### PR DESCRIPTION
Add kotlin-reflect explicitely instead of having the Android plugin pulling it transitively. 

Fixes some of these warnings:

```
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
```

There are still some warnings that will be (hopefully) fixed with Gradle 7
