### PR TITLE
[Runtime] add a client awareness OkHttp interceptor

### DIFF
--- a/apollo-runtime/api.txt
+++ b/apollo-runtime/api.txt
@@ -94,6 +94,13 @@ package com.apollographql.apollo {
     method public com.apollographql.apollo.ApolloClient.Builder useHttpGetMethodForQueries(boolean);
   }
 
+  public final class ApolloClientAwarenessInterceptor {
+    ctor public ApolloClientAwarenessInterceptor(error.NonExistentClass, error.NonExistentClass);
+    method public error.NonExistentClass getClientName();
+    method public error.NonExistentClass getClientVersion();
+    method public error.NonExistentClass intercept(error.NonExistentClass);
+  }
+
   public abstract interface ApolloMutationCall<T> implements com.apollographql.apollo.ApolloCall {
     method public abstract com.apollographql.apollo.ApolloMutationCall<T> cacheHeaders(CacheHeaders);
     method public abstract com.apollographql.apollo.ApolloMutationCall<T> clone();

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClientAwarenessInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClientAwarenessInterceptor.kt
@@ -1,0 +1,20 @@
+package com.apollographql.apollo
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * An [Interceptor] to add [Client Awareness](https://www.apollographql.com/docs/studio/client-awareness/).
+ *
+ * Add this interceptor to your [okhttp3.OkHttpClient] instance when creating your [ApolloClient]
+ */
+class ApolloClientAwarenessInterceptor(val clientName: String, val clientVersion: String): Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val newRequest = chain.request().newBuilder()
+        .addHeader("apollographql-client-name", clientName)
+        .addHeader("apollographql-client-version", clientVersion)
+        .build()
+
+    return chain.proceed(newRequest)
+  }
+}


### PR DESCRIPTION
Add `ApolloClientAwarenessInterceptor` to implement [Client Awareness](https://www.apollographql.com/docs/studio/client-awareness/#advanced-apollo-server-configuration).

Usage:

```
    val okHttpClient = OkHttpClient.Builder()
        .addInterceptor(ApolloClientAwarenessInterceptor(BuildConfig.VERSION_NAME, BuildConfig.APPLICATION_ID))
        .build()

    instance = ApolloClient.builder()
        .serverUrl("https://apollo-fullstack-tutorial.herokuapp.com/graphql")
        .okHttpClient(okHttpClient)
        .build()
``` 

I'd like to make the setup even easier but all approaches I can think of have major drawbacks:

* `fun ApolloClient.Builder.clientAwareness(context: Context): ApolloClient.Builder` to get name/version automagically from context is not possible because `apollo-runtime` doesn't know about Android `Context`
* `fun ApolloClient.Builder.clientAwareness(clientName: String, clientVersion: String): ApolloClient.Builder` is dangerous because adding an Interceptor for authentication is a super widely used use case and I prefer the calling code to be in control of the interceptors (for order and more generally it's more consistent than having your okHttpInstance modified under your feet).

Ultimately, I think it's ok to add the interceptor manually if we add the appropriate documentation page. If anyone has any ideas how to make this process easier, I'll take them