### PR TITLE
[Doc] cleanup the Android documentation. 

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -48,7 +48,7 @@ module.exports = {
           ],
           Reference: [
             'essentials/plugin-configuration',
-            'advanced/android',
+            'advanced/ui-tests',
             'essentials/custom-scalar-types',
             'advanced/no-runtime',
             'essentials/fragments',

--- a/docs/source/advanced/ui-tests.mdx
+++ b/docs/source/advanced/ui-tests.mdx
@@ -1,36 +1,10 @@
 ---
-title: Android support
+title: UI Tests
 ---
 
 import {MultiCodeBlock} from 'gatsby-theme-apollo-docs';
 
-Apollo Android has support artifacts to help with caching and testing.
-
-## SqlNormalizedCacheFactory
-
-Add the following `dependency`:
-
-```groovy
-implementation("com.apollographql.apollo:apollo-android-support:x.y.z")
-```
-
-SqlNormalizedCacheFactory uses the Android framework [SQLiteDatabase](https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase) databse to provide and instance of a `NormalizedCacheFactory`.
-
-<MultiCodeBlock>
-
-```kotlin
-val apolloSqlHelper = ApolloSqlHelper.create(context, "db_name")
-val cacheFactory = SqlNormalizedCacheFactory(apolloSqlHelper)
-```
-
-```java
-ApolloSqlHelper apolloSqlHelper = ApolloSqlHelper.create(context, "db_name");
-NormalizedCacheFactory cacheFactory = new SqlNormalizedCacheFactory(apolloSqlHelper);
-```
-
-</MultiCodeBlock>
-
-## ApolloIdlingResource
+Apollo Android offers a built-in [IdlingResource](https://developer.android.com/reference/androidx/test/espresso/IdlingResource) to help writing UI tests with Espresso. The `ApolloIdlingResource` will make sure that your tests wait for your GraphQL queries terminate before moving on with testing.
 
 Add the following `dependency`:
 
@@ -39,9 +13,7 @@ Add the following `dependency`:
 implementation("com.apollographql.apollo:apollo-idling-resource:x.y.z")
 ```
 
-The Apollo GraphQL client comes with a [IdlingResource](https://developer.android.com/training/testing/espresso/idling-resource) to use
- during your Android Espresso UI tests. It needs to be created and registered per ApolloClient instance. Register several IdlingResources
- with the same name will crash.
+If you have multiple `ApolloClients` you need to create and register multiple `ApolloIdlingResource` with different names. Registering several IdlingResources with the same name will crash.
 
 <MultiCodeBlock>
 

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -3,3 +3,4 @@
 /docs/android/advanced/file-upload/ /docs/android/essentials/mutations/#uploading-files
 
 /docs/android/essentials/caching/ /docs/android/essentials/normalized-cache
+/docs/android/advanced/android/ /docs/android/advanced/ui-tests/


### PR DESCRIPTION
Now that SqlNormalizedCache is multiplatform, it doesn't belong to Android anymore.

Android is mostly the espresso idling resource now so rename the page to "UI Tests"