### PR TITLE
Add a 3.0 migration section

### DIFF
--- a/docs/source/essentials/migration.mdx
+++ b/docs/source/essentials/migration.mdx
@@ -5,7 +5,17 @@ description: Migrate from older versions of Apollo Android
 
 import {MultiCodeBlock} from 'gatsby-theme-apollo-docs';
 
-## Migrating to 2.x
+## Migrating to 3.0
+
+### Kotlin first
+
+Apollo Android now generates Kotlin models by default
+
+### Fragments as interfaces
+
+The generated code now uses interfaces for Fragments (https://github.com/apollographql/apollo-android/issues/1854)
+
+## Migrating to 2.0
 
 ### Kotlin Multiplatform
 


### PR DESCRIPTION
Start gathering elements about the 3.0 migration.

A lot of things are still TBC but we can add items there as `dev-3.x` evolves, that'll make it easier to write the migration guide ultimately.