### PR TITLE
Introduce new response reader API to support reading from stream - part1

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResponseReader.kt
@@ -8,6 +8,8 @@ import com.apollographql.apollo.api.ScalarType
  */
 interface ResponseReader {
 
+  fun selectField(fields: Array<ResponseField>): Int
+
   fun readString(field: ResponseField): String?
 
   fun readInt(field: ResponseField): Int?
@@ -77,5 +79,25 @@ interface ResponseReader {
         }
       })
     }
+  }
+
+  fun ResponseField.shouldSkip(variableValues: Map<String, Any?>): Boolean {
+    for (condition in conditions) {
+      if (condition is ResponseField.BooleanCondition) {
+        val conditionValue = variableValues[condition.variableName] as Boolean
+        if (condition.isInverted) {
+          // means it's a skip directive
+          if (conditionValue) {
+            return true
+          }
+        } else {
+          // means it's an include directive
+          if (!conditionValue) {
+            return true
+          }
+        }
+      }
+    }
+    return false
   }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResponseReader.kt
@@ -80,24 +80,4 @@ interface ResponseReader {
       })
     }
   }
-
-  fun ResponseField.shouldSkip(variableValues: Map<String, Any?>): Boolean {
-    for (condition in conditions) {
-      if (condition is ResponseField.BooleanCondition) {
-        val conditionValue = variableValues[condition.variableName] as Boolean
-        if (condition.isInverted) {
-          // means it's a skip directive
-          if (conditionValue) {
-            return true
-          }
-        } else {
-          // means it's an include directive
-          if (!conditionValue) {
-            return true
-          }
-        }
-      }
-    }
-    return false
-  }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
@@ -39,11 +39,11 @@ class SimpleResponseReader private constructor(
   }
 
   override fun readInt(field: ResponseField): Int? {
-    return valueFor<Number>(field)?.toInt()
+    return valueFor<BigDecimal>(field)?.toNumber()?.toInt()
   }
 
   override fun readDouble(field: ResponseField): Double? {
-    return valueFor<Number>(field)?.toDouble()
+    return valueFor<BigDecimal>(field)?.toNumber()?.toDouble()
   }
 
   override fun readBoolean(field: ResponseField): Boolean? {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
@@ -26,7 +26,7 @@ class SimpleResponseReader private constructor(
       if (responseRecordSetIterator.hasNext()) {
         val (nextFieldName, _) = responseRecordSetIterator.next()
         val fieldIndex = fields.indexOfFirst { field -> field.responseName == nextFieldName }
-        if (fieldIndex != -1 && !fields[fieldIndex].shouldSkip(variableValues)) {
+        if (fieldIndex != -1) {
           return fieldIndex
         }
       } else {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/Common.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/Common.kt
@@ -452,6 +452,18 @@ private fun Number.castTo(type: TypeName): Number {
   }
 }
 
+internal fun TypeName.createMapperFun(): FunSpec {
+  return FunSpec.builder("Mapper")
+      .addAnnotation(
+          AnnotationSpec.builder(Suppress::class)
+              .addMember("%S", "FunctionName")
+              .build()
+      )
+      .returns(ResponseFieldMapper::class.asClassName().parameterizedBy(this))
+      .addStatement("return %T·{ invoke(it) }", ResponseFieldMapper::class)
+      .build()
+}
+
 internal fun Collection<CodeGenerationAst.TypeRef>.accessorProperties(): List<PropertySpec> {
   return map { type ->
     PropertySpec.builder("as${type.name}", type.asTypeName().copy(nullable = true))

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/FragmentType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/FragmentType.kt
@@ -11,6 +11,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
 
 internal fun CodeGenerationAst.FragmentType.typeSpec(generateAsInternal: Boolean): TypeSpec {
   val fragmentType = checkNotNull(nestedTypes[rootType]) {
@@ -36,7 +37,12 @@ internal fun CodeGenerationAst.FragmentType.typeSpec(generateAsInternal: Boolean
                   .addModifiers(KModifier.OPERATOR)
                   .returns(ClassName.bestGuess(fragmentType.name))
                   .addParameter(ParameterSpec.builder("reader", ResponseReader::class).build())
-                  .addStatement("return %T(reader)", defaultImplementation.asTypeName())
+                  .addParameter(CodeGenerationAst.typenameField.asOptionalParameterSpec())
+                  .addStatement(
+                      "return %T(reader, %L)",
+                      defaultImplementation.asTypeName(),
+                      CodeGenerationAst.typenameField.responseName
+                  )
                   .build()
           )
           .build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/ObjectType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/ObjectType.kt
@@ -47,6 +47,7 @@ internal fun CodeGenerationAst.ObjectType.objectTypeSpec(
                 .companionObjectBuilder()
                 .addProperty(responseFieldsPropertySpec(fields))
                 .addFunction(fields.toMapperFun(ClassName("", name)))
+                .addFunction(ClassName("", name).createMapperFun())
                 .build()
         )
       }

--- a/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
@@ -133,17 +133,29 @@ data class TestQuery(
           |""".trimMargin()), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): TypeWithGraphQLKeywords = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val on = readString(RESPONSE_FIELDS[1])
-        val null_ = readString(RESPONSE_FIELDS[2])
-        val alias = readString(RESPONSE_FIELDS[3])
-        TypeWithGraphQLKeywords(
-          __typename = __typename,
-          on = on,
-          null_ = null_,
-          alias = alias
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          TypeWithGraphQLKeywords {
+        return reader.run {
+          var __typename: String? = __typename
+          var on: String? = null
+          var null_: String? = null
+          var alias: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> on = readString(RESPONSE_FIELDS[1])
+              2 -> null_ = readString(RESPONSE_FIELDS[2])
+              3 -> alias = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          TypeWithGraphQLKeywords(
+            __typename = __typename!!,
+            on = on,
+            null_ = null_,
+            alias = alias
+          )
+        }
       }
 
       @Suppress("FunctionName")
@@ -170,14 +182,21 @@ data class TestQuery(
             null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val typeWithGraphQLKeywords =
-            readObject<TypeWithGraphQLKeywords>(RESPONSE_FIELDS[0]) { reader ->
-          TypeWithGraphQLKeywords(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var typeWithGraphQLKeywords: TypeWithGraphQLKeywords? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> typeWithGraphQLKeywords = readObject<TypeWithGraphQLKeywords>(RESPONSE_FIELDS[0]) { reader ->
+                TypeWithGraphQLKeywords(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            typeWithGraphQLKeywords = typeWithGraphQLKeywords
+          )
         }
-        Data(
-          typeWithGraphQLKeywords = typeWithGraphQLKeywords
-        )
       }
 
       @Suppress("FunctionName")

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -162,6 +162,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -220,6 +223,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -142,19 +142,26 @@ data class TestQuery(
           "unit" to "FOOT"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroWithReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        HeroWithReview(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroWithReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          HeroWithReview(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -197,17 +204,22 @@ data class TestQuery(
               "variableName" to "stars"))), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
-          HeroWithReview(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var heroWithReview: HeroWithReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
+                HeroWithReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            heroWithReview = heroWithReview
+          )
         }
-        Data(
-          heroWithReview = heroWithReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -112,19 +112,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("commentary", "commentary", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Review = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val stars = readInt(RESPONSE_FIELDS[1])!!
-        val commentary = readString(RESPONSE_FIELDS[2])
-        Review(
-          __typename = __typename,
-          stars = stars,
-          commentary = commentary
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Review {
+        return reader.run {
+          var __typename: String? = __typename
+          var stars: Int? = null
+          var commentary: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> stars = readInt(RESPONSE_FIELDS[1])
+              2 -> commentary = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Review(
+            __typename = __typename!!,
+            stars = stars!!,
+            commentary = commentary
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Review> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -153,19 +160,24 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "starsFloat" to 9.9), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val reviews = readList<Review>(RESPONSE_FIELDS[0]) { reader ->
-          reader.readObject<Review> { reader ->
-            Review(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var reviews: List<Review?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> reviews = readList<Review>(RESPONSE_FIELDS[0]) { reader ->
+                reader.readObject<Review> { reader ->
+                  Review(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Data(
+            reviews = reviews
+          )
         }
-        Data(
-          reviews = reviews
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -132,6 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Review> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -178,6 +181,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -149,17 +149,23 @@ data class TestQuery(
         ))
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -186,19 +192,25 @@ data class TestQuery(
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -237,23 +249,30 @@ data class TestQuery(
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -291,21 +310,28 @@ data class TestQuery(
             "variableName" to "friendsCount")), false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -332,17 +358,23 @@ data class TestQuery(
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroWithReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        HeroWithReview(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroWithReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          HeroWithReview(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -376,21 +408,27 @@ data class TestQuery(
           "review" to emptyMap<String, Any>()), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          var heroWithReview: HeroWithReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              1 -> heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
+                HeroWithReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero,
+            heroWithReview = heroWithReview
+          )
         }
-        val heroWithReview = readObject<HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
-          HeroWithReview(reader)
-        }
-        Data(
-          hero = hero,
-          heroWithReview = heroWithReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -166,6 +166,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -211,6 +214,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -273,6 +279,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -332,6 +341,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -375,6 +387,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroWithReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -429,6 +444,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.arguments_simple.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -118,6 +119,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -163,6 +167,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -223,6 +230,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -271,6 +281,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.arguments_simple.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -102,17 +101,23 @@ interface HeroDetails : GraphqlFragment {
         ))
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -139,19 +144,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -188,23 +199,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -234,19 +252,25 @@ interface HeroDetails : GraphqlFragment {
             "variableName" to "friendsCount")), false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[1]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        DefaultImpl(
-          __typename = __typename,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var friendsConnection: FriendsConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[1]) { reader ->
+                FriendsConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -268,6 +292,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -148,33 +148,45 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("links", "links", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Date>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        val appearanceDates = readList<Date>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readCustomType<Date>(CustomType.DATE)
-        }!!.map { it!! }
-        val fieldWithUnsupportedType = readCustomType<Any>(RESPONSE_FIELDS[4] as
-            ResponseField.CustomTypeField)!!
-        val profileLink = readCustomType<java.lang.String>(RESPONSE_FIELDS[5] as
-            ResponseField.CustomTypeField)!!
-        val links = readList<java.lang.String>(RESPONSE_FIELDS[6]) { reader ->
-          reader.readCustomType<java.lang.String>(CustomType.URL)
-        }!!.map { it!! }
-        Hero(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate,
-          appearanceDates = appearanceDates,
-          fieldWithUnsupportedType = fieldWithUnsupportedType,
-          profileLink = profileLink,
-          links = links
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Date? = null
+          var appearanceDates: List<Date>? = null
+          var fieldWithUnsupportedType: Any? = null
+          var profileLink: java.lang.String? = null
+          var links: List<java.lang.String>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Date>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              3 -> appearanceDates = readList<Date>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readCustomType<Date>(CustomType.DATE)
+              }?.map { it!! }
+              4 -> fieldWithUnsupportedType = readCustomType<Any>(RESPONSE_FIELDS[4] as
+                  ResponseField.CustomTypeField)
+              5 -> profileLink = readCustomType<java.lang.String>(RESPONSE_FIELDS[5] as
+                  ResponseField.CustomTypeField)
+              6 -> links = readList<java.lang.String>(RESPONSE_FIELDS[6]) { reader ->
+                reader.readCustomType<java.lang.String>(CustomType.URL)
+              }?.map { it!! }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!,
+            appearanceDates = appearanceDates!!,
+            fieldWithUnsupportedType = fieldWithUnsupportedType!!,
+            profileLink = profileLink!!,
+            links = links!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,17 +207,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -187,6 +187,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -223,6 +226,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -129,6 +129,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -165,6 +168,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -110,19 +110,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("links", "links", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val links = readList<Any>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readCustomType<Any>(CustomType.URL)
-        }!!.map { it!! }
-        Hero(
-          __typename = __typename,
-          links = links
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var links: List<Any>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> links = readList<Any>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readCustomType<Any>(CustomType.URL)
+              }?.map { it!! }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            links = links!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,17 +149,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -142,21 +142,29 @@ data class TestQuery(
         ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val deprecated = readString(RESPONSE_FIELDS[2])!!
-        val deprecatedBool = readBoolean(RESPONSE_FIELDS[3])!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          deprecated = deprecated,
-          deprecatedBool = deprecatedBool
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var deprecated: String? = null
+          var deprecatedBool: Boolean? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> deprecated = readString(RESPONSE_FIELDS[2])
+              3 -> deprecatedBool = readBoolean(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            deprecated = deprecated!!,
+            deprecatedBool = deprecatedBool!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -180,17 +188,22 @@ data class TestQuery(
             "variableName" to "episode")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -165,6 +165,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -204,6 +207,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -154,6 +154,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -214,6 +217,10 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
+          invoke(it) }
     }
   }
 
@@ -257,6 +264,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -326,6 +336,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -134,19 +134,26 @@ data class TestQuery(
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        HeroDetailsImpl(
-          __typename = __typename,
-          name = name,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          HeroDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -183,22 +190,30 @@ data class TestQuery(
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsHumanDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val homePlanet = readString(RESPONSE_FIELDS[2])
-        val id = readCustomType<String>(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField)!!
-        HeroDetailsHumanDetailsImpl(
-          __typename = __typename,
-          name = name,
-          homePlanet = homePlanet,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsHumanDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homePlanet: String? = null
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+              3 -> id = readCustomType<String>(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          HeroDetailsHumanDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            homePlanet = homePlanet,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
-          invoke(it) }
     }
   }
 
@@ -225,17 +240,23 @@ data class TestQuery(
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        OtherHero(
-          __typename = __typename,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -261,12 +282,12 @@ data class TestQuery(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> HeroDetailsImpl(reader)
-          "Human" -> HeroDetailsHumanDetailsImpl(reader)
-          else -> OtherHero(reader)
+          "Droid" -> HeroDetailsImpl(reader, typename)
+          "Human" -> HeroDetailsHumanDetailsImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -289,17 +310,22 @@ data class TestQuery(
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -67,6 +68,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -51,17 +50,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -73,6 +78,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -51,17 +50,23 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forString("homePlanet", "homePlanet", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val homePlanet = readString(RESPONSE_FIELDS[1])
-        DefaultImpl(
-          __typename = __typename,
-          homePlanet = homePlanet
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> homePlanet = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            homePlanet = homePlanet
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -73,6 +78,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.directive_with_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -67,6 +68,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -244,6 +244,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HumanCharacterImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -303,6 +306,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DroidCharacterImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -346,6 +352,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -417,6 +426,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -221,21 +221,29 @@ data class TestQuery(
         ResponseField.forString("homePlanet", "homePlanet", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HumanCharacterImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val homePlanet = readString(RESPONSE_FIELDS[3])
-        HumanCharacterImpl(
-          __typename = __typename,
-          id = id,
-          name = name,
-          homePlanet = homePlanet
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanCharacterImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> homePlanet = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          HumanCharacterImpl(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HumanCharacterImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -272,21 +280,29 @@ data class TestQuery(
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DroidCharacterImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[3])
-        DroidCharacterImpl(
-          __typename = __typename,
-          id = id,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidCharacterImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          DroidCharacterImpl(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DroidCharacterImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -313,17 +329,23 @@ data class TestQuery(
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        OtherHero(
-          __typename = __typename,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -351,12 +373,12 @@ data class TestQuery(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanCharacterImpl(reader)
-          "Droid" -> DroidCharacterImpl(reader)
-          else -> OtherHero(reader)
+          "Human" -> HumanCharacterImpl(reader, typename)
+          "Droid" -> DroidCharacterImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -379,17 +401,22 @@ data class TestQuery(
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -142,6 +142,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -200,6 +203,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -236,6 +242,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -125,17 +125,23 @@ data class TestQuery(
         ResponseField.forInt("totalCount", "totalCount", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -172,21 +178,28 @@ data class TestQuery(
         ))
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name,
+            friendsConnection = friendsConnection
+          )
         }
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -207,17 +220,22 @@ data class TestQuery(
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -123,23 +123,31 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        val firstAppearsIn = Episode.safeValueOf(readString(RESPONSE_FIELDS[3])!!)
-        Hero(
-          __typename = __typename,
-          name = name,
-          appearsIn = appearsIn,
-          firstAppearsIn = firstAppearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          var firstAppearsIn: Episode? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              3 -> firstAppearsIn = readString(RESPONSE_FIELDS[3])?.let { Episode.safeValueOf(it) }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!,
+            firstAppearsIn = firstAppearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -160,17 +168,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -148,6 +148,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -184,6 +187,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -124,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -169,6 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -231,6 +237,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -285,6 +294,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -321,6 +333,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -107,17 +107,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,19 +150,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,23 +207,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -244,21 +263,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -279,17 +305,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_friends_connection.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -121,6 +122,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -166,6 +170,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -226,6 +233,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -280,6 +290,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_friends_connection.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -105,17 +104,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -142,19 +147,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -191,23 +202,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -240,21 +258,28 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -277,6 +302,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -127,6 +127,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Homeworld> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -181,6 +184,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -226,6 +232,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -278,6 +287,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<PilotConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -338,6 +350,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -383,6 +398,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -435,6 +453,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<AllStarships1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -472,6 +493,9 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -110,17 +110,23 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Homeworld = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Homeworld(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Homeworld {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Homeworld(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Homeworld> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -153,21 +159,28 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forObject("homeworld", "homeworld", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        val homeworld = readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
-          Homeworld(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homeworld: Homeworld? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homeworld = readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+                Homeworld(reader)
+              }
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name,
+            homeworld = homeworld
+          )
         }
-        Node1(
-          __typename = __typename,
-          name = name,
-          homeworld = homeworld
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,19 +207,25 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -238,21 +257,27 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): PilotConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): PilotConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          PilotConnection(
+            __typename = __typename!!,
+            edges = edges
+          )
         }
-        PilotConnection(
-          __typename = __typename,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<PilotConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -288,23 +313,31 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forObject("pilotConnection", "pilotConnection", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])
-        val pilotConnection = readObject<PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
-          PilotConnection(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var pilotConnection: PilotConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> pilotConnection = readObject<PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
+                PilotConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            id = id!!,
+            name = name,
+            pilotConnection = pilotConnection
+          )
         }
-        Node(
-          __typename = __typename,
-          id = id,
-          name = name,
-          pilotConnection = pilotConnection
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -331,19 +364,25 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -375,21 +414,27 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): AllStarships1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): AllStarships1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          AllStarships1(
+            __typename = __typename!!,
+            edges = edges
+          )
         }
-        AllStarships1(
-          __typename = __typename,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<AllStarships1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -411,17 +456,22 @@ class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Varia
           "first" to 7), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val allStarships = readObject<AllStarships1>(RESPONSE_FIELDS[0]) { reader ->
-          AllStarships1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var allStarships: AllStarships1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> allStarships = readObject<AllStarships1>(RESPONSE_FIELDS[0]) { reader ->
+                AllStarships1(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            allStarships = allStarships
+          )
         }
-        Data(
-          allStarships = allStarships
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -7,7 +7,6 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -67,17 +66,23 @@ interface PilotFragment : GraphqlFragment {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Homeworld1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Homeworld1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Homeworld1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Homeworld1(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Homeworld1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -110,21 +115,28 @@ interface PilotFragment : GraphqlFragment {
         ResponseField.forObject("homeworld", "homeworld", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        val homeworld = readObject<Homeworld1>(RESPONSE_FIELDS[2]) { reader ->
-          Homeworld1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homeworld: Homeworld1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homeworld = readObject<Homeworld1>(RESPONSE_FIELDS[2]) { reader ->
+                Homeworld1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name,
+            homeworld = homeworld
+          )
         }
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          homeworld = homeworld
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -140,6 +152,7 @@ interface PilotFragment : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): PilotFragment = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): PilotFragment =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -83,6 +84,9 @@ interface PilotFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Homeworld1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -137,6 +141,9 @@ interface PilotFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -69,6 +70,9 @@ interface PlanetFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -7,7 +7,6 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -53,17 +52,23 @@ interface PlanetFragment : GraphqlFragment {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        DefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -75,6 +80,7 @@ interface PlanetFragment : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): PlanetFragment = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): PlanetFragment =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -7,7 +7,6 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_in_fragment.type.CustomType
@@ -98,17 +97,23 @@ interface StarshipFragment : GraphqlFragment {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Homeworld = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Homeworld(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Homeworld {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Homeworld(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Homeworld> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -141,21 +146,28 @@ interface StarshipFragment : GraphqlFragment {
         ResponseField.forObject("homeworld", "homeworld", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        val homeworld = readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
-          Homeworld(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homeworld: Homeworld? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homeworld = readObject<Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+                Homeworld(reader)
+              }
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name,
+            homeworld = homeworld
+          )
         }
-        Node1(
-          __typename = __typename,
-          name = name,
-          homeworld = homeworld
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -182,19 +194,25 @@ interface StarshipFragment : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -224,21 +242,27 @@ interface StarshipFragment : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): PilotConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): PilotConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          PilotConnection1(
+            __typename = __typename!!,
+            edges = edges
+          )
         }
-        PilotConnection1(
-          __typename = __typename,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<PilotConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -274,23 +298,31 @@ interface StarshipFragment : GraphqlFragment {
         ResponseField.forObject("pilotConnection", "pilotConnection", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])
-        val pilotConnection = readObject<PilotConnection1>(RESPONSE_FIELDS[3]) { reader ->
-          PilotConnection1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var pilotConnection: PilotConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> pilotConnection = readObject<PilotConnection1>(RESPONSE_FIELDS[3]) { reader ->
+                PilotConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            id = id!!,
+            name = name,
+            pilotConnection = pilotConnection
+          )
         }
-        DefaultImpl(
-          __typename = __typename,
-          id = id,
-          name = name,
-          pilotConnection = pilotConnection
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -313,6 +345,7 @@ interface StarshipFragment : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): StarshipFragment = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): StarshipFragment =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -7,6 +7,7 @@ package com.example.fragment_in_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_in_fragment.type.CustomType
@@ -114,6 +115,9 @@ interface StarshipFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Homeworld> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -168,6 +172,9 @@ interface StarshipFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -213,6 +220,9 @@ interface StarshipFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -263,6 +273,9 @@ interface StarshipFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<PilotConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -323,6 +336,9 @@ interface StarshipFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -135,6 +135,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsCharacterDetailsImpl> = ResponseFieldMapper {
+          invoke(it) }
     }
   }
 
@@ -189,6 +193,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsCharacterDetailsImpl> =
+          ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -223,6 +231,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -289,6 +300,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -113,20 +113,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsCharacterDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        HeroDetailsCharacterDetailsImpl(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsCharacterDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          HeroDetailsCharacterDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsCharacterDetailsImpl> = ResponseFieldMapper {
-          invoke(it) }
     }
   }
 
@@ -159,21 +167,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsHumanDetailsCharacterDetailsImpl =
-          reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        HeroDetailsHumanDetailsCharacterDetailsImpl(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsHumanDetailsCharacterDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          HeroDetailsHumanDetailsCharacterDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsCharacterDetailsImpl> =
-          ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,15 +209,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherHero(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -225,12 +245,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> HeroDetailsCharacterDetailsImpl(reader)
-          "Human" -> HeroDetailsHumanDetailsCharacterDetailsImpl(reader)
-          else -> OtherHero(reader)
+          "Droid" -> HeroDetailsCharacterDetailsImpl(reader, typename)
+          "Human" -> HeroDetailsHumanDetailsCharacterDetailsImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -253,17 +273,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -65,19 +64,27 @@ interface CharacterDetails : GraphqlFragment {
         ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -90,6 +97,7 @@ interface CharacterDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): CharacterDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): CharacterDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -85,6 +86,9 @@ interface CharacterDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -80,6 +81,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -60,19 +59,27 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -85,6 +92,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -60,19 +59,28 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CharacterDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        CharacterDetailsImpl(
-          __typename = __typename,
-          name = name,
-          birthDate = birthDate
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          CharacterDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          CharacterDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CharacterDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -99,17 +107,23 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherDefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherDefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherDefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherDefaultImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -133,12 +147,12 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> CharacterDetailsImpl(reader)
-          "Human" -> CharacterDetailsImpl(reader)
-          else -> OtherDefaultImpl(reader)
+          "Droid" -> CharacterDetailsImpl(reader, typename)
+          "Human" -> CharacterDetailsImpl(reader, typename)
+          else -> OtherDefaultImpl(reader, typename)
         }
       }
     }
@@ -153,6 +167,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_used_twice.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.fragment_used_twice.type.CustomType
@@ -81,6 +82,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CharacterDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -124,6 +128,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -193,6 +193,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -238,6 +241,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -300,6 +306,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -380,6 +389,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsDroidDroidDetailsImpl> = ResponseFieldMapper {
+          invoke(it) }
     }
   }
 
@@ -423,6 +436,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -468,6 +484,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -530,6 +549,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -600,6 +622,10 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
+          invoke(it) }
     }
   }
 
@@ -659,6 +685,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -737,6 +766,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -176,17 +176,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -213,19 +219,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -264,23 +276,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -330,28 +349,37 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("appearsIn", "appearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsDroidDroidDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        val primaryFunction = readString(RESPONSE_FIELDS[3])
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[4]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        HeroDetailsDroidDroidDetailsImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection,
-          primaryFunction = primaryFunction,
-          appearsIn = appearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsDroidDroidDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection1? = null
+          var primaryFunction: String? = null
+          var appearsIn: List<Episode?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection1(reader)
+              }
+              3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
+              4 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[4]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              else -> break
+            }
+          }
+          HeroDetailsDroidDroidDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!,
+            primaryFunction = primaryFunction,
+            appearsIn = appearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsDroidDroidDetailsImpl> = ResponseFieldMapper {
-          invoke(it) }
     }
   }
 
@@ -378,17 +406,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node2(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node2(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -415,19 +449,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node2>(RESPONSE_FIELDS[1]) { reader ->
-          Node2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node2? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node2>(RESPONSE_FIELDS[1]) { reader ->
+                Node2(reader)
+              }
+              else -> break
+            }
+          }
+          Edge2(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge2(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -466,23 +506,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge2>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge2> { reader ->
-            Edge2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge2?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge2>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge2> { reader ->
+                  Edge2(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection2(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection2(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -525,26 +572,34 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("appearsIn", "appearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsHumanDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection2>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection2(reader)
-        }!!
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[3]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        HeroDetailsHumanDetailsImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection,
-          appearsIn = appearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsHumanDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection2? = null
+          var appearsIn: List<Episode?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection2>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection2(reader)
+              }
+              3 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[3]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              else -> break
+            }
+          }
+          HeroDetailsHumanDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!,
+            appearsIn = appearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
-          invoke(it) }
     }
   }
 
@@ -582,21 +637,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("appearsIn", "appearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        OtherHero(
-          __typename = __typename,
-          name = name,
-          appearsIn = appearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -631,12 +693,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> HeroDetailsDroidDroidDetailsImpl(reader)
-          "Human" -> HeroDetailsHumanDetailsImpl(reader)
-          else -> OtherHero(reader)
+          "Droid" -> HeroDetailsDroidDroidDetailsImpl(reader, typename)
+          "Human" -> HeroDetailsHumanDetailsImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -659,17 +721,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -81,6 +82,9 @@ interface DroidDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -62,19 +61,26 @@ interface DroidDetails : GraphqlFragment {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -87,6 +93,7 @@ interface DroidDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -187,6 +188,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -232,6 +236,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -292,6 +299,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -354,6 +364,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DroidDroidDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -397,6 +410,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -442,6 +458,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -502,6 +521,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -556,6 +578,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HumanDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -599,6 +624,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -644,6 +672,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -704,6 +735,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -758,6 +792,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -171,17 +170,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node2(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node2(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -208,19 +213,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node2>(RESPONSE_FIELDS[1]) { reader ->
-          Node2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node2? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node2>(RESPONSE_FIELDS[1]) { reader ->
+                Node2(reader)
+              }
+              else -> break
+            }
+          }
+          Edge2(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge2(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -257,23 +268,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge2>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge2> { reader ->
-            Edge2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge2?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge2>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge2> { reader ->
+                  Edge2(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection2(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection2(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -310,23 +328,32 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DroidDroidDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection2>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection2(reader)
-        }!!
-        val primaryFunction = readString(RESPONSE_FIELDS[3])
-        DroidDroidDetailsImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          DroidDroidDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection2? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection2>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection2(reader)
+              }
+              3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          DroidDroidDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DroidDroidDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -353,17 +380,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node3 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node3(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node3 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node3(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -390,19 +423,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge3 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node3>(RESPONSE_FIELDS[1]) { reader ->
-          Node3(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge3 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node3? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node3>(RESPONSE_FIELDS[1]) { reader ->
+                Node3(reader)
+              }
+              else -> break
+            }
+          }
+          Edge3(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge3(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -439,23 +478,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection3 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge3>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge3> { reader ->
-            Edge3(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection3 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge3?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge3>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge3> { reader ->
+                  Edge3(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection3(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection3(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection3> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -488,21 +534,28 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection3>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection3(reader)
-        }!!
-        HumanDetailsImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection3? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection3>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection3(reader)
+              }
+              else -> break
+            }
+          }
+          HumanDetailsImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HumanDetailsImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -529,17 +582,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node4 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node4(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node4 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node4(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -566,19 +625,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge4 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node4>(RESPONSE_FIELDS[1]) { reader ->
-          Node4(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge4 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node4? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node4>(RESPONSE_FIELDS[1]) { reader ->
+                Node4(reader)
+              }
+              else -> break
+            }
+          }
+          Edge4(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge4(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -615,23 +680,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection4 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge4>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge4> { reader ->
-            Edge4(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection4 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge4?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge4>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge4> { reader ->
+                  Edge4(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection4(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection4(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection4> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -664,21 +736,28 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherDefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection4>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection4(reader)
-        }!!
-        OtherDefaultImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherDefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection4? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection4>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection4(reader)
+              }
+              else -> break
+            }
+          }
+          OtherDefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -758,12 +837,12 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> DroidDroidDetailsImpl(reader)
-          "Human" -> HumanDetailsImpl(reader)
-          else -> OtherDefaultImpl(reader)
+          "Droid" -> DroidDroidDetailsImpl(reader, typename)
+          "Human" -> HumanDetailsImpl(reader, typename)
+          else -> OtherDefaultImpl(reader, typename)
         }
       }
     }
@@ -792,6 +871,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -67,6 +68,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragment_with_inline_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -51,17 +50,23 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -73,6 +78,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -140,6 +140,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherR2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -228,6 +231,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherLuke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -300,6 +306,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -90,8 +90,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val humanDetailsDelegate: HumanDetails
   ) : R2, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl {
-        return HumanDetailsImpl(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl {
+        return HumanDetailsImpl(HumanDetails(reader, __typename))
       }
     }
   }
@@ -103,8 +103,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val droidDetailsDelegate: DroidDetails
   ) : R2, DroidDetails by droidDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): DroidDetailsImpl {
-        return DroidDetailsImpl(DroidDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetailsImpl {
+        return DroidDetailsImpl(DroidDetails(reader, __typename))
       }
     }
   }
@@ -126,15 +126,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherR2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherR2(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherR2 {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherR2(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherR2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -155,12 +160,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): R2 {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanDetailsImpl(reader)
-          "Droid" -> DroidDetailsImpl(reader)
-          else -> OtherR2(reader)
+          "Human" -> HumanDetailsImpl(reader, typename)
+          "Droid" -> DroidDetailsImpl(reader, typename)
+          else -> OtherR2(reader, typename)
         }
       }
     }
@@ -173,8 +178,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val humanDetailsDelegate: HumanDetails
   ) : Luke, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl1 {
-        return HumanDetailsImpl1(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl1 {
+        return HumanDetailsImpl1(HumanDetails(reader, __typename))
       }
     }
   }
@@ -186,8 +191,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val droidDetailsDelegate: DroidDetails
   ) : Luke, DroidDetails by droidDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): DroidDetailsImpl1 {
-        return DroidDetailsImpl1(DroidDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetailsImpl1 {
+        return DroidDetailsImpl1(DroidDetails(reader, __typename))
       }
     }
   }
@@ -209,15 +214,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherLuke = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherLuke(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherLuke {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherLuke(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherLuke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -238,12 +248,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Luke {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanDetailsImpl1(reader)
-          "Droid" -> DroidDetailsImpl1(reader)
-          else -> OtherLuke(reader)
+          "Human" -> HumanDetailsImpl1(reader, typename)
+          "Droid" -> DroidDetailsImpl1(reader, typename)
+          else -> OtherLuke(reader, typename)
         }
       }
     }
@@ -269,21 +279,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("luke", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
-          R2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var r2: R2? = null
+          var luke: Luke? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+                R2(reader)
+              }
+              1 -> luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+                Luke(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            r2 = r2,
+            luke = luke
+          )
         }
-        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
-          Luke(reader)
-        }
-        Data(
-          r2 = r2,
-          luke = luke
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -81,6 +82,9 @@ interface DroidDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -62,19 +61,26 @@ interface DroidDetails : GraphqlFragment {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -87,6 +93,7 @@ interface DroidDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -63,19 +62,26 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forDouble("height", "height", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -88,6 +94,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -82,6 +83,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -140,6 +140,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherR2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -228,6 +231,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherLuke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -300,6 +306,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -90,8 +90,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val humanDetailsDelegate: HumanDetails
   ) : R2, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl {
-        return HumanDetailsImpl(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl {
+        return HumanDetailsImpl(HumanDetails(reader, __typename))
       }
     }
   }
@@ -103,8 +103,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val droidDetailsDelegate: DroidDetails
   ) : R2, DroidDetails by droidDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): DroidDetailsImpl {
-        return DroidDetailsImpl(DroidDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetailsImpl {
+        return DroidDetailsImpl(DroidDetails(reader, __typename))
       }
     }
   }
@@ -126,15 +126,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherR2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherR2(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherR2 {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherR2(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherR2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -155,12 +160,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): R2 {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): R2 {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanDetailsImpl(reader)
-          "Droid" -> DroidDetailsImpl(reader)
-          else -> OtherR2(reader)
+          "Human" -> HumanDetailsImpl(reader, typename)
+          "Droid" -> DroidDetailsImpl(reader, typename)
+          else -> OtherR2(reader, typename)
         }
       }
     }
@@ -173,8 +178,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val humanDetailsDelegate: HumanDetails
   ) : Luke, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl1 {
-        return HumanDetailsImpl1(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl1 {
+        return HumanDetailsImpl1(HumanDetails(reader, __typename))
       }
     }
   }
@@ -186,8 +191,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val droidDetailsDelegate: DroidDetails
   ) : Luke, DroidDetails by droidDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): DroidDetailsImpl1 {
-        return DroidDetailsImpl1(DroidDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetailsImpl1 {
+        return DroidDetailsImpl1(DroidDetails(reader, __typename))
       }
     }
   }
@@ -209,15 +214,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherLuke = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherLuke(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherLuke {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherLuke(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherLuke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -238,12 +248,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Luke {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Luke {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanDetailsImpl1(reader)
-          "Droid" -> DroidDetailsImpl1(reader)
-          else -> OtherLuke(reader)
+          "Human" -> HumanDetailsImpl1(reader, typename)
+          "Droid" -> DroidDetailsImpl1(reader, typename)
+          else -> OtherLuke(reader, typename)
         }
       }
     }
@@ -269,21 +279,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("luke", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
-          R2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var r2: R2? = null
+          var luke: Luke? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+                R2(reader)
+              }
+              1 -> luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+                Luke(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            r2 = r2,
+            luke = luke
+          )
         }
-        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
-          Luke(reader)
-        }
-        Data(
-          r2 = r2,
-          luke = luke
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -81,6 +82,9 @@ interface DroidDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -62,19 +61,26 @@ interface DroidDetails : GraphqlFragment {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -87,6 +93,7 @@ interface DroidDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -63,19 +62,26 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forDouble("height", "height", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -88,6 +94,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.fragments_with_type_condition_nullable.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -82,6 +83,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -124,6 +124,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -169,6 +172,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -231,6 +237,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -294,6 +303,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -330,6 +342,9 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -107,17 +107,23 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,19 +150,25 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,23 +207,30 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -250,23 +269,31 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val type = Hero_type.safeValueOf(readString(RESPONSE_FIELDS[1])!!)
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          type = type,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var type: Hero_type? = null
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> type = readString(RESPONSE_FIELDS[1])?.let { Hero_type.safeValueOf(it) }
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            type = type!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -287,17 +314,22 @@ class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variable
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -106,17 +106,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,19 +149,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,23 +206,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,21 +262,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -278,17 +304,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -123,6 +123,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -168,6 +171,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -230,6 +236,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -284,6 +293,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -320,6 +332,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -106,17 +106,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,19 +149,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,23 +206,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,21 +262,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -278,17 +304,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -123,6 +123,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -168,6 +171,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -230,6 +236,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -284,6 +293,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -320,6 +332,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -106,17 +106,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,19 +149,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,23 +206,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,21 +262,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -278,17 +304,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -123,6 +123,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -168,6 +171,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -230,6 +236,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -284,6 +293,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -320,6 +332,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -106,17 +106,23 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,19 +149,25 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,23 +206,30 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,21 +262,28 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -278,17 +304,22 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -123,6 +123,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -168,6 +171,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -230,6 +236,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -284,6 +293,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -320,6 +332,9 @@ class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Ope
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -116,19 +116,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -149,17 +156,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -136,6 +136,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -172,6 +175,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
@@ -157,6 +157,10 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroAVeryAVeryAVeryAVeryAVeryAVeryAV> =
+          ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -199,6 +203,9 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
@@ -135,21 +135,28 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
             "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroAVeryAVeryAVeryAVeryAVeryAVeryAV =
-          reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName
-            = readString(RESPONSE_FIELDS[1])!!
-        HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(
-          __typename = __typename,
-          nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName =
-              nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroAVeryAVeryAVeryAVeryAVeryAVeryAV {
+        return reader.run {
+          var __typename: String? = __typename
+          var
+              nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName:
+              String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(
+            __typename = __typename!!,
+            nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName
+                =
+                nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroAVeryAVeryAVeryAVeryAVeryAVeryAV> =
-          ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -176,18 +183,22 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
             true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val heroAVeryAVeryAVeryAVeryAVeryAVeryAV =
-            readObject<HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>(RESPONSE_FIELDS[0]) { reader ->
-          HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var heroAVeryAVeryAVeryAVeryAVeryAVeryAV: HeroAVeryAVeryAVeryAVeryAVeryAVeryAV? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> heroAVeryAVeryAVeryAVeryAVeryAVeryAV = readObject<HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>(RESPONSE_FIELDS[0]) { reader ->
+                HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            heroAVeryAVeryAVeryAVeryAVeryAVeryAV = heroAVeryAVeryAVeryAVeryAVeryAVeryAV
+          )
         }
-        Data(
-          heroAVeryAVeryAVeryAVeryAVeryAVeryAV = heroAVeryAVeryAVeryAVeryAVeryAVeryAV
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -149,6 +149,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -201,6 +204,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -129,19 +129,26 @@ data class TestQuery(
         ResponseField.forString("commentary", "commentary", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val stars = readInt(RESPONSE_FIELDS[1])!!
-        val commentary = readString(RESPONSE_FIELDS[2])
-        CreateReview(
-          __typename = __typename,
-          stars = stars,
-          commentary = commentary
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CreateReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var stars: Int? = null
+          var commentary: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> stars = readInt(RESPONSE_FIELDS[1])
+              2 -> commentary = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CreateReview(
+            __typename = __typename!!,
+            stars = stars!!,
+            commentary = commentary
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -178,17 +185,22 @@ data class TestQuery(
               "blue" to 1.0))), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-          CreateReview(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var createReview: CreateReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+                CreateReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            createReview = createReview
+          )
         }
-        Data(
-          createReview = createReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -131,6 +131,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -175,6 +178,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherNonOptionalHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -242,6 +248,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -111,19 +111,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forDouble("height", "height", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        Human(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Human(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -150,17 +157,24 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherNonOptionalHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherNonOptionalHero(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          OtherNonOptionalHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherNonOptionalHero(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherNonOptionalHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -184,11 +198,11 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): NonOptionalHero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): NonOptionalHero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          else -> OtherNonOptionalHero(reader)
+          "Human" -> Human(reader, typename)
+          else -> OtherNonOptionalHero(reader, typename)
         }
       }
     }
@@ -212,17 +226,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "episode" to "EMPIRE"), false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val nonOptionalHero = readObject<NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
-          NonOptionalHero(reader)
-        }!!
-        Data(
-          nonOptionalHero = nonOptionalHero
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var nonOptionalHero: NonOptionalHero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> nonOptionalHero = readObject<NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
+                NonOptionalHero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            nonOptionalHero = nonOptionalHero!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
@@ -174,19 +174,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CharacterDroidImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        CharacterDroidImpl(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CharacterDroidImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CharacterDroidImpl(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CharacterDroidImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -216,19 +223,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("homePlanet", "homePlanet", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CharacterHumanImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val homePlanet = readString(RESPONSE_FIELDS[2])
-        CharacterHumanImpl(
-          __typename = __typename,
-          name = name,
-          homePlanet = homePlanet
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CharacterHumanImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CharacterHumanImpl(
+            __typename = __typename!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CharacterHumanImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -246,15 +260,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherSearch = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherSearch(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherSearch(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherSearch> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -274,12 +293,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Search {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Search {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> CharacterDroidImpl(reader)
-          "Human" -> CharacterHumanImpl(reader)
-          else -> OtherSearch(reader)
+          "Droid" -> CharacterDroidImpl(reader, typename)
+          "Human" -> CharacterHumanImpl(reader, typename)
+          else -> OtherSearch(reader, typename)
         }
       }
     }
@@ -308,19 +327,24 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "text" to "bla-bla"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
-          reader.readObject<Search> { reader ->
-            Search(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var search: List<Search?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
+                reader.readObject<Search> { reader ->
+                  Search(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Data(
+            search = search
+          )
         }
-        Data(
-          search = search
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
@@ -194,6 +194,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CharacterDroidImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,6 +246,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CharacterHumanImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -274,6 +280,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherSearch> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -345,6 +354,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -124,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -169,6 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -222,6 +228,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -287,6 +296,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -323,6 +335,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -107,17 +107,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,19 +150,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -189,21 +201,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> edges = readList<Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -243,23 +261,32 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("profileLink", "profileLink", null, false, CustomType.URL, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        val profileLink = readCustomType<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomTypeField)!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection,
-          profileLink = profileLink
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          var profileLink: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              3 -> profileLink = readCustomType<Any>(RESPONSE_FIELDS[3] as
+                  ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!,
+            profileLink = profileLink!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -280,17 +307,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -124,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Bar> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -164,6 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherFoo> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -231,6 +237,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -104,19 +104,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("bar", "bar", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Bar = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val foo = readString(RESPONSE_FIELDS[1])!!
-        val bar = readString(RESPONSE_FIELDS[2])!!
-        Bar(
-          __typename = __typename,
-          foo = foo,
-          bar = bar
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Bar {
+        return reader.run {
+          var __typename: String? = __typename
+          var foo: String? = null
+          var bar: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> foo = readString(RESPONSE_FIELDS[1])
+              2 -> bar = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Bar(
+            __typename = __typename!!,
+            foo = foo!!,
+            bar = bar!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Bar> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -140,17 +147,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("foo", "foo", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherFoo = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val foo = readString(RESPONSE_FIELDS[1])!!
-        OtherFoo(
-          __typename = __typename,
-          foo = foo
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherFoo {
+        return reader.run {
+          var __typename: String? = __typename
+          var foo: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> foo = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherFoo(
+            __typename = __typename!!,
+            foo = foo!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherFoo> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -171,12 +184,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Foo {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Foo {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "BarObject" -> Bar(reader)
-          "FooBar" -> Bar(reader)
-          else -> OtherFoo(reader)
+          "BarObject" -> Bar(reader, typename)
+          "FooBar" -> Bar(reader, typename)
+          else -> OtherFoo(reader, typename)
         }
       }
     }
@@ -202,17 +215,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("foo", "foo", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val foo = readObject<Foo>(RESPONSE_FIELDS[0]) { reader ->
-          Foo(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var foo: Foo? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> foo = readObject<Foo>(RESPONSE_FIELDS[0]) { reader ->
+                Foo(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            foo = foo
+          )
         }
-        Data(
-          foo = foo
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -132,6 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -202,6 +205,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -245,6 +251,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -315,6 +324,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -358,6 +370,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -427,6 +442,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -113,19 +113,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("appearsIn", "appearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        Friend(
-          __typename = __typename,
-          appearsIn = appearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend {
+        return reader.run {
+          var __typename: String? = __typename
+          var appearsIn: List<Episode?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              else -> break
+            }
+          }
+          Friend(
+            __typename = __typename!!,
+            appearsIn = appearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -169,25 +175,33 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        val friends = readList<Friend>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readObject<Friend> { reader ->
-            Friend(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          var friends: List<Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              3 -> friends = readList<Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<Friend> { reader ->
+                  Friend(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Human(
+            __typename = __typename!!,
+            name = name!!,
+            height = height,
+            friends = friends
+          )
         }
-        Human(
-          __typename = __typename,
-          name = name,
-          height = height,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -214,17 +228,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        Friend1(
-          __typename = __typename,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          Friend1(
+            __typename = __typename!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -268,25 +288,33 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Droid = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readObject<Friend1> { reader ->
-            Friend1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Droid {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          var friends: List<Friend1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<Friend1> { reader ->
+                  Friend1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Droid(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction,
+            friends = friends
+          )
         }
-        Droid(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -313,17 +341,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherHero(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -349,12 +383,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          "Droid" -> Droid(reader)
-          else -> OtherHero(reader)
+          "Human" -> Human(reader, typename)
+          "Droid" -> Droid(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -377,17 +411,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -133,19 +133,26 @@ data class TestQuery(
         ResponseField.forString("commentary", "commentary", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val stars = readInt(RESPONSE_FIELDS[1])!!
-        val commentary = readString(RESPONSE_FIELDS[2])
-        CreateReview(
-          __typename = __typename,
-          stars = stars,
-          commentary = commentary
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CreateReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var stars: Int? = null
+          var commentary: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> stars = readInt(RESPONSE_FIELDS[1])
+              2 -> commentary = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CreateReview(
+            __typename = __typename!!,
+            stars = stars!!,
+            commentary = commentary
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -172,17 +179,22 @@ data class TestQuery(
             "variableName" to "review")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-          CreateReview(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var createReview: CreateReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+                CreateReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            createReview = createReview
+          )
         }
-        Data(
-          createReview = createReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -153,6 +153,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,6 +198,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -125,6 +125,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<QueryType> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -171,6 +174,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -234,6 +240,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<__Schema> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -280,6 +289,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<__Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -325,6 +337,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -108,17 +108,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): QueryType = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        QueryType(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): QueryType {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          QueryType(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<QueryType> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -148,17 +154,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Type = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        Type(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Type {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Type(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -196,25 +208,32 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("types", "types", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): __Schema = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val queryType = readObject<QueryType>(RESPONSE_FIELDS[1]) { reader ->
-          QueryType(reader)
-        }!!
-        val types = readList<Type>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Type> { reader ->
-            Type(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): __Schema {
+        return reader.run {
+          var __typename: String? = __typename
+          var queryType: QueryType? = null
+          var types: List<Type>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> queryType = readObject<QueryType>(RESPONSE_FIELDS[1]) { reader ->
+                QueryType(reader)
+              }
+              2 -> types = readList<Type>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Type> { reader ->
+                  Type(reader)
+                }
+              }?.map { it!! }
+              else -> break
+            }
           }
-        }!!.map { it!! }
-        __Schema(
-          __typename = __typename,
-          queryType = queryType,
-          types = types
-        )
+          __Schema(
+            __typename = __typename!!,
+            queryType = queryType!!,
+            types = types!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<__Schema> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -244,17 +263,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): __Type = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])
-        __Type(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): __Type {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          __Type(
+            __typename = __typename!!,
+            name = name
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<__Type> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -279,21 +304,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "name" to "Vehicle"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val __schema = readObject<__Schema>(RESPONSE_FIELDS[0]) { reader ->
-          __Schema(reader)
-        }!!
-        val __type = readObject<__Type>(RESPONSE_FIELDS[1]) { reader ->
-          __Type(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var __schema: __Schema? = null
+          var __type: __Type? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __schema = readObject<__Schema>(RESPONSE_FIELDS[0]) { reader ->
+                __Schema(reader)
+              }
+              1 -> __type = readObject<__Type>(RESPONSE_FIELDS[1]) { reader ->
+                __Type(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            __schema = __schema!!,
+            __type = __type
+          )
         }
-        Data(
-          __schema = __schema,
-          __type = __type
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -130,17 +130,23 @@ internal data class CreateReviewForEpisode(
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): ListOfListOfObject = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        ListOfListOfObject(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): ListOfListOfObject {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          ListOfListOfObject(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<ListOfListOfObject> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -229,45 +235,56 @@ internal data class CreateReviewForEpisode(
         ResponseField.forList("listOfListOfObject", "listOfListOfObject", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val stars = readInt(RESPONSE_FIELDS[1])!!
-        val commentary = readString(RESPONSE_FIELDS[2])
-        val listOfListOfString = readList<List<String>>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readList<String> { reader ->
-            reader.readString()
-          }.map { it!! }
-        }?.map { it!! }
-        val listOfListOfEnum = readList<List<Episode>>(RESPONSE_FIELDS[4]) { reader ->
-          reader.readList<Episode> { reader ->
-            Episode.safeValueOf(reader.readString())
-          }.map { it!! }
-        }?.map { it!! }
-        val listOfListOfCustom = readList<List<Date>>(RESPONSE_FIELDS[5]) { reader ->
-          reader.readList<Date> { reader ->
-            reader.readCustomType<Date>(CustomType.DATE)
-          }.map { it!! }
-        }?.map { it!! }
-        val listOfListOfObject = readList<List<ListOfListOfObject>>(RESPONSE_FIELDS[6]) { reader ->
-          reader.readList<ListOfListOfObject> { reader ->
-            reader.readObject<ListOfListOfObject> { reader ->
-              ListOfListOfObject(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CreateReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var stars: Int? = null
+          var commentary: String? = null
+          var listOfListOfString: List<List<String>>? = null
+          var listOfListOfEnum: List<List<Episode>>? = null
+          var listOfListOfCustom: List<List<Date>>? = null
+          var listOfListOfObject: List<List<ListOfListOfObject>>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> stars = readInt(RESPONSE_FIELDS[1])
+              2 -> commentary = readString(RESPONSE_FIELDS[2])
+              3 -> listOfListOfString = readList<List<String>>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readList<String> { reader ->
+                  reader.readString()
+                }.map { it!! }
+              }?.map { it!! }
+              4 -> listOfListOfEnum = readList<List<Episode>>(RESPONSE_FIELDS[4]) { reader ->
+                reader.readList<Episode> { reader ->
+                  Episode.safeValueOf(reader.readString())
+                }.map { it!! }
+              }?.map { it!! }
+              5 -> listOfListOfCustom = readList<List<Date>>(RESPONSE_FIELDS[5]) { reader ->
+                reader.readList<Date> { reader ->
+                  reader.readCustomType<Date>(CustomType.DATE)
+                }.map { it!! }
+              }?.map { it!! }
+              6 -> listOfListOfObject = readList<List<ListOfListOfObject>>(RESPONSE_FIELDS[6]) { reader ->
+                reader.readList<ListOfListOfObject> { reader ->
+                  reader.readObject<ListOfListOfObject> { reader ->
+                    ListOfListOfObject(reader)
+                  }
+                }.map { it!! }
+              }?.map { it!! }
+              else -> break
             }
-          }.map { it!! }
-        }?.map { it!! }
-        CreateReview(
-          __typename = __typename,
-          stars = stars,
-          commentary = commentary,
-          listOfListOfString = listOfListOfString,
-          listOfListOfEnum = listOfListOfEnum,
-          listOfListOfCustom = listOfListOfCustom,
-          listOfListOfObject = listOfListOfObject
-        )
+          }
+          CreateReview(
+            __typename = __typename!!,
+            stars = stars!!,
+            commentary = commentary,
+            listOfListOfString = listOfListOfString,
+            listOfListOfEnum = listOfListOfEnum,
+            listOfListOfCustom = listOfListOfCustom,
+            listOfListOfObject = listOfListOfObject
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -294,17 +311,22 @@ internal data class CreateReviewForEpisode(
             "variableName" to "review")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-          CreateReview(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var createReview: CreateReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+                CreateReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            createReview = createReview
+          )
         }
-        Data(
-          createReview = createReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -147,6 +147,9 @@ internal data class CreateReviewForEpisode(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<ListOfListOfObject> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -285,6 +288,9 @@ internal data class CreateReviewForEpisode(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -327,6 +333,9 @@ internal data class CreateReviewForEpisode(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -154,6 +154,9 @@ data class CreateReviewForEpisodeMutation(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -196,6 +199,9 @@ data class CreateReviewForEpisodeMutation(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -134,19 +134,26 @@ data class CreateReviewForEpisodeMutation(
         ResponseField.forString("commentary", "commentary", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CreateReview = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val stars = readInt(RESPONSE_FIELDS[1])!!
-        val commentary = readString(RESPONSE_FIELDS[2])
-        CreateReview(
-          __typename = __typename,
-          stars = stars,
-          commentary = commentary
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CreateReview {
+        return reader.run {
+          var __typename: String? = __typename
+          var stars: Int? = null
+          var commentary: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> stars = readInt(RESPONSE_FIELDS[1])
+              2 -> commentary = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CreateReview(
+            __typename = __typename!!,
+            stars = stars!!,
+            commentary = commentary
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CreateReview> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -173,17 +180,22 @@ data class CreateReviewForEpisodeMutation(
             "variableName" to "review")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-          CreateReview(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var createReview: CreateReview? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+                CreateReview(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            createReview = createReview
+          )
         }
-        Data(
-          createReview = createReview
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
@@ -90,8 +90,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val droidDetailsDelegate: DroidDetails
   ) : Hero, DroidDetails by droidDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): DroidDetailsImpl {
-        return DroidDetailsImpl(DroidDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetailsImpl {
+        return DroidDetailsImpl(DroidDetails(reader, __typename))
       }
     }
   }
@@ -103,8 +103,8 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
     val humanDetailsDelegate: HumanDetails
   ) : Hero, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl {
-        return HumanDetailsImpl(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl {
+        return HumanDetailsImpl(HumanDetails(reader, __typename))
       }
     }
   }
@@ -126,15 +126,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherHero(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -155,12 +160,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> DroidDetailsImpl(reader)
-          "Human" -> HumanDetailsImpl(reader)
-          else -> OtherHero(reader)
+          "Droid" -> DroidDetailsImpl(reader, typename)
+          "Human" -> HumanDetailsImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -183,17 +188,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
@@ -140,6 +140,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -204,6 +207,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
@@ -7,6 +7,7 @@ package com.example.named_fragment_delegate.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -92,6 +93,9 @@ interface DroidDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -160,6 +164,9 @@ interface DroidDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
@@ -7,7 +7,6 @@ package com.example.named_fragment_delegate.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -76,17 +75,23 @@ interface DroidDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Friend1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Friend1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -128,25 +133,33 @@ interface DroidDetails : GraphqlFragment {
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readObject<Friend1> { reader ->
-            Friend1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          var friends: List<Friend1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<Friend1> { reader ->
+                  Friend1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction,
+            friends = friends
+          )
         }
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -163,6 +176,7 @@ interface DroidDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): DroidDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): DroidDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.named_fragment_delegate.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.named_fragment_delegate.type.CustomType
@@ -106,17 +105,23 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -143,19 +148,25 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -186,21 +197,27 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> edges = readList<Edge1>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -241,23 +258,32 @@ interface HumanDetails : GraphqlFragment {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val profileLink = readCustomType<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          profileLink = profileLink,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var profileLink: Any? = null
+          var friendsConnection: FriendsConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> profileLink = readCustomType<Any>(RESPONSE_FIELDS[2] as
+                  ResponseField.CustomTypeField)
+              3 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            profileLink = profileLink!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -280,6 +306,7 @@ interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.named_fragment_delegate.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.named_fragment_delegate.type.CustomType
@@ -122,6 +123,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -167,6 +171,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -218,6 +225,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -284,6 +294,9 @@ interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -156,6 +156,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -199,6 +202,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherFriend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -290,6 +296,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -343,6 +352,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -386,6 +398,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherFriend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -477,6 +492,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -520,6 +538,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -592,6 +613,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -136,19 +136,26 @@ data class TestQuery(
           "unit" to "FOOT"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        Human1(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Human1(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -175,17 +182,23 @@ data class TestQuery(
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherFriend = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherFriend(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherFriend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherFriend(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherFriend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -209,11 +222,11 @@ data class TestQuery(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human1(reader)
-          else -> OtherFriend(reader)
+          "Human" -> Human1(reader, typename)
+          else -> OtherFriend(reader, typename)
         }
       }
     }
@@ -253,23 +266,30 @@ data class TestQuery(
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend> { reader ->
-            Friend(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend> { reader ->
+                  Friend(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Human(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
         }
-        Human(
-          __typename = __typename,
-          name = name,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -303,19 +323,26 @@ data class TestQuery(
           "unit" to "METER"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val height = readDouble(RESPONSE_FIELDS[2])
-        Human2(
-          __typename = __typename,
-          name = name,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Human2(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -342,17 +369,23 @@ data class TestQuery(
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherFriend1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherFriend1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherFriend1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherFriend1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherFriend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -376,11 +409,11 @@ data class TestQuery(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend1 {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend1 {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human2(reader)
-          else -> OtherFriend1(reader)
+          "Human" -> Human2(reader, typename)
+          else -> OtherFriend1(reader, typename)
         }
       }
     }
@@ -420,23 +453,30 @@ data class TestQuery(
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Droid = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend1> { reader ->
-            Friend1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Droid {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<Friend1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend1> { reader ->
+                  Friend1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Droid(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
         }
-        Droid(
-          __typename = __typename,
-          name = name,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -463,17 +503,23 @@ data class TestQuery(
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherHero(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -499,12 +545,12 @@ data class TestQuery(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          "Droid" -> Droid(reader)
-          else -> OtherHero(reader)
+          "Human" -> Human(reader, typename)
+          "Droid" -> Droid(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -530,17 +576,22 @@ data class TestQuery(
             "variableName" to "episode")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -111,19 +111,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)!!
-        Hero(
-          __typename = __typename,
-          name = name,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> id = readCustomType<String>(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,17 +151,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -131,6 +131,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -167,6 +170,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
@@ -119,6 +119,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Child> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -159,6 +162,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Parent> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -220,6 +226,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Tree> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -256,6 +265,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
@@ -102,17 +102,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Child = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Child(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Child {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Child(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Child> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -136,17 +142,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Parent = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Parent(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Parent {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Parent(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Parent> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -179,27 +191,35 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("parent", "parent", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Tree = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val children = readList<Child>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Child> { reader ->
-            Child(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Tree {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var children: List<Child>? = null
+          var parent: Parent? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> children = readList<Child>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Child> { reader ->
+                  Child(reader)
+                }
+              }?.map { it!! }
+              3 -> parent = readObject<Parent>(RESPONSE_FIELDS[3]) { reader ->
+                Parent(reader)
+              }
+              else -> break
+            }
           }
-        }!!.map { it!! }
-        val parent = readObject<Parent>(RESPONSE_FIELDS[3]) { reader ->
-          Parent(reader)
+          Tree(
+            __typename = __typename!!,
+            name = name!!,
+            children = children!!,
+            parent = parent
+          )
         }
-        Tree(
-          __typename = __typename,
-          name = name,
-          children = children,
-          parent = parent
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Tree> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -220,17 +240,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("tree", "tree", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val tree = readObject<Tree>(RESPONSE_FIELDS[0]) { reader ->
-          Tree(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var tree: Tree? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> tree = readObject<Tree>(RESPONSE_FIELDS[0]) { reader ->
+                Tree(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            tree = tree
+          )
         }
-        Data(
-          tree = tree
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -132,6 +132,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Yield_> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -175,6 +178,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Character> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -206,6 +212,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherObject> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -281,6 +290,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -112,19 +112,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Yield_ = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val it_ = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        Yield_(
-          __typename = __typename,
-          it_ = it_,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Yield_ {
+        return reader.run {
+          var __typename: String? = __typename
+          var it_: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> it_ = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Yield_(
+            __typename = __typename!!,
+            it_ = it_!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Yield_> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -151,17 +158,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Character = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Character(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Character {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Character(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Character> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -179,15 +192,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherObject = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherObject(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherObject {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherObject(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherObject> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -203,12 +221,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Object {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Object {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> Character(reader)
-          "Human" -> Character(reader)
-          else -> OtherObject(reader)
+          "Droid" -> Character(reader, typename)
+          "Human" -> Character(reader, typename)
+          else -> OtherObject(reader, typename)
         }
       }
     }
@@ -240,23 +258,29 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "text" to "abc"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val yield_ = readObject<Yield_>(RESPONSE_FIELDS[0]) { reader ->
-          Yield_(reader)
-        }
-        val objects = readList<Object>(RESPONSE_FIELDS[1]) { reader ->
-          reader.readObject<Object> { reader ->
-            Object(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var yield_: Yield_? = null
+          var objects: List<Object?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> yield_ = readObject<Yield_>(RESPONSE_FIELDS[0]) { reader ->
+                Yield_(reader)
+              }
+              1 -> objects = readList<Object>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<Object> { reader ->
+                  Object(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Data(
+            yield_ = yield_,
+            objects = objects
+          )
         }
-        Data(
-          yield_ = yield_,
-          objects = objects
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
@@ -105,17 +105,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Hero(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Hero(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -139,19 +145,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val hero = readObject<Hero>(RESPONSE_FIELDS[1]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var __typename: String? = __typename
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> hero = readObject<Hero>(RESPONSE_FIELDS[1]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            __typename = __typename!!,
+            hero = hero
+          )
         }
-        Data(
-          __typename = __typename,
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
@@ -122,6 +122,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -164,6 +167,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
@@ -7,6 +7,7 @@ package com.example.root_query_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -78,6 +79,9 @@ interface QueryFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Hero1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -120,6 +124,9 @@ interface QueryFragment : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
@@ -7,7 +7,6 @@ package com.example.root_query_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -62,17 +61,23 @@ interface QueryFragment : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Hero1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Hero1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Hero1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -96,19 +101,25 @@ interface QueryFragment : GraphqlFragment {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val hero = readObject<Hero1>(RESPONSE_FIELDS[1]) { reader ->
-          Hero1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var hero: Hero1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> hero = readObject<Hero1>(RESPONSE_FIELDS[1]) { reader ->
+                Hero1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            hero = hero
+          )
         }
-        DefaultImpl(
-          __typename = __typename,
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -123,6 +134,7 @@ interface QueryFragment : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): QueryFragment = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): QueryFragment =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -94,8 +94,8 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
     val heroDetailsDelegate: HeroDetails
   ) : Hero, HeroDetails by heroDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HeroDetailsImpl {
-        return HeroDetailsImpl(HeroDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetailsImpl {
+        return HeroDetailsImpl(HeroDetails(reader, __typename))
       }
     }
   }
@@ -120,18 +120,24 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailsHumanDetailsImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        HeroDetailsHumanDetailsImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          HeroDetailsHumanDetailsImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          HeroDetailsHumanDetailsImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
-          invoke(it) }
     }
   }
 
@@ -152,15 +158,20 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherHero(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -181,12 +192,12 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> HeroDetailsImpl(reader)
-          "Human" -> HeroDetailsHumanDetailsImpl(reader)
-          else -> OtherHero(reader)
+          "Droid" -> HeroDetailsImpl(reader, typename)
+          "Human" -> HeroDetailsHumanDetailsImpl(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -209,17 +220,22 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -138,6 +138,10 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<HeroDetailsHumanDetailsImpl> = ResponseFieldMapper {
+          invoke(it) }
     }
   }
 
@@ -172,6 +176,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -236,6 +243,9 @@ internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Varia
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -30,8 +29,8 @@ internal interface HeroDetails : GraphqlFragment {
     val humanDetailsDelegate: HumanDetails
   ) : DefaultImpl, HumanDetails by humanDetailsDelegate {
     companion object {
-      operator fun invoke(reader: ResponseReader): HumanDetailsImpl {
-        return HumanDetailsImpl(HumanDetails(reader))
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetailsImpl {
+        return HumanDetailsImpl(HumanDetails(reader, __typename))
       }
     }
   }
@@ -53,15 +52,20 @@ internal interface HeroDetails : GraphqlFragment {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherDefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherDefaultImpl(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherDefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherDefaultImpl(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -80,11 +84,11 @@ internal interface HeroDetails : GraphqlFragment {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> HumanDetailsImpl(reader)
-          else -> OtherDefaultImpl(reader)
+          "Human" -> HumanDetailsImpl(reader, typename)
+          else -> OtherDefaultImpl(reader, typename)
         }
       }
     }
@@ -98,6 +102,7 @@ internal interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -66,6 +67,9 @@ internal interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherDefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -7,7 +7,6 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -51,17 +50,23 @@ internal interface HumanDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -73,6 +78,7 @@ internal interface HumanDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HumanDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HumanDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -7,6 +7,7 @@ package com.example.simple_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -67,6 +68,9 @@ internal interface HumanDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -131,6 +131,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -183,6 +186,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -226,6 +232,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -295,6 +304,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -111,19 +111,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val height = readDouble(RESPONSE_FIELDS[1])
-        val name = readString(RESPONSE_FIELDS[2])!!
-        Human(
-          __typename = __typename,
-          height = height,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var height: Double? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> height = readDouble(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Human(
+            __typename = __typename!!,
+            height = height,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -156,19 +163,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Droid = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[1])
-        val name = readString(RESPONSE_FIELDS[2])!!
-        Droid(
-          __typename = __typename,
-          primaryFunction = primaryFunction,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Droid {
+        return reader.run {
+          var __typename: String? = __typename
+          var primaryFunction: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> primaryFunction = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Droid(
+            __typename = __typename!!,
+            primaryFunction = primaryFunction,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,17 +209,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherHero(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHero> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -231,12 +251,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          "Droid" -> Droid(reader)
-          else -> OtherHero(reader)
+          "Human" -> Human(reader, typename)
+          "Droid" -> Droid(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -259,17 +279,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -137,25 +137,33 @@ data class TestQuery(
         ResponseField.forList("coordinates", "coordinates", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Starship = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val coordinates = readList<List<Double>>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readList<Double> { reader ->
-            reader.readDouble()
-          }.map { it!! }
-        }?.map { it!! }
-        Starship(
-          __typename = __typename,
-          id = id,
-          name = name,
-          coordinates = coordinates
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Starship {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var coordinates: List<List<Double>>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> coordinates = readList<List<Double>>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readList<Double> { reader ->
+                  reader.readDouble()
+                }.map { it!! }
+              }?.map { it!! }
+              else -> break
+            }
+          }
+          Starship(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            coordinates = coordinates
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -179,17 +187,22 @@ data class TestQuery(
             "variableName" to "id")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val starship = readObject<Starship>(RESPONSE_FIELDS[0]) { reader ->
-          Starship(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var starship: Starship? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> starship = readObject<Starship>(RESPONSE_FIELDS[0]) { reader ->
+                Starship(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            starship = starship
+          )
         }
-        Data(
-          starship = starship
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -164,6 +164,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -203,6 +206,9 @@ data class TestQuery(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -128,19 +128,26 @@ data class TestSubscription(
         ResponseField.forString("content", "content", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): CommentAdded = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readInt(RESPONSE_FIELDS[1])!!
-        val content = readString(RESPONSE_FIELDS[2])!!
-        CommentAdded(
-          __typename = __typename,
-          id = id,
-          content = content
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): CommentAdded {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: Int? = null
+          var content: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readInt(RESPONSE_FIELDS[1])
+              2 -> content = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          CommentAdded(
+            __typename = __typename!!,
+            id = id!!,
+            content = content!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<CommentAdded> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -167,17 +174,22 @@ data class TestSubscription(
             "variableName" to "repo")), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val commentAdded = readObject<CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
-          CommentAdded(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var commentAdded: CommentAdded? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> commentAdded = readObject<CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
+                CommentAdded(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            commentAdded = commentAdded
+          )
         }
-        Data(
-          commentAdded = commentAdded
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -148,6 +148,9 @@ data class TestSubscription(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<CommentAdded> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -190,6 +193,9 @@ data class TestSubscription(
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -122,6 +122,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -174,6 +177,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -219,6 +225,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -105,17 +105,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): R2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        R2(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): R2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          R2(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -148,19 +154,26 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Luke = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        Luke(
-          __typename = __typename,
-          id = id,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Luke {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Luke(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -185,21 +198,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "episode" to "EMPIRE"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
-          R2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var r2: R2? = null
+          var luke: Luke? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+                R2(reader)
+              }
+              1 -> luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+                Luke(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            r2 = r2,
+            luke = luke
+          )
         }
-        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
-          Luke(reader)
-        }
-        Data(
-          r2 = r2,
-          luke = luke
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -107,17 +107,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -144,19 +150,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -195,23 +207,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -244,21 +263,28 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): R2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        R2(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): R2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          R2(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -285,17 +311,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -322,19 +354,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -373,23 +411,30 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -428,23 +473,31 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Luke = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        Luke(
-          __typename = __typename,
-          id = id,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Luke {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var friendsConnection: FriendsConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          Luke(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -469,21 +522,27 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "episode" to "EMPIRE"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
-          R2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var r2: R2? = null
+          var luke: Luke? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> r2 = readObject<R2>(RESPONSE_FIELDS[0]) { reader ->
+                R2(reader)
+              }
+              1 -> luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
+                Luke(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            r2 = r2,
+            luke = luke
+          )
         }
-        val luke = readObject<Luke>(RESPONSE_FIELDS[1]) { reader ->
-          Luke(reader)
-        }
-        Data(
-          r2 = r2,
-          luke = luke
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -124,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -169,6 +172,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -231,6 +237,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -285,6 +294,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<R2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -328,6 +340,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -373,6 +388,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -435,6 +453,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -498,6 +519,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Luke> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -543,6 +567,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
@@ -105,13 +105,22 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forDouble("height", "height", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val height = readDouble(RESPONSE_FIELDS[1])
-        Human(
-          __typename = __typename,
-          height = height
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> height = readDouble(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Human(
+            __typename = __typename!!,
+            height = height
+          )
+        }
       }
 
       @Suppress("FunctionName")
@@ -148,15 +157,25 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Droid = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[2])
-        Droid(
-          __typename = __typename,
-          name = name,
-          primaryFunction = primaryFunction
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Droid {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          Droid(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
       }
 
       @Suppress("FunctionName")
@@ -181,11 +200,19 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHero = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherHero(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherHero(
+            __typename = __typename!!
+          )
+        }
       }
 
       @Suppress("FunctionName")
@@ -210,12 +237,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Hero {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          "Droid" -> Droid(reader)
-          else -> OtherHero(reader)
+          "Human" -> Human(reader, typename)
+          "Droid" -> Droid(reader, typename)
+          else -> OtherHero(reader, typename)
         }
       }
     }
@@ -238,13 +265,21 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forObject("hero", "hero", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
-          Hero(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var hero: Hero? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> hero = readObject<Hero>(RESPONSE_FIELDS[0]) { reader ->
+                Hero(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            hero = hero
+          )
         }
-        Data(
-          hero = hero
-        )
       }
 
       @Suppress("FunctionName")

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -135,6 +135,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherSearch> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -205,6 +208,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -7,6 +7,7 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.union_fragment.type.CustomType
@@ -82,6 +83,9 @@ interface Character : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -7,7 +7,6 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.example.union_fragment.type.CustomType
@@ -63,19 +62,26 @@ interface Character : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        DefaultImpl(
-          __typename = __typename,
-          id = id,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -88,6 +94,7 @@ interface Character : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): Character = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): Character =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -7,6 +7,7 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -61,6 +62,9 @@ interface Starship : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -7,7 +7,6 @@ package com.example.union_fragment.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -45,17 +44,23 @@ interface Starship : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -67,6 +72,7 @@ interface Starship : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): Starship = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): Starship =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -124,6 +124,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -194,6 +197,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -237,6 +243,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -307,6 +316,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -350,6 +362,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherFriend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -453,6 +468,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Character> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -493,6 +511,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -524,6 +545,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherSearch> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -594,6 +618,9 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -107,17 +107,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val firstAppearsIn = Episode.safeValueOf(readString(RESPONSE_FIELDS[1])!!)
-        Friend1(
-          __typename = __typename,
-          firstAppearsIn = firstAppearsIn
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var firstAppearsIn: Episode? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> firstAppearsIn = readString(RESPONSE_FIELDS[1])?.let { Episode.safeValueOf(it) }
+              else -> break
+            }
+          }
+          Friend1(
+            __typename = __typename!!,
+            firstAppearsIn = firstAppearsIn!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -161,25 +167,33 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val homePlanet = readString(RESPONSE_FIELDS[1])
-        val friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend1> { reader ->
-            Friend1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var homePlanet: String? = null
+          var friends: List<Friend1?>? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> homePlanet = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend1> { reader ->
+                  Friend1(reader)
+                }
+              }
+              3 -> name = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
           }
+          Human(
+            __typename = __typename!!,
+            homePlanet = homePlanet,
+            friends = friends,
+            name = name!!
+          )
         }
-        val name = readString(RESPONSE_FIELDS[3])!!
-        Human(
-          __typename = __typename,
-          homePlanet = homePlanet,
-          friends = friends,
-          name = name
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -206,17 +220,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        Friend2(
-          __typename = __typename,
-          id = id
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              else -> break
+            }
+          }
+          Friend2(
+            __typename = __typename!!,
+            id = id!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -260,25 +280,33 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Droid = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val primaryFunction = readString(RESPONSE_FIELDS[1])
-        val friends = readList<Friend2>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend2> { reader ->
-            Friend2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Droid {
+        return reader.run {
+          var __typename: String? = __typename
+          var primaryFunction: String? = null
+          var friends: List<Friend2?>? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> primaryFunction = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend2>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend2> { reader ->
+                  Friend2(reader)
+                }
+              }
+              3 -> name = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
           }
+          Droid(
+            __typename = __typename!!,
+            primaryFunction = primaryFunction,
+            friends = friends,
+            name = name!!
+          )
         }
-        val name = readString(RESPONSE_FIELDS[3])!!
-        Droid(
-          __typename = __typename,
-          primaryFunction = primaryFunction,
-          friends = friends,
-          name = name
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Droid> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -305,17 +333,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherFriend = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        OtherFriend(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherFriend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          OtherFriend(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherFriend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -341,12 +375,12 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          "Droid" -> Droid(reader)
-          else -> OtherFriend(reader)
+          "Human" -> Human(reader, typename)
+          "Droid" -> Droid(reader, typename)
+          else -> OtherFriend(reader, typename)
         }
       }
     }
@@ -392,25 +426,33 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Character = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)!!
-        val name = readString(RESPONSE_FIELDS[2])!!
-        val friends = readList<Friend>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readObject<Friend> { reader ->
-            Friend(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Character {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var friends: List<Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readCustomType<String>(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField)
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<Friend> { reader ->
+                  Friend(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Character(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            friends = friends
+          )
         }
-        Character(
-          __typename = __typename,
-          id = id,
-          name = name,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Character> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -434,17 +476,23 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Starship = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Starship(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Starship {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Starship(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Starship> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -462,15 +510,20 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherSearch = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        OtherSearch(
-          __typename = __typename
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): OtherSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          OtherSearch(
+            __typename = __typename!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherSearch> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -488,13 +541,13 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Search {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Search {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Droid" -> Character(reader)
-          "Human" -> Character(reader)
-          "Starship" -> Starship(reader)
-          else -> OtherSearch(reader)
+          "Droid" -> Character(reader, typename)
+          "Human" -> Character(reader, typename)
+          "Starship" -> Starship(reader, typename)
+          else -> OtherSearch(reader, typename)
         }
       }
     }
@@ -523,19 +576,24 @@ class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
           "text" to "test"), true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
-          reader.readObject<Search> { reader ->
-            Search(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var search: List<Search?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> search = readList<Search>(RESPONSE_FIELDS[0]) { reader ->
+                reader.readObject<Search> { reader ->
+                  Search(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Data(
+            search = search
+          )
         }
-        Data(
-          search = search
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -126,6 +126,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -171,6 +174,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -233,6 +239,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -287,6 +296,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -364,6 +376,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -434,6 +449,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -477,6 +495,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -540,6 +561,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<OtherHeroDetailQuery> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -625,6 +649,9 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -109,17 +109,23 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -146,19 +152,25 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
-          Node(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node>(RESPONSE_FIELDS[1]) { reader ->
+                Node(reader)
+              }
+              else -> break
+            }
+          }
+          Edge(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -197,23 +209,30 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge> { reader ->
-            Edge(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge> { reader ->
+                  Edge(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -246,21 +265,28 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection(reader)
-        }!!
-        Friend1(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection(reader)
+              }
+              else -> break
+            }
+          }
+          Friend1(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -309,27 +335,35 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-          Episode.safeValueOf(reader.readString())
-        }!!
-        val friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
-          reader.readObject<Friend1> { reader ->
-            Friend1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          var friends: List<Friend1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              3 -> friends = readList<Friend1>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<Friend1> { reader ->
+                  Friend1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          Friend(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!,
+            friends = friends
+          )
         }
-        Friend(
-          __typename = __typename,
-          name = name,
-          appearsIn = appearsIn,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -373,25 +407,33 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forDouble("height", "height", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Human = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend> { reader ->
-            Friend(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Human {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<Friend?>? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend> { reader ->
+                  Friend(reader)
+                }
+              }
+              3 -> height = readDouble(RESPONSE_FIELDS[3])
+              else -> break
+            }
           }
+          Human(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends,
+            height = height
+          )
         }
-        val height = readDouble(RESPONSE_FIELDS[3])
-        Human(
-          __typename = __typename,
-          name = name,
-          friends = friends,
-          height = height
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Human> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -418,17 +460,23 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Friend2 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Friend2(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Friend2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Friend2(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Friend2> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -467,23 +515,31 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): OtherHeroDetailQuery = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friends = readList<Friend2>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Friend2> { reader ->
-            Friend2(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null):
+          OtherHeroDetailQuery {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<Friend2?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<Friend2>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Friend2> { reader ->
+                  Friend2(reader)
+                }
+              }
+              else -> break
+            }
           }
+          OtherHeroDetailQuery(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
         }
-        OtherHeroDetailQuery(
-          __typename = __typename,
-          name = name,
-          friends = friends
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<OtherHeroDetailQuery> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -526,11 +582,11 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): HeroDetailQuery1 {
-        val typename = reader.readString(RESPONSE_FIELDS[0])
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetailQuery1 {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
         return when(typename) {
-          "Human" -> Human(reader)
-          else -> OtherHeroDetailQuery(reader)
+          "Human" -> Human(reader, typename)
+          else -> OtherHeroDetailQuery(reader, typename)
         }
       }
     }
@@ -553,17 +609,22 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operat
         ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Data = reader.run {
-        val heroDetailQuery = readObject<HeroDetailQuery1>(RESPONSE_FIELDS[0]) { reader ->
-          HeroDetailQuery1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Data {
+        return reader.run {
+          var heroDetailQuery: HeroDetailQuery1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> heroDetailQuery = readObject<HeroDetailQuery1>(RESPONSE_FIELDS[0]) { reader ->
+                HeroDetailQuery1(reader)
+              }
+              else -> break
+            }
+          }
+          Data(
+            heroDetailQuery = heroDetailQuery
+          )
         }
-        Data(
-          heroDetailQuery = heroDetailQuery
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Data> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -7,6 +7,7 @@ package com.example.unique_type_name.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -121,6 +122,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -166,6 +170,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -226,6 +233,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -280,6 +290,9 @@ interface HeroDetails : GraphqlFragment {
           )
         }
       }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -7,7 +7,6 @@ package com.example.unique_type_name.fragment
 
 import com.apollographql.apollo.api.GraphqlFragment
 import com.apollographql.apollo.api.ResponseField
-import com.apollographql.apollo.api.internal.ResponseFieldMapper
 import com.apollographql.apollo.api.internal.ResponseFieldMarshaller
 import com.apollographql.apollo.api.internal.ResponseReader
 import kotlin.Array
@@ -105,17 +104,23 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Node1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        Node1(
-          __typename = __typename,
-          name = name
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Node1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
+            }
+          }
+          Node1(
+            __typename = __typename!!,
+            name = name!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Node1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -142,19 +147,25 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("node", "node", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): Edge1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
-          Node1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): Edge1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var node: Node1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> node = readObject<Node1>(RESPONSE_FIELDS[1]) { reader ->
+                Node1(reader)
+              }
+              else -> break
+            }
+          }
+          Edge1(
+            __typename = __typename!!,
+            node = node
+          )
         }
-        Edge1(
-          __typename = __typename,
-          node = node
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<Edge1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -191,23 +202,30 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val totalCount = readInt(RESPONSE_FIELDS[1])
-        val edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
-          reader.readObject<Edge1> { reader ->
-            Edge1(reader)
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): FriendsConnection1 {
+        return reader.run {
+          var __typename: String? = __typename
+          var totalCount: Int? = null
+          var edges: List<Edge1?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> totalCount = readInt(RESPONSE_FIELDS[1])
+              2 -> edges = readList<Edge1>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<Edge1> { reader ->
+                  Edge1(reader)
+                }
+              }
+              else -> break
+            }
           }
+          FriendsConnection1(
+            __typename = __typename!!,
+            totalCount = totalCount,
+            edges = edges
+          )
         }
-        FriendsConnection1(
-          __typename = __typename,
-          totalCount = totalCount,
-          edges = edges
-        )
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -240,21 +258,28 @@ interface HeroDetails : GraphqlFragment {
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      operator fun invoke(reader: ResponseReader): DefaultImpl = reader.run {
-        val __typename = readString(RESPONSE_FIELDS[0])!!
-        val name = readString(RESPONSE_FIELDS[1])!!
-        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
-          FriendsConnection1(reader)
-        }!!
-        DefaultImpl(
-          __typename = __typename,
-          name = name,
-          friendsConnection = friendsConnection
-        )
+      operator fun invoke(reader: ResponseReader, __typename: String? = null): DefaultImpl {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: FriendsConnection1? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection1(reader)
+              }
+              else -> break
+            }
+          }
+          DefaultImpl(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
       }
-
-      @Suppress("FunctionName")
-      fun Mapper(): ResponseFieldMapper<DefaultImpl> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -277,6 +302,7 @@ interface HeroDetails : GraphqlFragment {
         |}
         """.trimMargin()
 
-    operator fun invoke(reader: ResponseReader): HeroDetails = DefaultImpl(reader)
+    operator fun invoke(reader: ResponseReader, __typename: String? = null): HeroDetails =
+        DefaultImpl(reader, __typename)
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/Record.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/Record.kt
@@ -15,7 +15,7 @@ class Record internal constructor(
     val key: String,
     private val _fields: MutableMap<String, Any?>,
     mutationId: Uuid?
-) {
+): Map<String, Any?> by _fields {
 
   val fields: Map<String, Any?> get() = _fields
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
@@ -19,20 +19,16 @@ class RealResponseReader<R : Map<String, Any?>>(
     internal val scalarTypeAdapters: ScalarTypeAdapters,
     internal val resolveDelegate: ResolveDelegate<R>
 ) : ResponseReader {
-  private val responseRecordSetIterator = recordSet.iterator()
   private val variableValues: Map<String, Any?> = operationVariables.valueMap()
+  private var selectedFieldIndex = -1
 
   override fun selectField(fields: Array<ResponseField>): Int {
-    while (true)
-      if (responseRecordSetIterator.hasNext()) {
-        val (nextFieldName, _) = responseRecordSetIterator.next()
-        val fieldIndex = fields.indexOfFirst { field -> field.responseName == nextFieldName }
-        if (fieldIndex != -1 && !fields[fieldIndex].shouldSkip(variableValues)) {
-          return fieldIndex
-        }
-      } else {
-        return -1
+    while (++selectedFieldIndex < fields.size) {
+      if (!fields[selectedFieldIndex].shouldSkip(variableValues)) {
+        return selectedFieldIndex
       }
+    }
+    return -1
   }
 
   override fun readString(field: ResponseField): String? {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseReader.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.internal.response
 
+import com.apollographql.apollo.api.BigDecimal
 import com.apollographql.apollo.api.CustomTypeAdapter
 import com.apollographql.apollo.api.CustomTypeValue.Companion.fromRawValue
 import com.apollographql.apollo.api.Operation
@@ -48,7 +49,7 @@ class RealResponseReader<R: Map<String, Any?>>(
   }
 
   override fun readInt(field: ResponseField): Int? {
-    val value = fieldValueResolver.valueFor<Number>(recordSet, field)
+    val value = fieldValueResolver.valueFor<BigDecimal>(recordSet, field)
     checkValue(field, value)
     willResolve(field, value)
     if (value == null) {
@@ -61,7 +62,7 @@ class RealResponseReader<R: Map<String, Any?>>(
   }
 
   override fun readDouble(field: ResponseField): Double? {
-    val value = fieldValueResolver.valueFor<Number>(recordSet, field)
+    val value = fieldValueResolver.valueFor<BigDecimal>(recordSet, field)
     checkValue(field, value)
     willResolve(field, value)
     if (value == null) {
@@ -170,12 +171,12 @@ class RealResponseReader<R: Map<String, Any?>>(
 
     override fun readInt(): Int {
       resolveDelegate.didResolveScalar(value)
-      return (value as Number).toInt()
+      return (value as BigDecimal).toInt()
     }
 
     override fun readDouble(): Double {
       resolveDelegate.didResolveScalar(value)
-      return (value as Number).toDouble()
+      return (value as BigDecimal).toDouble()
     }
 
     override fun readBoolean(): Boolean {


### PR DESCRIPTION
- Introduce new API `selectField` to be used in feature implementation of stream reader
- Provide implementation to existing Map based readers
- Update code generation to parse response based on `selectField`

Part of #2523

The actual implementation of stream readers will be introduced in next PR.