### PR TITLE
Remove operation generic type argument for wrap data API.

### DIFF
--- a/apollo-android-support/src/main/kotlin/com/apollographql/apollo/ApolloCallback.kt
+++ b/apollo-android-support/src/main/kotlin/com/apollographql/apollo/ApolloCallback.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.internal.Utils.__checkNotNull
 import android.os.Looper
 import com.apollographql.apollo.ApolloCallback
 import com.apollographql.apollo.api.Response
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
@@ -18,10 +19,10 @@ import com.apollographql.apollo.exception.ApolloParseException
  * attached to the main looper. This behaviour is intentional as [ApolloHttpException] internally has a reference
  * to raw [okhttp3.Response] that must be closed on the background, otherwise it throws [ ] exception.
  */
-class ApolloCallback<T>(callback: ApolloCall.Callback<T>, handler: Handler) : ApolloCall.Callback<T>() {
-  val delegate: ApolloCall.Callback<T>
+class ApolloCallback<D: Operation.Data>(callback: ApolloCall.Callback<D>, handler: Handler) : ApolloCall.Callback<D>() {
+  val delegate: ApolloCall.Callback<D>
   private val handler: Handler
-  override fun onResponse(response: Response<T>) {
+  override fun onResponse(response: Response<D>) {
     handler.post { delegate.onResponse(response) }
   }
 
@@ -56,7 +57,7 @@ class ApolloCallback<T>(callback: ApolloCall.Callback<T>, handler: Handler) : Ap
      * @param callback original callback to delegates calls
      * @param handler  the callback will be run on the thread to which this handler is attached
      */
-    fun <T> wrap(callback: ApolloCall.Callback<T>, handler: Handler): ApolloCallback<T> {
+    fun <D: Operation.Data> wrap(callback: ApolloCall.Callback<D>, handler: Handler): ApolloCallback<D> {
       return ApolloCallback(callback, handler)
     }
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Mutation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Mutation.kt
@@ -3,4 +3,4 @@ package com.apollographql.apollo.api
 /**
  * Represents a GraphQL mutation operation that will be sent to the server.
  */
-interface Mutation<D : Operation.Data, T, V : Operation.Variables> : Operation<D, T, V>
+interface Mutation<D : Operation.Data, V : Operation.Variables> : Operation<D, V>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
@@ -17,7 +17,7 @@ import kotlin.jvm.JvmField
 /**
  * Represents a GraphQL operation (mutation or query).
  */
-interface Operation<D : Operation.Data, T, V : Operation.Variables> {
+interface Operation<D : Operation.Data, V : Operation.Variables> {
   /**
    * Returns the raw GraphQL operation String.
    */
@@ -34,12 +34,6 @@ interface Operation<D : Operation.Data, T, V : Operation.Variables> {
   fun responseFieldMapper(): ResponseFieldMapper<D>
 
   /**
-   * Wraps the generated response data class [D] with another class. For example, a use case for this would be to
-   * wrap the generated response data class in an Optional i.e. Optional.fromNullable(data).
-   */
-  fun wrapData(data: D?): T?
-
-  /**
    * Returns GraphQL operation name [OperationName].
    */
   fun name(): OperationName
@@ -53,25 +47,25 @@ interface Operation<D : Operation.Data, T, V : Operation.Variables> {
    * Parses GraphQL operation raw response from the [source] with provided [scalarTypeAdapters] and returns result [Response]
    */
   @Throws(IOException::class)
-  fun parse(source: BufferedSource, scalarTypeAdapters: ScalarTypeAdapters): Response<T>
+  fun parse(source: BufferedSource, scalarTypeAdapters: ScalarTypeAdapters): Response<D>
 
   /**
    * Parses GraphQL operation raw response from the [byteString] with provided [scalarTypeAdapters] and returns result [Response]
    */
   @Throws(IOException::class)
-  fun parse(byteString: ByteString, scalarTypeAdapters: ScalarTypeAdapters): Response<T>
+  fun parse(byteString: ByteString, scalarTypeAdapters: ScalarTypeAdapters): Response<D>
 
   /**
    * Parses GraphQL operation raw response from the [source] and returns result [Response]
    */
   @Throws(IOException::class)
-  fun parse(source: BufferedSource): Response<T>
+  fun parse(source: BufferedSource): Response<D>
 
   /**
    * Parses GraphQL operation raw response from the [byteString] and returns result [Response]
    */
   @Throws(IOException::class)
-  fun parse(byteString: ByteString): Response<T>
+  fun parse(byteString: ByteString): Response<D>
 
   /**
    * Composes POST JSON-encoded request body to be sent to the GraphQL server.

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
@@ -5,4 +5,4 @@ import okio.ByteString
 /**
  * Represents a GraphQL query that will be sent to the server.
  */
-interface Query<D : Operation.Data, T, V : Operation.Variables> : Operation<D, T, V>
+interface Query<D : Operation.Data, V : Operation.Variables> : Operation<D, V>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
@@ -1,22 +1,21 @@
 package com.apollographql.apollo.api
 
-import kotlin.js.JsName
 import kotlin.jvm.JvmStatic
 
 /**
  * Represents either a successful or failed response received from the GraphQL server.
  */
-data class Response<T>(
+data class Response<D : Operation.Data>(
     /**
      * GraphQL operation this response represents of
      */
-    val operation: Operation<*, *, *>,
+    val operation: Operation<*, *>,
 
     /**
      * Parsed response of GraphQL [operation] execution.
      * Can be `null` in case if [operation] execution failed.
      */
-    val data: T?,
+    val data: D?,
 
     /**
      * GraphQL [operation] execution errors returned by the server to let client know that something has gone wrong.
@@ -45,7 +44,7 @@ data class Response<T>(
     val executionContext: ExecutionContext = ExecutionContext.Empty
 ) {
 
-  constructor(builder: Builder<T>) : this(
+  constructor(builder: Builder<D>) : this(
       operation = builder.operation,
       data = builder.data,
       errors = builder.errors,
@@ -57,7 +56,7 @@ data class Response<T>(
 
   fun hasErrors(): Boolean = !errors.isNullOrEmpty()
 
-  fun toBuilder(): Builder<T> = Builder<T>(operation)
+  fun toBuilder(): Builder<D> = Builder<D>(operation)
       .data(data)
       .errors(errors)
       .dependentKeys(dependentKeys)
@@ -90,15 +89,15 @@ data class Response<T>(
     return result
   }
 
-  class Builder<T> internal constructor(internal val operation: Operation<*, *, *>) {
-    internal var data: T? = null
+  class Builder<D : Operation.Data> internal constructor(internal val operation: Operation<*, *>) {
+    internal var data: D? = null
     internal var errors: List<Error>? = null
     internal var dependentKeys: Set<String>? = null
     internal var fromCache: Boolean = false
     internal var extensions: Map<String, Any?>? = null
     internal var executionContext: ExecutionContext = ExecutionContext.Empty
 
-    fun data(data: T?) = apply {
+    fun data(data: D?) = apply {
       this.data = data
     }
 
@@ -122,12 +121,12 @@ data class Response<T>(
       this.executionContext = executionContext
     }
 
-    fun build(): Response<T> = Response(this)
+    fun build(): Response<D> = Response(this)
   }
 
   companion object {
 
     @JvmStatic
-    fun <T> builder(operation: Operation<*, *, *>): Builder<T> = Builder(operation)
+    fun <D : Operation.Data> builder(operation: Operation<*, *>): Builder<D> = Builder(operation)
   }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Subscription.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Subscription.kt
@@ -3,4 +3,4 @@ package com.apollographql.apollo.api
 /**
  * Represents a GraphQL subscription.
  */
-interface Subscription<D : Operation.Data, T, V : Operation.Variables> : Operation<D, T, V>
+interface Subscription<D : Operation.Data, V : Operation.Variables> : Operation<D, V>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/OperationRequestBodyComposer.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/OperationRequestBodyComposer.kt
@@ -12,7 +12,7 @@ object OperationRequestBodyComposer {
 
   @JvmStatic
   fun compose(
-      operation: Operation<*, *, *>,
+      operation: Operation<*, *>,
       autoPersistQueries: Boolean,
       withQueryDocument: Boolean,
       scalarTypeAdapters: ScalarTypeAdapters

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResolveDelegate.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResolveDelegate.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
 
 interface ResolveDelegate<R> {
-  fun willResolveRootQuery(operation: Operation<*, *, *>)
+  fun willResolveRootQuery(operation: Operation<*, *>)
   fun willResolve(field: ResponseField, variables: Operation.Variables, value: Any?)
   fun didResolve(field: ResponseField, variables: Operation.Variables)
   fun didResolveScalar(value: Any?)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
@@ -18,9 +18,9 @@ object SimpleOperationResponseParser {
   @Throws(IOException::class)
   fun <D : Operation.Data, W> parse(
       source: BufferedSource,
-      operation: Operation<D, W, *>,
+      operation: Operation<D, *>,
       scalarTypeAdapters: ScalarTypeAdapters
-  ): Response<W> {
+  ): Response<D> {
     return BufferedSourceJsonReader(source).use { jsonReader ->
       jsonReader.beginObject()
 
@@ -44,7 +44,7 @@ object SimpleOperationResponseParser {
 
       Response(
           operation = operation,
-          data = operation.wrapData(data),
+          data = data,
           errors = errors,
           extensions = extensions.orEmpty()
       )

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
@@ -16,7 +16,7 @@ object SimpleOperationResponseParser {
 
   @JvmStatic
   @Throws(IOException::class)
-  fun <D : Operation.Data, W> parse(
+  fun <D : Operation.Data> parse(
       source: BufferedSource,
       operation: Operation<D, *>,
       scalarTypeAdapters: ScalarTypeAdapters

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo.api
 import okio.BufferedSource
 import okio.ByteString
 
-val EMPTY_OPERATION: Operation<*, *, *> = object : Operation<Operation.Data, Any?, Operation.Variables> {
+val EMPTY_OPERATION: Operation<*, *> = object : Operation<Operation.Data, Operation.Variables> {
   override fun variables(): Operation.Variables {
     return Operation.EMPTY_VARIABLES
   }
@@ -16,7 +16,6 @@ val EMPTY_OPERATION: Operation<*, *, *> = object : Operation<Operation.Data, Any
 
   override fun queryDocument() = throw UnsupportedOperationException()
   override fun responseFieldMapper() = throw UnsupportedOperationException()
-  override fun wrapData(data: Operation.Data?) = throw UnsupportedOperationException()
   override fun parse(source: BufferedSource) = throw UnsupportedOperationException()
   override fun parse(source: BufferedSource, scalarTypeAdapters: ScalarTypeAdapters) = throw UnsupportedOperationException()
   override fun parse(byteString: ByteString) = throw UnsupportedOperationException()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/OperationType.kt
@@ -59,13 +59,6 @@ internal fun CodeGenerationAst.OperationType.typeSpec(targetPackage: String, gen
           .addCode("return QUERY_DOCUMENT")
           .build()
       )
-      .addFunction(FunSpec.builder("wrapData")
-          .addModifiers(KModifier.OVERRIDE)
-          .addParameter(ParameterSpec.builder("data", dataType.rootType.asTypeName().copy(nullable = true)).build())
-          .returns(dataType.rootType.asTypeName().copy(nullable = true))
-          .addCode("return data")
-          .build()
-      )
       .addFunction(FunSpec.builder("variables")
           .addModifiers(KModifier.OVERRIDE)
           .returns(Operation.Variables::class.asClassName())
@@ -145,7 +138,7 @@ private fun CodeGenerationAst.OperationType.superInterfaceType(targetPackage: St
     CodeGenerationAst.OperationType.Type.QUERY -> Query::class.asClassName()
     CodeGenerationAst.OperationType.Type.MUTATION -> Mutation::class.asClassName()
     CodeGenerationAst.OperationType.Type.SUBSCRIPTION -> Subscription::class.asClassName()
-  }.parameterizedBy(dataTypeName, dataTypeName, Operation.Variables::class.asClassName())
+  }.parameterizedBy(dataTypeName, Operation.Variables::class.asClassName())
 }
 
 private val CodeGenerationAst.OperationType.primaryConstructorSpec: FunSpec

--- a/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
@@ -38,7 +38,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val operation: Input<String> = Input.absent()
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -56,7 +56,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -43,7 +43,7 @@ data class TestQuery(
   val episode: Input<Episode> = Input.absent(),
   val stars: Int,
   val greenValue: Double
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -65,7 +65,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -45,7 +45,7 @@ data class TestQuery(
   val includeName: Boolean,
   val friendsCount: Int,
   val listOfListOfStringArgs: List<List<String?>>
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -77,7 +77,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -35,10 +35,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -40,7 +40,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val episode: Input<Episode> = Input.absent()
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -58,7 +58,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -41,7 +41,7 @@ import okio.IOException
 data class TestQuery(
   val withDetails: Boolean,
   val skipHumanDetails: Boolean
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -57,7 +57,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -39,7 +39,7 @@ import okio.IOException
 data class TestQuery(
   val withDetails: Boolean,
   val skipHumanDetails: Boolean
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -55,7 +55,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -39,7 +39,7 @@ import okio.IOException
 data class TestQuery(
   val includeName: Boolean,
   val skipFriends: Boolean
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -55,7 +55,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarships.kt
@@ -36,10 +36,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class AllStarships : Query<AllStarships.Data, AllStarships.Data, Operation.Variables> {
+class AllStarships : Query<AllStarships.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -36,10 +36,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -37,10 +37,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetails.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetails : Query<HeroDetails.Data, HeroDetails.Data, Operation.Variables> {
+class HeroDetails : Query<HeroDetails.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_guava/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_java_optional/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_nullable/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetailsQuery : Query<HeroDetailsQuery.Data, HeroDetailsQuery.Data, Operation.Variables> {
+class HeroDetailsQuery : Query<HeroDetailsQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -37,10 +37,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
@@ -42,7 +42,6 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
       Input<Episode> = Input.absent()
 ) :
     Query<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data,
-    TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data,
     Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
@@ -62,7 +61,6 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -39,7 +39,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val ep: Episode
-) : Mutation<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Mutation<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -53,7 +53,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -31,10 +31,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -35,10 +35,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -41,7 +41,7 @@ import okio.IOException
 data class TestQuery(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Mutation<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -57,7 +57,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -44,7 +44,7 @@ import okio.IOException
 internal data class CreateReviewForEpisode(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<CreateReviewForEpisode.Data, CreateReviewForEpisode.Data, Operation.Variables> {
+) : Mutation<CreateReviewForEpisode.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -60,7 +60,6 @@ internal data class CreateReviewForEpisode(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -41,8 +41,7 @@ import okio.IOException
 data class CreateReviewForEpisodeMutation(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<CreateReviewForEpisodeMutation.Data, CreateReviewForEpisodeMutation.Data,
-    Operation.Variables> {
+) : Mutation<CreateReviewForEpisodeMutation.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -58,7 +57,6 @@ data class CreateReviewForEpisodeMutation(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -41,7 +41,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val episode: Input<Episode> = Input.absent()
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -59,7 +59,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -33,10 +33,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -37,10 +37,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-internal class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+internal class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -40,7 +40,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val id: String
-) : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -54,7 +54,6 @@ data class TestQuery(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -38,7 +38,7 @@ import okio.IOException
     "RemoveRedundantQualifierName")
 data class TestSubscription(
   val repo: String
-) : Subscription<TestSubscription.Data, TestSubscription.Data, Operation.Variables> {
+) : Subscription<TestSubscription.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {
@@ -52,7 +52,6 @@ data class TestSubscription(
 
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = variables
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
@@ -32,10 +32,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -34,10 +34,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -36,10 +36,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetailQuery : Query<HeroDetailQuery.Data, HeroDetailQuery.Data, Operation.Variables> {
+class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
   override fun operationId(): String = OPERATION_ID
   override fun queryDocument(): String = QUERY_DOCUMENT
-  override fun wrapData(data: Data?): Data? = data
   override fun variables(): Operation.Variables = Operation.EMPTY_VARIABLES
   override fun name(): OperationName = OPERATION_NAME
   override fun responseFieldMapper(): ResponseFieldMapper<Data> = ResponseFieldMapper.invoke {

--- a/apollo-idling-resource/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
+++ b/apollo-idling-resource/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.java
@@ -44,7 +44,7 @@ public class ApolloIdlingResourceTest {
   private static final long TIME_OUT_SECONDS = 3;
   private static final String IDLING_RESOURCE_NAME = "apolloIdlingResource";
 
-  private static final Query<Operation.Data, Object, Operation.Variables> EMPTY_QUERY = new Query<Operation.Data, Object, Operation.Variables>() {
+  private static final Query<Operation.Data, Operation.Variables> EMPTY_QUERY = new Query<Operation.Data, Operation.Variables>() {
 
     OperationName operationName = new OperationName() {
       @Override public String name() {
@@ -68,10 +68,6 @@ public class ApolloIdlingResourceTest {
       };
     }
 
-    @Override public Object wrapData(Data data) {
-      return data;
-    }
-
     @NotNull @Override public OperationName name() {
       return operationName;
     }
@@ -84,11 +80,11 @@ public class ApolloIdlingResourceTest {
       return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
     }
 
-    @NotNull @Override public Response<Object> parse(@NotNull BufferedSource source, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
+    @NotNull @Override public Response<Operation.Data> parse(@NotNull BufferedSource source, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }
 
-    @NotNull @Override public Response<Object> parse(@NotNull BufferedSource source) {
+    @NotNull @Override public Response<Operation.Data> parse(@NotNull BufferedSource source) {
       throw new UnsupportedOperationException();
     }
 
@@ -99,7 +95,7 @@ public class ApolloIdlingResourceTest {
     @NotNull @Override public Response parse(@NotNull ByteString byteString, @NotNull ScalarTypeAdapters scalarTypeAdapters) {
       throw new UnsupportedOperationException();
     }
-    
+
     @NotNull @Override public ByteString composeRequestBody(@NotNull ScalarTypeAdapters scalarTypeAdapters) {
       return OperationRequestBodyComposer.compose(this, false, true, ScalarTypeAdapters.DEFAULT);
     }
@@ -170,8 +166,8 @@ public class ApolloIdlingResourceTest {
     idlingResource = ApolloIdlingResource.create(IDLING_RESOURCE_NAME, apolloClient);
     assertThat(idlingResource.isIdleNow()).isTrue();
 
-    apolloClient.query(EMPTY_QUERY).enqueue(new ApolloCall.Callback<Object>() {
-      @Override public void onResponse(@NotNull Response<Object> response) {
+    apolloClient.query(EMPTY_QUERY).enqueue(new ApolloCall.Callback<Operation.Data>() {
+      @Override public void onResponse(@NotNull Response<Operation.Data> response) {
         latch.countDown();
       }
 
@@ -206,8 +202,8 @@ public class ApolloIdlingResourceTest {
     idlingResource = ApolloIdlingResource.create(IDLING_RESOURCE_NAME, apolloClient);
     assertThat(idlingResource.isIdleNow()).isTrue();
 
-    apolloClient.query(EMPTY_QUERY).watcher().enqueueAndWatch(new ApolloCall.Callback<Object>() {
-      @Override public void onResponse(@NotNull Response<Object> response) {
+    apolloClient.query(EMPTY_QUERY).watcher().enqueueAndWatch(new ApolloCall.Callback<Operation.Data>() {
+      @Override public void onResponse(@NotNull Response<Operation.Data> response) {
         latch.countDown();
       }
 

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloCancelCallTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloCancelCallTest.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.Utils.immediateExecutor
 import com.apollographql.apollo.Utils.immediateExecutorService
 import com.apollographql.apollo.Utils.readFileToString
 import com.apollographql.apollo.api.Input.Companion.fromNullable
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.cache.http.ApolloHttpCache
 import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore
@@ -47,13 +48,13 @@ class ApolloCancelCallTest {
         .build()
   }
 
-  class TestableCallback<T> : ApolloCall.Callback<T>() {
+  class TestableCallback<D: Operation.Data> : ApolloCall.Callback<D>() {
     val lock = Object()
     var completed = false
-    val responses = mutableListOf<Response<T>>()
+    val responses = mutableListOf<Response<D>>()
     val errors = mutableListOf<ApolloException>()
 
-    override fun onResponse(response: Response<T>) {
+    override fun onResponse(response: Response<D>) {
       synchronized(lock) {
         responses.add(response)
       }

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloInterceptorChainTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloInterceptorChainTest.kt
@@ -150,7 +150,7 @@ class ApolloInterceptorChainTest {
         .message("Intercepted")
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build()
-    val apolloResponse = builder<EpisodeHeroNameQuery.Data?>(query).build()
+    val apolloResponse = builder<EpisodeHeroNameQuery.Data>(query).build()
     return InterceptorResponse(okHttpResponse,
         apolloResponse, emptyList())
   }

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloInterceptorTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloInterceptorTest.kt
@@ -206,7 +206,7 @@ class ApolloInterceptorTest {
         .message("Intercepted")
         .body(ResponseBody.create(MediaType.parse("text/plain; charset=utf-8"), "fakeResponse"))
         .build()
-    val apolloResponse = builder<EpisodeHeroNameQuery.Data?>(query).build()
+    val apolloResponse = builder<EpisodeHeroNameQuery.Data>(query).build()
     return InterceptorResponse(okHttpResponse,
         apolloResponse, emptyList())
   }

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloPrefetchTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloPrefetchTest.kt
@@ -76,7 +76,7 @@ class ApolloPrefetchTest {
         apolloClient
             .query(AllPlanetsQuery())
             .httpCachePolicy(HttpCachePolicy.CACHE_ONLY.expireAfter(2, TimeUnit.SECONDS)),
-        Predicate<Response<AllPlanetsQuery.Data?>> { dataResponse -> !dataResponse.hasErrors() }
+        Predicate<Response<AllPlanetsQuery.Data>> { dataResponse -> !dataResponse.hasErrors() }
     )
   }
 
@@ -94,7 +94,7 @@ class ApolloPrefetchTest {
         server,
         "HttpCacheTestAllPlanets.json",
         apolloClient.query(AllPlanetsQuery()),
-        Predicate<Response<AllPlanetsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<AllPlanetsQuery.Data>> { response -> !response.hasErrors() }
     )
   }
 

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
@@ -82,7 +82,7 @@ class ApolloWatcherTest {
         server,
         "EpisodeHeroNameResponseNameChange.json",
         apolloClient!!.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> !response.hasErrors() }
     )
     watcher.cancel()
     assertThat(heroNameList[0]).isEqualTo("R2-D2")
@@ -169,7 +169,7 @@ class ApolloWatcherTest {
         server,
         "HeroAndFriendsNameWithIdsNameChange.json",
         apolloClient!!.query(friendsQuery).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
-        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     watcher.cancel()
     assertThat(heroNameList[0]).isEqualTo("R2-D2")
@@ -289,7 +289,7 @@ class ApolloWatcherTest {
         server,
         "EpisodeHeroNameResponseNameChange.json",
         apolloClient!!.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> !response.hasErrors() }
     )
     assertThat(heroNameList[0]).isEqualTo("R2-D2")
     assertThat(heroNameList.size).isEqualTo(1)

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/IntegrationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/IntegrationTest.kt
@@ -113,7 +113,7 @@ class IntegrationTest {
     server.enqueue(mockResponse("ResponseError.json"))
     assertResponse(
         apolloClient!!.query(AllPlanetsQuery()),
-        Predicate<Response<AllPlanetsQuery.Data?>> { response ->
+        Predicate<Response<AllPlanetsQuery.Data>> { response ->
           assertThat(response.hasErrors()).isTrue()
           assertThat(response.errors).containsExactly(Error(
               "Cannot query field \"names\" on type \"Species\".", listOf(Error.Location(3, 5)), emptyMap<String, Any>()))
@@ -197,7 +197,7 @@ class IntegrationTest {
     server.enqueue(mockResponse("ResponseDataNull.json"))
     assertResponse(
         apolloClient!!.query(HeroNameQuery()),
-        Predicate<Response<HeroNameQuery.Data?>> { response ->
+        Predicate<Response<HeroNameQuery.Data>> { response ->
           assertThat(response.data).isNull()
           assertThat(response.hasErrors()).isFalse()
           true
@@ -320,7 +320,7 @@ class IntegrationTest {
     server.enqueue(httpResponse)
     assertResponse(
         apolloClient!!.query(AllPlanetsQuery()),
-        Predicate { response: Response<AllPlanetsQuery.Data?> ->
+        Predicate { response: Response<AllPlanetsQuery.Data> ->
           assertThat(response.executionContext[OkHttpExecutionContext.KEY]).isNotNull()
           assertThat(response.executionContext[OkHttpExecutionContext.KEY]!!.response).isNotNull()
           assertThat(response.executionContext[OkHttpExecutionContext.KEY]!!.response.headers().toString())
@@ -334,7 +334,7 @@ class IntegrationTest {
               )
           assertThat(response.executionContext[OkHttpExecutionContext.KEY]!!.response.body()).isNull()
           true
-        } as Predicate<Response<AllPlanetsQuery.Data?>>
+        } as Predicate<Response<AllPlanetsQuery.Data>>
     )
   }
 
@@ -344,10 +344,10 @@ class IntegrationTest {
   }
 
   @Throws(Exception::class)
-  private fun <T> enqueueCall(call: ApolloQueryCall<T>): List<ApolloCall.StatusEvent?> {
+  private fun <D: Operation.Data> enqueueCall(call: ApolloQueryCall<D>): List<ApolloCall.StatusEvent?> {
     val statusEvents: MutableList<ApolloCall.StatusEvent?> = ArrayList()
-    call.enqueue(object : ApolloCall.Callback<T>() {
-      override fun onResponse(response: Response<T>) {}
+    call.enqueue(object : ApolloCall.Callback<D>() {
+      override fun onResponse(response: Response<D>) {}
       override fun onFailure(e: ApolloException) {}
       override fun onStatusEvent(event: ApolloCall.StatusEvent) {
         statusEvents.add(event)
@@ -358,7 +358,7 @@ class IntegrationTest {
 
   companion object {
     private val DATE_FORMAT = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-    private fun <T> assertResponse(call: ApolloCall<T>, predicate: Predicate<Response<T>>) {
+    private fun <D: Operation.Data> assertResponse(call: ApolloCall<D>, predicate: Predicate<Response<D>>) {
       Rx2Apollo.from(call)
           .test()
           .assertValue(predicate)

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/NormalizedCacheTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/NormalizedCacheTestCase.kt
@@ -233,7 +233,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
@@ -251,11 +251,11 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient!!.query(CharacterDetailsQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterDetailsQuery.Data?>> { (_, data) ->
+        Predicate<Response<CharacterDetailsQuery.Data>> { (_, data) ->
           assertThat(data).isNull()
           true
         }
@@ -269,7 +269,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroNameResponse.json",
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response ->
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response ->
           assertThat(response.hasErrors()).isFalse()
           Truth.assertThat(response.data).isNotNull()
           true
@@ -291,7 +291,7 @@ class NormalizedCacheTestCase {
   fun cacheOnlyMissReturnsNullData() {
     assertResponse(
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { (_, data) -> data == null }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { (_, data) -> data == null }
     )
   }
 
@@ -302,7 +302,7 @@ class NormalizedCacheTestCase {
         server,
         "AllPlanetsNullableField.json",
         apolloClient!!.query(AllPlanetsQuery()).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
-        Predicate<Response<AllPlanetsQuery.Data?>> { response ->
+        Predicate<Response<AllPlanetsQuery.Data>> { response ->
           Truth.assertThat(response).isNotNull()
           assertThat(response.hasErrors()).isFalse()
           true
@@ -310,7 +310,7 @@ class NormalizedCacheTestCase {
     )
     assertResponse(
         apolloClient!!.query(AllPlanetsQuery()).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<AllPlanetsQuery.Data?>> { response ->
+        Predicate<Response<AllPlanetsQuery.Data>> { response ->
           Truth.assertThat(response).isNotNull()
           assertThat(response.hasErrors()).isFalse()
           true
@@ -346,7 +346,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsWithFragmentResponse.json",
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE))),
-        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     val heroWithFriendsFragment = apolloClient!!.apolloStore.read(
         HeroWithFriendsFragment.DefaultImpl.Mapper(),
@@ -395,25 +395,25 @@ class NormalizedCacheTestCase {
         server,
         "HeroNameResponse.json",
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> !response.isFromCache }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> !response.isFromCache }
     )
     enqueueAndAssertResponse(
         server,
         "HeroNameResponse.json",
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> !response.isFromCache }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> !response.isFromCache }
     )
     assertResponse(
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> response.isFromCache }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> response.isFromCache }
     )
     assertResponse(
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))).responseFetcher(ApolloResponseFetchers.CACHE_FIRST),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> response.isFromCache }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> response.isFromCache }
     )
     assertResponse(
         apolloClient!!.query(EpisodeHeroNameQuery(fromNullable(Episode.EMPIRE))).responseFetcher(ApolloResponseFetchers.NETWORK_FIRST),
-        Predicate<Response<EpisodeHeroNameQuery.Data?>> { response -> response.isFromCache }
+        Predicate<Response<EpisodeHeroNameQuery.Data>> { response -> response.isFromCache }
     )
   }
 
@@ -442,7 +442,7 @@ class NormalizedCacheTestCase {
     Truth.assertThat(apolloClient!!.apolloStore.remove(from("2001")).execute()).isTrue()
     assertResponse(
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response ->
+            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response ->
       assertThat(response.isFromCache).isTrue()
       assertThat(response.data).isNull()
       true
@@ -452,7 +452,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
@@ -466,7 +466,7 @@ class NormalizedCacheTestCase {
     Truth.assertThat(apolloClient!!.apolloStore.remove(from("1002")).execute()).isTrue()
     assertResponse(
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response ->
+            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response ->
       assertThat(response.isFromCache).isTrue()
       assertThat(response.data).isNull()
       true
@@ -474,7 +474,7 @@ class NormalizedCacheTestCase {
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true
@@ -528,7 +528,7 @@ class NormalizedCacheTestCase {
         .execute()).isEqualTo(2)
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1000")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true
@@ -536,7 +536,7 @@ class NormalizedCacheTestCase {
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true
@@ -558,7 +558,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsNameResponse.json",
         apolloClient!!.query(HeroAndFriendsDirectivesQuery(episode = Input.fromNullable(Episode.JEDI), includeName = true, skipFriends = false)),
-        Predicate<Response<HeroAndFriendsDirectivesQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsDirectivesQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient!!.query(HeroAndFriendsDirectivesQuery(episode = Input.fromNullable(Episode.JEDI), includeName = true, skipFriends = false)).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
@@ -599,7 +599,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroNameResponse.json",
         apolloClient.query(HeroAndFriendsDirectivesQuery(episode = Input.fromNullable(Episode.JEDI), includeName = true, skipFriends = true)),
-        Predicate<Response<HeroAndFriendsDirectivesQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsDirectivesQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient.query(HeroAndFriendsDirectivesQuery(episode = Input.fromNullable(Episode.JEDI), includeName = true, skipFriends = true)).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
@@ -611,7 +611,7 @@ class NormalizedCacheTestCase {
     )
     assertResponse(
         apolloClient.query(HeroAndFriendsDirectivesQuery( episode = Input.fromNullable(Episode.JEDI), includeName = true, skipFriends = false)).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<HeroAndFriendsDirectivesQuery.Data?>> { (_, data) ->
+        Predicate<Response<HeroAndFriendsDirectivesQuery.Data>> { (_, data) ->
           assertThat(data).isNull()
           true
         }
@@ -652,7 +652,7 @@ class NormalizedCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+            .responseFetcher(ApolloResponseFetchers.NETWORK_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     val dump = apolloClient.apolloStore.normalizedCache().dump()
     Truth.assertThat(prettifyDump(dump)).isEqualTo("""OptimisticNormalizedCache {}
@@ -732,7 +732,7 @@ LruNormalizedCache {
     assertThat(apolloClient!!.apolloStore.remove(from("2001"), true).execute()).isTrue()
     assertResponse(
         apolloClient!!.query(HeroAndFriendsNamesWithIDsQuery(fromNullable(Episode.NEWHOPE)))
-            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response ->
+            .responseFetcher(ApolloResponseFetchers.CACHE_ONLY), Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response ->
       assertThat(response.isFromCache).isTrue()
       assertThat(response.data).isNull()
       true
@@ -740,7 +740,7 @@ LruNormalizedCache {
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1000")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true
@@ -748,7 +748,7 @@ LruNormalizedCache {
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true
@@ -756,7 +756,7 @@ LruNormalizedCache {
     )
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1003")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
-        Predicate<Response<CharacterNameByIdQuery.Data?>> { response ->
+        Predicate<Response<CharacterNameByIdQuery.Data>> { response ->
           assertThat(response.isFromCache).isTrue()
           assertThat(response.data).isNull()
           true

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/OptimisticCacheTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/OptimisticCacheTestCase.kt
@@ -60,7 +60,7 @@ class OptimisticCacheTestCase {
         server,
         "HeroAndFriendsNameResponse.json",
         apolloClient!!.query(query),
-        Predicate<Response<HeroAndFriendsNamesQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesQuery.Data>> { response -> !response.hasErrors() }
     )
     val mutationId = UUID.randomUUID()
     val data = HeroAndFriendsNamesQuery.Data(HeroAndFriendsNamesQuery.Hero(
@@ -111,7 +111,7 @@ class OptimisticCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient!!.query(query1),
-        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     val data1 = HeroAndFriendsNamesWithIDsQuery.Data(
         HeroAndFriendsNamesWithIDsQuery.Hero(
@@ -151,7 +151,7 @@ class OptimisticCacheTestCase {
         server,
         "HeroNameWithIdResponse.json",
         apolloClient!!.query(query2),
-        Predicate<Response<HeroNameWithIdQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroNameWithIdQuery.Data>> { response -> !response.hasErrors() }
     )
     val data2 = HeroNameWithIdQuery.Data(HeroNameWithIdQuery.Hero(
         "Human",
@@ -231,7 +231,7 @@ class OptimisticCacheTestCase {
         server,
         "HeroNameWithEnumsResponse.json",
         apolloClient!!.query(HeroNameWithEnumsQuery()),
-        Predicate<Response<HeroNameWithEnumsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroNameWithEnumsQuery.Data>> { response -> !response.hasErrors() }
     )
     val mutationId = UUID.randomUUID()
     apolloClient!!.apolloStore.writeOptimisticUpdates(
@@ -262,12 +262,12 @@ class OptimisticCacheTestCase {
   @Throws(Exception::class)
   fun mutation_and_query_watcher() {
     server.enqueue(mockResponse("ReviewsEmpireEpisodeResponse.json"))
-    val watcherData: MutableList<ReviewsByEpisodeQuery.Data?> = ArrayList()
+    val watcherData: MutableList<ReviewsByEpisodeQuery.Data> = ArrayList()
     apolloClient!!.query(ReviewsByEpisodeQuery(Episode.EMPIRE)).responseFetcher(ApolloResponseFetchers.NETWORK_FIRST)
         .watcher().refetchResponseFetcher(ApolloResponseFetchers.CACHE_FIRST)
         .enqueueAndWatch(object : ApolloCall.Callback<ReviewsByEpisodeQuery.Data>() {
           override fun onResponse(response: Response<ReviewsByEpisodeQuery.Data>) {
-            watcherData.add(response.data)
+            watcherData.add(response.data!!)
           }
 
           override fun onFailure(e: ApolloException) {}
@@ -338,13 +338,13 @@ class OptimisticCacheTestCase {
         server,
         "HeroAndFriendsNameWithIdsResponse.json",
         apolloClient!!.query(query1),
-        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesWithIDsQuery.Data>> { response -> !response.hasErrors() }
     )
     enqueueAndAssertResponse(
         server,
         "HeroNameWithIdResponse.json",
         apolloClient!!.query(query2),
-        Predicate<Response<HeroNameWithIdQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroNameWithIdQuery.Data>> { response -> !response.hasErrors() }
     )
     val data1 = HeroAndFriendsNamesWithIDsQuery.Data(
         HeroAndFriendsNamesWithIDsQuery.Hero(

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.Utils.immediateExecutor
 import com.apollographql.apollo.Utils.immediateExecutorService
 import com.apollographql.apollo.api.Input.Companion.fromNullable
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.cache.CacheHeaders
 import com.apollographql.apollo.cache.normalized.CacheKey.Companion.from
 import com.apollographql.apollo.cache.normalized.CacheReference
@@ -240,7 +241,7 @@ class ResponseNormalizationTest {
   }
 
   @Throws(Exception::class)
-  private fun <T> assertHasNoErrors(mockResponse: String, query: Query<*, T, *>) {
+  private fun <D: Operation.Data> assertHasNoErrors(mockResponse: String, query: Query<D, *>) {
     enqueueAndAssertResponse(
         server,
         mockResponse,

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo.api.CustomTypeValue
 import com.apollographql.apollo.api.CustomTypeValue.GraphQLString
 import com.apollographql.apollo.api.Input.Companion.fromNullable
 import com.apollographql.apollo.api.Query
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.cache.normalized.CacheKey.Companion.from
 import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy
@@ -476,7 +477,7 @@ class ResponseWriteTestCase {
   }
 
   @Throws(Exception::class)
-  private fun <T> assertCachedQueryResponse(query: Query<*, T, *>, predicate: Predicate<Response<T>>) {
+  private fun <D: Operation.Data> assertCachedQueryResponse(query: Query<D, *>, predicate: Predicate<Response<D>>) {
     assertResponse(
         apolloClient!!.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
         predicate

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/Rx3ApolloTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/Rx3ApolloTest.kt
@@ -218,58 +218,6 @@ class Rx3ApolloTest {
         }
   }
 
-  @Test
-  fun disposingAnOperationDoesNotThrowUndeliverableException() {
-    /*
-     * A simple cache that will always throw errors
-     */
-    val cacheFactory = object: NormalizedCacheFactory<NormalizedCache>() {
-      override fun create(recordFieldAdapter: RecordFieldJsonAdapter): NormalizedCache {
-        return object: NormalizedCache() {
-          override fun clearAll() {
-            throw Exception("not implemented")
-          }
-
-          override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
-            throw Exception("not implemented")
-          }
-
-          override fun performMerge(apolloRecord: Record, oldRecord: Record?, cacheHeaders: CacheHeaders): Set<String> {
-            throw Exception("not implemented")
-          }
-
-          override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
-            throw Exception("not implemented")
-          }
-        }
-      }
-    }
-
-    val apolloClient = ApolloClient.builder()
-        .normalizedCache(cacheFactory)
-        .serverUrl("https://unused/")
-        .build()
-
-
-    val savedHandler = RxJavaPlugins.getErrorHandler()
-
-    var undeliverableException: Throwable? = null
-    RxJavaPlugins.setErrorHandler {
-      undeliverableException = it
-    }
-
-    val operation = apolloClient.apolloStore.write(EpisodeHeroNameQuery(Input.fromNullable(EMPIRE)), EpisodeHeroNameQuery.Data(EpisodeHeroNameQuery.Hero("", "")))
-    val testObserver = Rx3Apollo.from(operation)
-        .test()
-
-    testObserver.dispose()
-
-    // Since there is no cancellation mechanism for the ApolloStoreOperation, the only way to see if an error is thrown is to wait here
-    Thread.sleep(200)
-    Truth.assertThat(undeliverableException == null).isTrue()
-    RxJavaPlugins.setErrorHandler(savedHandler)
-  }
-
   companion object {
     private const val FILE_EPISODE_HERO_NAME_WITH_ID = "EpisodeHeroNameResponseWithId.json"
     private const val FILE_EPISODE_HERO_NAME_CHANGE = "EpisodeHeroNameResponseNameChange.json"

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/SendOperationIdentifiersTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/SendOperationIdentifiersTest.kt
@@ -82,7 +82,7 @@ class SendOperationIdentifiersTest {
         server,
         "HeroAndFriendsNameResponse.json",
         apolloClient.query(heroAndFriendsNamesQuery),
-        Predicate<Response<HeroAndFriendsNamesQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<HeroAndFriendsNamesQuery.Data>> { response -> !response.hasErrors() }
     )
     Truth.assertThat(applicationInterceptorHeader.get()).isTrue()
     Truth.assertThat(networkInterceptorHeader.get()).isTrue()

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/Utils.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/Utils.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo
 
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers.CACHE_ONLY
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers.NETWORK_ONLY
@@ -45,22 +46,22 @@ object Utils {
     return MockResponse().setChunkedBody(readFileToString(Utils::class.java, "/$fileName"), 32)
   }
 
-  fun <T> assertResponse(call: ApolloCall<T>, predicate: Predicate<Response<T>>) {
+  fun <D: Operation.Data> assertResponse(call: ApolloCall<D>, predicate: Predicate<Response<D>>) {
     Rx2Apollo.from(call)
         .test()
         .assertValue(predicate)
   }
 
   @Throws(Exception::class)
-  fun <T> enqueueAndAssertResponse(server: MockWebServer, mockResponse: String, call: ApolloCall<T>,
-                                   predicate: Predicate<Response<T>>) {
+  fun <D: Operation.Data> enqueueAndAssertResponse(server: MockWebServer, mockResponse: String, call: ApolloCall<D>,
+                                   predicate: Predicate<Response<D>>) {
     server.enqueue(mockResponse(mockResponse))
     assertResponse(call, predicate)
   }
 
   @Throws(Exception::class)
-  fun <T> cacheAndAssertCachedResponse(server: MockWebServer, mockResponse: String, call: ApolloQueryCall<T>,
-                                       predicate: Predicate<Response<T>>) {
+  fun <D: Operation.Data> cacheAndAssertCachedResponse(server: MockWebServer, mockResponse: String, call: ApolloQueryCall<D>,
+                                       predicate: Predicate<Response<D>>) {
     server.enqueue(mockResponse(mockResponse))
     assertResponse(
         call.responseFetcher(NETWORK_ONLY),

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/QueryRefetchTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/QueryRefetchTest.kt
@@ -90,7 +90,7 @@ class QueryRefetchTest {
         server!!,
         "ReviewsEmpireEpisodeResponse.json",
         apolloClient!!.query(ReviewsByEpisodeQuery(Episode.EMPIRE)).responseFetcher(ApolloResponseFetchers.NETWORK_FIRST),
-        Predicate<Response<ReviewsByEpisodeQuery.Data?>> { response -> !response.hasErrors() }
+        Predicate<Response<ReviewsByEpisodeQuery.Data>> { response -> !response.hasErrors() }
     )
     assertResponse(
         apolloClient!!.query(ReviewsByEpisodeQuery(Episode.EMPIRE)).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.kt
@@ -223,7 +223,7 @@ class ApolloServerInterceptorFileUploadTest {
     interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, requestHeaders, true, false)
   }
 
-  private fun assertDefaultRequestHeaders(request: Request, mutation: Operation<*, *, *>) {
+  private fun assertDefaultRequestHeaders(request: Request, mutation: Operation<*, *>) {
     Truth.assertThat(request.url()).isEqualTo(serverUrl)
     Truth.assertThat(request.method()).isEqualTo("POST")
     Truth.assertThat(request.header(ApolloServerInterceptor.HEADER_ACCEPT_TYPE)).isEqualTo(ApolloServerInterceptor.ACCEPT_TYPE)

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/subscription/SubscriptionNormalizedCacheTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/subscription/SubscriptionNormalizedCacheTest.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo.internal.subscription
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.ApolloSubscriptionCall
 import com.apollographql.apollo.IdFieldCacheKeyResolver
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import com.apollographql.apollo.cache.normalized.NormalizedCache
 import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy
@@ -247,13 +248,13 @@ private class MockSubscriptionTransport : SubscriptionTransport {
   }
 }
 
-private class SubscriptionManagerCallbackAdapter<T> : ApolloSubscriptionCall.Callback<T> {
-  var response: Response<T>? = null
+private class SubscriptionManagerCallbackAdapter<D: Operation.Data> : ApolloSubscriptionCall.Callback<D> {
+  var response: Response<D>? = null
   var completed = false
   var terminated = false
   var connected = false
 
-  override fun onResponse(response: Response<T>) {
+  override fun onResponse(response: Response<D>) {
     this.response = response
   }
 

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/CacheKeyResolver.kt
@@ -32,7 +32,7 @@ abstract class CacheKeyResolver {
 
     @JvmStatic
     @Suppress("UNUSED_PARAMETER")
-    fun rootKeyForOperation(operation: Operation<*, *, *>): CacheKey {
+    fun rootKeyForOperation(operation: Operation<*, *>): CacheKey {
       return ROOT_CACHE_KEY
     }
   }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ResponseNormalizer.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ResponseNormalizer.kt
@@ -28,7 +28,7 @@ abstract class ResponseNormalizer<R> : ResolveDelegate<R> {
     return dependentKeys
   }
 
-  override fun willResolveRootQuery(operation: Operation<*, *, *>) {
+  override fun willResolveRootQuery(operation: Operation<*, *>) {
     willResolveRecord(rootKeyForOperation(operation))
   }
 
@@ -131,7 +131,7 @@ abstract class ResponseNormalizer<R> : ResolveDelegate<R> {
   companion object {
     @JvmField
     val NO_OP_NORMALIZER: ResponseNormalizer<*> = object : ResponseNormalizer<Any?>() {
-      override fun willResolveRootQuery(operation: Operation<*, *, *>) {}
+      override fun willResolveRootQuery(operation: Operation<*, *>) {}
       override fun willResolve(field: ResponseField, variables: Operation.Variables, value: Any?) {}
       override fun didResolve(field: ResponseField, variables: Operation.Variables) {}
       override fun didResolveScalar(value: Any?) {}

--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
@@ -120,9 +120,9 @@ interface ApolloStore {
    * @param <V>       type of operation variables
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with cached data for specified operation
   </V></T></D> */
-  fun <D : Operation.Data, T, V : Operation.Variables> read(
-      operation: Operation<D, T, V>
-  ): ApolloStoreOperation<T>
+  fun <D : Operation.Data, V : Operation.Variables> read(
+      operation: Operation<D, V>
+  ): ApolloStoreOperation<D>
 
   /**
    * Read GraphQL operation response from store.
@@ -136,12 +136,12 @@ interface ApolloStore {
    * @param <V>                 type of operation variables
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with cached response for specified operation
   </V></T></D> */
-  fun <D : Operation.Data, T, V : Operation.Variables> read(
-      operation: Operation<D, T, V>,
+  fun <D : Operation.Data, V : Operation.Variables> read(
+      operation: Operation<D, V>,
       responseFieldMapper: ResponseFieldMapper<D>,
       responseNormalizer: ResponseNormalizer<Record>,
       cacheHeaders: CacheHeaders
-  ): ApolloStoreOperation<Response<T>>
+  ): ApolloStoreOperation<Response<D>>
 
   /**
    * Read GraphQL fragment from store.
@@ -169,8 +169,8 @@ interface ApolloStore {
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of [Record] which
    * have changed
   </V></T></D> */
-  fun <D : Operation.Data, T, V : Operation.Variables> write(
-      operation: Operation<D, T, V>,
+  fun <D : Operation.Data, V : Operation.Variables> write(
+      operation: Operation<D, V>,
       operationData: D
   ): ApolloStoreOperation<Set<String>>
 
@@ -184,8 +184,8 @@ interface ApolloStore {
    * @param <V>           type of operation variables
    * @return {@ApolloStoreOperation} to be performed
   </V></T></D> */
-  fun <D : Operation.Data, T, V : Operation.Variables> writeAndPublish(
-      operation: Operation<D, T, V>,
+  fun <D : Operation.Data, V : Operation.Variables> writeAndPublish(
+      operation: Operation<D, V>,
       operationData: D
   ): ApolloStoreOperation<Boolean>
 
@@ -228,8 +228,8 @@ interface ApolloStore {
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of [Record] which
    * have changed
    */
-  fun <D : Operation.Data, T, V : Operation.Variables> writeOptimisticUpdates(
-      operation: Operation<D, T, V>,
+  fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdates(
+      operation: Operation<D, V>,
       operationData: D,
       mutationId: UUID
   ): ApolloStoreOperation<Set<String>>
@@ -243,8 +243,8 @@ interface ApolloStore {
    * @param mutationId    mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed
    */
-  fun <D : Operation.Data, T, V : Operation.Variables> writeOptimisticUpdatesAndPublish(
-      operation: Operation<D, T, V>,
+  fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdatesAndPublish(
+      operation: Operation<D, V>,
       operationData: D,
       mutationId: UUID
   ): ApolloStoreOperation<Boolean>

--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/NoOpApolloStore.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/NoOpApolloStore.kt
@@ -80,17 +80,17 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     error("Cannot get cacheKeyResolver: no cache configured")
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> read(
-      operation: Operation<D, T, V>): ApolloStoreOperation<T> {
+  override fun <D : Operation.Data, V : Operation.Variables> read(
+      operation: Operation<D, V>): ApolloStoreOperation<D> {
     error("Cannot read operation: no cache configured")
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> read(
-      operation: Operation<D, T, V>, responseFieldMapper: ResponseFieldMapper<D>,
-      responseNormalizer: ResponseNormalizer<Record>, cacheHeaders: CacheHeaders): ApolloStoreOperation<Response<T>> {
+  override fun <D : Operation.Data, V : Operation.Variables> read(
+      operation: Operation<D, V>, responseFieldMapper: ResponseFieldMapper<D>,
+      responseNormalizer: ResponseNormalizer<Record>, cacheHeaders: CacheHeaders): ApolloStoreOperation<Response<D>> {
     // This is called in the default path when no cache is configured, do not trigger an error
     // Instead return an empty response. This will be seen as a cache MISS and the request will go to the network.
-    return emptyOperation(builder<T>(operation).build())
+    return emptyOperation(builder<D>(operation).build())
   }
 
   override fun <F : GraphqlFragment> read(fieldMapper: ResponseFieldMapper<F>,
@@ -98,14 +98,14 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     error("Cannot read fragment: no cache configured")
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> write(
-      operation: Operation<D, T, V>, operationData: D): ApolloStoreOperation<Set<String>> {
+  override fun <D : Operation.Data, V : Operation.Variables> write(
+      operation: Operation<D, V>, operationData: D): ApolloStoreOperation<Set<String>> {
     // Should we throw here instead?
     return emptyOperation(emptySet())
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> writeAndPublish(
-      operation: Operation<D, T, V>, operationData: D): ApolloStoreOperation<Boolean> {
+  override fun <D : Operation.Data, V : Operation.Variables> writeAndPublish(
+      operation: Operation<D, V>, operationData: D): ApolloStoreOperation<Boolean> {
     // Should we throw here instead?
     return emptyOperation(false)
   }
@@ -122,12 +122,12 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     return emptyOperation(false)
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> writeOptimisticUpdates(operation: Operation<D, T, V>, operationData: D, mutationId: UUID): ApolloStoreOperation<Set<String>> {
+  override fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdates(operation: Operation<D, V>, operationData: D, mutationId: UUID): ApolloStoreOperation<Set<String>> {
     // Should we throw here instead?
     return emptyOperation(emptySet())
   }
 
-  override fun <D : Operation.Data, T, V : Operation.Variables> writeOptimisticUpdatesAndPublish(operation: Operation<D, T, V>, operationData: D,
+  override fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdatesAndPublish(operation: Operation<D, V>, operationData: D,
                                                                                                  mutationId: UUID): ApolloStoreOperation<Boolean> {
     // Should we throw here instead?
     return emptyOperation(java.lang.Boolean.FALSE)

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
@@ -2,16 +2,17 @@ package com.apollographql.apollo
 
 import com.apollographql.apollo.api.ApolloExperimental
 import com.apollographql.apollo.api.ExecutionContext
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Response
 import kotlinx.coroutines.flow.Flow
 
-interface ApolloCall<T> {
+interface ApolloCall<D: Operation.Data> {
   @ApolloExperimental
-  fun execute(executionContext: ExecutionContext = ExecutionContext.Empty): Flow<Response<T>>
+  fun execute(executionContext: ExecutionContext = ExecutionContext.Empty): Flow<Response<D>>
 }
 
-interface ApolloQueryCall<T> : ApolloCall<T>
+interface ApolloQueryCall<D: Operation.Data> : ApolloCall<D>
 
-interface ApolloMutationCall<T> : ApolloCall<T>
+interface ApolloMutationCall<D: Operation.Data> : ApolloCall<D>
 
-interface ApolloSubscriptionCall<T> : ApolloCall<T>
+interface ApolloSubscriptionCall<D: Operation.Data> : ApolloCall<D>

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
@@ -27,19 +27,19 @@ class ApolloClient(
   private val coroutineDispatcherContext = executionContext[ApolloCoroutineDispatcherContext]
       ?: ApolloCoroutineDispatcherContext(Dispatchers.Default)
 
-  fun <D : Operation.Data, V : Operation.Variables> mutate(mutation: Mutation<D, D, V>): ApolloMutationCall<D> {
+  fun <D : Operation.Data, V : Operation.Variables> mutate(mutation: Mutation<D, V>): ApolloMutationCall<D> {
     return mutation.prepareCall()
   }
 
-  fun <D : Operation.Data, V : Operation.Variables> query(query: Query<D, D, V>): ApolloQueryCall<D> {
+  fun <D : Operation.Data, V : Operation.Variables> query(query: Query<D, V>): ApolloQueryCall<D> {
     return query.prepareCall()
   }
 
-  fun <D : Operation.Data, V : Operation.Variables> subscribe(query: Subscription<D, D, V>): ApolloQueryCall<D> {
+  fun <D : Operation.Data, V : Operation.Variables> subscribe(query: Subscription<D, V>): ApolloQueryCall<D> {
     return query.prepareCall()
   }
 
-  private fun <D : Operation.Data, V : Operation.Variables> Operation<D, D, V>.prepareCall(): RealApolloCall<D> {
+  private fun <D : Operation.Data, V : Operation.Variables> Operation<D, V>.prepareCall(): RealApolloCall<D> {
     return RealApolloCall(
         operation = this,
         scalarTypeAdapters = scalarTypeAdapters,

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/interceptor/ApolloRequest.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/interceptor/ApolloRequest.kt
@@ -8,7 +8,7 @@ import com.benasher44.uuid.uuid4
 
 @ApolloExperimental
 class ApolloRequest<D : Operation.Data>(
-    val operation: Operation<D, D, *>,
+    val operation: Operation<D, *>,
     val scalarTypeAdapters: ScalarTypeAdapters,
     val executionContext: ExecutionContext
 ) {

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/internal/RealApolloCall.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/internal/RealApolloCall.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.map
 @ApolloExperimental
 @ExperimentalCoroutinesApi
 class RealApolloCall<D : Operation.Data> constructor(
-    private val operation: Operation<D, D, *>,
+    private val operation: Operation<D, *>,
     private val scalarTypeAdapters: ScalarTypeAdapters,
     private val interceptors: List<ApolloRequestInterceptor>,
     private val executionContext: ExecutionContext

--- a/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockQuery.kt
+++ b/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockQuery.kt
@@ -12,7 +12,7 @@ import okio.BufferedSource
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 
-internal class MockQuery : Query<MockQuery.Data, MockQuery.Data, Operation.Variables> {
+internal class MockQuery : Query<MockQuery.Data, Operation.Variables> {
 
   override fun composeRequestBody(
       autoPersistQueries: Boolean,
@@ -43,8 +43,6 @@ internal class MockQuery : Query<MockQuery.Data, MockQuery.Data, Operation.Varia
   override fun responseFieldMapper(): ResponseFieldMapper<Data> {
     throw UnsupportedOperationException("Unsupported")
   }
-
-  override fun wrapData(data: Data?): Data? = data
 
   override fun name(): OperationName = object : OperationName {
     override fun name(): String = "MockQuery"

--- a/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockSubscription.kt
+++ b/apollo-runtime-kotlin/src/commonTest/kotlin/com/apollographql/apollo/mock/MockSubscription.kt
@@ -11,7 +11,7 @@ import okio.BufferedSource
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 
-internal class MockSubscription : Subscription<MockSubscription.Data, MockSubscription.Data, Operation.Variables> {
+internal class MockSubscription : Subscription<MockSubscription.Data, Operation.Variables> {
 
   override fun composeRequestBody(
       autoPersistQueries: Boolean,
@@ -41,8 +41,6 @@ internal class MockSubscription : Subscription<MockSubscription.Data, MockSubscr
   override fun responseFieldMapper(): ResponseFieldMapper<Data> {
     throw UnsupportedOperationException("Unsupported")
   }
-
-  override fun wrapData(data: Data?): Data? = data
 
   override fun name(): OperationName = object : OperationName {
     override fun name(): String = "MockSubscription"

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -22,14 +22,14 @@ import org.jetbrains.annotations.Nullable;
  * <p>In order to execute the request again, call the {@link ApolloCall#clone()} method which creates a new ApolloCall
  * object.</p>
  */
-public interface ApolloCall<T> extends Cancelable {
+public interface ApolloCall<D extends Operation.Data> extends Cancelable {
   /**
    * Schedules the request to be executed at some point in the future.
    *
    * @param callback Callback which will handle the response or a failure exception.
    * @throws IllegalStateException when the call has already been executed
    */
-  void enqueue(@Nullable Callback<T> callback);
+  void enqueue(@Nullable Callback<D> callback);
 
   /**
    * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
@@ -42,7 +42,7 @@ public interface ApolloCall<T> extends Cancelable {
    *                     defined in {@link ApolloCacheHeaders}.
    * @return The ApolloCall object with the provided {@link CacheHeaders}.
    */
-  @Deprecated @NotNull ApolloCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+  @Deprecated @NotNull ApolloCall<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
   /**
    * Creates a new, identical call to this one which can be enqueued or executed even if this call has already been.
@@ -51,14 +51,14 @@ public interface ApolloCall<T> extends Cancelable {
    *
    * @return The cloned ApolloCall object.
    */
-  @Deprecated @NotNull ApolloCall<T> clone();
+  @Deprecated @NotNull ApolloCall<D> clone();
 
   /**
    * Returns GraphQL operation this call executes
    *
    * @return {@link Operation}
    */
-  @NotNull Operation operation();
+  @NotNull Operation<D, ?> operation();
 
   /**
    * Cancels this {@link ApolloCall}. If the call was started with {@link #enqueue(Callback)}, the
@@ -67,10 +67,10 @@ public interface ApolloCall<T> extends Cancelable {
    */
   @Override void cancel();
 
-  @NotNull Builder<T> toBuilder();
+  @NotNull Builder<D> toBuilder();
 
-  interface Builder<T> {
-    @NotNull ApolloCall<T> build();
+  interface Builder<D extends Operation.Data> {
+    @NotNull ApolloCall<D> build();
 
     /**
      * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
@@ -81,13 +81,13 @@ public interface ApolloCall<T> extends Cancelable {
      *                     defined in {@link ApolloCacheHeaders}.
      * @return The builder
      */
-    @NotNull Builder<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+    @NotNull Builder<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
   }
 
   /**
    * Communicates responses from a server or offline requests.
    */
-  abstract class Callback<T> {
+  abstract class Callback<D extends Operation.Data> {
 
     /**
      * Gets called when GraphQL response is received and parsed successfully. Depending on the
@@ -96,7 +96,7 @@ public interface ApolloCall<T> extends Cancelable {
      *
      * @param response the GraphQL response
      */
-    public abstract void onResponse(@NotNull Response<T> response);
+    public abstract void onResponse(@NotNull Response<D> response);
 
     /**
      * Gets called when an unexpected exception occurs while creating the request or processing the response.

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -144,34 +144,34 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   }
 
   @Override
-  public <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
-      @NotNull Mutation<D, T, V> mutation) {
+  public <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
+      @NotNull Mutation<D, V> mutation) {
     return newCall(mutation).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
   }
 
   @Override
-  public <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
-      @NotNull Mutation<D, T, V> mutation, @NotNull D withOptimisticUpdates) {
+  public <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
+      @NotNull Mutation<D, V> mutation, @NotNull D withOptimisticUpdates) {
     checkNotNull(withOptimisticUpdates, "withOptimisticUpdate == null");
     return newCall(mutation).toBuilder().responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .optimisticUpdates(Optional.<Operation.Data>fromNullable(withOptimisticUpdates)).build();
   }
 
   @Override
-  public <D extends Query.Data, T, V extends Query.Variables> ApolloQueryCall<T> query(@NotNull Query<D, T, V> query) {
+  public <D extends Query.Data, V extends Query.Variables> ApolloQueryCall<D> query(@NotNull Query<D, V> query) {
     return newCall(query);
   }
 
   @Override
-  public <D extends Operation.Data, T, V extends Operation.Variables> ApolloPrefetch prefetch(
-      @NotNull Operation<D, T, V> operation) {
+  public <D extends Operation.Data, V extends Operation.Variables> ApolloPrefetch prefetch(
+      @NotNull Operation<D, V> operation) {
     return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, scalarTypeAdapters, dispatcher, logger,
         tracker);
   }
 
   @Override
-  public <D extends Subscription.Data, T, V extends Subscription.Variables> ApolloSubscriptionCall<T> subscribe(
-      @NotNull Subscription<D, T, V> subscription) {
+  public <D extends Subscription.Data, V extends Subscription.Variables> ApolloSubscriptionCall<D> subscribe(
+      @NotNull Subscription<D, V> subscription) {
     return new RealApolloSubscriptionCall<>(subscription, subscriptionManager, apolloStore, ApolloSubscriptionCall.CachePolicy.NO_CACHE,
         dispatcher, responseFieldMapperFactory, logger);
   }
@@ -342,9 +342,9 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
   }
 
-  private <D extends Operation.Data, T, V extends Operation.Variables> RealApolloCall<T> newCall(
-      @NotNull Operation<D, T, V> operation) {
-    return RealApolloCall.<T>builder()
+  private <D extends Operation.Data, V extends Operation.Variables> RealApolloCall<D> newCall(
+      @NotNull Operation<D, V> operation) {
+    return RealApolloCall.<D>builder()
         .operation(operation)
         .serverUrl(serverUrl)
         .httpCallFactory(httpCallFactory)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -1,6 +1,7 @@
 package com.apollographql.apollo;
 
 import com.apollographql.apollo.api.Mutation;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.cache.CacheHeaders;
@@ -13,7 +14,7 @@ import java.util.List;
 /**
  * A call prepared to execute GraphQL mutation operation.
  */
-public interface ApolloMutationCall<T> extends ApolloCall<T> {
+public interface ApolloMutationCall<D extends Operation.Data> extends ApolloCall<D> {
 
   /**
    * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
@@ -26,7 +27,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    *                     defined in {@link com.apollographql.apollo.cache.ApolloCacheHeaders}.
    * @return The ApolloCall object with the provided {@link CacheHeaders}.
    */
-  @Deprecated @NotNull @Override ApolloMutationCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+  @Deprecated @NotNull @Override ApolloMutationCall<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
   /**
    * <p>Sets a list of {@link ApolloQueryWatcher} query names to be re-fetched once this mutation completed.</p>
@@ -34,7 +35,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param operationNames array of {@link OperationName} query names to be re-fetched
    * @return {@link ApolloMutationCall} that will trigger re-fetching provided queries
    */
-  @Deprecated @NotNull ApolloMutationCall<T> refetchQueries(@NotNull OperationName... operationNames);
+  @Deprecated @NotNull ApolloMutationCall<D> refetchQueries(@NotNull OperationName... operationNames);
 
   /**
    * <p>Sets a list of {@link Query} to be re-fetched once this mutation completed.</p>
@@ -42,7 +43,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param queries array of {@link Query} to be re-fetched
    * @return {@link ApolloMutationCall} that will trigger re-fetching provided queries
    */
-  @Deprecated @NotNull ApolloMutationCall<T> refetchQueries(@NotNull Query... queries);
+  @Deprecated @NotNull ApolloMutationCall<D> refetchQueries(@NotNull Query... queries);
 
   /**
    * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
@@ -52,16 +53,16 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
    * @param requestHeaders The {@link RequestHeaders} to use for this request.
    * @return The ApolloCall object with the provided {@link RequestHeaders}.
    */
-  @Deprecated @NotNull ApolloMutationCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+  @Deprecated @NotNull ApolloMutationCall<D> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
-  @Deprecated @NotNull @Override ApolloMutationCall<T> clone();
+  @Deprecated @NotNull @Override ApolloMutationCall<D> clone();
 
-  @NotNull @Override ApolloMutationCall.Builder<T> toBuilder();
+  @NotNull @Override ApolloMutationCall.Builder<D> toBuilder();
 
-  interface Builder<T> extends ApolloCall.Builder<T> {
-    @NotNull @Override ApolloMutationCall<T> build();
+  interface Builder<D extends Operation.Data> extends ApolloCall.Builder<D> {
+    @NotNull @Override ApolloMutationCall<D> build();
 
-    @NotNull @Override Builder<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+    @NotNull @Override Builder<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
     /**
      * <p>Sets a list of {@link ApolloQueryWatcher} query names to be re-fetched once this mutation completed.</p>
@@ -69,7 +70,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
      * @param operationNames array of {@link OperationName} query names to be re-fetched
      * @return The Builder
      */
-    @NotNull Builder<T> refetchQueryNames(@NotNull List<OperationName> operationNames);
+    @NotNull Builder<D> refetchQueryNames(@NotNull List<OperationName> operationNames);
 
     /**
      * <p>Sets a list of {@link Query} to be re-fetched once this mutation completed.</p>
@@ -77,7 +78,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
      * @param queries array of {@link Query} to be re-fetched
      * @return The Builder
      */
-    @NotNull Builder<T> refetchQueries(@NotNull List<Query> queries);
+    @NotNull Builder<D> refetchQueries(@NotNull List<Query> queries);
 
     /**
      * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
@@ -87,7 +88,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
      * @param requestHeaders The {@link RequestHeaders} to use for this request.
      * @return The Builder
      */
-    @NotNull Builder<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+    @NotNull Builder<D> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
   }
   /**
@@ -100,8 +101,8 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
      * @param mutation the {@link Mutation} which needs to be performed
      * @return prepared {@link ApolloMutationCall} call to be executed at some point in the future
      */
-    <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
-        @NotNull Mutation<D, T, V> mutation);
+    <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
+        @NotNull Mutation<D, V> mutation);
 
     /**
      * <p>Creates and prepares a new {@link ApolloMutationCall} call with optimistic updates.</p>
@@ -114,7 +115,7 @@ public interface ApolloMutationCall<T> extends ApolloCall<T> {
      * @param withOptimisticUpdates optimistic updates for this mutation
      * @return prepared {@link ApolloMutationCall} call to be executed at some point in the future
      */
-    <D extends Mutation.Data, T, V extends Mutation.Variables> ApolloMutationCall<T> mutate(
-        @NotNull Mutation<D, T, V> mutation, @NotNull D withOptimisticUpdates);
+    <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
+        @NotNull Mutation<D, V> mutation, @NotNull D withOptimisticUpdates);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
@@ -112,8 +112,8 @@ public interface ApolloPrefetch extends Cancelable {
      * @param operation the operation which needs to be performed
      * @return The ApolloPrefetch object with the wrapped operation object
      */
-    <D extends Operation.Data, T, V extends Operation.Variables> ApolloPrefetch prefetch(
-        @NotNull Operation<D, T, V> operation);
+    <D extends Operation.Data, V extends Operation.Variables> ApolloPrefetch prefetch(
+        @NotNull Operation<D, V> operation);
 
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -1,5 +1,6 @@
 package com.apollographql.apollo;
 
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.OperationName;
 import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.api.cache.http.HttpCachePolicy;
@@ -11,14 +12,14 @@ import org.jetbrains.annotations.NotNull;
 /**
  * A call prepared to execute GraphQL query operation.
  */
-public interface ApolloQueryCall<T> extends ApolloCall<T> {
+public interface ApolloQueryCall<D extends Operation.Data> extends ApolloCall<D> {
   /**
    * Returns a watcher to watch the changes to the normalized cache records this query depends on or when mutation call
    * triggers to re-fetch this query after it completes via {@link ApolloMutationCall#refetchQueries(OperationName...)}
    *
    * @return {@link ApolloQueryWatcher}
    */
-  @NotNull ApolloQueryWatcher<T> watcher();
+  @NotNull ApolloQueryWatcher<D> watcher();
 
   /**
    * Sets the http cache policy for response/request cache.
@@ -28,7 +29,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    * @param httpCachePolicy {@link HttpCachePolicy.Policy} to set
    * @return {@link ApolloQueryCall} with the provided {@link HttpCachePolicy.Policy}
    */
-  @Deprecated @NotNull ApolloQueryCall<T> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
+  @Deprecated @NotNull ApolloQueryCall<D> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
 
   /**
    * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
@@ -41,7 +42,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    *                     defined in {@link com.apollographql.apollo.cache.ApolloCacheHeaders}.
    * @return The ApolloCall object with the provided {@link CacheHeaders}.
    */
-  @Deprecated @NotNull @Override ApolloQueryCall<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+  @Deprecated @NotNull @Override ApolloQueryCall<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
   /**
    * Sets the {@link ResponseFetcher} strategy for an ApolloCall object.
@@ -51,7 +52,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    * @param fetcher the {@link ResponseFetcher} to use.
    * @return The ApolloCall object with the provided CacheControl strategy
    */
-  @Deprecated @NotNull ApolloQueryCall<T> responseFetcher(@NotNull ResponseFetcher fetcher);
+  @Deprecated @NotNull ApolloQueryCall<D> responseFetcher(@NotNull ResponseFetcher fetcher);
 
   /**
    * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
@@ -63,14 +64,14 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
    * @param requestHeaders The {@link RequestHeaders} to use for this request.
    * @return The ApolloCall object with the provided {@link RequestHeaders}.
    */
-  @Deprecated @NotNull ApolloQueryCall<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+  @Deprecated @NotNull ApolloQueryCall<D> requestHeaders(@NotNull RequestHeaders requestHeaders);
 
-  @Deprecated @NotNull @Override ApolloQueryCall<T> clone();
+  @Deprecated @NotNull @Override ApolloQueryCall<D> clone();
 
-  @NotNull @Override Builder<T> toBuilder();
+  @NotNull @Override Builder<D> toBuilder();
 
-  interface Builder<T> extends ApolloCall.Builder<T> {
-    @NotNull @Override ApolloQueryCall<T> build();
+  interface Builder<D extends Operation.Data> extends ApolloCall.Builder<D> {
+    @NotNull @Override ApolloQueryCall<D> build();
 
     /**
      * Sets the {@link CacheHeaders} to use for this call. {@link com.apollographql.apollo.interceptor.FetchOptions} will
@@ -81,7 +82,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
      *                     defined in {@link com.apollographql.apollo.cache.ApolloCacheHeaders}.
      * @return The ApolloCall object with the provided {@link CacheHeaders}.
      */
-    @NotNull @Override Builder<T> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
+    @NotNull @Override Builder<D> cacheHeaders(@NotNull CacheHeaders cacheHeaders);
 
     /**
      * Sets the http cache policy for response/request cache.
@@ -89,7 +90,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
      * @param httpCachePolicy {@link HttpCachePolicy.Policy} to set
      * @return {@link ApolloQueryCall} with the provided {@link HttpCachePolicy.Policy}
      */
-    @NotNull Builder<T> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
+    @NotNull Builder<D> httpCachePolicy(@NotNull HttpCachePolicy.Policy httpCachePolicy);
 
     /**
      * Sets the {@link ResponseFetcher} strategy for an ApolloCall object.
@@ -97,7 +98,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
      * @param fetcher the {@link ResponseFetcher} to use.
      * @return The ApolloCall object with the provided CacheControl strategy
      */
-    @NotNull Builder<T> responseFetcher(@NotNull ResponseFetcher fetcher);
+    @NotNull Builder<D> responseFetcher(@NotNull ResponseFetcher fetcher);
 
     /**
      * Sets the {@link RequestHeaders} to use for this call. These headers will be added to the HTTP request when
@@ -107,7 +108,7 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
      * @param requestHeaders The {@link RequestHeaders} to use for this request.
      * @return The Builder
      */
-    @NotNull Builder<T> requestHeaders(@NotNull RequestHeaders requestHeaders);
+    @NotNull Builder<D> requestHeaders(@NotNull RequestHeaders requestHeaders);
   }
 
   /**
@@ -120,6 +121,6 @@ public interface ApolloQueryCall<T> extends ApolloCall<T> {
      * @param query the operation which needs to be performed
      * @return prepared {@link ApolloQueryCall} call to be executed at some point in the future
      */
-    <D extends Query.Data, T, V extends Query.Variables> ApolloQueryCall<T> query(@NotNull Query<D, T, V> query);
+    <D extends Query.Data, V extends Query.Variables> ApolloQueryCall<D> query(@NotNull Query<D, V> query);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryWatcher.java
@@ -1,21 +1,22 @@
 package com.apollographql.apollo;
 
 import com.apollographql.apollo.api.Operation;
+import com.apollographql.apollo.api.Query;
 import com.apollographql.apollo.fetcher.ResponseFetcher;
 import com.apollographql.apollo.internal.util.Cancelable;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public interface ApolloQueryWatcher<T> extends Cancelable {
+public interface ApolloQueryWatcher<D extends Operation.Data> extends Cancelable {
 
-  ApolloQueryWatcher<T> enqueueAndWatch(@Nullable ApolloCall.Callback<T> callback);
+  ApolloQueryWatcher<D> enqueueAndWatch(@Nullable ApolloCall.Callback<D> callback);
 
   /**
    * @param fetcher The {@link ResponseFetcher} to use when the call is refetched due to a field changing in the
    * cache.
    */
-  @NotNull ApolloQueryWatcher<T> refetchResponseFetcher(@NotNull ResponseFetcher fetcher);
+  @NotNull ApolloQueryWatcher<D> refetchResponseFetcher(@NotNull ResponseFetcher fetcher);
 
   /**
    * Returns GraphQL watched operation.
@@ -41,5 +42,5 @@ public interface ApolloQueryWatcher<T> extends Cancelable {
    *
    * @return The cloned ApolloQueryWatcher object.
    */
-  @NotNull ApolloQueryWatcher<T> clone();
+  @NotNull ApolloQueryWatcher<D> clone();
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>In order to execute the request again, call the {@link ApolloSubscriptionCall#clone()} method which creates a new
  * {@code ApolloSubscriptionCall} object.</p>
  */
-public interface ApolloSubscriptionCall<T> extends Cancelable {
+public interface ApolloSubscriptionCall<D extends Subscription.Data> extends Cancelable {
 
   /**
    * Sends {@link Subscription} to the subscription server and starts listening for the pushed updates. To cancel this
@@ -26,14 +26,14 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
    * @throws ApolloCanceledException when the call has already been canceled
    * @throws IllegalStateException   when the call has already been executed
    */
-  void execute(@NotNull Callback<T> callback);
+  void execute(@NotNull Callback<D> callback);
 
   /**
    * Creates a new, identical call to this one which can be executed even if this call has already been.
    *
    * @return The cloned {@code ApolloSubscriptionCall} object.
    */
-  ApolloSubscriptionCall<T> clone();
+  ApolloSubscriptionCall<D> clone();
 
   /**
    * Sets the cache policy for response/request cache.
@@ -41,7 +41,7 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
    * @param cachePolicy {@link CachePolicy} to set
    * @return {@link ApolloSubscriptionCall} with the provided {@link CachePolicy}
    */
-  @NotNull ApolloSubscriptionCall<T> cachePolicy(@NotNull CachePolicy cachePolicy);
+  @NotNull ApolloSubscriptionCall<D> cachePolicy(@NotNull CachePolicy cachePolicy);
 
   /**
    * Factory for creating {@link ApolloSubscriptionCall} calls.
@@ -53,8 +53,8 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
      * @param subscription to be sent to the subscription server to start listening pushed updates
      * @return prepared {@link ApolloSubscriptionCall} call to be executed
      */
-    <D extends Subscription.Data, T, V extends Subscription.Variables> ApolloSubscriptionCall<T> subscribe(
-        @NotNull Subscription<D, T, V> subscription);
+    <D extends Subscription.Data, V extends Subscription.Variables> ApolloSubscriptionCall<D> subscribe(
+        @NotNull Subscription<D, V> subscription);
   }
 
   /**
@@ -80,7 +80,7 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
   /**
    * Communicates responses from a subscription server.
    */
-  interface Callback<T> {
+  interface Callback<D extends Subscription.Data> {
 
     /**
      * Gets called when GraphQL response is received and parsed successfully. This may be called multiple times. {@link
@@ -88,7 +88,7 @@ public interface ApolloSubscriptionCall<T> extends Cancelable {
      *
      * @param response the GraphQL response
      */
-    void onResponse(@NotNull Response<T> response);
+    void onResponse(@NotNull Response<D> response);
 
     /**
      * Gets called when an unexpected exception occurs while creating the request or processing the response. Will be

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
@@ -131,7 +131,7 @@ public class ApolloAutoPersistedOperationInterceptor implements ApolloIntercepto
       this(false, true, true);
     }
 
-    @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?, ?, ?> operation) {
+    @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?, ?> operation) {
       if (operation instanceof Query && !persistQueries) {
         return null;
       }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
@@ -12,5 +12,5 @@ interface ApolloInterceptorFactory {
    *
    * @return the interceptor or null if no interceptor is needed for this operation
    */
-  fun newInterceptor(logger: ApolloLogger, operation: Operation<*, *, *>): ApolloInterceptor?
+  fun newInterceptor(logger: ApolloLogger, operation: Operation<*, *>): ApolloInterceptor?
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.kt
@@ -73,7 +73,7 @@ class ApolloServerInterceptor(
     callBack.onFetch(FetchSourceType.NETWORK)
     val httpCall: Call
     httpCall = try {
-      if (request.useHttpGetMethodForQueries && request.operation is Query<*, *, *>) {
+      if (request.useHttpGetMethodForQueries && request.operation is Query<*, *>) {
         httpGetCall(request.operation, request.cacheHeaders, request.requestHeaders,
             request.sendQueryDocument, request.autoPersistQueries)
       } else {
@@ -111,7 +111,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun httpGetCall(operation: Operation<*, *, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
+  fun httpGetCall(operation: Operation<*, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
                   writeQueryDocument: Boolean, autoPersistQueries: Boolean): Call {
     val requestBuilder = Request.Builder()
         .url(httpGetUrl(serverUrl, operation, scalarTypeAdapters, writeQueryDocument, autoPersistQueries))
@@ -121,7 +121,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun httpPostCall(operation: Operation<*, *, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
+  fun httpPostCall(operation: Operation<*, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
                    writeQueryDocument: Boolean, autoPersistQueries: Boolean): Call {
     var requestBody = RequestBody.create(MEDIA_TYPE, httpPostRequestBody(operation, scalarTypeAdapters,
         writeQueryDocument, autoPersistQueries))
@@ -135,7 +135,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun decorateRequest(requestBuilder: Request.Builder, operation: Operation<*, *, *>, cacheHeaders: CacheHeaders,
+  fun decorateRequest(requestBuilder: Request.Builder, operation: Operation<*, *>, cacheHeaders: CacheHeaders,
                       requestHeaders: RequestHeaders) {
     requestBuilder
         .header(HEADER_ACCEPT_TYPE, ACCEPT_TYPE)
@@ -171,18 +171,18 @@ class ApolloServerInterceptor(
     val MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8")
 
     @Throws(IOException::class)
-    fun cacheKey(operation: Operation<*, *, *>, scalarTypeAdapters: ScalarTypeAdapters?): String {
+    fun cacheKey(operation: Operation<*, *>, scalarTypeAdapters: ScalarTypeAdapters?): String {
       return httpPostRequestBody(operation, scalarTypeAdapters, true, true).md5().hex()
     }
 
     @Throws(IOException::class)
-    fun httpPostRequestBody(operation: Operation<*, *, *>, scalarTypeAdapters: ScalarTypeAdapters?,
+    fun httpPostRequestBody(operation: Operation<*, *>, scalarTypeAdapters: ScalarTypeAdapters?,
                             writeQueryDocument: Boolean, autoPersistQueries: Boolean): ByteString {
       return operation.composeRequestBody(autoPersistQueries, writeQueryDocument, scalarTypeAdapters!!)
     }
 
     @Throws(IOException::class)
-    fun httpGetUrl(serverUrl: HttpUrl, operation: Operation<*, *, *>,
+    fun httpGetUrl(serverUrl: HttpUrl, operation: Operation<*, *>,
                    scalarTypeAdapters: ScalarTypeAdapters?, writeQueryDocument: Boolean,
                    autoPersistQueries: Boolean): HttpUrl {
       val urlBuilder = serverUrl.newBuilder()
@@ -200,7 +200,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun addVariablesUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *, *>,
+    fun addVariablesUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *>,
                                       scalarTypeAdapters: ScalarTypeAdapters?) {
       val buffer = Buffer()
       val jsonWriter = of(buffer)
@@ -213,7 +213,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun addExtensionsUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *, *>) {
+    fun addExtensionsUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *>) {
       val buffer = Buffer()
       val jsonWriter = of(buffer)
       jsonWriter.serializeNulls = true
@@ -271,7 +271,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun transformToMultiPartIfUploadExists(originalBody: RequestBody?, operation: Operation<*, *, *>): RequestBody? {
+    fun transformToMultiPartIfUploadExists(originalBody: RequestBody?, operation: Operation<*, *>): RequestBody? {
       val allUploads = ArrayList<FileUploadMeta>()
       for (variableName in operation.variables().valueMap().keys) {
         val value = operation.variables().valueMap()[variableName]

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/NoOpSubscriptionManager.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/NoOpSubscriptionManager.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.internal.subscription
 
+import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Subscription
 import com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener
 import com.apollographql.apollo.subscription.SubscriptionManagerState
@@ -7,11 +8,11 @@ import com.apollographql.apollo.subscription.SubscriptionManagerState
 class NoOpSubscriptionManager : SubscriptionManager {
   val errorMessage = "No `SubscriptionTransport.Factory` found, please add one to your `ApolloClient` with `ApolloClient.Builder.subscriptionTransportFactory`"
 
-  override fun <T> subscribe(subscription: Subscription<*, T, *>, callback: SubscriptionManager.Callback<T>) {
+  override fun <D : Operation.Data> subscribe(subscription: Subscription<D, *>, callback: SubscriptionManager.Callback<D>) {
     throw IllegalStateException(errorMessage)
   }
 
-  override fun unsubscribe(subscription: Subscription<*, *, *>) {
+  override fun unsubscribe(subscription: Subscription<*, *>) {
     throw IllegalStateException(errorMessage)
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.internal.subscription;
 
 import com.apollographql.apollo.api.Error;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.api.ScalarTypeAdapters;
 import com.apollographql.apollo.api.Subscription;
@@ -94,7 +95,7 @@ public final class RealSubscriptionManager implements SubscriptionManager {
   }
 
   @Override
-  public <T> void subscribe(@NotNull final Subscription<?, T, ?> subscription, @NotNull final SubscriptionManager.Callback<T> callback) {
+  public <D extends Operation.Data> void subscribe(@NotNull final Subscription<D, ?> subscription, @NotNull final SubscriptionManager.Callback<D> callback) {
     checkNotNull(subscription, "subscription == null");
     checkNotNull(callback, "callback == null");
     dispatcher.execute(new Runnable() {
@@ -502,10 +503,10 @@ public final class RealSubscriptionManager implements SubscriptionManager {
 
   private static class SubscriptionRecord {
     final UUID id;
-    final Subscription<?, ?, ?> subscription;
+    final Subscription<?, ?> subscription;
     final SubscriptionManager.Callback<?> callback;
 
-    SubscriptionRecord(UUID id, Subscription<?, ?, ?> subscription, SubscriptionManager.Callback<?> callback) {
+    SubscriptionRecord(UUID id, Subscription<?, ?> subscription, SubscriptionManager.Callback<?> callback) {
       this.id = id;
       this.subscription = subscription;
       this.callback = callback;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.internal.subscription;
 
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Subscription;
 import com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener;
 import com.apollographql.apollo.subscription.SubscriptionManagerState;
@@ -11,17 +12,16 @@ public interface SubscriptionManager {
    * Starts provided subscription. Establishes connection to the subscription server if it was previously disconnected.
    *
    * @param subscription to start
-   * @param callback     to be called on result
-   * @param <T>
+   * @param callback to be called on result
    */
-  <T> void subscribe(@NotNull Subscription<?, T, ?> subscription, @NotNull RealSubscriptionManager.Callback<T> callback);
+  <D extends Operation.Data> void subscribe(@NotNull Subscription<D, ?> subscription, @NotNull RealSubscriptionManager.Callback<D> callback);
 
   /**
    * Stops provided subscription. If there are no active subscriptions left, disconnects from the subscription server.
    *
    * @param subscription to stop
    */
-  void unsubscribe(@NotNull Subscription<?, ?, ?> subscription);
+  void unsubscribe(@NotNull Subscription<?, ?> subscription);
 
   /**
    * Returns the current state of subscription manager.
@@ -45,8 +45,7 @@ public interface SubscriptionManager {
   void removeOnStateChangeListener(@NotNull OnSubscriptionManagerStateChangeListener onStateChangeListener);
 
   /**
-   * Put the {@link SubscriptionManager} in a connectible state. Does not necessarily open a web
-   * socket.
+   * Put the {@link SubscriptionManager} in a connectible state. Does not necessarily open a web socket.
    */
   void start();
 
@@ -55,8 +54,8 @@ public interface SubscriptionManager {
    */
   void stop();
 
-  interface Callback<T> {
-    void onResponse(@NotNull SubscriptionResponse<T> response);
+  interface Callback<D extends Subscription.Data> {
+    void onResponse(@NotNull SubscriptionResponse<D> response);
 
     void onError(@NotNull ApolloSubscriptionException error);
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
@@ -7,12 +7,12 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 
-public final class SubscriptionResponse<T> {
-  @NotNull public final Subscription<?, T, ?> subscription;
-  @NotNull public final Response<T> response;
+public final class SubscriptionResponse<D extends Subscription.Data> {
+  @NotNull public final Subscription<D, ?> subscription;
+  @NotNull public final Response<D> response;
   @NotNull public final Collection<Record> cacheRecords;
 
-  public SubscriptionResponse(@NotNull Subscription<?, T, ?> subscription, @NotNull Response<T> response,
+  public SubscriptionResponse(@NotNull Subscription<D, ?> subscription, @NotNull Response<D> response,
       @NotNull Collection<Record> cacheRecords) {
     this.subscription = subscription;
     this.response = response;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -22,18 +22,18 @@ import java.util.Map;
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 @SuppressWarnings("WeakerAccess")
-public final class OperationResponseParser<D extends Operation.Data, W> {
-  final Operation<D, W, ?> operation;
+public final class OperationResponseParser<D extends Operation.Data> {
+  final Operation<D, ?> operation;
   final ResponseFieldMapper responseFieldMapper;
   final ScalarTypeAdapters scalarTypeAdapters;
   final ResponseNormalizer<Map<String, Object>> responseNormalizer;
 
-  @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D, W, ?> operation,
+  @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D, ?> operation,
       ResponseFieldMapper responseFieldMapper, ScalarTypeAdapters scalarTypeAdapters) {
     this(operation, responseFieldMapper, scalarTypeAdapters, (ResponseNormalizer<Map<String, Object>>) ResponseNormalizer.NO_OP_NORMALIZER);
   }
 
-  public OperationResponseParser(Operation<D, W, ?> operation, ResponseFieldMapper responseFieldMapper,
+  public OperationResponseParser(Operation<D, ?> operation, ResponseFieldMapper responseFieldMapper,
       ScalarTypeAdapters scalarTypeAdapters, ResponseNormalizer<Map<String, Object>> responseNormalizer) {
     this.operation = operation;
     this.responseFieldMapper = responseFieldMapper;
@@ -42,7 +42,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
   }
 
   @SuppressWarnings("unchecked")
-  public Response<W> parse(@NotNull Map<String, Object> payload) {
+  public Response<D> parse(@NotNull Map<String, Object> payload) {
     checkNotNull(payload, "payload == null");
 
     responseNormalizer.willResolveRootQuery(operation);
@@ -66,15 +66,15 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
       }
     }
 
-    return Response.<W>builder(operation)
-        .data(operation.wrapData(data))
+    return Response.<D>builder(operation)
+        .data(data)
         .errors(errors)
         .dependentKeys(responseNormalizer.dependentKeys())
         .extensions((Map<String, Object>) payload.get("extensions"))
         .build();
   }
 
-  public Response<W> parse(BufferedSource source) throws IOException {
+  public Response<D> parse(BufferedSource source) throws IOException {
     responseNormalizer.willResolveRootQuery(operation);
     BufferedSourceJsonReader jsonReader = null;
     try {
@@ -110,8 +110,8 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
         }
       }
       jsonReader.endObject();
-      return Response.<W>builder(operation)
-          .data(operation.wrapData(data))
+      return Response.<D>builder(operation)
+          .data(data)
           .errors(errors)
           .dependentKeys(responseNormalizer.dependentKeys())
           .extensions(extensions)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.java
@@ -67,11 +67,11 @@ public abstract class OperationClientMessage {
     private final ScalarTypeAdapters scalarTypeAdapters;
 
     public final String subscriptionId;
-    public final Subscription<?, ?, ?> subscription;
+    public final Subscription<?, ?> subscription;
     public final boolean autoPersistSubscription;
     public final boolean sendSubscriptionDocument;
 
-    public Start(@NotNull String subscriptionId, @NotNull Subscription<?, ?, ?> subscription,
+    public Start(@NotNull String subscriptionId, @NotNull Subscription<?, ?> subscription,
         @NotNull ScalarTypeAdapters scalarTypeAdapters, boolean autoPersistSubscription, boolean sendSubscriptionDocument) {
       this.subscriptionId = checkNotNull(subscriptionId, "subscriptionId == null");
       this.subscription = checkNotNull(subscription, "subscription == null");

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.java
@@ -77,9 +77,6 @@ import static com.google.common.truth.Truth.assertThat;
         return "";
       }
 
-      @Override public Object wrapData(Data data) {
-        return data;
-      }
 
       @NotNull @Override public Response parse(@NotNull BufferedSource source) {
         throw new UnsupportedOperationException();

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.java
@@ -57,10 +57,6 @@ public class ResponseFetcherTest {
         return "";
       }
 
-      @Override public Object wrapData(Data data) {
-        return data;
-      }
-
       @NotNull @Override public Response parse(@NotNull BufferedSource source) {
        throw new UnsupportedOperationException();
       }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
@@ -274,7 +274,7 @@ public class ApolloAutoPersistedOperationInterceptorTest {
         .build();
   }
 
-  static class MockOperation implements Operation<MockOperation.Data, MockOperation.Data, Operation.Variables> {
+  static class MockOperation implements Operation<MockOperation.Data, Operation.Variables> {
 
     @Override public String queryDocument() {
       throw new UnsupportedOperationException();
@@ -285,10 +285,6 @@ public class ApolloAutoPersistedOperationInterceptorTest {
     }
 
     @Override public ResponseFieldMapper<Data> responseFieldMapper() {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override public Data wrapData(Data data) {
       throw new UnsupportedOperationException();
     }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -62,7 +62,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testDoesNotCacheErrorResponse() {
-    Operation<?, ?, ?> operation = mock(Operation.class);
+    Operation<?,?> operation = mock(Operation.class);
     Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
@@ -79,7 +79,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testCachesErrorResponseWhenStorePartialResponsesCacheHeaderPresent() {
-    Operation<?, ?, ?> operation = mock(Operation.class);
+    Operation<?, ?> operation = mock(Operation.class);
     Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
@@ -104,7 +104,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testDoesCachesNonErrorResponse() {
-    Operation<?, ?, ?> operation = mock(Operation.class);
+    Operation<?, ?> operation = mock(Operation.class);
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
         com.apollographql.apollo.api.Response.builder(operation).build(),

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
@@ -156,7 +156,7 @@ public class SubscriptionAutoPersistTest {
     }
   }
 
-  private static final class MockSubscription implements Subscription<Operation.Data, Operation.Data, Operation.Variables> {
+  private static final class MockSubscription implements Subscription<Operation.Data, Operation.Variables> {
     final String operationId;
 
     MockSubscription(String operationId) {
@@ -181,10 +181,6 @@ public class SubscriptionAutoPersistTest {
           };
         }
       };
-    }
-
-    @Override public Data wrapData(Data data) {
-      return data;
     }
 
     @NotNull @Override public OperationName name() {
@@ -231,15 +227,15 @@ public class SubscriptionAutoPersistTest {
     }
   }
 
-  private static class SubscriptionManagerCallbackAdapter<T> implements SubscriptionManager.Callback<T> {
-    volatile SubscriptionResponse<T> response;
+  private static class SubscriptionManagerCallbackAdapter<D extends Operation.Data> implements SubscriptionManager.Callback<D> {
+    volatile SubscriptionResponse<D> response;
     volatile ApolloSubscriptionException error;
     volatile Throwable networkError;
     volatile boolean completed;
     volatile boolean terminated;
     volatile boolean connected;
 
-    @Override public void onResponse(@NotNull SubscriptionResponse<T> response) {
+    @Override public void onResponse(@NotNull SubscriptionResponse<D> response) {
       this.response = response;
     }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.kt
@@ -52,12 +52,12 @@ class SubscriptionManagerTest {
 
   @Test
   fun connecting() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     assertThat(subscriptionTransportFactory.subscriptionTransport).isNotNull()
     assertThat(subscriptionTransportFactory.subscriptionTransport.connected).isTrue()
     assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage).isNull()
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.CONNECTING)
-    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data>())
     assertThat(subscriptionTransportFactory.subscriptionTransport.connected).isTrue()
     assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage).isNull()
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.CONNECTING)
@@ -67,7 +67,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun connected() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.CONNECTED)
     assertThat(subscriptionTransportFactory.subscriptionTransport.lastSentMessage).isInstanceOf(OperationClientMessage.Init::class.java)
@@ -76,7 +76,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun active() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.ACTIVE)
@@ -87,7 +87,7 @@ class SubscriptionManagerTest {
   @Test
   @Throws(Exception::class)
   fun disconnected() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     subscriptionManager.unsubscribe(subscription1)
@@ -102,12 +102,12 @@ class SubscriptionManagerTest {
   @Test
   @Throws(Exception::class)
   fun reconnect() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     subscriptionManager.unsubscribe(subscription1)
     onStateChangeListener.awaitState(SubscriptionManagerState.DISCONNECTED, RealSubscriptionManager.INACTIVITY_TIMEOUT + 800, TimeUnit.MILLISECONDS)
-    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.ACTIVE)
@@ -118,7 +118,7 @@ class SubscriptionManagerTest {
   @Test
   @Throws(Exception::class)
   fun disconnectedOnConnectionAcknowledgeTimeout() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     assertThat(subscriptionManager.timer.tasks).containsKey(RealSubscriptionManager.CONNECTION_ACKNOWLEDGE_TIMEOUT_TIMER_TASK_ID)
     onStateChangeListener.awaitState(SubscriptionManagerState.DISCONNECTED, RealSubscriptionManager.CONNECTION_ACKNOWLEDGE_TIMEOUT + 800, TimeUnit.MILLISECONDS)
@@ -129,9 +129,9 @@ class SubscriptionManagerTest {
 
   @Test
   fun disconnectedOnTransportFailure() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
-    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription2, subscriptionManagerCallback2)
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
@@ -146,9 +146,9 @@ class SubscriptionManagerTest {
 
   @Test
   fun unsubscribeOnComplete() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
-    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription2, subscriptionManagerCallback2)
     val subscriptionIds: List<UUID> = ArrayList(subscriptionManager.subscriptions.keys)
     subscriptionTransportFactory.callback.onConnected()
@@ -161,9 +161,9 @@ class SubscriptionManagerTest {
 
   @Test
   fun unsubscribeOnError() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
-    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription2, subscriptionManagerCallback2)
     val subscriptionIds: List<UUID> = ArrayList(subscriptionManager.subscriptions.keys)
     subscriptionTransportFactory.callback.onConnected()
@@ -179,7 +179,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun notifyOnData() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
     val subscriptionIds: List<UUID> = ArrayList(subscriptionManager.subscriptions.keys)
     subscriptionTransportFactory.callback.onConnected()
@@ -190,7 +190,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun notifyOnConnected() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
     subscriptionTransportFactory.callback.onConnected()
     assertThat(subscriptionManagerCallback1.connected).isTrue()
@@ -198,9 +198,9 @@ class SubscriptionManagerTest {
 
   @Test
   fun duplicateSubscriptions() {
-    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback1 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback1)
-    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback2 = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback2)
     assertThat(subscriptionManagerCallback2.error).isNull()
   }
@@ -208,7 +208,7 @@ class SubscriptionManagerTest {
   @Test
   @Throws(Exception::class)
   fun reconnectingAfterHeartbeatTimeout() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionKeepAlive())
@@ -227,7 +227,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun startWhenConnected() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.CONNECTED)
     subscriptionManager.start()
@@ -236,7 +236,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun startWhenActive() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.ACTIVE)
@@ -246,7 +246,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun startWhenStopped() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     subscriptionManager.stop()
@@ -264,8 +264,8 @@ class SubscriptionManagerTest {
 
   @Test
   fun stopWhenConnected() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
-    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
+    subscriptionManager.subscribe(subscription2, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.CONNECTED)
     subscriptionManager.stop()
@@ -274,7 +274,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun stopWhenActive() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.ACTIVE)
@@ -284,7 +284,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun stopWhenStopped() {
-    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data?>())
+    subscriptionManager.subscribe(subscription1, SubscriptionManagerCallbackAdapter<Operation.Data>())
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
     subscriptionManager.stop()
@@ -296,7 +296,7 @@ class SubscriptionManagerTest {
   @Test
   fun subscriptionWhenStopped() {
     subscriptionManager.stop()
-    val subscriptionManagerCallback = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback)
     assertThat(subscriptionManager.state).isEqualTo(SubscriptionManagerState.STOPPED)
     assertThat(subscriptionManagerCallback.error).isInstanceOf(ApolloSubscriptionException::class.java)
@@ -305,7 +305,7 @@ class SubscriptionManagerTest {
 
   @Test
   fun connectionTerminated() {
-    val subscriptionManagerCallback = SubscriptionManagerCallbackAdapter<Operation.Data?>()
+    val subscriptionManagerCallback = SubscriptionManagerCallbackAdapter<Operation.Data>()
     subscriptionManager.subscribe(subscription1, subscriptionManagerCallback)
     subscriptionTransportFactory.callback.onConnected()
     subscriptionTransportFactory.callback.onMessage(OperationServerMessage.ConnectionAcknowledge())
@@ -353,7 +353,7 @@ class SubscriptionManagerTest {
     }
   }
 
-  private class MockSubscription(val operationId: String) : Subscription<Operation.Data, Operation.Data, Operation.Variables> {
+  private class MockSubscription(val operationId: String) : Subscription<Operation.Data, Operation.Variables> {
     override fun queryDocument(): String {
       return "subscription {\n  commentAdded(repoFullName: \"repo\") {\n    __typename\n    id\n    content\n  }\n}"
     }
@@ -366,7 +366,6 @@ class SubscriptionManagerTest {
       }
     }
 
-    override fun wrapData(data: Operation.Data?) = data
     override fun name() = object : OperationName {
       override fun name(): String = "SomeSubscription"
     }
@@ -387,9 +386,9 @@ class SubscriptionManagerTest {
     override fun composeRequestBody() = throw UnsupportedOperationException()
   }
 
-  private class SubscriptionManagerCallbackAdapter<T> : SubscriptionManager.Callback<T> {
+  private class SubscriptionManagerCallbackAdapter<D : Operation.Data> : SubscriptionManager.Callback<D> {
     @Volatile
-    var response: SubscriptionResponse<T>? = null
+    var response: SubscriptionResponse<D>? = null
 
     @Volatile
     var error: ApolloSubscriptionException? = null
@@ -405,7 +404,7 @@ class SubscriptionManagerTest {
 
     @Volatile
     var connected = false
-    override fun onResponse(response: SubscriptionResponse<T>) {
+    override fun onResponse(response: SubscriptionResponse<D>) {
       this.response = response
     }
 

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/WebSocketSubscriptionTransportMessageTest.kt
@@ -189,13 +189,10 @@ class WebSocketSubscriptionTransportMessageTest {
     override fun onClosed() {}
   }
 
-  private class MockSubscription : Subscription<Operation.Data, Operation.Data, Operation.Variables> {
+  private class MockSubscription : Subscription<Operation.Data, Operation.Variables> {
     override fun queryDocument() = "subscription{commentAdded{id  name}"
 
     override fun variables() = Operation.EMPTY_VARIABLES
-
-
-    override fun wrapData(data: Operation.Data?) = data
 
     override fun name() = object : OperationName {
       override fun name() = "SomeSubscription"

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/Rx2Apollo.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloPrefetch;
 import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.ApolloSubscriptionCall;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.exception.ApolloException;
@@ -43,21 +44,21 @@ public class Rx2Apollo {
    * Converts an {@link ApolloQueryWatcher} to an asynchronous Observable.
    *
    * @param watcher the ApolloQueryWatcher to convert.
-   * @param <T>     the value type
+   * @param <D>     the value type
    * @return the converted Observable
    * @throws NullPointerException if watcher == null
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Observable<Response<T>> from(@NotNull final ApolloQueryWatcher<T> watcher) {
+  public static <D extends Operation.Data> Observable<Response<D>> from(@NotNull final ApolloQueryWatcher<D> watcher) {
     checkNotNull(watcher, "watcher == null");
-    return Observable.create(new ObservableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {
-        ApolloQueryWatcher<T> clone = watcher.clone();
+    return Observable.create(new ObservableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final ObservableEmitter<Response<D>> emitter) throws Exception {
+        ApolloQueryWatcher<D> clone = watcher.clone();
         cancelOnObservableDisposed(emitter, clone);
 
-        clone.enqueueAndWatch(new ApolloCall.Callback<T>() {
-          @Override public void onResponse(@NotNull Response<T> response) {
+        clone.enqueueAndWatch(new ApolloCall.Callback<D>() {
+          @Override public void onResponse(@NotNull Response<D> response) {
             if (!emitter.isDisposed()) {
               emitter.onNext(response);
             }
@@ -79,22 +80,22 @@ public class Rx2Apollo {
    * on the {@link com.apollographql.apollo.fetcher.ResponseFetcher} used with the call.
    *
    * @param call the ApolloCall to convert
-   * @param <T>  the value type.
+   * @param <D>  the value type.
    * @return the converted Observable
    * @throws NullPointerException if originalCall == null
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Observable<Response<T>> from(@NotNull final ApolloCall<T> call) {
+  public static <D extends Operation.Data> Observable<Response<D>> from(@NotNull final ApolloCall<D> call) {
     checkNotNull(call, "call == null");
 
-    return Observable.create(new ObservableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {
-        ApolloCall<T> clone = call.clone();
+    return Observable.create(new ObservableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final ObservableEmitter<Response<D>> emitter) throws Exception {
+        ApolloCall<D> clone = call.clone();
         cancelOnObservableDisposed(emitter, clone);
 
-        clone.enqueue(new ApolloCall.Callback<T>() {
-          @Override public void onResponse(@NotNull Response<T> response) {
+        clone.enqueue(new ApolloCall.Callback<D>() {
+          @Override public void onResponse(@NotNull Response<D> response) {
             if (!emitter.isDisposed()) {
               emitter.onNext(response);
             }
@@ -153,23 +154,23 @@ public class Rx2Apollo {
 
   @NotNull
   @CheckReturnValue
-  public static <T> Flowable<Response<T>> from(@NotNull ApolloSubscriptionCall<T> call) {
+  public static <D extends Operation.Data> Flowable<Response<D>> from(@NotNull ApolloSubscriptionCall<D> call) {
     return from(call, BackpressureStrategy.LATEST);
   }
 
   @NotNull
   @CheckReturnValue
-  public static <T> Flowable<Response<T>> from(@NotNull final ApolloSubscriptionCall<T> call,
+  public static <D extends Operation.Data> Flowable<Response<D>> from(@NotNull final ApolloSubscriptionCall<D> call,
       @NotNull BackpressureStrategy backpressureStrategy) {
     checkNotNull(call, "originalCall == null");
     checkNotNull(backpressureStrategy, "backpressureStrategy == null");
-    return Flowable.create(new FlowableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final FlowableEmitter<Response<T>> emitter) throws Exception {
-        ApolloSubscriptionCall<T> clone = call.clone();
+    return Flowable.create(new FlowableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final FlowableEmitter<Response<D>> emitter) throws Exception {
+        ApolloSubscriptionCall<D> clone = call.clone();
         cancelOnFlowableDisposed(emitter, clone);
         clone.execute(
-            new ApolloSubscriptionCall.Callback<T>() {
-              @Override public void onResponse(@NotNull Response<T> response) {
+            new ApolloSubscriptionCall.Callback<D>() {
+              @Override public void onResponse(@NotNull Response<D> response) {
                 if (!emitter.isCancelled()) {
                   emitter.onNext(response);
                 }
@@ -205,19 +206,19 @@ public class Rx2Apollo {
    * Converts an {@link ApolloStoreOperation} to a Single.
    *
    * @param operation the ApolloStoreOperation to convert
-   * @param <T>       the value type
+   * @param <D>       the value type
    * @return the converted Single
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {
+  public static <D extends Operation.Data> Single<D> from(@NotNull final ApolloStoreOperation<D> operation) {
     checkNotNull(operation, "operation == null");
-    return Single.create(new SingleOnSubscribe<T>() {
+    return Single.create(new SingleOnSubscribe<D>() {
       @Override
-      public void subscribe(final SingleEmitter<T> emitter) {
-        operation.enqueue(new ApolloStoreOperation.Callback<T>() {
+      public void subscribe(final SingleEmitter<D> emitter) {
+        operation.enqueue(new ApolloStoreOperation.Callback<D>() {
           @Override
-          public void onSuccess(T result) {
+          public void onSuccess(D result) {
             if (!emitter.isDisposed()) {
               emitter.onSuccess(result);
             }

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
@@ -30,24 +30,24 @@ inline fun ApolloPrefetch.rx(): Completable =
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloStoreOperation<T>.rx(): Single<T> =
+inline fun <D : Operation.Data> ApolloStoreOperation<D>.rx(): Single<D> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloQueryWatcher<T>.rx(): Observable<Response<T>> =
+inline fun <D : Operation.Data> ApolloQueryWatcher<D>.rx(): Observable<Response<D>> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloCall<T>.rx(): Observable<Response<T>> =
+inline fun <D : Operation.Data> ApolloCall<D>.rx(): Observable<Response<D>> =
     Rx2Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloSubscriptionCall<T>.rx(
+inline fun <D : Operation.Data> ApolloSubscriptionCall<D>.rx(
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
-): Flowable<Response<T>> = Rx2Apollo.from(this, backpressureStrategy)
+): Flowable<Response<D>> = Rx2Apollo.from(this, backpressureStrategy)
 
 /**
  * Creates a new [ApolloQueryCall] call and then converts it to an [Observable].
@@ -57,20 +57,20 @@ inline fun <T> ApolloSubscriptionCall<T>.rx(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery(
-    query: Query<D, T, V>,
-    configure: ApolloQueryCall<T>.() -> ApolloQueryCall<T> = { this }
-): Observable<Response<T>> = query(query).configure().rx()
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
+    query: Query<D, V>,
+    configure: ApolloQueryCall<D>.() -> ApolloQueryCall<D> = { this }
+): Observable<Response<D>> = query(query).configure().rx()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, T, V>,
-    configure: ApolloMutationCall<T>.() -> ApolloMutationCall<T> = { this }
-): Single<Response<T>> = mutate(mutation).configure().rx().singleOrError()
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, V>,
+    configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
+): Single<Response<D>> = mutate(mutation).configure().rx().singleOrError()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
@@ -81,19 +81,19 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutat
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, T, V>,
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, V>,
     withOptimisticUpdates: D,
-    configure: ApolloMutationCall<T>.() -> ApolloMutationCall<T> = { this }
-): Single<Response<T>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
+    configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
+): Single<Response<D>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
 
 /**
  * Creates the [ApolloPrefetch] by wrapping the operation object inside and then converts it to a [Completable].
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefetch(
-    operation: Operation<D, T, V>
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch(
+    operation: Operation<D, V>
 ): Completable = prefetch(operation).rx()
 
 /**
@@ -103,7 +103,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefe
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxSubscribe(
-    subscription: Subscription<D, T, V>,
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxSubscribe(
+    subscription: Subscription<D, V>,
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
-): Flowable<Response<T>> = subscribe(subscription).rx(backpressureStrategy)
+): Flowable<Response<D>> = subscribe(subscription).rx(backpressureStrategy)

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/Rx3Apollo.java
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/Rx3Apollo.java
@@ -4,6 +4,7 @@ import com.apollographql.apollo.ApolloCall;
 import com.apollographql.apollo.ApolloPrefetch;
 import com.apollographql.apollo.ApolloQueryWatcher;
 import com.apollographql.apollo.ApolloSubscriptionCall;
+import com.apollographql.apollo.api.Operation;
 import com.apollographql.apollo.api.Response;
 import com.apollographql.apollo.cache.normalized.ApolloStoreOperation;
 import com.apollographql.apollo.exception.ApolloException;
@@ -42,21 +43,21 @@ public class Rx3Apollo {
    * Converts an {@link ApolloQueryWatcher} to an asynchronous Observable.
    *
    * @param watcher the ApolloQueryWatcher to convert.
-   * @param <T>     the value type
+   * @param <D>     the value type
    * @return the converted Observable
    * @throws NullPointerException if watcher == null
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Observable<Response<T>> from(@NotNull final ApolloQueryWatcher<T> watcher) {
+  public static <D extends Operation.Data> Observable<Response<D>> from(@NotNull final ApolloQueryWatcher<D> watcher) {
     checkNotNull(watcher, "watcher == null");
-    return Observable.create(new ObservableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {
-        ApolloQueryWatcher<T> clone = watcher.clone();
+    return Observable.create(new ObservableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final ObservableEmitter<Response<D>> emitter) throws Exception {
+        ApolloQueryWatcher<D> clone = watcher.clone();
         cancelOnObservableDisposed(emitter, clone);
 
-        clone.enqueueAndWatch(new ApolloCall.Callback<T>() {
-          @Override public void onResponse(@NotNull Response<T> response) {
+        clone.enqueueAndWatch(new ApolloCall.Callback<D>() {
+          @Override public void onResponse(@NotNull Response<D> response) {
             if (!emitter.isDisposed()) {
               emitter.onNext(response);
             }
@@ -78,21 +79,21 @@ public class Rx3Apollo {
    * on the {@link com.apollographql.apollo.fetcher.ResponseFetcher} used with the call.
    *
    * @param call the ApolloCall to convert
-   * @param <T>  the value type.
+   * @param <D>  the value type.
    * @return the converted Observable
    * @throws NullPointerException if originalCall == null
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Observable<Response<T>> from(@NotNull final ApolloCall<T> call) {
+  public static <D extends Operation.Data> Observable<Response<D>> from(@NotNull final ApolloCall<D> call) {
     checkNotNull(call, "call == null");
 
-    return Observable.create(new ObservableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final ObservableEmitter<Response<T>> emitter) throws Exception {
-        ApolloCall<T> clone = call.clone();
+    return Observable.create(new ObservableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final ObservableEmitter<Response<D>> emitter) throws Exception {
+        ApolloCall<D> clone = call.clone();
         cancelOnObservableDisposed(emitter, clone);
-        clone.enqueue(new ApolloCall.Callback<T>() {
-          @Override public void onResponse(@NotNull Response<T> response) {
+        clone.enqueue(new ApolloCall.Callback<D>() {
+          @Override public void onResponse(@NotNull Response<D> response) {
             if (!emitter.isDisposed()) {
               emitter.onNext(response);
             }
@@ -151,23 +152,23 @@ public class Rx3Apollo {
 
   @NotNull
   @CheckReturnValue
-  public static <T> Flowable<Response<T>> from(@NotNull ApolloSubscriptionCall<T> call) {
+  public static <D extends Operation.Data> Flowable<Response<D>> from(@NotNull ApolloSubscriptionCall<D> call) {
     return from(call, BackpressureStrategy.LATEST);
   }
 
   @NotNull
   @CheckReturnValue
-  public static <T> Flowable<Response<T>> from(@NotNull final ApolloSubscriptionCall<T> call,
+  public static <D extends Operation.Data> Flowable<Response<D>> from(@NotNull final ApolloSubscriptionCall<D> call,
       @NotNull BackpressureStrategy backpressureStrategy) {
     checkNotNull(call, "originalCall == null");
     checkNotNull(backpressureStrategy, "backpressureStrategy == null");
-    return Flowable.create(new FlowableOnSubscribe<Response<T>>() {
-      @Override public void subscribe(final FlowableEmitter<Response<T>> emitter) throws Exception {
-        ApolloSubscriptionCall<T> clone = call.clone();
+    return Flowable.create(new FlowableOnSubscribe<Response<D>>() {
+      @Override public void subscribe(final FlowableEmitter<Response<D>> emitter) throws Exception {
+        ApolloSubscriptionCall<D> clone = call.clone();
         cancelOnFlowableDisposed(emitter, clone);
         clone.execute(
-            new ApolloSubscriptionCall.Callback<T>() {
-              @Override public void onResponse(@NotNull Response<T> response) {
+            new ApolloSubscriptionCall.Callback<D>() {
+              @Override public void onResponse(@NotNull Response<D> response) {
                 if (!emitter.isCancelled()) {
                   emitter.onNext(response);
                 }
@@ -203,19 +204,19 @@ public class Rx3Apollo {
    * Converts an {@link ApolloStoreOperation} to a Single.
    *
    * @param operation the ApolloStoreOperation to convert
-   * @param <T>       the value type
+   * @param <D>       the value type
    * @return the converted Single
    */
   @NotNull
   @CheckReturnValue
-  public static <T> Single<T> from(@NotNull final ApolloStoreOperation<T> operation) {
+  public static <D extends Operation.Data> Single<D> from(@NotNull final ApolloStoreOperation<D> operation) {
     checkNotNull(operation, "operation == null");
-    return Single.create(new SingleOnSubscribe<T>() {
+    return Single.create(new SingleOnSubscribe<D>() {
       @Override
-      public void subscribe(final SingleEmitter<T> emitter) {
-        operation.enqueue(new ApolloStoreOperation.Callback<T>() {
+      public void subscribe(final SingleEmitter<D> emitter) {
+        operation.enqueue(new ApolloStoreOperation.Callback<D>() {
           @Override
-          public void onSuccess(T result) {
+          public void onSuccess(D result) {
             if (!emitter.isDisposed()) {
               emitter.onSuccess(result);
             }

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/RxJavaExtensions.kt
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/RxJavaExtensions.kt
@@ -30,24 +30,24 @@ inline fun ApolloPrefetch.rx(): Completable =
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloStoreOperation<T>.rx(): Single<T> =
+inline fun <D : Operation.Data> ApolloStoreOperation<D>.rx(): Single<D> =
     Rx3Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloQueryWatcher<T>.rx(): Observable<Response<T>> =
+inline fun <D : Operation.Data> ApolloQueryWatcher<D>.rx(): Observable<Response<D>> =
     Rx3Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloCall<T>.rx(): Observable<Response<T>> =
+inline fun <D : Operation.Data> ApolloCall<D>.rx(): Observable<Response<D>> =
     Rx3Apollo.from(this)
 
 @JvmSynthetic
 @CheckReturnValue
-inline fun <T> ApolloSubscriptionCall<T>.rx(
+inline fun <D : Operation.Data> ApolloSubscriptionCall<D>.rx(
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
-): Flowable<Response<T>> = Rx3Apollo.from(this, backpressureStrategy)
+): Flowable<Response<D>> = Rx3Apollo.from(this, backpressureStrategy)
 
 /**
  * Creates a new [ApolloQueryCall] call and then converts it to an [Observable].
@@ -57,20 +57,20 @@ inline fun <T> ApolloSubscriptionCall<T>.rx(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxQuery(
-    query: Query<D, T, V>,
-    configure: ApolloQueryCall<T>.() -> ApolloQueryCall<T> = { this }
-): Observable<Response<T>> = query(query).configure().rx()
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
+    query: Query<D, V>,
+    configure: ApolloQueryCall<D>.() -> ApolloQueryCall<D> = { this }
+): Observable<Response<D>> = query(query).configure().rx()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, T, V>,
-    configure: ApolloMutationCall<T>.() -> ApolloMutationCall<T> = { this }
-): Single<Response<T>> = mutate(mutation).configure().rx().singleOrError()
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, V>,
+    configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
+): Single<Response<D>> = mutate(mutation).configure().rx().singleOrError()
 
 /**
  * Creates a new [ApolloMutationCall] call and then converts it to a [Single].
@@ -81,19 +81,19 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutat
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, T, V>,
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
+    mutation: Mutation<D, V>,
     withOptimisticUpdates: D,
-    configure: ApolloMutationCall<T>.() -> ApolloMutationCall<T> = { this }
-): Single<Response<T>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
+    configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
+): Single<Response<D>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
 
 /**
  * Creates the [ApolloPrefetch] by wrapping the operation object inside and then converts it to a [Completable].
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefetch(
-    operation: Operation<D, T, V>
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch(
+    operation: Operation<D, V>
 ): Completable = prefetch(operation).rx()
 
 /**
@@ -103,7 +103,7 @@ inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxPrefe
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, T, V : Operation.Variables> ApolloClient.rxSubscribe(
-    subscription: Subscription<D, T, V>,
+inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxSubscribe(
+    subscription: Subscription<D, V>,
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
-): Flowable<Response<T>> = subscribe(subscription).rx(backpressureStrategy)
+): Flowable<Response<D>> = subscribe(subscription).rx(backpressureStrategy)


### PR DESCRIPTION
As Java codegen is not a thing any more, we don't need API to wrap data and extra `Operation` generic type.