### PR TITLE
[Java codegen] Do not try to annotate primitive types in List type parameters

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ClassNames.kt
@@ -37,7 +37,13 @@ object ClassNames {
       ParameterizedTypeName.get(LIST, ClassName.get(type))
 
   fun parameterizedListOf(typeArgument: TypeName): TypeName =
-      ParameterizedTypeName.get(LIST, typeArgument.let { if (it.isPrimitive) it.box() else it.withoutAnnotations() })
+      ParameterizedTypeName.get(LIST, typeArgument.let {
+        if (it.isPrimitive) {
+          it.box()
+        } else {
+          it.withoutAnnotations()
+        }
+      })
 
   fun <K : Any, V : Any> parameterizedMapOf(keyTypeArgument: Class<K>, valueTypeArgument: Class<V>): TypeName =
       ParameterizedTypeName.get(MAP, ClassName.get(keyTypeArgument).withoutAnnotations(),

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/JavaTypeResolver.kt
@@ -14,13 +14,23 @@ class JavaTypeResolver(
     private val packageName: String,
     private val deprecated: Boolean = false
 ) {
-  fun resolve(typeName: String, isOptional: Boolean = !typeName.endsWith("!"),
-      nullableValueType: NullableValueType? = null): TypeName {
+  fun resolve(
+      typeName: String,
+      isOptional: Boolean = !typeName.endsWith("!"),
+      nullableValueType: NullableValueType? = null,
+      supportsAnnotations: Boolean = true
+  ): TypeName {
     val normalizedTypeName = typeName.removeSuffix("!")
     val isList = normalizedTypeName.startsWith('[') && normalizedTypeName.endsWith(']')
     val customScalarType = context.customTypeMap[normalizedTypeName]
     val javaType = when {
-      isList -> ClassNames.parameterizedListOf(resolve(normalizedTypeName.removeSurrounding("[", "]"), false))
+      isList -> ClassNames.parameterizedListOf(
+          resolve(
+              typeName = normalizedTypeName.removeSurrounding("[", "]"),
+              isOptional = false,
+              supportsAnnotations = false
+          )
+      )
       normalizedTypeName == ScalarType.STRING.name -> ClassNames.STRING
       normalizedTypeName == ScalarType.INT.name -> if (isOptional) TypeName.INT.box() else TypeName.INT
       normalizedTypeName == ScalarType.BOOLEAN.name -> if (isOptional) TypeName.BOOLEAN.box() else TypeName.BOOLEAN
@@ -29,21 +39,33 @@ class JavaTypeResolver(
       else -> ClassName.get(packageName, normalizedTypeName.capitalize())
     }
 
-    return if (javaType.isPrimitive) {
-      javaType.let { if (deprecated) it.annotated(Annotations.DEPRECATED) else it }
-    } else if (isOptional) {
-      when (nullableValueType ?: context.nullableValueType) {
-        NullableValueType.APOLLO_OPTIONAL -> parameterizedOptional(javaType)
-        NullableValueType.GUAVA_OPTIONAL -> parameterizedGuavaOptional(javaType)
-        NullableValueType.JAVA_OPTIONAL -> parameterizedJavaOptional(javaType)
-        NullableValueType.INPUT_TYPE -> parameterizedInputType(javaType)
-        else -> javaType.annotated(Annotations.NULLABLE)
-      }.let {
-        if (deprecated) it.annotated(Annotations.DEPRECATED) else it
+    return when {
+      !supportsAnnotations -> {
+        // Adding an annotation to a primitive type will crash in javapoet's TypeName.box()
+        // The underlying issue is that the annotation should be on the field name and not on the type name but it is a more
+        // complex issue. Don't add the annotation for now if the type is used in a context where annotations do not make sense.
+        // See https://github.com/apollographql/apollo-android/issues/2660
+        // See https://github.com/apollographql/apollo-android/issues/2246
+        javaType
       }
-    } else {
-      javaType.annotated(Annotations.NONNULL).let {
-        if (deprecated) it.annotated(Annotations.DEPRECATED) else it
+      javaType.isPrimitive -> {
+        javaType.let { if (deprecated) it.annotated(Annotations.DEPRECATED) else it }
+      }
+      isOptional -> {
+        when (nullableValueType ?: context.nullableValueType) {
+          NullableValueType.APOLLO_OPTIONAL -> parameterizedOptional(javaType)
+          NullableValueType.GUAVA_OPTIONAL -> parameterizedGuavaOptional(javaType)
+          NullableValueType.JAVA_OPTIONAL -> parameterizedJavaOptional(javaType)
+          NullableValueType.INPUT_TYPE -> parameterizedInputType(javaType)
+          else -> javaType.annotated(Annotations.NULLABLE)
+        }.let {
+          if (deprecated) it.annotated(Annotations.DEPRECATED) else it
+        }
+      }
+      else -> {
+        javaType.annotated(Annotations.NONNULL).let {
+          if (deprecated) it.annotated(Annotations.DEPRECATED) else it
+        }
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -27,6 +27,8 @@ import com.example.mutation_create_review.type.CustomType;
 import com.example.mutation_create_review.type.Episode;
 import com.example.mutation_create_review.type.ReviewInput;
 import java.io.IOException;
+import java.lang.Boolean;
+import java.lang.Deprecated;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -43,7 +45,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpisode.Data, Optional<CreateReviewForEpisode.Data>, CreateReviewForEpisode.Variables> {
-  public static final String OPERATION_ID = "c07e5abc4b4070cd773623194c07f546e609af467a1d34f7bf01c37272245296";
+  public static final String OPERATION_ID = "ddb5b88794340f1233d8b0d93bf51320b4e285a912f0914ddbaba8fc430e6db7";
 
   public static final String QUERY_DOCUMENT = QueryDocumentMinifier.minify(
     "mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {\n"
@@ -59,6 +61,7 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
         + "      name\n"
         + "    }\n"
         + "  }\n"
+        + "  stat_collect\n"
         + "}"
   );
 
@@ -236,10 +239,13 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
         .put("kind", "Variable")
         .put("variableName", "review")
         .build())
-      .build(), true, Collections.<ResponseField.Condition>emptyList())
+      .build(), true, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forList("stat_collect", "stat_collect", null, false, Collections.<ResponseField.Condition>emptyList())
     };
 
     final Optional<CreateReview> createReview;
+
+    final @NotNull @Deprecated List<Boolean> stat_collect;
 
     private transient volatile String $toString;
 
@@ -247,12 +253,21 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
 
     private transient volatile boolean $hashCodeMemoized;
 
-    public Data(@Nullable CreateReview createReview) {
+    public Data(@Nullable CreateReview createReview,
+        @NotNull @Deprecated List<Boolean> stat_collect) {
       this.createReview = Optional.fromNullable(createReview);
+      this.stat_collect = Utils.checkNotNull(stat_collect, "stat_collect == null");
     }
 
     public Optional<CreateReview> createReview() {
       return this.createReview;
+    }
+
+    /**
+     * For testing https://github.com/apollographql/apollo-android/issues/2660
+     */
+    public @NotNull @Deprecated List<Boolean> stat_collect() {
+      return this.stat_collect;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -261,6 +276,14 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
         @Override
         public void marshal(ResponseWriter writer) {
           writer.writeObject($responseFields[0], createReview.isPresent() ? createReview.get().marshaller() : null);
+          writer.writeList($responseFields[1], stat_collect, new ResponseWriter.ListWriter() {
+            @Override
+            public void write(List items, ResponseWriter.ListItemWriter listItemWriter) {
+              for (Object item : items) {
+                listItemWriter.writeBoolean((Boolean) item);
+              }
+            }
+          });
         }
       };
     }
@@ -269,7 +292,8 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
     public String toString() {
       if ($toString == null) {
         $toString = "Data{"
-          + "createReview=" + createReview
+          + "createReview=" + createReview + ", "
+          + "stat_collect=" + stat_collect
           + "}";
       }
       return $toString;
@@ -282,7 +306,8 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
       }
       if (o instanceof Data) {
         Data that = (Data) o;
-        return this.createReview.equals(that.createReview);
+        return this.createReview.equals(that.createReview)
+         && this.stat_collect.equals(that.stat_collect);
       }
       return false;
     }
@@ -293,6 +318,8 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
         int h = 1;
         h *= 1000003;
         h ^= createReview.hashCode();
+        h *= 1000003;
+        h ^= stat_collect.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -310,7 +337,13 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
             return createReviewFieldMapper.map(reader);
           }
         });
-        return new Data(createReview);
+        final List<Boolean> stat_collect = reader.readList($responseFields[1], new ResponseReader.ListReader<Boolean>() {
+          @Override
+          public Boolean read(ResponseReader.ListItemReader listItemReader) {
+            return listItemReader.readBoolean();
+          }
+        });
+        return new Data(createReview, stat_collect);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.java
@@ -265,6 +265,7 @@ public final class CreateReviewForEpisode implements Mutation<CreateReviewForEpi
 
     /**
      * For testing https://github.com/apollographql/apollo-android/issues/2660
+     * @deprecated Deprecated
      */
     public @NotNull @Deprecated List<Boolean> stat_collect() {
       return this.stat_collect;

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -27,6 +27,7 @@ import java.util.Date
 import kotlin.Any
 import kotlin.Array
 import kotlin.Boolean
+import kotlin.Deprecated
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -270,10 +271,19 @@ internal data class CreateReviewForEpisode(
    * Data from the response after executing this GraphQL operation
    */
   data class Data(
-    val createReview: CreateReview?
+    val createReview: CreateReview?,
+    /**
+     * For testing https://github.com/apollographql/apollo-android/issues/2660
+     */
+    @Deprecated(message = "Deprecated")
+    val stat_collect: List<Boolean>
   ) : Operation.Data {
     override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeObject(RESPONSE_FIELDS[0], this@Data.createReview?.marshaller())
+      writer.writeList(RESPONSE_FIELDS[1], this@Data.stat_collect) { value, listItemWriter ->
+        value?.forEach { value ->
+          listItemWriter.writeBoolean(value)}
+      }
     }
 
     companion object {
@@ -284,15 +294,20 @@ internal data class CreateReviewForEpisode(
               "variableName" to "ep"),
             "review" to mapOf<String, Any>(
               "kind" to "Variable",
-              "variableName" to "review")), true, null)
+              "variableName" to "review")), true, null),
+          ResponseField.forList("stat_collect", "stat_collect", null, false, null)
           )
 
       operator fun invoke(reader: ResponseReader): Data = reader.run {
         val createReview = readObject<CreateReview>(RESPONSE_FIELDS[0]) { reader ->
           CreateReview(reader)
         }
+        val stat_collect = readList<Boolean>(RESPONSE_FIELDS[1]) { reader ->
+          reader.readBoolean()
+        }!!.map { it!! }
         Data(
-          createReview = createReview
+          createReview = createReview,
+          stat_collect = stat_collect
         )
       }
 
@@ -303,7 +318,7 @@ internal data class CreateReviewForEpisode(
 
   companion object {
     const val OPERATION_ID: String =
-        "c07e5abc4b4070cd773623194c07f546e609af467a1d34f7bf01c37272245296"
+        "ddb5b88794340f1233d8b0d93bf51320b4e285a912f0914ddbaba8fc430e6db7"
 
     val QUERY_DOCUMENT: String = QueryDocumentMinifier.minify(
           """
@@ -320,6 +335,7 @@ internal data class CreateReviewForEpisode(
           |      name
           |    }
           |  }
+          |  stat_collect
           |}
           """.trimMargin()
         )

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/TestOperation.graphql
@@ -9,4 +9,5 @@ mutation CreateReviewForEpisode($ep: Episode!, $review: ReviewInput!) {
       name
     }
   }
+  stat_collect
 }

--- a/apollo-compiler/src/test/graphql/schema.sdl
+++ b/apollo-compiler/src/test/graphql/schema.sdl
@@ -263,6 +263,8 @@ enum LengthUnit {
 """The mutation type, represents all updates we can make to our data"""
 type Mutation {
   createReview(episode: Episode, review: ReviewInput!): Review
+  """For testing https://github.com/apollographql/apollo-android/issues/2660"""
+  stat_collect: [Boolean!]! @deprecated
 }
 
 """Information for paginating this connection"""

--- a/apollo-compiler/src/test/graphql/schema.sdl
+++ b/apollo-compiler/src/test/graphql/schema.sdl
@@ -264,7 +264,7 @@ enum LengthUnit {
 type Mutation {
   createReview(episode: Episode, review: ReviewInput!): Review
   """For testing https://github.com/apollographql/apollo-android/issues/2660"""
-  stat_collect: [Boolean!]! @deprecated
+  stat_collect: [Boolean!]! @deprecated(reason: "Deprecated")
 }
 
 """Information for paginating this connection"""


### PR DESCRIPTION
See [the comment in the code](https://github.com/apollographql/apollo-android/pull/2663/files#diff-078a76dcbd8dae7fe7a7be94217398071ee19b6a09d7cf6af347ab8ab67071a4R44) for the details. This is also related to #2246. We should set the annotation on fields instead of types but that would require a more comprehensive rewrite of the codegen so this patch simply avoid to annotate type parameters.

fixes #2660