### PR TITLE
[SDL] allow to have schemas without mutations/subscriptions

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/IntrospectionSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/IntrospectionSchema.kt
@@ -10,9 +10,9 @@ import java.io.File
 import java.io.InputStream
 
 data class IntrospectionSchema(
-    val queryType: String = "query",
-    val mutationType: String = "mutation",
-    val subscriptionType: String = "subscription",
+    val queryType: String,
+    val mutationType: String?,
+    val subscriptionType: String?,
     val types: Map<String, Type>) : Map<String, IntrospectionSchema.Type> by types {
   sealed class Type(val kind: Kind) {
     abstract val name: String
@@ -162,9 +162,9 @@ data class IntrospectionSchema(
 
     fun IntrospectionQuery.Schema.toIntrospectionSchema(): IntrospectionSchema {
       return IntrospectionSchema(
-          queryType = queryType?.name ?: "query",
-          mutationType = mutationType?.name ?: "mutation",
-          subscriptionType = subscriptionType?.name ?: "subscription",
+          queryType = queryType?.name ?: "Query",
+          mutationType = mutationType?.name,
+          subscriptionType = subscriptionType?.name,
           types = types.associateBy { it.name }
       )
     }
@@ -172,9 +172,9 @@ data class IntrospectionSchema(
     fun IntrospectionSchema.wrap(): IntrospectionQuery.Wrapper {
       return IntrospectionQuery.Wrapper(
           __schema = IntrospectionQuery.Schema(
-              queryType = IntrospectionQuery.QueryType(this.queryType),
-              mutationType = IntrospectionQuery.MutationType(this.mutationType),
-              subscriptionType = IntrospectionQuery.SubscriptionType(this.subscriptionType),
+              queryType = this.queryType.let { IntrospectionQuery.QueryType(it) },
+              mutationType = this.mutationType?.let { IntrospectionQuery.MutationType(it) },
+              subscriptionType = this.subscriptionType?.let { IntrospectionQuery.SubscriptionType(it) },
               types = types.values.toList()
           )
       )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/introspection2sdl.kt
@@ -34,9 +34,9 @@ fun IntrospectionSchema.toSDL(sink: BufferedSink) {
     sink.writeUtf8("\n")
   }
   sink.writeUtf8("schema {\n")
-  sink.writeUtf8("  subscription: $subscriptionType\n")
   sink.writeUtf8("  query: $queryType\n")
-  sink.writeUtf8("  mutation: $mutationType\n")
+  mutationType?.let { sink.writeUtf8("  mutation: $it\n") }
+  subscriptionType?.let { sink.writeUtf8("  subscription: $it\n") }
   sink.writeUtf8("}\n")
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
@@ -14,9 +14,9 @@ data class GraphSdlSchema(
   data class Schema(
       val description: String?,
       val directives: List<Directive>,
-      val queryRootOperationType: TypeRef.Named,
-      val mutationRootOperationType: TypeRef.Named,
-      val subscriptionRootOperationType: TypeRef.Named
+      val queryRootOperationType: String,
+      val mutationRootOperationType: String?,
+      val subscriptionRootOperationType: String?
   )
 
   sealed class TypeDefinition {
@@ -144,9 +144,9 @@ data class GraphSdlSchema(
 
 fun GraphSdlSchema.toIntrospectionSchema(): IntrospectionSchema {
   return IntrospectionSchema(
-      queryType = schema.queryRootOperationType.typeName,
-      mutationType = schema.mutationRootOperationType.typeName,
-      subscriptionType = schema.subscriptionRootOperationType.typeName,
+      queryType = schema.queryRootOperationType,
+      mutationType = schema.mutationRootOperationType,
+      subscriptionType = schema.subscriptionRootOperationType,
       types = typeDefinitions.mapValues { (_, typeDefinition) ->
         when (typeDefinition) {
           is GraphSdlSchema.TypeDefinition.Enum -> typeDefinition.toIntrospectionType()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
@@ -15,23 +15,6 @@ import java.io.File
 
 class GraphSdlParseTest() {
 
-  @Test
-  fun `SDL schema parsed successfully and produced the same introspection schema`() {
-    /**
-     * Things to watch out:
-     * - leading/trailing spaces in descriptions
-     * - defaultValue coercion
-     */
-    val actualSchema = GraphSdlSchema(File("src/test/sdl/schema.sdl")).toIntrospectionSchema().normalize()
-    val expectedSchema = IntrospectionSchema(File("src/test/sdl/schema.json")).normalize()
-
-    assertEquals(actualSchema.toString(), expectedSchema.toString())
-  }
-
-  private fun IntrospectionSchema.normalize(): IntrospectionSchema {
-    return copy(types = toSortedMap().mapValues { (_, type) -> type.normalize() })
-  }
-
   /**
    * GraphQL has Int and Float, json has only Number, map everything to Double
    */
@@ -54,6 +37,23 @@ class GraphSdlParseTest() {
         it.copy(defaultValue = it.defaultValue.normalizeNumbers())
       }.sortedBy { field -> field.name })
     }
+  }
+
+  @Test
+  fun `SDL schema parsed successfully and produced the same introspection schema`() {
+    /**
+     * Things to watch out:
+     * - leading/trailing spaces in descriptions
+     * - defaultValue coercion
+     */
+    val actualSchema = GraphSdlSchema(File("src/test/sdl/schema.sdl")).toIntrospectionSchema().normalize()
+    val expectedSchema = IntrospectionSchema(File("src/test/sdl/schema.json")).normalize()
+
+    assertEquals(actualSchema.toString(), expectedSchema.toString())
+  }
+
+  private fun IntrospectionSchema.normalize(): IntrospectionSchema {
+    return copy(types = toSortedMap().mapValues { (_, type) -> type.normalize() })
   }
 
   @Test

--- a/apollo-compiler/src/test/sdl/schema.sdl
+++ b/apollo-compiler/src/test/sdl/schema.sdl
@@ -423,5 +423,4 @@ scalar UnsupportedType
 schema {
   query: Query
   mutation: Mutation
-  subscription: subscription
 }


### PR DESCRIPTION
From [the spec](https://spec.graphql.org/June2018/#sec-Root-Operation-Types), it is allowed to have SDL schemas without subscriptions/mutations.

SDL will use the default of `Query`, `Mutation`, `Subscription` if no `schema {}` definition is found.
Introspection doesn't have default value so whatever is returned will be used and an error will be thrown if there's no "query" root type.

Fixes #2683 