### PR TITLE
[Gradle Plugin] Make CheckDuplicate task cacheable

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloCheckDuplicatesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloCheckDuplicatesTask.kt
@@ -5,12 +5,14 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class ApolloCheckDuplicatesTask : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
@@ -10,7 +10,7 @@ import java.io.File
 class GradleBuildCacheTests {
 
   @Test
-  fun `generate and check apollo classes tasks are cached`() {
+  fun `generate and check apollo classes task are cached`() {
     TestUtils.withDirectory { dir ->
       val project1 = File(dir, "project1")
       val project2 = File(dir, "directory/project2")
@@ -25,17 +25,11 @@ class GradleBuildCacheTests {
       System.out.println("Generate sources project1")
       var result = TestUtils.executeTask("generateMainServiceApolloSources", project1, "--build-cache")
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":module:generateMainServiceApolloSources")!!.outcome)
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
 
       System.out.println("Generate sources project2")
       result = TestUtils.executeTask("generateMainServiceApolloSources", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":module:generateMainServiceApolloSources")!!.outcome)
-
-      System.out.println("Check Duplicates project1")
-      result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project1, "--build-cache")
-      Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
-
-      System.out.println("Check Duplicates project2")
-      result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
     }
   }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
@@ -10,7 +10,7 @@ import java.io.File
 class GradleBuildCacheTests {
 
   @Test
-  fun `generate apollo classes task is cached`() {
+  fun `generate and check apollo classes tasks are cached`() {
     TestUtils.withDirectory { dir ->
       val project1 = File(dir, "project1")
       val project2 = File(dir, "directory/project2")
@@ -21,33 +21,20 @@ class GradleBuildCacheTests {
 
       File(project2, "build.gradle.kts").replaceInText("../../../../", "../../../../../")
       File(project2, "settings.gradle.kts").replaceInText("../buildCache", "../../buildCache")
-      System.out.println("building project1")
+
+      System.out.println("Generate sources project1")
       var result = TestUtils.executeTask("generateMainServiceApolloSources", project1, "--build-cache")
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":module:generateMainServiceApolloSources")!!.outcome)
 
-      System.out.println("building project2")
+      System.out.println("Generate sources project2")
       result = TestUtils.executeTask("generateMainServiceApolloSources", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":module:generateMainServiceApolloSources")!!.outcome)
-    }
-  }
 
-  @Test
-  fun `check apollo classes duplicate task is cached`() {
-    TestUtils.withDirectory { dir ->
-      val project1 = File(dir, "project1")
-      val project2 = File(dir, "directory/project2")
-      project2.mkdirs()
-
-      File(System.getProperty("user.dir"), "testProjects/buildCache").copyRecursively(project1)
-      File(System.getProperty("user.dir"), "testProjects/buildCache").copyRecursively(project2)
-
-      File(project2, "build.gradle.kts").replaceInText("../../../../", "../../../../../")
-      File(project2, "settings.gradle.kts").replaceInText("../buildCache", "../../buildCache")
-      System.out.println("building project1")
-      var result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project1, "--build-cache")
+      System.out.println("Check Duplicates project1")
+      result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project1, "--build-cache")
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
 
-      System.out.println("building project2")
+      System.out.println("Check Duplicates project2")
       result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
     }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.gradle.test
 
-import com.apollographql.apollo.gradle.internal.child
 import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.replaceInText
 import org.gradle.testkit.runner.TaskOutcome
@@ -29,6 +28,28 @@ class GradleBuildCacheTests {
       System.out.println("building project2")
       result = TestUtils.executeTask("generateMainServiceApolloSources", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":module:generateMainServiceApolloSources")!!.outcome)
+    }
+  }
+
+  @Test
+  fun `check apollo classes duplicate task is cached`() {
+    TestUtils.withDirectory { dir ->
+      val project1 = File(dir, "project1")
+      val project2 = File(dir, "directory/project2")
+      project2.mkdirs()
+
+      File(System.getProperty("user.dir"), "testProjects/buildCache").copyRecursively(project1)
+      File(System.getProperty("user.dir"), "testProjects/buildCache").copyRecursively(project2)
+
+      File(project2, "build.gradle.kts").replaceInText("../../../../", "../../../../../")
+      File(project2, "settings.gradle.kts").replaceInText("../buildCache", "../../buildCache")
+      System.out.println("building project1")
+      var result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project1, "--build-cache")
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
+
+      System.out.println("building project2")
+      result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project2, "--build-cache")
+      Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
     }
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/GradleBuildCacheTests.kt
@@ -32,7 +32,7 @@ class GradleBuildCacheTests {
 
       System.out.println("Check Duplicates project1")
       result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project1, "--build-cache")
-      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
+      Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":checkMainServiceApolloDuplicates")!!.outcome)
 
       System.out.println("Check Duplicates project2")
       result = TestUtils.executeTask("checkMainServiceApolloDuplicates", project2, "--build-cache")


### PR DESCRIPTION
Fix for #2681

**Summary**
When enabling the gradle build cache, since ApolloCheckDuplicatesTask is not marked as a CacheableTask (but has an output), this task won't be optimized against the same generated models (ApolloGenerateSourcesTask is already marked as a CacheableTask).