### PR TITLE
[KMP] set the Content-Type to `application/json; charset=utf-8` on iOS as well

### DIFF
--- a/apollo-runtime-kotlin/src/iosMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
+++ b/apollo-runtime-kotlin/src/iosMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
@@ -152,6 +152,7 @@ actual class ApolloHttpNetworkTransport(
       val postBody = operation.composeRequestBody(scalarTypeAdapters).toByteArray().toNSData()
       setHTTPMethod("POST")
       headers
+          .plus("Content-Type" to "application/json; charset=utf-8")
           .plus(httpExecutionContext?.headers ?: emptyMap())
           .forEach { (key, value) -> setValue(value, forHTTPHeaderField = key) }
       setCachePolicy(NSURLRequestReloadIgnoringCacheData)


### PR DESCRIPTION

closes #2665 