### PR TITLE
Add support for `@deprecated` directive without any deprecation reason

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -177,7 +177,7 @@ class GraphQLCompiler(val logger: Logger = NoOpLogger) {
     fieldsToVisit.addAll(this)
     while (fieldsToVisit.isNotEmpty()) {
       val field = fieldsToVisit.removeAt(fieldsToVisit.lastIndex)
-      if (field.isDeprecated) {
+      if (field.deprecationReason != null) {
         deprecatedUsages.add(DeprecatedUsage(filePath, field.sourceLocation, field))
       }
       fieldsToVisit.addAll(field.fields)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/AST.kt
@@ -80,8 +80,7 @@ internal data class ObjectType(
       val type: FieldType,
       val description: String,
       val isOptional: Boolean,
-      val isDeprecated: Boolean,
-      val deprecationReason: String,
+      val deprecationReason: String?, // null if not deprecated
       val arguments: Map<String, Any?>,
       val conditions: List<Condition>
   ) {
@@ -101,8 +100,7 @@ internal data class EnumType(
       val constName: String,
       val value: String,
       val description: String,
-      val isDeprecated: Boolean,
-      val deprecationReason: String
+      val deprecationReason: String?
   )
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/EnumTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/EnumTypeBuilder.kt
@@ -12,7 +12,6 @@ internal fun TypeDeclaration.ast() = EnumType(
           constName = value.name.toUpperCase().escapeKotlinReservedWord(),
           value = value.name,
           description = value.description,
-          isDeprecated = value.isDeprecated,
           deprecationReason = value.deprecationReason
       )
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/FragmentTypeBuilder.kt
@@ -67,8 +67,7 @@ internal fun Map<FragmentRef, Fragment>.astFragmentsObjectFieldType(
             )),
             description = "",
             isOptional = isOptional,
-            isDeprecated = false,
-            deprecationReason = "",
+            deprecationReason = null,
             arguments = emptyMap(),
             conditions = fragmentRef.conditions
                 .filter { condition -> condition.kind == Condition.Kind.BOOLEAN.rawValue }
@@ -105,8 +104,7 @@ internal fun Map<FragmentRef, Fragment>.astFragmentsObjectFieldType(
       ),
       description = "",
       isOptional = false,
-      isDeprecated = false,
-      deprecationReason = "",
+      deprecationReason = null,
       arguments = emptyMap(),
       conditions = emptyList()
   )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/InlineFragmentTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/InlineFragmentTypeBuilder.kt
@@ -48,8 +48,7 @@ internal fun InlineFragment.inlineFragmentField(
       type = FieldType.Fragment(typeRef),
       description = "",
       isOptional = true,
-      isDeprecated = false,
-      deprecationReason = "",
+      deprecationReason = null,
       arguments = emptyMap(),
       conditions = conditions.filter { it.kind == Condition.Kind.BOOLEAN.rawValue }.map { directive ->
         ObjectType.Field.Condition.Directive(variableName = directive.variableName, inverted = directive.inverted)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/ObjectFieldBuilder.kt
@@ -27,7 +27,6 @@ private fun Field.scalar(context: Context): ObjectType.Field {
       ),
       description = description,
       isOptional = !type.endsWith("!") || isConditional,
-      isDeprecated = isDeprecated,
       deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },
       conditions = normalizedConditions
@@ -71,7 +70,6 @@ private fun Field.array(context: Context): ObjectType.Field {
       type = fieldType,
       description = description,
       isOptional = !type.endsWith("!") || isConditional,
-      isDeprecated = isDeprecated,
       deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },
       conditions = normalizedConditions
@@ -96,7 +94,6 @@ private fun Field.`object`(context: Context): ObjectType.Field {
       type = FieldType.Object(typeRef),
       description = description,
       isOptional = !type.endsWith("!") || isConditional,
-      isDeprecated = isDeprecated,
       deprecationReason = deprecationReason,
       arguments = args.associate { it.name to it.value },
       conditions = normalizedConditions

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/EnumType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/EnumType.kt
@@ -48,7 +48,7 @@ private val EnumType.Value.enumConstTypeSpec: TypeSpec
     return TypeSpec
         .anonymousClassBuilder()
         .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
-        .applyIf(isDeprecated) { addAnnotation(KotlinCodeGen.deprecatedAnnotation(deprecationReason)) }
+        .applyIf(deprecationReason != null) { addAnnotation(KotlinCodeGen.deprecatedAnnotation(deprecationReason!!)) }
         .addSuperclassConstructorParameter("%S", value)
         .build()
   }
@@ -97,7 +97,7 @@ private fun EnumType.toSealedClassTypeSpec(generateAsInternal: Boolean): TypeSpe
 private fun EnumType.Value.toObjectTypeSpec(superClass: TypeName): TypeSpec {
   return TypeSpec.objectBuilder(constName)
       .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
-      .applyIf(isDeprecated) { addAnnotation(KotlinCodeGen.deprecatedAnnotation(deprecationReason)) }
+      .applyIf(deprecationReason != null) { addAnnotation(KotlinCodeGen.deprecatedAnnotation(deprecationReason!!)) }
       .superclass(superClass)
       .addSuperclassConstructorParameter("rawValue = %S", value)
       .build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -70,7 +70,7 @@ internal object KotlinCodeGen {
               name = name,
               type = if (isOptional) type.asTypeName().copy(nullable = true) else type.asTypeName()
           )
-          .applyIf(isDeprecated) { addAnnotation(deprecatedAnnotation(deprecationReason)) }
+          .applyIf(deprecationReason != null) { addAnnotation(deprecatedAnnotation(deprecationReason!!)) }
           .applyIf(description.isNotBlank()) { addKdoc("%L\n", description) }
           .initializer(initializer)
           .build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Field.kt
@@ -27,8 +27,7 @@ data class Field(
     val fragmentRefs: List<FragmentRef>,
     val inlineFragments: List<InlineFragment> = emptyList(),
     val description: String = "",
-    val isDeprecated: Boolean = false,
-    val deprecationReason: String = "",
+    val deprecationReason: String? = null, // null if not deprecated
     val conditions: List<Condition> = emptyList(),
     val sourceLocation: SourceLocation
 ) : CodeGenerator {
@@ -70,7 +69,7 @@ data class Field(
         .addStatement("return this.\$L", responseName.escapeJavaReservedWord())
         .let { if (description.isNotEmpty()) it.addJavadoc("\$L\n", description) else it }
         .let {
-          if (isDeprecated && deprecationReason.isNotEmpty()) {
+          if (deprecationReason != null) {
             it.addJavadoc("@deprecated \$L\n", deprecationReason)
           } else {
             it
@@ -147,7 +146,7 @@ data class Field(
 
   private fun toTypeName(responseType: String, context: CodeGenerationContext): TypeName {
     val packageName = if (isNonScalar()) "" else context.ir.typesPackageName
-    return JavaTypeResolver(context, packageName, isDeprecated).resolve(responseType, isOptional())
+    return JavaTypeResolver(context, packageName, deprecationReason != null).resolve(responseType, isOptional())
   }
 
   private fun methodResponseType(): String {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IRBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IRBuilder.kt
@@ -112,8 +112,7 @@ class IRBuilder(private val schema: IntrospectionSchema,
             TypeDeclarationValue(
                 name = value.name,
                 description = value.description?.trim() ?: "",
-                isDeprecated = value.isDeprecated || !value.deprecationReason.isNullOrBlank(),
-                deprecationReason = value.deprecationReason ?: ""
+                deprecationReason = value.deprecationReason
             )
           } ?: emptyList(),
           fields = (type as? IntrospectionSchema.Type.InputObject)?.inputFields?.map { field ->

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclaration.kt
@@ -34,7 +34,7 @@ data class TypeDeclaration(
             }
           }
           .apply {
-            if (value.isDeprecated == true) {
+            if (value.deprecationReason != null) {
               addAnnotation(Annotations.DEPRECATED)
               if (!value.deprecationReason.isNullOrBlank()) {
                 addJavadoc("@deprecated \$L\n", value.deprecationReason)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclarationValue.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/TypeDeclarationValue.kt
@@ -3,6 +3,5 @@ package com.apollographql.apollo.compiler.ir
 data class TypeDeclarationValue(
     val name: String,
     val description: String = "",
-    val isDeprecated: Boolean = false,
-    val deprecationReason: String = ""
+    val deprecationReason: String? = null
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
@@ -330,8 +330,7 @@ class GraphQLDocumentParser(
               )
             },
             description = schemaField.description?.trim() ?: "",
-            isDeprecated = schemaField.isDeprecated,
-            deprecationReason = schemaField.deprecationReason ?: "",
+            deprecationReason = schemaField.deprecationReason,
             conditions = conditions,
             sourceLocation = SourceLocation(start)
         ),
@@ -427,7 +426,7 @@ class GraphQLDocumentParser(
 
     val decoratedParentFields = parentFields.let { (parentFields, usedTypes) ->
       // if inline fragment conditional type contains the same field as parent type
-      // carry over meta info such as: `description`, `isDeprecated`, `deprecationReason`
+      // carry over meta info such as: `description`, `deprecationReason`
       val decoratedFields = parentFields.map { parentField ->
         when (schemaType) {
           is IntrospectionSchema.Type.Interface -> schemaType.fields?.find { it.name == parentField.fieldName }
@@ -437,8 +436,7 @@ class GraphQLDocumentParser(
         }?.let { field ->
           parentField.copy(
               description = field.description ?: parentField.description,
-              isDeprecated = field.isDeprecated,
-              deprecationReason = field.deprecationReason ?: ""
+              deprecationReason = field.deprecationReason
           )
         } ?: parentField
       }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/IntrospectionSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/introspection/IntrospectionSchema.kt
@@ -115,6 +115,83 @@ data class IntrospectionSchema(
     ENUM, INTERFACE, OBJECT, INPUT_OBJECT, SCALAR, NON_NULL, LIST, UNION
   }
 
+  private fun validate(): IntrospectionSchema {
+    return copy(
+        types = types.mapValues {
+          when (val type = it.value) {
+            is Type.Object -> type.validate()
+            is Type.Enum -> type.validate()
+            is Type.InputObject -> type.validate()
+            else -> type
+          }
+        }
+    )
+  }
+
+  private fun Type.Object.validate() = copy(fields = fields?.map { it.validate() })
+
+  private fun Type.Enum.validate() = copy(enumValues = enumValues.map { it.validate() })
+
+  private fun Type.InputObject.validate() = copy(inputFields = inputFields.map { it.validate() })
+
+  private fun InputField.validate(): InputField {
+    return when {
+      isDeprecated && deprecationReason == null -> {
+        println("InputField '$name' is marked as deprecated but did not provide a reason. Falling back to 'No longer supported'")
+        copy(deprecationReason = "No longuer supported")
+      }
+      !isDeprecated && deprecationReason !== null -> {
+        println("InputField '$name' is marked as not deprecated but provided a reason. Marking as deprecated")
+        copy(isDeprecated = true)
+      }
+      else -> this
+    }
+  }
+
+  private fun Type.Enum.Value.validate(): Type.Enum.Value {
+    return when {
+      isDeprecated && deprecationReason == null -> {
+        println("EnumValue '$name' is marked as deprecated but did not provide a reason. Falling back to 'No longer supported'")
+        copy(deprecationReason = "No longuer supported")
+      }
+      !isDeprecated && deprecationReason !== null -> {
+        println("EnumValue '$name' is marked as not deprecated but provided a reason. Marking as deprecated")
+        copy(isDeprecated = true)
+      }
+      else -> this
+    }
+  }
+
+  private fun Field.validate(): Field {
+    return when {
+      isDeprecated && deprecationReason == null -> {
+        println("Field '$name' is marked as deprecated but did not provide a reason. Falling back to 'No longer supported'")
+        copy(deprecationReason = "No longuer supported")
+      }
+      !isDeprecated && deprecationReason !== null -> {
+        println("Field '$name' is marked as not deprecated but provided a reason. Marking as deprecated")
+        copy(isDeprecated = true)
+      }
+      else -> this
+    }.copy(args = args.map {
+      it.validate()
+    })
+  }
+
+  private fun Field.Argument.validate(): Field.Argument {
+    return when {
+      isDeprecated && deprecationReason == null -> {
+        println("Argument '$name' is marked as deprecated but did not provide a reason. Falling back to 'No longer supported'")
+        copy(deprecationReason = "No longuer supported")
+      }
+      !isDeprecated && deprecationReason !== null -> {
+        println("Argument '$name' is marked as not deprecated but provided a reason. Marking as deprecated")
+        copy(isDeprecated = true)
+      }
+      else -> this
+    }
+  }
+
   companion object {
     private val UTF8_BOM = "EFBBBF".decodeHex()
 
@@ -166,7 +243,7 @@ data class IntrospectionSchema(
           mutationType = mutationType?.name,
           subscriptionType = subscriptionType?.name,
           types = types.associateBy { it.name }
-      )
+      ).validate()
     }
 
     fun IntrospectionSchema.wrap(): IntrospectionQuery.Wrapper {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/sdl/GraphSdlSchema.kt
@@ -294,7 +294,7 @@ private fun GraphSdlSchema.TypeDefinition.Field.Argument.toIntrospectionType(sch
 
 private fun List<GraphSdlSchema.Directive>.findDeprecatedDirective(): DeprecateDirective? {
   return find { directive -> directive.name == "deprecated" }?.let { directive ->
-    DeprecateDirective(directive.arguments["reason"]?.removePrefix("\"")?.removeSuffix("\""))
+    DeprecateDirective(directive.arguments["reason"]?.removePrefix("\"")?.removeSuffix("\"") ?: "No longer supported")
   }
 }
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.graphql
@@ -3,5 +3,6 @@ query TestQuery($episode: Episode) {
     name
     deprecated
     deprecatedBool
+    deprecatedWithNoReason
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_ID = "8f4a8c01b4bf0eb76356829f8062621ff66c3b53b6bf92753661cca41ef3ade4";
+  public static final String OPERATION_ID = "0ec7777648f4df19577e26ccefd76b5323e29426288a9e43770e8671a25865bc";
 
   public static final String QUERY_DOCUMENT = QueryDocumentMinifier.minify(
     "query TestQuery($episode: Episode) {\n"
@@ -50,6 +50,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         + "    name\n"
         + "    deprecated\n"
         + "    deprecatedBool\n"
+        + "    deprecatedWithNoReason\n"
         + "  }\n"
         + "}"
   );
@@ -301,7 +302,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("__typename", "__typename", null, false, Collections.<ResponseField.Condition>emptyList()),
       ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
       ResponseField.forString("deprecated", "deprecated", null, false, Collections.<ResponseField.Condition>emptyList()),
-      ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("deprecatedWithNoReason", "deprecatedWithNoReason", null, false, Collections.<ResponseField.Condition>emptyList())
     };
 
     final @NotNull String __typename;
@@ -312,6 +314,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     final @Deprecated boolean deprecatedBool;
 
+    final @NotNull @Deprecated String deprecatedWithNoReason;
+
     private transient volatile String $toString;
 
     private transient volatile int $hashCode;
@@ -319,11 +323,13 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
     private transient volatile boolean $hashCodeMemoized;
 
     public Hero(@NotNull String __typename, @NotNull String name,
-        @NotNull @Deprecated String deprecated, @Deprecated boolean deprecatedBool) {
+        @NotNull @Deprecated String deprecated, @Deprecated boolean deprecatedBool,
+        @NotNull @Deprecated String deprecatedWithNoReason) {
       this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.name = Utils.checkNotNull(name, "name == null");
       this.deprecated = Utils.checkNotNull(deprecated, "deprecated == null");
       this.deprecatedBool = deprecatedBool;
+      this.deprecatedWithNoReason = Utils.checkNotNull(deprecatedWithNoReason, "deprecatedWithNoReason == null");
     }
 
     public @NotNull String __typename() {
@@ -353,6 +359,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return this.deprecatedBool;
     }
 
+    /**
+     * Test deprecated field with no reason
+     * @deprecated No longer supported
+     */
+    public @NotNull @Deprecated String deprecatedWithNoReason() {
+      return this.deprecatedWithNoReason;
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public ResponseFieldMarshaller marshaller() {
       return new ResponseFieldMarshaller() {
@@ -362,6 +376,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeString($responseFields[1], name);
           writer.writeString($responseFields[2], deprecated);
           writer.writeBoolean($responseFields[3], deprecatedBool);
+          writer.writeString($responseFields[4], deprecatedWithNoReason);
         }
       };
     }
@@ -373,7 +388,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           + "__typename=" + __typename + ", "
           + "name=" + name + ", "
           + "deprecated=" + deprecated + ", "
-          + "deprecatedBool=" + deprecatedBool
+          + "deprecatedBool=" + deprecatedBool + ", "
+          + "deprecatedWithNoReason=" + deprecatedWithNoReason
           + "}";
       }
       return $toString;
@@ -389,7 +405,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         return this.__typename.equals(that.__typename)
          && this.name.equals(that.name)
          && this.deprecated.equals(that.deprecated)
-         && this.deprecatedBool == that.deprecatedBool;
+         && this.deprecatedBool == that.deprecatedBool
+         && this.deprecatedWithNoReason.equals(that.deprecatedWithNoReason);
       }
       return false;
     }
@@ -406,6 +423,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         h ^= deprecated.hashCode();
         h *= 1000003;
         h ^= Boolean.valueOf(deprecatedBool).hashCode();
+        h *= 1000003;
+        h ^= deprecatedWithNoReason.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -419,7 +438,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String name = reader.readString($responseFields[1]);
         final String deprecated = reader.readString($responseFields[2]);
         final boolean deprecatedBool = reader.readBoolean($responseFields[3]);
-        return new Hero(__typename, name, deprecated, deprecatedBool);
+        final String deprecatedWithNoReason = reader.readString($responseFields[4]);
+        return new Hero(__typename, name, deprecated, deprecatedBool, deprecatedWithNoReason);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -122,13 +122,19 @@ data class TestQuery(
      * Test deprecated field
      */
     @Deprecated(message = "For test purpose only")
-    val deprecatedBool: Boolean
+    val deprecatedBool: Boolean,
+    /**
+     * Test deprecated field with no reason
+     */
+    @Deprecated(message = "No longer supported")
+    val deprecatedWithNoReason: String
   ) {
     fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
       writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
       writer.writeString(RESPONSE_FIELDS[2], this@Hero.deprecated)
       writer.writeBoolean(RESPONSE_FIELDS[3], this@Hero.deprecatedBool)
+      writer.writeString(RESPONSE_FIELDS[4], this@Hero.deprecatedWithNoReason)
     }
 
     companion object {
@@ -136,7 +142,9 @@ data class TestQuery(
           ResponseField.forString("__typename", "__typename", null, false, null),
           ResponseField.forString("name", "name", null, false, null),
           ResponseField.forString("deprecated", "deprecated", null, false, null),
-          ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null)
+          ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null),
+          ResponseField.forString("deprecatedWithNoReason", "deprecatedWithNoReason", null, false,
+              null)
           )
 
       operator fun invoke(reader: ResponseReader): Hero = reader.run {
@@ -144,11 +152,13 @@ data class TestQuery(
         val name = readString(RESPONSE_FIELDS[1])!!
         val deprecated = readString(RESPONSE_FIELDS[2])!!
         val deprecatedBool = readBoolean(RESPONSE_FIELDS[3])!!
+        val deprecatedWithNoReason = readString(RESPONSE_FIELDS[4])!!
         Hero(
           __typename = __typename,
           name = name,
           deprecated = deprecated,
-          deprecatedBool = deprecatedBool
+          deprecatedBool = deprecatedBool,
+          deprecatedWithNoReason = deprecatedWithNoReason
         )
       }
 
@@ -191,7 +201,7 @@ data class TestQuery(
 
   companion object {
     const val OPERATION_ID: String =
-        "8f4a8c01b4bf0eb76356829f8062621ff66c3b53b6bf92753661cca41ef3ade4"
+        "0ec7777648f4df19577e26ccefd76b5323e29426288a9e43770e8671a25865bc"
 
     val QUERY_DOCUMENT: String = QueryDocumentMinifier.minify(
           """
@@ -201,6 +211,7 @@ data class TestQuery(
           |    name
           |    deprecated
           |    deprecatedBool
+          |    deprecatedWithNoReason
           |  }
           |}
           """.trimMargin()

--- a/apollo-compiler/src/test/graphql/schema.sdl
+++ b/apollo-compiler/src/test/graphql/schema.sdl
@@ -27,6 +27,9 @@ interface Character {
   """Test deprecated field"""
   deprecated: String! @deprecated(reason: "For test purpose only")
 
+  """Test deprecated field with no reason"""
+  deprecatedWithNoReason: String! @deprecated
+
   """Test deprecated field"""
   deprecatedBool: Boolean! @deprecated(reason: "For test purpose only")
 


### PR DESCRIPTION
deprecatedReason will fall back to 'No longer supported'

I also realised that we support `@deprecated` on input fields and arguments, making `apollo-android` ahead of the [spec](https://github.com/graphql/graphql-spec/pull/525) :)

Fixes #2664