### PR TITLE
Change the way how name for fragment types generated

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -27,7 +27,6 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="50" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="50" />
-      <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="false" />
     </JetCodeStyleSettings>
     <XML>
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/CodeGenerationAstBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/CodeGenerationAstBuilder.kt
@@ -372,7 +372,6 @@ private class CodeGenerationAstBuilder(
           abstract = true
       )
     }
-
     val objectTypeBuilder = ObjectTypeBuilder(
         schema = schema,
         customTypes = customTypes,
@@ -384,7 +383,7 @@ private class CodeGenerationAstBuilder(
     )
     val defaultImplementationType = if (inlineFragments.isEmpty() && fragmentRefs.isEmpty()) {
       nestedTypeContainer.registerObjectType(
-          typeName = "DefaultImpl",
+          typeName = "${rootType.name}Impl",
           enclosingType = rootType
       ) { typeRef ->
         objectTypeBuilder.buildObjectType(
@@ -398,7 +397,7 @@ private class CodeGenerationAstBuilder(
     } else {
       objectTypeBuilder.buildObjectTypeWithFragments(
           schemaType = schema.resolveType(schema.resolveType(typeCondition)),
-          typeName = "DefaultImpl",
+          typeName = "${rootType.name}Impl",
           fields = fields,
           inlineFragments = inlineFragments,
           fragmentRefs = fragmentRefs,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/ResponseAdapter.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/ResponseAdapter.kt
@@ -56,7 +56,6 @@ internal fun CodeGenerationAst.FragmentType.responseAdapterTypeSpec(generateAsIn
       .build()
 }
 
-
 private fun CodeGenerationAst.ObjectType.responseAdapterTypeSpec(): TypeSpec {
   return TypeSpec.objectBuilder("${this.name}_ResponseAdapter")
       .addSuperinterface(ResponseAdapter::class.asTypeName().parameterizedBy(this.typeRef.asTypeName()))

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails.kt
@@ -133,7 +133,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The friends of the character exposed as a connection with edges

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetails_ResponseAdapter.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any>(
@@ -27,7 +27,8 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
         "variableName" to "friendsCount")), false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var friendsConnection: HeroDetails.FriendsConnection1? = null
@@ -40,14 +41,14 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
           else -> break
         }
       }
-      HeroDetails.DefaultImpl(
+      HeroDetails.HeroDetailsImpl(
         __typename = __typename!!,
         friendsConnection = friendsConnection!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
       FriendsConnection1_ResponseAdapter.toResponse(writer, value.friendsConnection)

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -119,7 +119,7 @@ data class TestQuery(
   /**
    * A character from the Star Wars universe
    */
-  data class HeroDetailsImpl(
+  data class CharacterHero(
     override val __typename: String = "Character",
     /**
      * The name of the character
@@ -132,12 +132,12 @@ data class TestQuery(
   ) : HeroDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
 
-  data class HeroDetailsHumanDetailsImpl(
+  data class CharacterHumanHero(
     override val __typename: String,
     /**
      * The name of the character
@@ -154,7 +154,7 @@ data class TestQuery(
   ) : HeroDetails, HumanDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery_ResponseAdapter.kt
@@ -49,7 +49,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.HeroDetailsImpl> {
+  object CharacterHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -57,7 +57,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsImpl {
+        TestQuery.CharacterHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -70,7 +70,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsImpl(
+        TestQuery.CharacterHero(
           __typename = __typename!!,
           name = name!!,
           id = id!!
@@ -78,15 +78,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HeroDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.id)
     }
   }
 
-  object HeroDetailsHumanDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsHumanDetailsImpl> {
+  object CharacterHumanHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -95,7 +94,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsHumanDetailsImpl {
+        TestQuery.CharacterHumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -110,7 +109,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsHumanDetailsImpl(
+        TestQuery.CharacterHumanHero(
           __typename = __typename!!,
           name = name!!,
           homePlanet = homePlanet,
@@ -119,7 +118,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HeroDetailsHumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
@@ -166,16 +165,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.HeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.HeroDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.HeroDetailsHumanDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHero -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHumanHero -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails.kt
@@ -29,7 +29,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HeroDetails_ResponseAdapter.kt
@@ -16,13 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -33,14 +34,14 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
           else -> break
         }
       }
-      HeroDetails.DefaultImpl(
+      HeroDetails.HeroDetailsImpl(
         __typename = __typename!!,
         name = name!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails.kt
@@ -29,7 +29,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * The home planet of the human, or null if unknown

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/HumanDetails_ResponseAdapter.kt
@@ -16,13 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("homePlanet", "homePlanet", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var homePlanet: String? = null
@@ -33,14 +34,14 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         homePlanet = homePlanet
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.homePlanet)
   }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -200,7 +200,7 @@ data class TestQuery(
     override fun marshaller(): ResponseFieldMarshaller
   }
 
-  data class HumanCharacterImpl(
+  data class HumanCharacterHero(
     override val __typename: String,
     /**
      * The ID of the human
@@ -217,12 +217,12 @@ data class TestQuery(
   ) : Human, Character1, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HumanCharacterImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanCharacterHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
 
-  data class DroidCharacterImpl(
+  data class DroidCharacterHero(
     override val __typename: String,
     /**
      * The ID of the droid
@@ -239,7 +239,7 @@ data class TestQuery(
   ) : Droid, Character1, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.DroidCharacterImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidCharacterHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery_ResponseAdapter.kt
@@ -49,7 +49,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HumanCharacterImpl_ResponseAdapter : ResponseAdapter<TestQuery.HumanCharacterImpl> {
+  object HumanCharacterHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanCharacterHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
@@ -58,7 +58,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanCharacterImpl {
+        TestQuery.HumanCharacterHero {
       return reader.run {
         var __typename: String? = __typename
         var id: String? = null
@@ -73,7 +73,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HumanCharacterImpl(
+        TestQuery.HumanCharacterHero(
           __typename = __typename!!,
           id = id!!,
           name = name!!,
@@ -82,7 +82,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanCharacterImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanCharacterHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, value.id)
       writer.writeString(RESPONSE_FIELDS[2], value.name)
@@ -90,7 +90,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object DroidCharacterImpl_ResponseAdapter : ResponseAdapter<TestQuery.DroidCharacterImpl> {
+  object DroidCharacterHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidCharacterHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
@@ -99,7 +99,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidCharacterImpl {
+        TestQuery.DroidCharacterHero {
       return reader.run {
         var __typename: String? = __typename
         var id: String? = null
@@ -114,7 +114,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.DroidCharacterImpl(
+        TestQuery.DroidCharacterHero(
           __typename = __typename!!,
           id = id!!,
           name = name!!,
@@ -123,7 +123,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidCharacterImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidCharacterHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, value.id)
       writer.writeString(RESPONSE_FIELDS[2], value.name)
@@ -170,16 +170,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.HumanCharacterImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.DroidCharacterImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanCharacterHero_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidCharacterHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.HumanCharacterImpl -> TestQuery_ResponseAdapter.HumanCharacterImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.DroidCharacterImpl -> TestQuery_ResponseAdapter.DroidCharacterImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanCharacterHero -> TestQuery_ResponseAdapter.HumanCharacterHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidCharacterHero -> TestQuery_ResponseAdapter.DroidCharacterHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails.kt
@@ -138,7 +138,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/HeroDetails_ResponseAdapter.kt
@@ -18,14 +18,15 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -40,7 +41,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
           else -> break
         }
       }
-      HeroDetails.DefaultImpl(
+      HeroDetails.HeroDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         friendsConnection = friendsConnection!!
@@ -48,7 +49,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeObject(RESPONSE_FIELDS[2]) { writer ->

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment.kt
@@ -62,7 +62,7 @@ interface PilotFragment : GraphqlFragment {
   /**
    * An individual person or character within the Star Wars universe.
    */
-  data class DefaultImpl(
+  data class PilotFragmentImpl(
     override val __typename: String = "Person",
     /**
      * The name of this person.

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PilotFragment_ResponseAdapter.kt
@@ -16,7 +16,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object PilotFragment_ResponseAdapter : ResponseAdapter<PilotFragment.DefaultImpl> {
+object PilotFragment_ResponseAdapter : ResponseAdapter<PilotFragment.PilotFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, true, null),
@@ -24,7 +24,7 @@ object PilotFragment_ResponseAdapter : ResponseAdapter<PilotFragment.DefaultImpl
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      PilotFragment.DefaultImpl {
+      PilotFragment.PilotFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -39,7 +39,7 @@ object PilotFragment_ResponseAdapter : ResponseAdapter<PilotFragment.DefaultImpl
           else -> break
         }
       }
-      PilotFragment.DefaultImpl(
+      PilotFragment.PilotFragmentImpl(
         __typename = __typename!!,
         name = name,
         homeworld = homeworld
@@ -47,7 +47,7 @@ object PilotFragment_ResponseAdapter : ResponseAdapter<PilotFragment.DefaultImpl
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: PilotFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: PilotFragment.PilotFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     if(value.homeworld == null) {

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment.kt
@@ -31,7 +31,7 @@ interface PlanetFragment : GraphqlFragment {
    * A large mass, planet or planetoid in the Star Wars Universe, at the time of
    * 0 ABY.
    */
-  data class DefaultImpl(
+  data class PlanetFragmentImpl(
     override val __typename: String = "Planet",
     /**
      * The name of this planet.

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/PlanetFragment_ResponseAdapter.kt
@@ -16,14 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object PlanetFragment_ResponseAdapter : ResponseAdapter<PlanetFragment.DefaultImpl> {
+object PlanetFragment_ResponseAdapter : ResponseAdapter<PlanetFragment.PlanetFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, true, null)
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      PlanetFragment.DefaultImpl {
+      PlanetFragment.PlanetFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -34,14 +34,14 @@ object PlanetFragment_ResponseAdapter : ResponseAdapter<PlanetFragment.DefaultIm
           else -> break
         }
       }
-      PlanetFragment.DefaultImpl(
+      PlanetFragment.PlanetFragmentImpl(
         __typename = __typename!!,
         name = name
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: PlanetFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: PlanetFragment.PlanetFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment.kt
@@ -147,7 +147,7 @@ interface StarshipFragment : GraphqlFragment {
   /**
    * A single transport craft that has hyperdrive capability.
    */
-  data class DefaultImpl(
+  data class StarshipFragmentImpl(
     override val __typename: String = "Starship",
     /**
      * The ID of an object

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/StarshipFragment_ResponseAdapter.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object StarshipFragment_ResponseAdapter : ResponseAdapter<StarshipFragment.DefaultImpl> {
+object StarshipFragment_ResponseAdapter : ResponseAdapter<StarshipFragment.StarshipFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
@@ -27,7 +27,7 @@ object StarshipFragment_ResponseAdapter : ResponseAdapter<StarshipFragment.Defau
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      StarshipFragment.DefaultImpl {
+      StarshipFragment.StarshipFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var id: String? = null
@@ -44,7 +44,7 @@ object StarshipFragment_ResponseAdapter : ResponseAdapter<StarshipFragment.Defau
           else -> break
         }
       }
-      StarshipFragment.DefaultImpl(
+      StarshipFragment.StarshipFragmentImpl(
         __typename = __typename!!,
         id = id!!,
         name = name,
@@ -53,7 +53,7 @@ object StarshipFragment_ResponseAdapter : ResponseAdapter<StarshipFragment.Defau
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: StarshipFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: StarshipFragment.StarshipFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, value.id)
     writer.writeString(RESPONSE_FIELDS[2], value.name)

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -96,7 +96,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
     scalarTypeAdapters = scalarTypeAdapters
   )
 
-  data class HeroDetailsCharacterDetailsImpl(
+  data class CharacterHero(
     override val __typename: String,
     /**
      * The name of the character
@@ -109,12 +109,12 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : HeroDetails, CharacterDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsCharacterDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
 
-  data class HeroDetailsHumanDetailsCharacterDetailsImpl(
+  data class CharacterHumanHero(
     override val __typename: String,
     /**
      * The name of the character
@@ -127,7 +127,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : HeroDetails, HumanDetails, CharacterDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsHumanDetailsCharacterDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery_ResponseAdapter.kt
@@ -50,8 +50,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HeroDetailsCharacterDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsCharacterDetailsImpl> {
+  object CharacterHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -59,7 +58,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsCharacterDetailsImpl {
+        TestQuery.CharacterHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -72,7 +71,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsCharacterDetailsImpl(
+        TestQuery.CharacterHero(
           __typename = __typename!!,
           name = name!!,
           birthDate = birthDate!!
@@ -80,16 +79,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter,
-        value: TestQuery.HeroDetailsCharacterDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.birthDate)
     }
   }
 
-  object HeroDetailsHumanDetailsCharacterDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsHumanDetailsCharacterDetailsImpl> {
+  object CharacterHumanHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -97,7 +94,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsHumanDetailsCharacterDetailsImpl {
+        TestQuery.CharacterHumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -110,7 +107,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsHumanDetailsCharacterDetailsImpl(
+        TestQuery.CharacterHumanHero(
           __typename = __typename!!,
           name = name!!,
           birthDate = birthDate!!
@@ -118,8 +115,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter,
-        value: TestQuery.HeroDetailsHumanDetailsCharacterDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.birthDate)
@@ -159,16 +155,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.HeroDetailsCharacterDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsCharacterDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.HeroDetailsCharacterDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsCharacterDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.HeroDetailsHumanDetailsCharacterDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsCharacterDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHero -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHumanHero -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails.kt
@@ -35,7 +35,7 @@ interface CharacterDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class CharacterDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/CharacterDetails_ResponseAdapter.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object CharacterDetails_ResponseAdapter : ResponseAdapter<CharacterDetails.DefaultImpl> {
+object CharacterDetails_ResponseAdapter : ResponseAdapter<CharacterDetails.CharacterDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
@@ -26,7 +26,7 @@ object CharacterDetails_ResponseAdapter : ResponseAdapter<CharacterDetails.Defau
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      CharacterDetails.DefaultImpl {
+      CharacterDetails.CharacterDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -39,7 +39,7 @@ object CharacterDetails_ResponseAdapter : ResponseAdapter<CharacterDetails.Defau
           else -> break
         }
       }
-      CharacterDetails.DefaultImpl(
+      CharacterDetails.CharacterDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         birthDate = birthDate!!
@@ -47,7 +47,7 @@ object CharacterDetails_ResponseAdapter : ResponseAdapter<CharacterDetails.Defau
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: CharacterDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: CharacterDetails.CharacterDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.birthDate)

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails.kt
@@ -30,7 +30,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HeroDetails_ResponseAdapter.kt
@@ -18,14 +18,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forCustomType("birthDate", "birthDate", null, false, CustomType.DATE, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -38,7 +39,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
           else -> break
         }
       }
-      HeroDetails.DefaultImpl(
+      HeroDetails.HeroDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         birthDate = birthDate!!
@@ -46,7 +47,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.birthDate)

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails.kt
@@ -30,7 +30,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class CharacterDetailsImpl(
+  data class CharacterHumanDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character
@@ -40,10 +40,10 @@ interface HumanDetails : GraphqlFragment {
      * The date character was born.
      */
     override val birthDate: Any
-  ) : DefaultImpl, CharacterDetails {
+  ) : HumanDetailsImpl, CharacterDetails {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HumanDetails_ResponseAdapter.CharacterDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        HumanDetails_ResponseAdapter.CharacterHumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -51,16 +51,16 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class OtherDefaultImpl(
+  data class OtherHumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
      */
     override val name: String
-  ) : HumanDetails, DefaultImpl {
+  ) : HumanDetails, HumanDetailsImpl {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HumanDetails_ResponseAdapter.OtherDefaultImpl_ResponseAdapter.toResponse(writer, this)
+        HumanDetails_ResponseAdapter.OtherHumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -68,7 +68,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  interface DefaultImpl : HumanDetails {
+  interface HumanDetailsImpl : HumanDetails {
     override val __typename: String
 
     /**

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/HumanDetails_ResponseAdapter.kt
@@ -18,29 +18,31 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
     return when(typename) {
-      "Droid" -> CharacterDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-      "Human" -> CharacterDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-      else -> OtherDefaultImpl_ResponseAdapter.fromResponse(reader, typename)
+      "Droid" -> CharacterHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+      "Human" -> CharacterHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+      else -> OtherHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     when(value) {
-      is HumanDetails.CharacterDetailsImpl -> CharacterDetailsImpl_ResponseAdapter.toResponse(writer, value)
-      is HumanDetails.OtherDefaultImpl -> OtherDefaultImpl_ResponseAdapter.toResponse(writer, value)
+      is HumanDetails.CharacterHumanDetailsImpl -> CharacterHumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
+      is HumanDetails.OtherHumanDetailsImpl -> OtherHumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
     }
   }
 
-  object CharacterDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetails.CharacterDetailsImpl> {
+  object CharacterHumanDetailsImpl_ResponseAdapter :
+      ResponseAdapter<HumanDetails.CharacterHumanDetailsImpl> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -48,7 +50,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HumanDetails.CharacterDetailsImpl {
+        HumanDetails.CharacterHumanDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -61,7 +63,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
             else -> break
           }
         }
-        HumanDetails.CharacterDetailsImpl(
+        HumanDetails.CharacterHumanDetailsImpl(
           __typename = __typename!!,
           name = name!!,
           birthDate = birthDate!!
@@ -69,21 +71,22 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HumanDetails.CharacterDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HumanDetails.CharacterHumanDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.birthDate)
     }
   }
 
-  object OtherDefaultImpl_ResponseAdapter : ResponseAdapter<HumanDetails.OtherDefaultImpl> {
+  object OtherHumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetails.OtherHumanDetailsImpl>
+      {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HumanDetails.OtherDefaultImpl {
+        HumanDetails.OtherHumanDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -94,14 +97,14 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
             else -> break
           }
         }
-        HumanDetails.OtherDefaultImpl(
+        HumanDetails.OtherHumanDetailsImpl(
           __typename = __typename!!,
           name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HumanDetails.OtherDefaultImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HumanDetails.OtherHumanDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -221,7 +221,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
     fun edgesFilterNotNull(): List<Edge1>? = edges?.filterNotNull()
   }
 
-  data class HeroDetailsDroidDroidDetailsImpl(
+  data class CharacterDroidHero(
     override val __typename: String,
     /**
      * The name of the character
@@ -242,7 +242,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : HeroDetails, Droid, DroidDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsDroidDroidDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterDroidHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -306,7 +306,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
     fun edgesFilterNotNull(): List<Edge2>? = edges?.filterNotNull()
   }
 
-  data class HeroDetailsHumanDetailsImpl(
+  data class CharacterHumanHero(
     override val __typename: String,
     /**
      * The name of the character
@@ -323,7 +323,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : HeroDetails, HumanDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery_ResponseAdapter.kt
@@ -169,8 +169,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HeroDetailsDroidDroidDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsDroidDroidDetailsImpl> {
+  object CharacterDroidHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterDroidHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -180,7 +179,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsDroidDroidDetailsImpl {
+        TestQuery.CharacterDroidHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -201,7 +200,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsDroidDroidDetailsImpl(
+        TestQuery.CharacterDroidHero(
           __typename = __typename!!,
           name = name!!,
           friendsConnection = friendsConnection!!,
@@ -211,8 +210,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter,
-        value: TestQuery.HeroDetailsDroidDroidDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterDroidHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
@@ -344,8 +342,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HeroDetailsHumanDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsHumanDetailsImpl> {
+  object CharacterHumanHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -354,7 +351,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsHumanDetailsImpl {
+        TestQuery.CharacterHumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -373,7 +370,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsHumanDetailsImpl(
+        TestQuery.CharacterHumanHero(
           __typename = __typename!!,
           name = name!!,
           friendsConnection = friendsConnection!!,
@@ -382,7 +379,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HeroDetailsHumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
@@ -445,16 +442,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.HeroDetailsDroidDroidDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterDroidHero_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.HeroDetailsDroidDroidDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsDroidDroidDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.HeroDetailsHumanDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterDroidHero -> TestQuery_ResponseAdapter.CharacterDroidHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHumanHero -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails.kt
@@ -34,7 +34,7 @@ interface DroidDetails : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DefaultImpl(
+  data class DroidDetailsImpl(
     override val __typename: String = "Droid",
     /**
      * What others call this droid

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/DroidDetails_ResponseAdapter.kt
@@ -16,14 +16,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> {
+object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DroidDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      DroidDetails.DroidDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -36,7 +37,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
           else -> break
         }
       }
-      DroidDetails.DefaultImpl(
+      DroidDetails.DroidDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         primaryFunction = primaryFunction
@@ -44,7 +45,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DroidDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails.kt
@@ -130,7 +130,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  interface Droid : DefaultImpl {
+  interface Droid : HeroDetailsImpl {
     override val __typename: String
 
     /**
@@ -201,7 +201,7 @@ interface HeroDetails : GraphqlFragment {
     }
   }
 
-  data class DroidDroidDetailsImpl(
+  data class DroidHeroDetailsImpl(
     override val __typename: String,
     /**
      * What others call this droid
@@ -215,10 +215,10 @@ interface HeroDetails : GraphqlFragment {
      * This droid's primary function
      */
     override val primaryFunction: String?
-  ) : Droid, DroidDetails, DefaultImpl {
+  ) : Droid, DroidDetails, HeroDetailsImpl {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetails_ResponseAdapter.DroidDroidDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        HeroDetails_ResponseAdapter.DroidHeroDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -281,7 +281,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl(
+  data class HumanHeroDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -291,10 +291,10 @@ interface HeroDetails : GraphqlFragment {
      * The friends of the character exposed as a connection with edges
      */
     override val friendsConnection: FriendsConnection3
-  ) : DefaultImpl, HumanDetails {
+  ) : HeroDetailsImpl, HumanDetails {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetails_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        HeroDetails_ResponseAdapter.HumanHeroDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -357,7 +357,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class OtherDefaultImpl(
+  data class OtherHeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character
@@ -367,10 +367,10 @@ interface HeroDetails : GraphqlFragment {
      * The friends of the character exposed as a connection with edges
      */
     override val friendsConnection: FriendsConnection4
-  ) : HeroDetails, DefaultImpl {
+  ) : HeroDetails, HeroDetailsImpl {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetails_ResponseAdapter.OtherDefaultImpl_ResponseAdapter.toResponse(writer, this)
+        HeroDetails_ResponseAdapter.OtherHeroDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -425,7 +425,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  interface DefaultImpl : HeroDetails {
+  interface HeroDetailsImpl : HeroDetails {
     override val __typename: String
 
     /**

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HeroDetails_ResponseAdapter.kt
@@ -18,27 +18,28 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
     return when(typename) {
-      "Droid" -> DroidDroidDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-      "Human" -> HumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-      else -> OtherDefaultImpl_ResponseAdapter.fromResponse(reader, typename)
+      "Droid" -> DroidHeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+      "Human" -> HumanHeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+      else -> OtherHeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     when(value) {
-      is HeroDetails.DroidDroidDetailsImpl -> DroidDroidDetailsImpl_ResponseAdapter.toResponse(writer, value)
-      is HeroDetails.HumanDetailsImpl -> HumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
-      is HeroDetails.OtherDefaultImpl -> OtherDefaultImpl_ResponseAdapter.toResponse(writer, value)
+      is HeroDetails.DroidHeroDetailsImpl -> DroidHeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
+      is HeroDetails.HumanHeroDetailsImpl -> HumanHeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
+      is HeroDetails.OtherHeroDetailsImpl -> OtherHeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
     }
   }
 
@@ -160,8 +161,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  object DroidDroidDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.DroidDroidDetailsImpl>
-      {
+  object DroidHeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.DroidHeroDetailsImpl> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -170,7 +170,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetails.DroidDroidDetailsImpl {
+        HeroDetails.DroidHeroDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -187,7 +187,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
             else -> break
           }
         }
-        HeroDetails.DroidDroidDetailsImpl(
+        HeroDetails.DroidHeroDetailsImpl(
           __typename = __typename!!,
           name = name!!,
           friendsConnection = friendsConnection!!,
@@ -196,7 +196,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.DroidDroidDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.DroidHeroDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
@@ -324,7 +324,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.HumanDetailsImpl> {
+  object HumanHeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.HumanHeroDetailsImpl> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -332,7 +332,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetails.HumanDetailsImpl {
+        HeroDetails.HumanHeroDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -347,7 +347,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
             else -> break
           }
         }
-        HeroDetails.HumanDetailsImpl(
+        HeroDetails.HumanHeroDetailsImpl(
           __typename = __typename!!,
           name = name!!,
           friendsConnection = friendsConnection!!
@@ -355,7 +355,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.HumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.HumanHeroDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
@@ -482,7 +482,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  object OtherDefaultImpl_ResponseAdapter : ResponseAdapter<HeroDetails.OtherDefaultImpl> {
+  object OtherHeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.OtherHeroDetailsImpl> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -490,7 +490,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetails.OtherDefaultImpl {
+        HeroDetails.OtherHeroDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -505,7 +505,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
             else -> break
           }
         }
-        HeroDetails.OtherDefaultImpl(
+        HeroDetails.OtherHeroDetailsImpl(
           __typename = __typename!!,
           name = name!!,
           friendsConnection = friendsConnection!!
@@ -513,7 +513,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.OtherDefaultImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.OtherHeroDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeObject(RESPONSE_FIELDS[2]) { writer ->

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails.kt
@@ -29,7 +29,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/HumanDetails_ResponseAdapter.kt
@@ -16,13 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -33,14 +34,14 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         name = name!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -97,15 +97,15 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl(
-    val delegate: HumanDetails.DefaultImpl
+  data class HumanR2(
+    val delegate: HumanDetails.HumanDetailsImpl
   ) : R2, HumanDetails by delegate
 
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DroidDetailsImpl(
-    val delegate: DroidDetails.DefaultImpl
+  data class DroidR2(
+    val delegate: DroidDetails.DroidDetailsImpl
   ) : R2, DroidDetails by delegate
 
   /**
@@ -137,15 +137,15 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl1(
-    val delegate: HumanDetails.DefaultImpl
+  data class HumanLuke(
+    val delegate: HumanDetails.HumanDetailsImpl
   ) : Luke, HumanDetails by delegate
 
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DroidDetailsImpl1(
-    val delegate: DroidDetails.DefaultImpl
+  data class DroidLuke(
+    val delegate: DroidDetails.DroidDetailsImpl
   ) : Luke, DroidDetails by delegate
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery_ResponseAdapter.kt
@@ -63,24 +63,22 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.HumanDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanDetailsImpl {
-      return TestQuery.HumanDetailsImpl(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object HumanR2_ResponseAdapter : ResponseAdapter<TestQuery.HumanR2> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanR2 {
+      return TestQuery.HumanR2(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanR2) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.DroidDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidDetailsImpl {
-      return TestQuery.DroidDetailsImpl(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object DroidR2_ResponseAdapter : ResponseAdapter<TestQuery.DroidR2> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidR2 {
+      return TestQuery.DroidR2(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidR2) {
       DroidDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -118,39 +116,37 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.R2 {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanR2_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidR2_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherR2_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.R2) {
       when(value) {
-        is TestQuery.HumanDetailsImpl -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.DroidDetailsImpl -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanR2 -> TestQuery_ResponseAdapter.HumanR2_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidR2 -> TestQuery_ResponseAdapter.DroidR2_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherR2 -> TestQuery_ResponseAdapter.OtherR2_ResponseAdapter.toResponse(writer, value)
       }
     }
   }
 
-  object HumanDetailsImpl1_ResponseAdapter : ResponseAdapter<TestQuery.HumanDetailsImpl1> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanDetailsImpl1 {
-      return TestQuery.HumanDetailsImpl1(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object HumanLuke_ResponseAdapter : ResponseAdapter<TestQuery.HumanLuke> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanLuke {
+      return TestQuery.HumanLuke(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanDetailsImpl1) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanLuke) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object DroidDetailsImpl1_ResponseAdapter : ResponseAdapter<TestQuery.DroidDetailsImpl1> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidDetailsImpl1 {
-      return TestQuery.DroidDetailsImpl1(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object DroidLuke_ResponseAdapter : ResponseAdapter<TestQuery.DroidLuke> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidLuke {
+      return TestQuery.DroidLuke(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidDetailsImpl1) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidLuke) {
       DroidDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -188,16 +184,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Luke {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.HumanDetailsImpl1_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.DroidDetailsImpl1_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanLuke_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidLuke_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherLuke_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Luke) {
       when(value) {
-        is TestQuery.HumanDetailsImpl1 -> TestQuery_ResponseAdapter.HumanDetailsImpl1_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.DroidDetailsImpl1 -> TestQuery_ResponseAdapter.DroidDetailsImpl1_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanLuke -> TestQuery_ResponseAdapter.HumanLuke_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidLuke -> TestQuery_ResponseAdapter.DroidLuke_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherLuke -> TestQuery_ResponseAdapter.OtherLuke_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails.kt
@@ -34,7 +34,7 @@ interface DroidDetails : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DefaultImpl(
+  data class DroidDetailsImpl(
     override val __typename: String = "Droid",
     /**
      * What others call this droid

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/DroidDetails_ResponseAdapter.kt
@@ -16,14 +16,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> {
+object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DroidDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      DroidDetails.DroidDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -36,7 +37,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
           else -> break
         }
       }
-      DroidDetails.DefaultImpl(
+      DroidDetails.DroidDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         primaryFunction = primaryFunction
@@ -44,7 +45,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DroidDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails.kt
@@ -35,7 +35,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/HumanDetails_ResponseAdapter.kt
@@ -17,14 +17,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forDouble("height", "height", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -37,7 +38,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         height = height
@@ -45,7 +46,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeDouble(RESPONSE_FIELDS[2], value.height)

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery.kt
@@ -97,15 +97,15 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl(
-    val delegate: HumanDetails.DefaultImpl
+  data class HumanR2(
+    val delegate: HumanDetails.HumanDetailsImpl
   ) : R2, HumanDetails by delegate
 
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DroidDetailsImpl(
-    val delegate: DroidDetails.DefaultImpl
+  data class DroidR2(
+    val delegate: DroidDetails.DroidDetailsImpl
   ) : R2, DroidDetails by delegate
 
   /**
@@ -137,15 +137,15 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl1(
-    val delegate: HumanDetails.DefaultImpl
+  data class HumanLuke(
+    val delegate: HumanDetails.HumanDetailsImpl
   ) : Luke, HumanDetails by delegate
 
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DroidDetailsImpl1(
-    val delegate: DroidDetails.DefaultImpl
+  data class DroidLuke(
+    val delegate: DroidDetails.DroidDetailsImpl
   ) : Luke, DroidDetails by delegate
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/TestQuery_ResponseAdapter.kt
@@ -63,24 +63,22 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.HumanDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanDetailsImpl {
-      return TestQuery.HumanDetailsImpl(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object HumanR2_ResponseAdapter : ResponseAdapter<TestQuery.HumanR2> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanR2 {
+      return TestQuery.HumanR2(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanR2) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.DroidDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidDetailsImpl {
-      return TestQuery.DroidDetailsImpl(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object DroidR2_ResponseAdapter : ResponseAdapter<TestQuery.DroidR2> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidR2 {
+      return TestQuery.DroidR2(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidR2) {
       DroidDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -118,39 +116,37 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.R2 {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanR2_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidR2_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherR2_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.R2) {
       when(value) {
-        is TestQuery.HumanDetailsImpl -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.DroidDetailsImpl -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanR2 -> TestQuery_ResponseAdapter.HumanR2_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidR2 -> TestQuery_ResponseAdapter.DroidR2_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherR2 -> TestQuery_ResponseAdapter.OtherR2_ResponseAdapter.toResponse(writer, value)
       }
     }
   }
 
-  object HumanDetailsImpl1_ResponseAdapter : ResponseAdapter<TestQuery.HumanDetailsImpl1> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanDetailsImpl1 {
-      return TestQuery.HumanDetailsImpl1(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object HumanLuke_ResponseAdapter : ResponseAdapter<TestQuery.HumanLuke> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanLuke {
+      return TestQuery.HumanLuke(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanDetailsImpl1) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanLuke) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object DroidDetailsImpl1_ResponseAdapter : ResponseAdapter<TestQuery.DroidDetailsImpl1> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidDetailsImpl1 {
-      return TestQuery.DroidDetailsImpl1(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object DroidLuke_ResponseAdapter : ResponseAdapter<TestQuery.DroidLuke> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidLuke {
+      return TestQuery.DroidLuke(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidDetailsImpl1) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidLuke) {
       DroidDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -188,16 +184,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Luke {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.HumanDetailsImpl1_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.DroidDetailsImpl1_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanLuke_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidLuke_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherLuke_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Luke) {
       when(value) {
-        is TestQuery.HumanDetailsImpl1 -> TestQuery_ResponseAdapter.HumanDetailsImpl1_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.DroidDetailsImpl1 -> TestQuery_ResponseAdapter.DroidDetailsImpl1_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanLuke -> TestQuery_ResponseAdapter.HumanLuke_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidLuke -> TestQuery_ResponseAdapter.DroidLuke_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherLuke -> TestQuery_ResponseAdapter.OtherLuke_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails.kt
@@ -34,7 +34,7 @@ interface DroidDetails : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DefaultImpl(
+  data class DroidDetailsImpl(
     override val __typename: String = "Droid",
     /**
      * What others call this droid

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/DroidDetails_ResponseAdapter.kt
@@ -16,14 +16,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> {
+object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DroidDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      DroidDetails.DroidDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -36,7 +37,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
           else -> break
         }
       }
-      DroidDetails.DefaultImpl(
+      DroidDetails.DroidDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         primaryFunction = primaryFunction
@@ -44,7 +45,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DroidDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails.kt
@@ -35,7 +35,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition_nullable/fragment/HumanDetails_ResponseAdapter.kt
@@ -17,14 +17,15 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forDouble("height", "height", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -37,7 +38,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         height = height
@@ -45,7 +46,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeDouble(RESPONSE_FIELDS[2], value.height)

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -96,7 +96,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanNonOptionalHero(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -109,7 +109,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : NonOptionalHero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanNonOptionalHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -142,7 +142,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
      */
     val name: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanNonOptionalHero(): HumanNonOptionalHero? = this as? HumanNonOptionalHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery_ResponseAdapter.kt
@@ -46,14 +46,15 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanNonOptionalHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanNonOptionalHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
       ResponseField.forDouble("height", "height", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.HumanNonOptionalHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -66,7 +67,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanNonOptionalHero(
           __typename = __typename!!,
           name = name!!,
           height = height
@@ -74,7 +75,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanNonOptionalHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeDouble(RESPONSE_FIELDS[2], value.height)
@@ -122,14 +123,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
         TestQuery.NonOptionalHero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanNonOptionalHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherNonOptionalHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.NonOptionalHero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanNonOptionalHero -> TestQuery_ResponseAdapter.HumanNonOptionalHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherNonOptionalHero -> TestQuery_ResponseAdapter.OtherNonOptionalHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
@@ -159,7 +159,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
     override fun marshaller(): ResponseFieldMarshaller
   }
 
-  data class CharacterDroidImpl(
+  data class CharacterDroidSearch(
     override val __typename: String,
     /**
      * The name of the character
@@ -172,12 +172,12 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Character1, Droid, Search {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.CharacterDroidImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterDroidSearch_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
 
-  data class CharacterHumanImpl(
+  data class CharacterHumanSearch(
     override val __typename: String,
     /**
      * The name of the character
@@ -190,7 +190,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Character1, Human, Search {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.CharacterHumanImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHumanSearch_ResponseAdapter.toResponse(writer, this)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery_ResponseAdapter.kt
@@ -56,7 +56,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object CharacterDroidImpl_ResponseAdapter : ResponseAdapter<TestQuery.CharacterDroidImpl> {
+  object CharacterDroidSearch_ResponseAdapter : ResponseAdapter<TestQuery.CharacterDroidSearch> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -64,7 +64,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.CharacterDroidImpl {
+        TestQuery.CharacterDroidSearch {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -77,7 +77,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.CharacterDroidImpl(
+        TestQuery.CharacterDroidSearch(
           __typename = __typename!!,
           name = name!!,
           primaryFunction = primaryFunction
@@ -85,14 +85,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterDroidImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterDroidSearch) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
     }
   }
 
-  object CharacterHumanImpl_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanImpl> {
+  object CharacterHumanSearch_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanSearch> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -100,7 +100,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.CharacterHumanImpl {
+        TestQuery.CharacterHumanSearch {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -113,7 +113,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.CharacterHumanImpl(
+        TestQuery.CharacterHumanSearch(
           __typename = __typename!!,
           name = name!!,
           homePlanet = homePlanet
@@ -121,7 +121,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanSearch) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
@@ -161,16 +161,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Search {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.CharacterDroidImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.CharacterHumanImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterDroidSearch_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterHumanSearch_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Search) {
       when(value) {
-        is TestQuery.CharacterDroidImpl -> TestQuery_ResponseAdapter.CharacterDroidImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.CharacterHumanImpl -> TestQuery_ResponseAdapter.CharacterHumanImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterDroidSearch -> TestQuery_ResponseAdapter.CharacterDroidSearch_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHumanSearch -> TestQuery_ResponseAdapter.CharacterHumanSearch_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherSearch -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -95,14 +95,14 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * For testing fragment type coercion
    */
-  data class Bar(
+  data class BarFoo(
     override val __typename: String = "Bar",
     override val foo: String,
     val bar: String
   ) : Foo {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Bar_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.BarFoo_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -129,7 +129,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
 
     val foo: String
 
-    fun asBar(): Bar? = this as? Bar
+    fun asBarFoo(): BarFoo? = this as? BarFoo
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery_ResponseAdapter.kt
@@ -48,14 +48,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Bar_ResponseAdapter : ResponseAdapter<TestQuery.Bar> {
+  object BarFoo_ResponseAdapter : ResponseAdapter<TestQuery.BarFoo> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("foo", "foo", null, false, null),
       ResponseField.forString("bar", "bar", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Bar {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.BarFoo {
       return reader.run {
         var __typename: String? = __typename
         var foo: String? = null
@@ -68,7 +68,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Bar(
+        TestQuery.BarFoo(
           __typename = __typename!!,
           foo = foo!!,
           bar = bar!!
@@ -76,7 +76,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Bar) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.BarFoo) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.foo)
       writer.writeString(RESPONSE_FIELDS[2], value.bar)
@@ -122,15 +122,15 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Foo {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "BarObject" -> TestQuery_ResponseAdapter.Bar_ResponseAdapter.fromResponse(reader, typename)
-        "FooBar" -> TestQuery_ResponseAdapter.Bar_ResponseAdapter.fromResponse(reader, typename)
+        "BarObject" -> TestQuery_ResponseAdapter.BarFoo_ResponseAdapter.fromResponse(reader, typename)
+        "FooBar" -> TestQuery_ResponseAdapter.BarFoo_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherFoo_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Foo) {
       when(value) {
-        is TestQuery.Bar -> TestQuery_ResponseAdapter.Bar_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.BarFoo -> TestQuery_ResponseAdapter.BarFoo_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherFoo -> TestQuery_ResponseAdapter.OtherFoo_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -117,7 +117,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHero(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -134,7 +134,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -161,7 +161,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class Droid(
+  data class DroidHero(
     override val __typename: String = "Droid",
     /**
      * What others call this droid
@@ -178,7 +178,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -213,9 +213,9 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
      */
     val name: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHero(): HumanHero? = this as? HumanHero
 
-    fun asDroid(): Droid? = this as? Droid
+    fun asDroidHero(): DroidHero? = this as? DroidHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery_ResponseAdapter.kt
@@ -87,7 +87,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -95,7 +95,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forList("friends", "friends", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -114,7 +114,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanHero(
           __typename = __typename!!,
           name = name!!,
           height = height,
@@ -123,7 +123,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeDouble(RESPONSE_FIELDS[2], value.height)
@@ -171,7 +171,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Droid_ResponseAdapter : ResponseAdapter<TestQuery.Droid> {
+  object DroidHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -179,7 +179,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forList("friends", "friends", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Droid {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -198,7 +198,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Droid(
+        TestQuery.DroidHero(
           __typename = __typename!!,
           name = name!!,
           primaryFunction = primaryFunction,
@@ -207,7 +207,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Droid) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
@@ -264,16 +264,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Droid -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidHero -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
@@ -97,15 +97,15 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DroidDetailsImpl(
-    val delegate: DroidDetails.DefaultImpl
+  data class DroidHero(
+    val delegate: DroidDetails.DroidDetailsImpl
   ) : Hero, DroidDetails by delegate
 
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl(
-    val delegate: HumanDetails.DefaultImpl
+  data class HumanHero(
+    val delegate: HumanDetails.HumanDetailsImpl
   ) : Hero, HumanDetails by delegate
 
   /**

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery_ResponseAdapter.kt
@@ -50,24 +50,22 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.DroidDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.DroidDetailsImpl {
-      return TestQuery.DroidDetailsImpl(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object DroidHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidHero> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidHero {
+      return TestQuery.DroidHero(DroidDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidHero) {
       DroidDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.HumanDetailsImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HumanDetailsImpl {
-      return TestQuery.HumanDetailsImpl(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
+      return TestQuery.HumanHero(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -105,16 +103,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.DroidDetailsImpl -> TestQuery_ResponseAdapter.DroidDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.HumanDetailsImpl -> TestQuery_ResponseAdapter.HumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidHero -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails.kt
@@ -71,7 +71,7 @@ interface DroidDetails : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DefaultImpl(
+  data class DroidDetailsImpl(
     override val __typename: String = "Droid",
     /**
      * What others call this droid

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/DroidDetails_ResponseAdapter.kt
@@ -17,7 +17,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> {
+object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DroidDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
@@ -25,7 +25,8 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
     ResponseField.forList("friends", "friends", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      DroidDetails.DroidDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -44,7 +45,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
           else -> break
         }
       }
-      DroidDetails.DefaultImpl(
+      DroidDetails.DroidDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         primaryFunction = primaryFunction,
@@ -53,7 +54,7 @@ object DroidDetails_ResponseAdapter : ResponseAdapter<DroidDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: DroidDetails.DroidDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails.kt
@@ -134,7 +134,7 @@ interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/HumanDetails_ResponseAdapter.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
@@ -27,7 +27,8 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
     ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -44,7 +45,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         profileLink = profileLink!!,
@@ -53,7 +54,7 @@ object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> 
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomTypeField, value.profileLink)

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -122,7 +122,7 @@ data class TestQuery(
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human1(
+  data class HumanFriend(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -135,7 +135,7 @@ data class TestQuery(
   ) : Friend {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human1_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -168,7 +168,7 @@ data class TestQuery(
      */
     val name: String
 
-    fun asHuman1(): Human1? = this as? Human1
+    fun asHumanFriend(): HumanFriend? = this as? HumanFriend
 
     fun marshaller(): ResponseFieldMarshaller
   }
@@ -176,7 +176,7 @@ data class TestQuery(
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHero(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -189,7 +189,7 @@ data class TestQuery(
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -199,7 +199,7 @@ data class TestQuery(
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human2(
+  data class HumanFriend1(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -212,7 +212,7 @@ data class TestQuery(
   ) : Friend1 {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human2_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanFriend1_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -245,7 +245,7 @@ data class TestQuery(
      */
     val name: String
 
-    fun asHuman2(): Human2? = this as? Human2
+    fun asHumanFriend1(): HumanFriend1? = this as? HumanFriend1
 
     fun marshaller(): ResponseFieldMarshaller
   }
@@ -253,7 +253,7 @@ data class TestQuery(
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class Droid(
+  data class DroidHero(
     override val __typename: String = "Droid",
     /**
      * What others call this droid
@@ -266,7 +266,7 @@ data class TestQuery(
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -301,9 +301,9 @@ data class TestQuery(
      */
     val name: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHero(): HumanHero? = this as? HumanHero
 
-    fun asDroid(): Droid? = this as? Droid
+    fun asDroidHero(): DroidHero? = this as? DroidHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery_ResponseAdapter.kt
@@ -53,7 +53,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human1_ResponseAdapter : ResponseAdapter<TestQuery.Human1> {
+  object HumanFriend_ResponseAdapter : ResponseAdapter<TestQuery.HumanFriend> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -61,7 +61,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
         "unit" to "FOOT"), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human1 {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanFriend {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -74,7 +74,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human1(
+        TestQuery.HumanFriend(
           __typename = __typename!!,
           name = name!!,
           height = height
@@ -82,7 +82,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human1) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanFriend) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeDouble(RESPONSE_FIELDS[2], value.height)
@@ -128,27 +128,27 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Friend {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human1_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherFriend_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Friend) {
       when(value) {
-        is TestQuery.Human1 -> TestQuery_ResponseAdapter.Human1_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanFriend -> TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherFriend -> TestQuery_ResponseAdapter.OtherFriend_ResponseAdapter.toResponse(writer, value)
       }
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
       ResponseField.forList("friends", "friends", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -165,7 +165,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanHero(
           __typename = __typename!!,
           name = name!!,
           friends = friends
@@ -173,7 +173,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -190,7 +190,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human2_ResponseAdapter : ResponseAdapter<TestQuery.Human2> {
+  object HumanFriend1_ResponseAdapter : ResponseAdapter<TestQuery.HumanFriend1> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -198,7 +198,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
         "unit" to "METER"), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human2 {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanFriend1 {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -211,7 +211,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human2(
+        TestQuery.HumanFriend1(
           __typename = __typename!!,
           name = name!!,
           height = height
@@ -219,7 +219,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human2) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanFriend1) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeDouble(RESPONSE_FIELDS[2], value.height)
@@ -265,27 +265,27 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Friend1 {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human2_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanFriend1_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherFriend1_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Friend1) {
       when(value) {
-        is TestQuery.Human2 -> TestQuery_ResponseAdapter.Human2_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanFriend1 -> TestQuery_ResponseAdapter.HumanFriend1_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherFriend1 -> TestQuery_ResponseAdapter.OtherFriend1_ResponseAdapter.toResponse(writer, value)
       }
     }
   }
 
-  object Droid_ResponseAdapter : ResponseAdapter<TestQuery.Droid> {
+  object DroidHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
       ResponseField.forList("friends", "friends", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Droid {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -302,7 +302,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Droid(
+        TestQuery.DroidHero(
           __typename = __typename!!,
           name = name!!,
           friends = friends
@@ -310,7 +310,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Droid) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -366,16 +366,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Droid -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidHero -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -117,7 +117,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A character from the Star Wars universe
    */
-  data class Character(
+  data class CharacterObject(
     override val __typename: String = "Character",
     /**
      * The name of the character
@@ -126,7 +126,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Object {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Character_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterObject_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -144,7 +144,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   interface Object {
     val __typename: String
 
-    fun asCharacter(): Character? = this as? Character
+    fun asCharacterObject(): CharacterObject? = this as? CharacterObject
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery_ResponseAdapter.kt
@@ -105,13 +105,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Character_ResponseAdapter : ResponseAdapter<TestQuery.Character> {
+  object CharacterObject_ResponseAdapter : ResponseAdapter<TestQuery.CharacterObject> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Character {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.CharacterObject {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -122,14 +123,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Character(
+        TestQuery.CharacterObject(
           __typename = __typename!!,
           name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Character) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterObject) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
@@ -168,15 +169,15 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Object {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.Character_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.Character_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterObject_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterObject_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherObject_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Object) {
       when(value) {
-        is TestQuery.Character -> TestQuery_ResponseAdapter.Character_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterObject -> TestQuery_ResponseAdapter.CharacterObject_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherObject -> TestQuery_ResponseAdapter.OtherObject_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment.kt
@@ -57,7 +57,7 @@ interface QueryFragment : GraphqlFragment {
   /**
    * The query type, represents all of the entry points into our object graph
    */
-  data class DefaultImpl(
+  data class QueryFragmentImpl(
     override val __typename: String = "Query",
     override val hero: Hero1?
   ) : QueryFragment {

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/QueryFragment_ResponseAdapter.kt
@@ -16,14 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl> {
+object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.QueryFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forObject("hero", "hero", null, true, null)
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      QueryFragment.DefaultImpl {
+      QueryFragment.QueryFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var hero: QueryFragment.Hero1? = null
@@ -36,14 +36,14 @@ object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl
           else -> break
         }
       }
-      QueryFragment.DefaultImpl(
+      QueryFragment.QueryFragmentImpl(
         __typename = __typename!!,
         hero = hero
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: QueryFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: QueryFragment.QueryFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     if(value.hero == null) {
       writer.writeObject(RESPONSE_FIELDS[1], null)

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/DroidFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/DroidFragment.kt
@@ -34,7 +34,7 @@ interface DroidFragment : GraphqlFragment {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class DefaultImpl(
+  data class DroidFragmentImpl(
     override val __typename: String = "Droid",
     /**
      * What others call this droid

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/DroidFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/DroidFragment_ResponseAdapter.kt
@@ -16,7 +16,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object DroidFragment_ResponseAdapter : ResponseAdapter<DroidFragment.DefaultImpl> {
+object DroidFragment_ResponseAdapter : ResponseAdapter<DroidFragment.DroidFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
@@ -24,7 +24,7 @@ object DroidFragment_ResponseAdapter : ResponseAdapter<DroidFragment.DefaultImpl
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      DroidFragment.DefaultImpl {
+      DroidFragment.DroidFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -37,7 +37,7 @@ object DroidFragment_ResponseAdapter : ResponseAdapter<DroidFragment.DefaultImpl
           else -> break
         }
       }
-      DroidFragment.DefaultImpl(
+      DroidFragment.DroidFragmentImpl(
         __typename = __typename!!,
         name = name!!,
         primaryFunction = primaryFunction
@@ -45,7 +45,7 @@ object DroidFragment_ResponseAdapter : ResponseAdapter<DroidFragment.DefaultImpl
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: DroidFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: DroidFragment.DroidFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/HeroFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/HeroFragment.kt
@@ -29,7 +29,7 @@ interface HeroFragment : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroFragmentImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/HeroFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/HeroFragment_ResponseAdapter.kt
@@ -16,13 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroFragment_ResponseAdapter : ResponseAdapter<HeroFragment.DefaultImpl> {
+object HeroFragment_ResponseAdapter : ResponseAdapter<HeroFragment.HeroFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroFragment.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroFragment.HeroFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -33,14 +34,14 @@ object HeroFragment_ResponseAdapter : ResponseAdapter<HeroFragment.DefaultImpl> 
           else -> break
         }
       }
-      HeroFragment.DefaultImpl(
+      HeroFragment.HeroFragmentImpl(
         __typename = __typename!!,
         name = name!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroFragment.HeroFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/QueryFragment.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/QueryFragment.kt
@@ -126,7 +126,7 @@ interface QueryFragment : GraphqlFragment {
   /**
    * The query type, represents all of the entry points into our object graph
    */
-  data class DefaultImpl(
+  data class QueryFragmentImpl(
     override val __typename: String = "Query",
     override val hero: Hero1?,
     override val droid: Droid1?,

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/QueryFragment_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/QueryFragment_ResponseAdapter.kt
@@ -16,7 +16,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl> {
+object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.QueryFragmentImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forObject("hero", "hero", null, true, null),
@@ -27,7 +27,7 @@ object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
-      QueryFragment.DefaultImpl {
+      QueryFragment.QueryFragmentImpl {
     return reader.run {
       var __typename: String? = __typename
       var hero: QueryFragment.Hero1? = null
@@ -48,7 +48,7 @@ object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl
           else -> break
         }
       }
-      QueryFragment.DefaultImpl(
+      QueryFragment.QueryFragmentImpl(
         __typename = __typename!!,
         hero = hero,
         droid = droid,
@@ -57,7 +57,7 @@ object QueryFragment_ResponseAdapter : ResponseAdapter<QueryFragment.DefaultImpl
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: QueryFragment.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: QueryFragment.QueryFragmentImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     if(value.hero == null) {
       writer.writeObject(RESPONSE_FIELDS[1], null)

--- a/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery.kt
@@ -98,7 +98,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHero(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -115,7 +115,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -161,7 +161,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
      */
     val appearsIn: List<Episode?>
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHero(): HumanHero? = this as? HumanHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery_ResponseAdapter.kt
@@ -70,7 +70,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -78,7 +78,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forDouble("height", "height", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -95,7 +95,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanHero(
           __typename = __typename!!,
           name = name!!,
           appearsIn = appearsIn!!,
@@ -104,7 +104,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { values, listItemWriter ->
@@ -165,14 +165,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -101,11 +101,11 @@ internal class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A character from the Star Wars universe
    */
-  data class HeroDetailsImpl(
-    val delegate: HeroDetails.DefaultImpl
+  data class CharacterHero(
+    val delegate: HeroDetails.HeroDetailsImpl
   ) : HeroDetails by delegate, Hero
 
-  data class HeroDetailsHumanDetailsImpl(
+  data class CharacterHumanHero(
     override val __typename: String,
     /**
      * What this human calls themselves
@@ -114,7 +114,7 @@ internal class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : HeroDetails, HumanDetails, Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery_ResponseAdapter.kt
@@ -49,26 +49,25 @@ internal object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<TestQuery.HeroDetailsImpl> {
+  object CharacterHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHero> {
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsImpl {
-      return TestQuery.HeroDetailsImpl(HeroDetails_ResponseAdapter.fromResponse(reader, __typename))
+        TestQuery.CharacterHero {
+      return TestQuery.CharacterHero(HeroDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HeroDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHero) {
       HeroDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object HeroDetailsHumanDetailsImpl_ResponseAdapter :
-      ResponseAdapter<TestQuery.HeroDetailsHumanDetailsImpl> {
+  object CharacterHumanHero_ResponseAdapter : ResponseAdapter<TestQuery.CharacterHumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.HeroDetailsHumanDetailsImpl {
+        TestQuery.CharacterHumanHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -79,14 +78,14 @@ internal object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.HeroDetailsHumanDetailsImpl(
+        TestQuery.CharacterHumanHero(
           __typename = __typename!!,
           name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.HeroDetailsHumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterHumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
@@ -125,16 +124,16 @@ internal object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.HeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.HeroDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.HeroDetailsHumanDetailsImpl -> TestQuery_ResponseAdapter.HeroDetailsHumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHero -> TestQuery_ResponseAdapter.CharacterHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterHumanHero -> TestQuery_ResponseAdapter.CharacterHumanHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails.kt
@@ -24,19 +24,19 @@ internal interface HeroDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class HumanDetailsImpl(
-    val delegate: HumanDetails.DefaultImpl
-  ) : DefaultImpl, HumanDetails by delegate
+  data class HumanHeroDetailsImpl(
+    val delegate: HumanDetails.HumanDetailsImpl
+  ) : HeroDetailsImpl, HumanDetails by delegate
 
   /**
    * A character from the Star Wars universe
    */
-  data class OtherDefaultImpl(
+  data class OtherHeroDetailsImpl(
     override val __typename: String = "Character"
-  ) : HeroDetails, DefaultImpl {
+  ) : HeroDetails, HeroDetailsImpl {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetails_ResponseAdapter.OtherDefaultImpl_ResponseAdapter.toResponse(writer, this)
+        HeroDetails_ResponseAdapter.OtherHeroDetailsImpl_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -44,7 +44,7 @@ internal interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  interface DefaultImpl : HeroDetails {
+  interface HeroDetailsImpl : HeroDetails {
     override val __typename: String
 
     fun asHumanDetails(): HumanDetails? = this as? HumanDetails

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HeroDetails_ResponseAdapter.kt
@@ -16,44 +16,45 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-internal object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+internal object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
     return when(typename) {
-      "Human" -> HumanDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
-      else -> OtherDefaultImpl_ResponseAdapter.fromResponse(reader, typename)
+      "Human" -> HumanHeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
+      else -> OtherHeroDetailsImpl_ResponseAdapter.fromResponse(reader, typename)
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     when(value) {
-      is HeroDetails.HumanDetailsImpl -> HumanDetailsImpl_ResponseAdapter.toResponse(writer, value)
-      is HeroDetails.OtherDefaultImpl -> OtherDefaultImpl_ResponseAdapter.toResponse(writer, value)
+      is HeroDetails.HumanHeroDetailsImpl -> HumanHeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
+      is HeroDetails.OtherHeroDetailsImpl -> OtherHeroDetailsImpl_ResponseAdapter.toResponse(writer, value)
     }
   }
 
-  object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.HumanDetailsImpl> {
+  object HumanHeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.HumanHeroDetailsImpl> {
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetails.HumanDetailsImpl {
-      return HeroDetails.HumanDetailsImpl(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
+        HeroDetails.HumanHeroDetailsImpl {
+      return HeroDetails.HumanHeroDetailsImpl(HumanDetails_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.HumanDetailsImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.HumanHeroDetailsImpl) {
       HumanDetails_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object OtherDefaultImpl_ResponseAdapter : ResponseAdapter<HeroDetails.OtherDefaultImpl> {
+  object OtherHeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetails.OtherHeroDetailsImpl> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetails.OtherDefaultImpl {
+        HeroDetails.OtherHeroDetailsImpl {
       return reader.run {
         var __typename: String? = __typename
         while(true) {
@@ -62,13 +63,13 @@ internal object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.Defaul
             else -> break
           }
         }
-        HeroDetails.OtherDefaultImpl(
+        HeroDetails.OtherHeroDetailsImpl(
           __typename = __typename!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.OtherDefaultImpl) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.OtherHeroDetailsImpl) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails.kt
@@ -29,7 +29,7 @@ internal interface HumanDetails : GraphqlFragment {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HumanDetailsImpl(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/HumanDetails_ResponseAdapter.kt
@@ -16,13 +16,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-internal object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.DefaultImpl> {
+internal object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.HumanDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HumanDetails.HumanDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -33,14 +34,14 @@ internal object HumanDetails_ResponseAdapter : ResponseAdapter<HumanDetails.Defa
           else -> break
         }
       }
-      HumanDetails.DefaultImpl(
+      HumanDetails.HumanDetailsImpl(
         __typename = __typename!!,
         name = name!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HumanDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HumanDetails.HumanDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -96,7 +96,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHero(
     override val __typename: String = "Human",
     /**
      * Height in the preferred unit, default is meters
@@ -109,7 +109,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -117,7 +117,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class Droid(
+  data class DroidHero(
     override val __typename: String = "Droid",
     /**
      * This droid's primary function
@@ -130,7 +130,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -163,9 +163,9 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
      */
     val name: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHero(): HumanHero? = this as? HumanHero
 
-    fun asDroid(): Droid? = this as? Droid
+    fun asDroidHero(): DroidHero? = this as? DroidHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery_ResponseAdapter.kt
@@ -49,14 +49,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forDouble("height", "height", null, true, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
       return reader.run {
         var __typename: String? = __typename
         var height: Double? = null
@@ -69,7 +69,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanHero(
           __typename = __typename!!,
           height = height,
           name = name!!
@@ -77,21 +77,21 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeDouble(RESPONSE_FIELDS[1], value.height)
       writer.writeString(RESPONSE_FIELDS[2], value.name)
     }
   }
 
-  object Droid_ResponseAdapter : ResponseAdapter<TestQuery.Droid> {
+  object DroidHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Droid {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidHero {
       return reader.run {
         var __typename: String? = __typename
         var primaryFunction: String? = null
@@ -104,7 +104,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Droid(
+        TestQuery.DroidHero(
           __typename = __typename!!,
           primaryFunction = primaryFunction,
           name = name!!
@@ -112,7 +112,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Droid) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.primaryFunction)
       writer.writeString(RESPONSE_FIELDS[2], value.name)
@@ -158,16 +158,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Droid -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidHero -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
@@ -96,7 +96,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHero(
     override val __typename: String = "Human",
     /**
      * Height in the preferred unit, default is meters
@@ -105,7 +105,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -113,7 +113,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class Droid(
+  data class DroidHero(
     override val __typename: String = "Droid",
     /**
      * What others call this droid
@@ -126,7 +126,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Hero {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -150,9 +150,9 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   interface Hero {
     val __typename: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHero(): HumanHero? = this as? HumanHero
 
-    fun asDroid(): Droid? = this as? Droid
+    fun asDroidHero(): DroidHero? = this as? DroidHero
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery_ResponseAdapter.kt
@@ -49,13 +49,13 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanHero_ResponseAdapter : ResponseAdapter<TestQuery.HumanHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forDouble("height", "height", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanHero {
       return reader.run {
         var __typename: String? = __typename
         var height: Double? = null
@@ -66,27 +66,27 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanHero(
           __typename = __typename!!,
           height = height
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeDouble(RESPONSE_FIELDS[1], value.height)
     }
   }
 
-  object Droid_ResponseAdapter : ResponseAdapter<TestQuery.Droid> {
+  object DroidHero_ResponseAdapter : ResponseAdapter<TestQuery.DroidHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
       ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Droid {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidHero {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -99,7 +99,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Droid(
+        TestQuery.DroidHero(
           __typename = __typename!!,
           name = name!!,
           primaryFunction = primaryFunction
@@ -107,7 +107,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Droid) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidHero) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
@@ -147,16 +147,16 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Hero {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Hero) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Droid -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanHero -> TestQuery_ResponseAdapter.HumanHero_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidHero -> TestQuery_ResponseAdapter.DroidHero_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherHero -> TestQuery_ResponseAdapter.OtherHero_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -98,12 +98,12 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A character from the Star Wars universe
    */
-  data class CharacterImpl(
-    val delegate: Character.DefaultImpl
+  data class CharacterSearch(
+    val delegate: Character.CharacterImpl
   ) : Search, Character by delegate
 
-  data class StarshipImpl(
-    val delegate: Starship.DefaultImpl
+  data class StarshipSearch(
+    val delegate: Starship.StarshipImpl
   ) : Search, Starship by delegate
 
   data class OtherSearch(

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery_ResponseAdapter.kt
@@ -58,23 +58,24 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object CharacterImpl_ResponseAdapter : ResponseAdapter<TestQuery.CharacterImpl> {
+  object CharacterSearch_ResponseAdapter : ResponseAdapter<TestQuery.CharacterSearch> {
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQuery.CharacterImpl {
-      return TestQuery.CharacterImpl(Character_ResponseAdapter.fromResponse(reader, __typename))
+        TestQuery.CharacterSearch {
+      return TestQuery.CharacterSearch(Character_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterSearch) {
       Character_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
 
-  object StarshipImpl_ResponseAdapter : ResponseAdapter<TestQuery.StarshipImpl> {
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.StarshipImpl {
-      return TestQuery.StarshipImpl(Starship_ResponseAdapter.fromResponse(reader, __typename))
+  object StarshipSearch_ResponseAdapter : ResponseAdapter<TestQuery.StarshipSearch> {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.StarshipSearch {
+      return TestQuery.StarshipSearch(Starship_ResponseAdapter.fromResponse(reader, __typename))
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.StarshipImpl) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.StarshipSearch) {
       Starship_ResponseAdapter.toResponse(writer, value.delegate)
     }
   }
@@ -112,17 +113,17 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Search {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.CharacterImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.CharacterImpl_ResponseAdapter.fromResponse(reader, typename)
-        "Starship" -> TestQuery_ResponseAdapter.StarshipImpl_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.fromResponse(reader, typename)
+        "Starship" -> TestQuery_ResponseAdapter.StarshipSearch_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Search) {
       when(value) {
-        is TestQuery.CharacterImpl -> TestQuery_ResponseAdapter.CharacterImpl_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.StarshipImpl -> TestQuery_ResponseAdapter.StarshipImpl_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterSearch -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.StarshipSearch -> TestQuery_ResponseAdapter.StarshipSearch_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherSearch -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character.kt
@@ -34,7 +34,7 @@ interface Character : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class CharacterImpl(
     override val __typename: String = "Character",
     /**
      * The ID of the character

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Character_ResponseAdapter.kt
@@ -17,14 +17,14 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object Character_ResponseAdapter : ResponseAdapter<Character.DefaultImpl> {
+object Character_ResponseAdapter : ResponseAdapter<Character.CharacterImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): Character.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?): Character.CharacterImpl {
     return reader.run {
       var __typename: String? = __typename
       var id: String? = null
@@ -37,7 +37,7 @@ object Character_ResponseAdapter : ResponseAdapter<Character.DefaultImpl> {
           else -> break
         }
       }
-      Character.DefaultImpl(
+      Character.CharacterImpl(
         __typename = __typename!!,
         id = id!!,
         name = name!!
@@ -45,7 +45,7 @@ object Character_ResponseAdapter : ResponseAdapter<Character.DefaultImpl> {
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: Character.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: Character.CharacterImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, value.id)
     writer.writeString(RESPONSE_FIELDS[2], value.name)

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship.kt
@@ -23,7 +23,7 @@ interface Starship : GraphqlFragment {
    */
   val name: String
 
-  data class DefaultImpl(
+  data class StarshipImpl(
     override val __typename: String = "Starship",
     /**
      * The name of the starship

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/Starship_ResponseAdapter.kt
@@ -16,13 +16,13 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object Starship_ResponseAdapter : ResponseAdapter<Starship.DefaultImpl> {
+object Starship_ResponseAdapter : ResponseAdapter<Starship.StarshipImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): Starship.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?): Starship.StarshipImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -33,14 +33,14 @@ object Starship_ResponseAdapter : ResponseAdapter<Starship.DefaultImpl> {
           else -> break
         }
       }
-      Starship.DefaultImpl(
+      Starship.StarshipImpl(
         __typename = __typename!!,
         name = name!!
       )
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: Starship.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: Starship.StarshipImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -114,7 +114,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanFriend(
     override val __typename: String = "Human",
     /**
      * The home planet of the human, or null if unknown
@@ -131,7 +131,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Friend {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -158,7 +158,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * An autonomous mechanical character in the Star Wars universe
    */
-  data class Droid(
+  data class DroidFriend(
     override val __typename: String = "Droid",
     /**
      * This droid's primary function
@@ -175,7 +175,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Friend {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.DroidFriend_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -210,9 +210,9 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
      */
     val name: String
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanFriend(): HumanFriend? = this as? HumanFriend
 
-    fun asDroid(): Droid? = this as? Droid
+    fun asDroidFriend(): DroidFriend? = this as? DroidFriend
 
     fun marshaller(): ResponseFieldMarshaller
   }
@@ -220,7 +220,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   /**
    * A character from the Star Wars universe
    */
-  data class Character(
+  data class CharacterSearch(
     override val __typename: String = "Character",
     /**
      * The ID of the character
@@ -237,14 +237,14 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Search {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Character_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.toResponse(writer, this)
       }
     }
 
     fun friendsFilterNotNull(): List<Friend>? = friends?.filterNotNull()
   }
 
-  data class Starship(
+  data class StarshipSearch(
     override val __typename: String = "Starship",
     /**
      * The name of the starship
@@ -253,7 +253,7 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   ) : Search {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        TestQuery_ResponseAdapter.Starship_ResponseAdapter.toResponse(writer, this)
+        TestQuery_ResponseAdapter.StarshipSearch_ResponseAdapter.toResponse(writer, this)
       }
     }
   }
@@ -271,9 +271,9 @@ class TestQuery : Query<TestQuery.Data, Operation.Variables> {
   interface Search {
     val __typename: String
 
-    fun asCharacter(): Character? = this as? Character
+    fun asCharacterSearch(): CharacterSearch? = this as? CharacterSearch
 
-    fun asStarship(): Starship? = this as? Starship
+    fun asStarshipSearch(): StarshipSearch? = this as? StarshipSearch
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery_ResponseAdapter.kt
@@ -88,7 +88,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<TestQuery.Human> {
+  object HumanFriend_ResponseAdapter : ResponseAdapter<TestQuery.HumanFriend> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("homePlanet", "homePlanet", null, true, null),
@@ -96,7 +96,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.HumanFriend {
       return reader.run {
         var __typename: String? = __typename
         var homePlanet: String? = null
@@ -115,7 +115,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Human(
+        TestQuery.HumanFriend(
           __typename = __typename!!,
           homePlanet = homePlanet,
           friends = friends,
@@ -124,7 +124,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.HumanFriend) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.homePlanet)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -172,7 +172,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Droid_ResponseAdapter : ResponseAdapter<TestQuery.Droid> {
+  object DroidFriend_ResponseAdapter : ResponseAdapter<TestQuery.DroidFriend> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
@@ -180,7 +180,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Droid {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.DroidFriend {
       return reader.run {
         var __typename: String? = __typename
         var primaryFunction: String? = null
@@ -199,7 +199,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Droid(
+        TestQuery.DroidFriend(
           __typename = __typename!!,
           primaryFunction = primaryFunction,
           friends = friends,
@@ -208,7 +208,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Droid) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.DroidFriend) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.primaryFunction)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -265,22 +265,22 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Friend {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> TestQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        "Droid" -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.DroidFriend_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherFriend_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Friend) {
       when(value) {
-        is TestQuery.Human -> TestQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Droid -> TestQuery_ResponseAdapter.Droid_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.HumanFriend -> TestQuery_ResponseAdapter.HumanFriend_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.DroidFriend -> TestQuery_ResponseAdapter.DroidFriend_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherFriend -> TestQuery_ResponseAdapter.OtherFriend_ResponseAdapter.toResponse(writer, value)
       }
     }
   }
 
-  object Character_ResponseAdapter : ResponseAdapter<TestQuery.Character> {
+  object CharacterSearch_ResponseAdapter : ResponseAdapter<TestQuery.CharacterSearch> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forCustomType("id", "id", null, false, CustomType.ID, null),
@@ -288,7 +288,8 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       ResponseField.forList("friends", "friends", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Character {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.CharacterSearch {
       return reader.run {
         var __typename: String? = __typename
         var id: String? = null
@@ -307,7 +308,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Character(
+        TestQuery.CharacterSearch(
           __typename = __typename!!,
           id = id!!,
           name = name!!,
@@ -316,7 +317,7 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Character) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.CharacterSearch) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomTypeField, value.id)
       writer.writeString(RESPONSE_FIELDS[2], value.name)
@@ -334,13 +335,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     }
   }
 
-  object Starship_ResponseAdapter : ResponseAdapter<TestQuery.Starship> {
+  object StarshipSearch_ResponseAdapter : ResponseAdapter<TestQuery.StarshipSearch> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Starship {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.StarshipSearch {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -351,14 +353,14 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
             else -> break
           }
         }
-        TestQuery.Starship(
+        TestQuery.StarshipSearch(
           __typename = __typename!!,
           name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Starship) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.StarshipSearch) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
@@ -397,17 +399,17 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
     override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Search {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Droid" -> TestQuery_ResponseAdapter.Character_ResponseAdapter.fromResponse(reader, typename)
-        "Human" -> TestQuery_ResponseAdapter.Character_ResponseAdapter.fromResponse(reader, typename)
-        "Starship" -> TestQuery_ResponseAdapter.Starship_ResponseAdapter.fromResponse(reader, typename)
+        "Droid" -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.fromResponse(reader, typename)
+        "Starship" -> TestQuery_ResponseAdapter.StarshipSearch_ResponseAdapter.fromResponse(reader, typename)
         else -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: TestQuery.Search) {
       when(value) {
-        is TestQuery.Character -> TestQuery_ResponseAdapter.Character_ResponseAdapter.toResponse(writer, value)
-        is TestQuery.Starship -> TestQuery_ResponseAdapter.Starship_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.CharacterSearch -> TestQuery_ResponseAdapter.CharacterSearch_ResponseAdapter.toResponse(writer, value)
+        is TestQuery.StarshipSearch -> TestQuery_ResponseAdapter.StarshipSearch_ResponseAdapter.toResponse(writer, value)
         is TestQuery.OtherSearch -> TestQuery_ResponseAdapter.OtherSearch_ResponseAdapter.toResponse(writer, value)
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -207,7 +207,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
   /**
    * A humanoid creature from the Star Wars universe
    */
-  data class Human(
+  data class HumanHeroDetailQuery1(
     override val __typename: String = "Human",
     /**
      * What this human calls themselves
@@ -224,7 +224,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
   ) : HeroDetailQuery1 {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetailQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, this)
+        HeroDetailQuery_ResponseAdapter.HumanHeroDetailQuery1_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -251,7 +251,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
   /**
    * A character from the Star Wars universe
    */
-  data class OtherHeroDetailQuery(
+  data class OtherHeroDetailQuery1(
     override val __typename: String = "Character",
     /**
      * The name of the character
@@ -264,7 +264,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
   ) : HeroDetailQuery1 {
     override fun marshaller(): ResponseFieldMarshaller {
       return ResponseFieldMarshaller { writer ->
-        HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery_ResponseAdapter.toResponse(writer, this)
+        HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery1_ResponseAdapter.toResponse(writer, this)
       }
     }
 
@@ -301,7 +301,7 @@ class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
      */
     val friends: List<Friend3?>?
 
-    fun asHuman(): Human? = this as? Human
+    fun asHumanHeroDetailQuery1(): HumanHeroDetailQuery1? = this as? HumanHeroDetailQuery1
 
     fun marshaller(): ResponseFieldMarshaller
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery_ResponseAdapter.kt
@@ -269,7 +269,8 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
     }
   }
 
-  object Human_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Human> {
+  object HumanHeroDetailQuery1_ResponseAdapter :
+      ResponseAdapter<HeroDetailQuery.HumanHeroDetailQuery1> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -277,7 +278,8 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
       ResponseField.forDouble("height", "height", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailQuery.Human {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailQuery.HumanHeroDetailQuery1 {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -296,7 +298,7 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
             else -> break
           }
         }
-        HeroDetailQuery.Human(
+        HeroDetailQuery.HumanHeroDetailQuery1(
           __typename = __typename!!,
           name = name!!,
           friends = friends,
@@ -305,7 +307,7 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.Human) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.HumanHeroDetailQuery1) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -354,8 +356,8 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
     }
   }
 
-  object OtherHeroDetailQuery_ResponseAdapter :
-      ResponseAdapter<HeroDetailQuery.OtherHeroDetailQuery> {
+  object OtherHeroDetailQuery1_ResponseAdapter :
+      ResponseAdapter<HeroDetailQuery.OtherHeroDetailQuery1> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null),
       ResponseField.forString("name", "name", null, false, null),
@@ -363,7 +365,7 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        HeroDetailQuery.OtherHeroDetailQuery {
+        HeroDetailQuery.OtherHeroDetailQuery1 {
       return reader.run {
         var __typename: String? = __typename
         var name: String? = null
@@ -380,7 +382,7 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
             else -> break
           }
         }
-        HeroDetailQuery.OtherHeroDetailQuery(
+        HeroDetailQuery.OtherHeroDetailQuery1(
           __typename = __typename!!,
           name = name!!,
           friends = friends
@@ -388,7 +390,7 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.OtherHeroDetailQuery) {
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.OtherHeroDetailQuery1) {
       writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       writer.writeString(RESPONSE_FIELDS[1], value.name)
       writer.writeList(RESPONSE_FIELDS[2], value.friends) { values, listItemWriter ->
@@ -416,15 +418,15 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
         HeroDetailQuery.HeroDetailQuery1 {
       val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
       return when(typename) {
-        "Human" -> HeroDetailQuery_ResponseAdapter.Human_ResponseAdapter.fromResponse(reader, typename)
-        else -> HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery_ResponseAdapter.fromResponse(reader, typename)
+        "Human" -> HeroDetailQuery_ResponseAdapter.HumanHeroDetailQuery1_ResponseAdapter.fromResponse(reader, typename)
+        else -> HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery1_ResponseAdapter.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.HeroDetailQuery1) {
       when(value) {
-        is HeroDetailQuery.Human -> HeroDetailQuery_ResponseAdapter.Human_ResponseAdapter.toResponse(writer, value)
-        is HeroDetailQuery.OtherHeroDetailQuery -> HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery_ResponseAdapter.toResponse(writer, value)
+        is HeroDetailQuery.HumanHeroDetailQuery1 -> HeroDetailQuery_ResponseAdapter.HumanHeroDetailQuery1_ResponseAdapter.toResponse(writer, value)
+        is HeroDetailQuery.OtherHeroDetailQuery1 -> HeroDetailQuery_ResponseAdapter.OtherHeroDetailQuery1_ResponseAdapter.toResponse(writer, value)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails.kt
@@ -138,7 +138,7 @@ interface HeroDetails : GraphqlFragment {
   /**
    * A character from the Star Wars universe
    */
-  data class DefaultImpl(
+  data class HeroDetailsImpl(
     override val __typename: String = "Character",
     /**
      * The name of the character

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/HeroDetails_ResponseAdapter.kt
@@ -18,14 +18,15 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
+object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.HeroDetailsImpl> {
   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
     ResponseField.forString("__typename", "__typename", null, false, null),
     ResponseField.forString("name", "name", null, false, null),
     ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.DefaultImpl {
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      HeroDetails.HeroDetailsImpl {
     return reader.run {
       var __typename: String? = __typename
       var name: String? = null
@@ -40,7 +41,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
           else -> break
         }
       }
-      HeroDetails.DefaultImpl(
+      HeroDetails.HeroDetailsImpl(
         __typename = __typename!!,
         name = name!!,
         friendsConnection = friendsConnection!!
@@ -48,7 +49,7 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.DefaultImpl> {
     }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetails.DefaultImpl) {
+  override fun toResponse(writer: ResponseWriter, value: HeroDetails.HeroDetailsImpl) {
     writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     writer.writeString(RESPONSE_FIELDS[1], value.name)
     writer.writeObject(RESPONSE_FIELDS[2]) { writer ->

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/NormalizedCacheTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/NormalizedCacheTestCase.kt
@@ -173,11 +173,11 @@ class NormalizedCacheTestCase {
       assertThat(response.hasErrors()).isFalse()
       assertThat(response.data!!.hero?.name).isEqualTo("R2-D2")
       assertThat(response.data!!.hero?.name).isEqualTo("R2-D2")
-      val hero = response.data!!.hero as HeroParentTypeDependentFieldQuery.Droid
+      val hero = response.data!!.hero as HeroParentTypeDependentFieldQuery.DroidHero
       assertThat(hero?.friends).hasSize(3)
       assertThat(hero?.friends?.get(0)?.name).isEqualTo("Luke Skywalker")
       assertThat(hero?.friends?.get(0)?.name).isEqualTo("Luke Skywalker")
-      assertThat((hero?.friends?.get(0) as HeroParentTypeDependentFieldQuery.Human2).height).isWithin(1.72)
+      assertThat((hero?.friends?.get(0) as HeroParentTypeDependentFieldQuery.HumanFriend1).height).isWithin(1.72)
       true
     }
   }
@@ -191,8 +191,8 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(HeroTypeDependentAliasedFieldQuery(fromNullable(Episode.NEWHOPE)))
     ) { response ->
       assertThat(response.hasErrors()).isFalse()
-      assertThat(response.data!!.hero).isInstanceOf(HeroTypeDependentAliasedFieldQuery.Droid::class.java)
-      assertThat((response.data!!.hero as HeroTypeDependentAliasedFieldQuery.Droid?)?.property).isEqualTo("Astromech")
+      assertThat(response.data!!.hero).isInstanceOf(HeroTypeDependentAliasedFieldQuery.DroidHero::class.java)
+      assertThat((response.data!!.hero as HeroTypeDependentAliasedFieldQuery.DroidHero?)?.property).isEqualTo("Astromech")
       true
     }
     server.enqueue(mockResponse("HeroTypeDependentAliasedFieldResponseHuman.json"))
@@ -202,8 +202,8 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(HeroTypeDependentAliasedFieldQuery(fromNullable(Episode.NEWHOPE)))
     ) { response ->
       assertThat(response.hasErrors()).isFalse()
-      assertThat(response.data!!.hero).isInstanceOf(HeroTypeDependentAliasedFieldQuery.Human::class.java)
-      assertThat((response.data!!.hero as HeroTypeDependentAliasedFieldQuery.Human?)?.property).isEqualTo("Tatooine")
+      assertThat(response.data!!.hero).isInstanceOf(HeroTypeDependentAliasedFieldQuery.HumanHero::class.java)
+      assertThat((response.data!!.hero as HeroTypeDependentAliasedFieldQuery.HumanHero?)?.property).isEqualTo("Tatooine")
       true
     }
   }
@@ -239,7 +239,7 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { (_, data) ->
       assertThat(data!!.character).isNotNull()
-      assertThat((data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Han Solo")
+      assertThat((data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Han Solo")
       true
     }
   }
@@ -434,7 +434,7 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Han Solo")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Han Solo")
       true
     }
 
@@ -458,7 +458,7 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Han Solo")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Han Solo")
       true
     }
 
@@ -485,7 +485,7 @@ class NormalizedCacheTestCase {
     ) { response ->
       assertThat(response.isFromCache).isTrue()
       Truth.assertThat(response.data).isNotNull()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Leia Organa")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Leia Organa")
       true
     }
   }
@@ -507,21 +507,21 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(CharacterNameByIdQuery("1000")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Luke Skywalker")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Luke Skywalker")
       true
     }
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Han Solo")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Han Solo")
       true
     }
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1003")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Leia Organa")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Leia Organa")
       true
     }
     Truth.assertThat(apolloClient!!.apolloStore.remove(Arrays.asList(from("1002"), from("1000")))
@@ -546,7 +546,7 @@ class NormalizedCacheTestCase {
         apolloClient!!.query(CharacterNameByIdQuery("1003")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Leia Organa")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Leia Organa")
       true
     }
   }
@@ -710,21 +710,21 @@ LruNormalizedCache {
         apolloClient!!.query(CharacterNameByIdQuery("1000")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Luke Skywalker")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Luke Skywalker")
       true
     }
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1002")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Han Solo")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Han Solo")
       true
     }
     assertResponse(
         apolloClient!!.query(CharacterNameByIdQuery("1003")).responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
     ) { response ->
       assertThat(response.isFromCache).isTrue()
-      assertThat((response.data!!.character as CharacterNameByIdQuery.Human?)?.name).isEqualTo("Leia Organa")
+      assertThat((response.data!!.character as CharacterNameByIdQuery.HumanCharacter?)?.name).isEqualTo("Leia Organa")
       true
     }
 

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
@@ -268,15 +268,15 @@ class ResponseWriteTestCase {
         id = "2001",
         name = "R222-D222",
         friends = listOf(
-            HeroAndFriendsWithFragmentsQuery.HumanWithIdFragmentImpl(
-                HumanWithIdFragment.DefaultImpl(
+            HeroAndFriendsWithFragmentsQuery.HumanFriend(
+                HumanWithIdFragment.HumanWithIdFragmentImpl(
                     __typename = "Human",
                     id = "1006",
                     name = "SuperMan"
                 )
             ),
-            HeroAndFriendsWithFragmentsQuery.HumanWithIdFragmentImpl(
-                HumanWithIdFragment.DefaultImpl(
+            HeroAndFriendsWithFragmentsQuery.HumanFriend(
+                HumanWithIdFragment.HumanWithIdFragmentImpl(
                     __typename = "Human",
                     id = "1004",
                     name = "Beast"
@@ -315,16 +315,16 @@ class ResponseWriteTestCase {
       assertThat(data!!.hero?.__typename).isEqualTo("Droid")
       assertThat(data.hero?.name).isEqualTo("R2-D2")
       assertThat(data.hero?.friends).hasSize(3)
-      val asHuman = data.hero?.friends?.get(0) as? EpisodeHeroWithInlineFragmentQuery.Human
+      val asHuman = data.hero?.friends?.get(0) as? EpisodeHeroWithInlineFragmentQuery.HumanFriend
       assertThat(asHuman?.__typename).isEqualTo("Human")
       assertThat(asHuman?.id).isEqualTo("1000")
       assertThat(asHuman?.name).isEqualTo("Luke Skywalker")
       assertThat(asHuman?.height).isWithin(1.5)
-      val asDroid1 = data.hero?.friends?.get(1) as? EpisodeHeroWithInlineFragmentQuery.Droid
+      val asDroid1 = data.hero?.friends?.get(1) as? EpisodeHeroWithInlineFragmentQuery.DroidFriend
       assertThat(asDroid1?.__typename).isEqualTo("Droid")
       assertThat(asDroid1?.name).isEqualTo("Android")
       assertThat(asDroid1?.primaryFunction).isEqualTo("Hunt and destroy iOS devices")
-      val asDroid2 = data.hero?.friends?.get(2) as EpisodeHeroWithInlineFragmentQuery.Droid
+      val asDroid2 = data.hero?.friends?.get(2) as EpisodeHeroWithInlineFragmentQuery.DroidFriend
       assertThat(asDroid2.__typename).isEqualTo("Droid")
       assertThat(asDroid2.name).isEqualTo("Battle Droid")
       assertThat(asDroid2.primaryFunction).isEqualTo("Controlled alternative to human soldiers")
@@ -334,13 +334,13 @@ class ResponseWriteTestCase {
         __typename = "Droid",
         name = "R22-D22",
         friends = listOf(
-            EpisodeHeroWithInlineFragmentQuery.Human(
+            EpisodeHeroWithInlineFragmentQuery.HumanFriend(
                 __typename = "Human",
                 id = "1002",
                 name = "Han Solo",
                 height = 2.5
             ),
-            EpisodeHeroWithInlineFragmentQuery.Droid(
+            EpisodeHeroWithInlineFragmentQuery.DroidFriend(
                 __typename = "Droid",
                 primaryFunction = "Entertainment",
                 name = "RD",
@@ -354,12 +354,12 @@ class ResponseWriteTestCase {
       assertThat(data!!.hero?.__typename).isEqualTo("Droid")
       assertThat(data.hero?.name).isEqualTo("R22-D22")
       assertThat(data.hero?.friends).hasSize(2)
-      val asHuman = data.hero?.friends?.get(0) as? EpisodeHeroWithInlineFragmentQuery.Human
+      val asHuman = data.hero?.friends?.get(0) as? EpisodeHeroWithInlineFragmentQuery.HumanFriend
       assertThat(asHuman?.__typename).isEqualTo("Human")
       assertThat(asHuman?.id).isEqualTo("1002")
       assertThat(asHuman?.name).isEqualTo("Han Solo")
       assertThat(asHuman?.height).isWithin(2.5)
-      val asDroid = data.hero?.friends?.get(1) as? EpisodeHeroWithInlineFragmentQuery.Droid
+      val asDroid = data.hero?.friends?.get(1) as? EpisodeHeroWithInlineFragmentQuery.DroidFriend
       assertThat(asDroid?.__typename).isEqualTo("Droid")
       assertThat(asDroid?.name).isEqualTo("RD")
       assertThat(asDroid?.primaryFunction).isEqualTo("Entertainment")
@@ -393,20 +393,20 @@ class ResponseWriteTestCase {
       true
     }
     apolloClient!!.apolloStore.write(
-        HeroWithFriendsFragment.DefaultImpl(
+        HeroWithFriendsFragment.HeroWithFriendsFragmentImpl(
             __typename = "Droid",
             id = "2001",
             name = "R222-D222",
             friends = listOf(
-                HeroWithFriendsFragment.HumanWithIdFragmentImpl(
-                    HumanWithIdFragment.DefaultImpl(
+                HeroWithFriendsFragment.HumanFriend1(
+                    HumanWithIdFragment.HumanWithIdFragmentImpl(
                         __typename = "Human",
                         id = "1000",
                         name = "SuperMan"
                     )
                 ),
-                HeroWithFriendsFragment.HumanWithIdFragmentImpl(
-                    HumanWithIdFragment.DefaultImpl(
+                HeroWithFriendsFragment.HumanFriend1(
+                    HumanWithIdFragment.HumanWithIdFragmentImpl(
                         __typename = "Human",
                         id = "1002",
                         name = "Han Solo"
@@ -416,7 +416,7 @@ class ResponseWriteTestCase {
         ), from("2001"), query.variables()
     ).execute()
     apolloClient!!.apolloStore.write(
-        HumanWithIdFragment.DefaultImpl(
+        HumanWithIdFragment.HumanWithIdFragmentImpl(
             "Human",
             "1002",
             "Beast"

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCallbackService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCallbackService.kt
@@ -72,7 +72,7 @@ class ApolloCallbackService(apolloClient: ApolloClient) : GitHubDataSource(apoll
       }
 
       override fun onResponse(response: Response<GithubRepositoryCommitsQuery.Data>) {
-        val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.Commit?
+        val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.CommitTarget?
         val commits = headCommit?.history?.edges?.filterNotNull().orEmpty()
         commitsSubject.onNext(commits)
       }

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloCoroutinesService.kt
@@ -67,7 +67,7 @@ class ApolloCoroutinesService(
     job = CoroutineScope(processContext).launch {
       try {
         val response = apolloClient.query(commitsQuery).await()
-        val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.Commit?
+        val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.CommitTarget?
 
         val commits = headCommit?.history?.edges?.filterNotNull().orEmpty()
 

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloRxService.kt
@@ -71,7 +71,7 @@ class ApolloRxService(
         .subscribeOn(processScheduler)
         .observeOn(resultScheduler)
         .map { response ->
-          val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.Commit
+          val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.CommitTarget
           headCommit?.history?.edges?.filterNotNull().orEmpty()
         }
         .subscribe(

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloWatcherService.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/data/ApolloWatcherService.kt
@@ -59,7 +59,7 @@ class ApolloWatcherService(apolloClient: ApolloClient) : GitHubDataSource(apollo
     )
 
     val callback = createCallback<GithubRepositoryCommitsQuery.Data> { response ->
-      val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.Commit?
+      val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.CommitTarget?
       val commits = headCommit?.history?.edges?.filterNotNull().orEmpty()
       commitsSubject.onNext(commits)
     }

--- a/samples/multiplatform/kmp-lib-sample/src/commonMain/kotlin/com/apollographql/apollo/kmpsample/data/ApolloCoroutinesRepository.kt
+++ b/samples/multiplatform/kmp-lib-sample/src/commonMain/kotlin/com/apollographql/apollo/kmpsample/data/ApolloCoroutinesRepository.kt
@@ -51,7 +51,7 @@ class ApolloCoroutinesRepository {
 
   suspend fun fetchCommits(repositoryName: String): List<GithubRepositoryCommitsQuery.Edge?> {
     val response = apolloClient.query(GithubRepositoryCommitsQuery(repositoryName)).execute().single()
-    val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.Commit?
+    val headCommit = response.data?.viewer?.repository?.ref?.target as GithubRepositoryCommitsQuery.CommitTarget?
     return headCommit?.history?.edges.orEmpty()
   }
 


### PR DESCRIPTION
- Use type condition as class / interface name with suffix of parent type for named fragments.
- Use root type with `Impl` suffix as name for default implementation of named fragment.