### PR TITLE
unconditionnaly add the message to the Kotlin Decprecated annotation

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -41,9 +41,7 @@ internal object KotlinCodeGen {
   fun deprecatedAnnotation(message: String) = AnnotationSpec
       .builder(Deprecated::class)
       .apply {
-        if (message.isNotBlank()) {
-          addMember("message = %S", message)
-        }
+        addMember("message = %S", message)
       }
       .build()
 

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestOperation.graphql
@@ -4,5 +4,6 @@ query TestQuery($episode: Episode) {
     deprecated
     deprecatedBool
     deprecatedWithNoReason
+    deprecatedWithBlankReason
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery.Data>, TestQuery.Variables> {
-  public static final String OPERATION_ID = "0ec7777648f4df19577e26ccefd76b5323e29426288a9e43770e8671a25865bc";
+  public static final String OPERATION_ID = "82ddc716280f1e2f832345d489f265f98280abf0d9a0257c09ca5bd3779dfd2f";
 
   public static final String QUERY_DOCUMENT = QueryDocumentMinifier.minify(
     "query TestQuery($episode: Episode) {\n"
@@ -51,6 +51,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         + "    deprecated\n"
         + "    deprecatedBool\n"
         + "    deprecatedWithNoReason\n"
+        + "    deprecatedWithBlankReason\n"
         + "  }\n"
         + "}"
   );
@@ -303,7 +304,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       ResponseField.forString("name", "name", null, false, Collections.<ResponseField.Condition>emptyList()),
       ResponseField.forString("deprecated", "deprecated", null, false, Collections.<ResponseField.Condition>emptyList()),
       ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, Collections.<ResponseField.Condition>emptyList()),
-      ResponseField.forString("deprecatedWithNoReason", "deprecatedWithNoReason", null, false, Collections.<ResponseField.Condition>emptyList())
+      ResponseField.forString("deprecatedWithNoReason", "deprecatedWithNoReason", null, false, Collections.<ResponseField.Condition>emptyList()),
+      ResponseField.forString("deprecatedWithBlankReason", "deprecatedWithBlankReason", null, false, Collections.<ResponseField.Condition>emptyList())
     };
 
     final @NotNull String __typename;
@@ -316,6 +318,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     final @NotNull @Deprecated String deprecatedWithNoReason;
 
+    final @NotNull @Deprecated String deprecatedWithBlankReason;
+
     private transient volatile String $toString;
 
     private transient volatile int $hashCode;
@@ -324,12 +328,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
 
     public Hero(@NotNull String __typename, @NotNull String name,
         @NotNull @Deprecated String deprecated, @Deprecated boolean deprecatedBool,
-        @NotNull @Deprecated String deprecatedWithNoReason) {
+        @NotNull @Deprecated String deprecatedWithNoReason,
+        @NotNull @Deprecated String deprecatedWithBlankReason) {
       this.__typename = Utils.checkNotNull(__typename, "__typename == null");
       this.name = Utils.checkNotNull(name, "name == null");
       this.deprecated = Utils.checkNotNull(deprecated, "deprecated == null");
       this.deprecatedBool = deprecatedBool;
       this.deprecatedWithNoReason = Utils.checkNotNull(deprecatedWithNoReason, "deprecatedWithNoReason == null");
+      this.deprecatedWithBlankReason = Utils.checkNotNull(deprecatedWithBlankReason, "deprecatedWithBlankReason == null");
     }
 
     public @NotNull String __typename() {
@@ -367,6 +373,14 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
       return this.deprecatedWithNoReason;
     }
 
+    /**
+     * Test deprecated field with blank reason
+     * @deprecated 
+     */
+    public @NotNull @Deprecated String deprecatedWithBlankReason() {
+      return this.deprecatedWithBlankReason;
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     public ResponseFieldMarshaller marshaller() {
       return new ResponseFieldMarshaller() {
@@ -377,6 +391,7 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           writer.writeString($responseFields[2], deprecated);
           writer.writeBoolean($responseFields[3], deprecatedBool);
           writer.writeString($responseFields[4], deprecatedWithNoReason);
+          writer.writeString($responseFields[5], deprecatedWithBlankReason);
         }
       };
     }
@@ -389,7 +404,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
           + "name=" + name + ", "
           + "deprecated=" + deprecated + ", "
           + "deprecatedBool=" + deprecatedBool + ", "
-          + "deprecatedWithNoReason=" + deprecatedWithNoReason
+          + "deprecatedWithNoReason=" + deprecatedWithNoReason + ", "
+          + "deprecatedWithBlankReason=" + deprecatedWithBlankReason
           + "}";
       }
       return $toString;
@@ -406,7 +422,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
          && this.name.equals(that.name)
          && this.deprecated.equals(that.deprecated)
          && this.deprecatedBool == that.deprecatedBool
-         && this.deprecatedWithNoReason.equals(that.deprecatedWithNoReason);
+         && this.deprecatedWithNoReason.equals(that.deprecatedWithNoReason)
+         && this.deprecatedWithBlankReason.equals(that.deprecatedWithBlankReason);
       }
       return false;
     }
@@ -425,6 +442,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         h ^= Boolean.valueOf(deprecatedBool).hashCode();
         h *= 1000003;
         h ^= deprecatedWithNoReason.hashCode();
+        h *= 1000003;
+        h ^= deprecatedWithBlankReason.hashCode();
         $hashCode = h;
         $hashCodeMemoized = true;
       }
@@ -439,7 +458,8 @@ public final class TestQuery implements Query<TestQuery.Data, Optional<TestQuery
         final String deprecated = reader.readString($responseFields[2]);
         final boolean deprecatedBool = reader.readBoolean($responseFields[3]);
         final String deprecatedWithNoReason = reader.readString($responseFields[4]);
-        return new Hero(__typename, name, deprecated, deprecatedBool, deprecatedWithNoReason);
+        final String deprecatedWithBlankReason = reader.readString($responseFields[5]);
+        return new Hero(__typename, name, deprecated, deprecatedBool, deprecatedWithNoReason, deprecatedWithBlankReason);
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -127,7 +127,12 @@ data class TestQuery(
      * Test deprecated field with no reason
      */
     @Deprecated(message = "No longer supported")
-    val deprecatedWithNoReason: String
+    val deprecatedWithNoReason: String,
+    /**
+     * Test deprecated field with blank reason
+     */
+    @Deprecated(message = "")
+    val deprecatedWithBlankReason: String
   ) {
     fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
@@ -135,6 +140,7 @@ data class TestQuery(
       writer.writeString(RESPONSE_FIELDS[2], this@Hero.deprecated)
       writer.writeBoolean(RESPONSE_FIELDS[3], this@Hero.deprecatedBool)
       writer.writeString(RESPONSE_FIELDS[4], this@Hero.deprecatedWithNoReason)
+      writer.writeString(RESPONSE_FIELDS[5], this@Hero.deprecatedWithBlankReason)
     }
 
     companion object {
@@ -144,7 +150,9 @@ data class TestQuery(
           ResponseField.forString("deprecated", "deprecated", null, false, null),
           ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null),
           ResponseField.forString("deprecatedWithNoReason", "deprecatedWithNoReason", null, false,
-              null)
+              null),
+          ResponseField.forString("deprecatedWithBlankReason", "deprecatedWithBlankReason", null,
+              false, null)
           )
 
       operator fun invoke(reader: ResponseReader): Hero = reader.run {
@@ -153,12 +161,14 @@ data class TestQuery(
         val deprecated = readString(RESPONSE_FIELDS[2])!!
         val deprecatedBool = readBoolean(RESPONSE_FIELDS[3])!!
         val deprecatedWithNoReason = readString(RESPONSE_FIELDS[4])!!
+        val deprecatedWithBlankReason = readString(RESPONSE_FIELDS[5])!!
         Hero(
           __typename = __typename,
           name = name,
           deprecated = deprecated,
           deprecatedBool = deprecatedBool,
-          deprecatedWithNoReason = deprecatedWithNoReason
+          deprecatedWithNoReason = deprecatedWithNoReason,
+          deprecatedWithBlankReason = deprecatedWithBlankReason
         )
       }
 
@@ -201,7 +211,7 @@ data class TestQuery(
 
   companion object {
     const val OPERATION_ID: String =
-        "0ec7777648f4df19577e26ccefd76b5323e29426288a9e43770e8671a25865bc"
+        "82ddc716280f1e2f832345d489f265f98280abf0d9a0257c09ca5bd3779dfd2f"
 
     val QUERY_DOCUMENT: String = QueryDocumentMinifier.minify(
           """
@@ -212,6 +222,7 @@ data class TestQuery(
           |    deprecated
           |    deprecatedBool
           |    deprecatedWithNoReason
+          |    deprecatedWithBlankReason
           |  }
           |}
           """.trimMargin()

--- a/apollo-compiler/src/test/graphql/schema.sdl
+++ b/apollo-compiler/src/test/graphql/schema.sdl
@@ -30,6 +30,9 @@ interface Character {
   """Test deprecated field with no reason"""
   deprecatedWithNoReason: String! @deprecated
 
+  """Test deprecated field with blank reason"""
+  deprecatedWithBlankReason: String! @deprecated(reason: "")
+
   """Test deprecated field"""
   deprecatedBool: Boolean! @deprecated(reason: "For test purpose only")
 


### PR DESCRIPTION
#2692 fixed the `@deprecated` without arguments, this pull request fixes `@deprecated(reason: "")`.

Note: It feels a bit weird to have a @Deprecated annotation without a reason but I don't think it's correct to default to `"No longer supported"` for blank reasons as the schema explicitly defines the empty string as the reason.

Closes #2714