### PR TITLE
[codegen] Revert default values as Kotlin default parameters and made skipField more robust

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleResponseReader.kt
@@ -130,15 +130,15 @@ class SimpleResponseReader private constructor(
   private fun shouldSkip(field: ResponseField): Boolean {
     for (condition in field.conditions) {
       if (condition is ResponseField.BooleanCondition) {
-        val conditionValue = variableValues[condition.variableName] as Boolean
+        val conditionValue = variableValues[condition.variableName] as Boolean?
         if (condition.isInverted) {
           // means it's a skip directive
-          if (conditionValue) {
+          if (conditionValue == true) {
             return true
           }
         } else {
           // means it's an include directive
-          if (!conditionValue) {
+          if (conditionValue == false) {
             return true
           }
         }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ast/builder/OperationTypeBuilder.kt
@@ -56,7 +56,7 @@ internal fun Operation.ast(
                     typesPackageName = context.typesPackageName
                 ),
                 isOptional = variable.optional(),
-                defaultValue = variable.defaultValue,
+                defaultValue = null,
                 description = ""
             )
           }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/OperationType.kt
@@ -169,23 +169,13 @@ private val OperationType.primaryConstructorSpec: FunSpec
           val typeName = variable.type.asTypeName().let {
             if (variable.isOptional) Input::class.asClassName().parameterizedBy(it) else it
           }
-          val defaultValue = variable.defaultValue?.toDefaultValueCodeBlock(typeName, variable.type)
-              .let { code ->
-                if (variable.isOptional) {
-                  code?.let { CodeBlock.of("%T.optional(%L)", Input::class, it) } ?: CodeBlock.of("%T.absent()", Input::class)
-                } else {
-                  code
-                }
-              }
 
           ParameterSpec
               .builder(
                   name = variable.name,
                   type = typeName
               )
-              .applyIf(defaultValue != null) {
-                defaultValue(defaultValue!!)
-              }
+              .applyIf(variable.isOptional) { defaultValue("%T.absent()", Input::class.asClassName()) }
               .build()
         })
         .build()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Variable.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/Variable.kt
@@ -3,7 +3,6 @@ package com.apollographql.apollo.compiler.ir
 data class Variable(
     val name: String,
     val type: String,
-    val defaultValue: Any?,
     val sourceLocation: SourceLocation
 ) {
   fun optional(): Boolean = !type.endsWith(suffix = "!")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentParser.kt
@@ -238,7 +238,8 @@ class GraphQLDocumentParser(
         result = Variable(
             name = name,
             type = type,
-            defaultValue = defaultValue()?.value()?.parse(schema.resolveType(type)),
+            // parse doesn't work with nullable types (see https://github.com/apollographql/apollo-android/issues/2742)
+            // defaultValue = defaultValue()?.value()?.parse(schema.resolveType(type)),
             sourceLocation = SourceLocation(variable().NAME().symbol)
         ),
         usedTypes = setOf(schemaType.name)

--- a/apollo-compiler/src/test/graphql/com/example/variable_default_value/GetHero.kt
+++ b/apollo-compiler/src/test/graphql/com/example/variable_default_value/GetHero.kt
@@ -43,7 +43,8 @@ import okio.IOException
 data class GetHero(
   val myBool: Input<Boolean> = Input.absent(),
   val unit: LengthUnit,
-  val listOfInts: Input<List<Int?>> = Input.absent()
+  val listOfInts: Input<List<Int?>> = Input.absent(),
+  val first: Input<Int> = Input.absent()
 ) : Query<GetHero.Data, GetHero.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
@@ -54,6 +55,9 @@ data class GetHero(
       this["unit"] = this@GetHero.unit
       if (this@GetHero.listOfInts.defined) {
         this["listOfInts"] = this@GetHero.listOfInts.value
+      }
+      if (this@GetHero.first.defined) {
+        this["first"] = this@GetHero.first.value
       }
     }
 
@@ -70,6 +74,9 @@ data class GetHero(
             }
           }
         })
+      }
+      if (this@GetHero.first.defined) {
+        writer.writeInt("first", this@GetHero.first.value)
       }
     }
   }
@@ -128,6 +135,41 @@ data class GetHero(
   }
 
   /**
+   * A connection object for a character's friends
+   */
+  data class FriendsConnection(
+    val __typename: String = "FriendsConnection",
+    /**
+     * The total number of friends
+     */
+    val totalCount: Int?
+  ) {
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection.totalCount)
+    }
+
+    companion object {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forInt("totalCount", "totalCount", null, true, null)
+          )
+
+      operator fun invoke(reader: ResponseReader): FriendsConnection = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])!!
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        FriendsConnection(
+          __typename = __typename,
+          totalCount = totalCount
+        )
+      }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection> = ResponseFieldMapper { invoke(it) }
+    }
+  }
+
+  /**
    * A humanoid creature from the Star Wars universe
    */
   data class AsHuman(
@@ -137,6 +179,10 @@ data class GetHero(
      */
     val name: String?,
     /**
+     * The friends of the human exposed as a connection with edges
+     */
+    val friendsConnection: FriendsConnection,
+    /**
      * Height in the preferred unit, default is meters
      */
     val height: Double?
@@ -144,7 +190,8 @@ data class GetHero(
     override fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@AsHuman.__typename)
       writer.writeString(RESPONSE_FIELDS[1], this@AsHuman.name)
-      writer.writeDouble(RESPONSE_FIELDS[2], this@AsHuman.height)
+      writer.writeObject(RESPONSE_FIELDS[2], this@AsHuman.friendsConnection.marshaller())
+      writer.writeDouble(RESPONSE_FIELDS[3], this@AsHuman.height)
     }
 
     companion object {
@@ -153,6 +200,10 @@ data class GetHero(
           ResponseField.forString("name", "name", null, true, listOf(
             ResponseField.Condition.booleanCondition("myBool", false)
           )),
+          ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any>(
+            "first" to mapOf<String, Any>(
+              "kind" to "Variable",
+              "variableName" to "first")), false, null),
           ResponseField.forDouble("height", "height", mapOf<String, Any>(
             "unit" to mapOf<String, Any>(
               "kind" to "Variable",
@@ -162,16 +213,55 @@ data class GetHero(
       operator fun invoke(reader: ResponseReader): AsHuman = reader.run {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])
-        val height = readDouble(RESPONSE_FIELDS[2])
+        val friendsConnection = readObject<FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+          FriendsConnection(reader)
+        }!!
+        val height = readDouble(RESPONSE_FIELDS[3])
         AsHuman(
           __typename = __typename,
           name = name,
+          friendsConnection = friendsConnection,
           height = height
         )
       }
 
       @Suppress("FunctionName")
       fun Mapper(): ResponseFieldMapper<AsHuman> = ResponseFieldMapper { invoke(it) }
+    }
+  }
+
+  /**
+   * A connection object for a character's friends
+   */
+  data class FriendsConnection1(
+    val __typename: String = "FriendsConnection",
+    /**
+     * The total number of friends
+     */
+    val totalCount: Int?
+  ) {
+    fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
+      writer.writeString(RESPONSE_FIELDS[0], this@FriendsConnection1.__typename)
+      writer.writeInt(RESPONSE_FIELDS[1], this@FriendsConnection1.totalCount)
+    }
+
+    companion object {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forInt("totalCount", "totalCount", null, true, null)
+          )
+
+      operator fun invoke(reader: ResponseReader): FriendsConnection1 = reader.run {
+        val __typename = readString(RESPONSE_FIELDS[0])!!
+        val totalCount = readInt(RESPONSE_FIELDS[1])
+        FriendsConnection1(
+          __typename = __typename,
+          totalCount = totalCount
+        )
+      }
+
+      @Suppress("FunctionName")
+      fun Mapper(): ResponseFieldMapper<FriendsConnection1> = ResponseFieldMapper { invoke(it) }
     }
   }
 
@@ -184,11 +274,16 @@ data class GetHero(
      * The name of the character
      */
     val name: String?,
+    /**
+     * The friends of the character exposed as a connection with edges
+     */
+    val friendsConnection: FriendsConnection1,
     val asHuman: AsHuman?
   ) {
     fun marshaller(): ResponseFieldMarshaller = ResponseFieldMarshaller.invoke { writer ->
       writer.writeString(RESPONSE_FIELDS[0], this@Hero.__typename)
       writer.writeString(RESPONSE_FIELDS[1], this@Hero.name)
+      writer.writeObject(RESPONSE_FIELDS[2], this@Hero.friendsConnection.marshaller())
       writer.writeFragment(this@Hero.asHuman?.marshaller())
     }
 
@@ -198,6 +293,10 @@ data class GetHero(
           ResponseField.forString("name", "name", null, true, listOf(
             ResponseField.Condition.booleanCondition("myBool", false)
           )),
+          ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any>(
+            "first" to mapOf<String, Any>(
+              "kind" to "Variable",
+              "variableName" to "first")), false, null),
           ResponseField.forFragment("__typename", "__typename", listOf(
             ResponseField.Condition.typeCondition(arrayOf("Human"))
           ))
@@ -206,12 +305,16 @@ data class GetHero(
       operator fun invoke(reader: ResponseReader): Hero = reader.run {
         val __typename = readString(RESPONSE_FIELDS[0])!!
         val name = readString(RESPONSE_FIELDS[1])
-        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[2]) { reader ->
+        val friendsConnection = readObject<FriendsConnection1>(RESPONSE_FIELDS[2]) { reader ->
+          FriendsConnection1(reader)
+        }!!
+        val asHuman = readFragment<AsHuman>(RESPONSE_FIELDS[3]) { reader ->
           AsHuman(reader)
         }
         Hero(
           __typename = __typename,
           name = name,
+          friendsConnection = friendsConnection,
           asHuman = asHuman
         )
       }
@@ -297,16 +400,20 @@ data class GetHero(
 
   companion object {
     const val OPERATION_ID: String =
-        "174c448da54ce10fe5ade777417fe38dcbc242e68cd54f905a7c6e465e02fdf1"
+        "6fd8246fe0a8a5557f683859ee3b34ad8702b590a811ff0adc73d112967700c3"
 
     val QUERY_DOCUMENT: String = QueryDocumentMinifier.minify(
           """
-          |query GetHero(${'$'}myBool: Boolean = true, ${'$'}unit: LengthUnit! = FOOT, ${'$'}listOfInts: [Int] = [1, 2, 3]) {
+          |query GetHero(${'$'}myBool: Boolean = true, ${'$'}unit: LengthUnit! = FOOT, ${'$'}listOfInts: [Int] = [1, 2, 3], ${'$'}first: Int = null) {
           |  hero {
           |    __typename
           |    name @include(if: ${'$'}myBool)
           |    ... on Human {
           |      height(unit: ${'$'}unit)
+          |    }
+          |    friendsConnection(first: ${'$'}first) {
+          |      __typename
+          |      totalCount
           |    }
           |  }
           |  heroWithReview(listOfInts: ${'$'}listOfInts) {

--- a/apollo-compiler/src/test/graphql/com/example/variable_default_value/GetHero.kt
+++ b/apollo-compiler/src/test/graphql/com/example/variable_default_value/GetHero.kt
@@ -41,9 +41,9 @@ import okio.IOException
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter")
 data class GetHero(
-  val myBool: Input<Boolean> = Input.optional(true),
-  val unit: LengthUnit = LengthUnit.safeValueOf("FOOT"),
-  val listOfInts: Input<List<Int?>> = Input.optional(listOf(1, 2, 3))
+  val myBool: Input<Boolean> = Input.absent(),
+  val unit: LengthUnit,
+  val listOfInts: Input<List<Int?>> = Input.absent()
 ) : Query<GetHero.Data, GetHero.Data, Operation.Variables> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {

--- a/apollo-compiler/src/test/graphql/com/example/variable_default_value/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/variable_default_value/TestOperation.graphql
@@ -2,6 +2,7 @@ query GetHero(
   $myBool: Boolean = true,
   $unit: LengthUnit! = FOOT,
   $listOfInts: [Int] = [1, 2, 3]
+  $first: Int = null,
   # FIXME
   #$review: ReviewInput! = {
   #  stars: 0,
@@ -14,9 +15,12 @@ query GetHero(
 ) {
   hero {
     name @include(if: $myBool)
-      ... on Human {
-        height(unit: $unit)
-      }
+    ... on Human {
+      height(unit: $unit)
+    }
+    friendsConnection(first: $first) {
+      totalCount
+    }
   }
   heroWithReview(listOfInts: $listOfInts) {
     name

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -52,6 +52,11 @@ configure<ApolloExtension> {
     sourceFolder.set("com/apollographql/apollo/integration/performance")
     rootPackageName.set("com.apollographql.apollo.integration.performance")
   }
+  service("directives") {
+    sourceFolder.set("com/apollographql/apollo/integration/directives")
+    rootPackageName.set("com.apollographql.apollo.integration.directives")
+    generateKotlinModels.set(true)
+  }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
@@ -68,5 +73,11 @@ tasks.withType(Test::class.java) {
   } else {
     // Enable some GC monitoring tools
     jvmArgs = listOf("-verbose:gc", "-Xloggc:gc.log", "-XX:+PrintGC", "-XX:+PrintGCDetails", "-XX:+PrintGCTimeStamps")
+  }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_1_8.toString()
   }
 }

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/directives/operations.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/directives/operations.graphql
@@ -1,0 +1,5 @@
+query MyQuery($myBool: Boolean = false) {
+    getCityByName(name: "London") {
+        id @include(if: $myBool)
+    }
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/directives/schema.sdl
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/directives/schema.sdl
@@ -1,0 +1,7 @@
+type Query {
+  getCityByName(name: String!): City
+}
+
+type City {
+  id: ID
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/directives/DirectivesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/directives/DirectivesTest.kt
@@ -25,7 +25,7 @@ class DirectivesTest {
   }
 
   @Test
-  fun `parse does not over fetch with default input`() {
+  fun `parse does not over fetch with skip directive`() {
     val responseJson = """
         {
           "data": {
@@ -36,7 +36,7 @@ class DirectivesTest {
           }
         }
       """.trimIndent()
-    val data = MyQuery(Input.absent()).parse(responseJson.byteInputStream().source().buffer()).data
+    val data = MyQuery(Input.optional(false)).parse(responseJson.byteInputStream().source().buffer()).data
     Truth.assertThat(data!!.getCityByName!!.id).isEqualTo(null)
   }
 }

--- a/apollo-integration/src/test/java/com/apollographql/apollo/directives/DirectivesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/directives/DirectivesTest.kt
@@ -1,0 +1,42 @@
+package com.apollographql.apollo.directives
+
+import com.apollographql.apollo.integration.directives.MyQuery
+import com.google.common.truth.Truth
+import okio.buffer
+import okio.source
+import org.junit.Test
+import com.apollographql.apollo.api.Input
+
+class DirectivesTest {
+  @Test
+  fun `parse does not crash with absent input`() {
+    val responseJson = """
+        {
+          "data": {
+            "getCityByName": {
+              "__typename": "City",
+              "id": "2643743"
+            }
+          }
+        }
+      """.trimIndent()
+    val data = MyQuery(Input.absent()).parse(responseJson.byteInputStream().source().buffer()).data
+    Truth.assertThat(data?.getCityByName?.__typename).isEqualTo("City")
+  }
+
+  @Test
+  fun `parse does not over fetch with default input`() {
+    val responseJson = """
+        {
+          "data": {
+            "getCityByName": {
+              "__typename": "City",
+              "id": "2643743"
+            }
+          }
+        }
+      """.trimIndent()
+    val data = MyQuery(Input.absent()).parse(responseJson.byteInputStream().source().buffer()).data
+    Truth.assertThat(data!!.getCityByName!!.id).isEqualTo(null)
+  }
+}


### PR DESCRIPTION
Revert #2704 as the default should be to not send optional variables and using default Kotlin parameters would overwrite that:

The below query:

```graphql
query GetHero($myBool: Boolean = true)
```

Should generate the Kotlin model:

```kotlin
data class GetHero(val myBool: Input<Boolean> = Input.absent())
```

Even though no variable will be sent to the server in the `{ "variables:" {....} }`, the server will still know the default value from the GraphQL query.

Also, really fix the main problem behind #2703: make `SimpleResponseReader` more robust to missing variable values by using safe casts. This is not 100% correct when reading from the cache as some fields will end up being overfetched but the solution to that problem is more complex and will be done in another PR