### PR TITLE
[Doc] for Java users, put Groovy first for Gradle configuration

### DIFF
--- a/docs/source/essentials/get-started-java.mdx
+++ b/docs/source/essentials/get-started-java.mdx
@@ -4,15 +4,58 @@ title: Get started with Java
 
 import {MultiCodeBlock} from 'gatsby-theme-apollo-docs';
 
-
-import AddPlugin from "../shared/add-plugin.mdx"
 import DownloadSchema from "../shared/download-schema.mdx"
 import AddQuery from "../shared/add-query.mdx"
 
 ## Add the Gradle plugin
 
-<AddPlugin />
+In your app Gradle file, apply the `com.apollographql.apollo` plugin:
 
+Using the [plugins DSL](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block):
+
+<MultiCodeBlock>
+
+```groovy
+plugins {
+  // ...
+  id("com.apollographql.apollo").version("x.y.z")
+}
+```
+
+```kotlin
+plugins {
+  // ...
+  id("com.apollographql.apollo").version("x.y.z")
+}
+```
+
+</MultiCodeBlock>
+
+Or using the [legacy syntax](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application):
+
+<MultiCodeBlock>
+
+```groovy
+buildscript {
+  // ...
+  classpath("com.apollographql.apollo:apollo-gradle-plugin:x.y.z")
+}
+
+apply plugin: "com.apollographql.apollo"
+```
+
+```kotlin
+buildscript {
+  // ...
+  classpath("com.apollographql.apollo:apollo-gradle-plugin:x.y.z")
+}
+
+apply(plugin = "com.apollographql.apollo")
+```
+
+</MultiCodeBlock>
+
+The plugin is hosted on the Gradle plugin portal, Jcenter and Maven Central.
 ## Add the runtime dependencies
 
 ```kotlin

--- a/docs/source/shared/download-schema.mdx
+++ b/docs/source/shared/download-schema.mdx
@@ -1,6 +1,8 @@
 
 Apollo Android requires your GraphQL server's schema as a `schema.json` file. You can obtain the contents of this file by running an introspection query on your server.
 
+**Note**: If you don't have a GraphQL server yet, you can use the server from the [tutorial](https://www.apollographql.com/docs/android/tutorial/00-introduction/): https://apollo-fullstack-tutorial.herokuapp.com/graphql.
+
 The Apollo Gradle plugin exposes a `downloadApolloSchema` task to help you obtain your schema. Provide this task your server's GraphQL endpoint and the output location for the `schema.json` file:
 
 ```bash:title=(shell)


### PR DESCRIPTION
Java users are more likely to use Groovy for Gradle configuration so put that first.