### PR TITLE
[Build scripts] be more strict about what we download from jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ plugins {
 }
 
 repositories {
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
@@ -20,7 +20,11 @@ buildscript {
     }
     google()
     mavenCentral()
-    jcenter()
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE
@@ -47,8 +51,12 @@ repositories {
     url = uri("../../../build/localMaven")
   }
   google() // for aapt2
-  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
-  jcenter() // for org.jetbrains.trove4j, depended on by lint
+  mavenCentral()
+  jcenter {
+    content {
+      includeGroup("org.jetbrains.trove4j")
+    }
+  }
 }
 
 dependencies {

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
@@ -7,7 +7,11 @@ buildscript {
     }
     google()
     mavenCentral()
-    jcenter()
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
   dependencies {
     // ADD BUILDSCRIPT DEPENDENCIES HERE
@@ -26,7 +30,11 @@ repositories {
   }
   google() // for aapt2
   mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
-  jcenter() // for org.jetbrains.trove4j, depended on by lint
+  jcenter {
+    content {
+      includeGroup("org.jetbrains.trove4j")
+    }
+  }
 }
 
 dependencies {

--- a/apollo-gradle-plugin/testProjects/buildCache/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildCache/build.gradle.kts
@@ -2,10 +2,10 @@ buildscript {
     apply(from = "../../../../gradle/dependencies.gradle")
 
     repositories {
-        jcenter()
         maven {
             url = uri("../../../../build/localMaven")
         }
+        mavenCentral()
     }
     dependencies {
         classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))

--- a/apollo-gradle-plugin/testProjects/compilationUnitAndroid/build.gradle
+++ b/apollo-gradle-plugin/testProjects/compilationUnitAndroid/build.gradle
@@ -7,7 +7,11 @@ buildscript {
     }
     google()
     mavenCentral()
-    jcenter()
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
   dependencies {
     classpath(dep.android.plugin)
@@ -19,7 +23,11 @@ repositories {
   maven {
     url = uri("../../../build/localMaven")
   }
-  google() // for aapt2
-  mavenCentral() // for jetbrainsAnnotations, depended on by apolloApi
-  jcenter() // for org.jetbrains.trove4j, depended on by lint
+  google()
+  mavenCentral()
+  jcenter {
+    content {
+      includeGroup("org.jetbrains.trove4j")
+    }
+  }
 }

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
   apply(from = "../../../gradle/dependencies.gradle")
 
   repositories {
-    jcenter()
+    mavenCentral()
     maven {
       url = uri("../../../build/localMaven")
     }

--- a/apollo-gradle-plugin/testProjects/mismatchedVersions/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/mismatchedVersions/build.gradle.kts
@@ -3,7 +3,7 @@ buildscript {
     apply(from = "../../../gradle/dependencies.gradle")
 
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url = uri("../../../build/localMaven")
         }
@@ -16,6 +16,6 @@ buildscript {
 
 subprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/build.gradle.kts
@@ -2,10 +2,10 @@ buildscript {
   apply(from = "../../../gradle/dependencies.gradle")
 
   repositories {
-    jcenter()
     maven {
       url = uri("../../../build/localMaven")
     }
+    mavenCentral()
   }
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/build.gradle.kts
@@ -2,10 +2,10 @@ buildscript {
   apply(from = "../../../gradle/dependencies.gradle")
 
   repositories {
-    jcenter()
     maven {
       url = uri("../../../build/localMaven")
     }
+    mavenCentral()
   }
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/build.gradle.kts
@@ -2,10 +2,10 @@ buildscript {
   apply(from = "../../../gradle/dependencies.gradle")
 
   repositories {
-    jcenter()
     maven {
       url = uri("../../../build/localMaven")
     }
+    mavenCentral()
   }
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))

--- a/apollo-gradle-plugin/testProjects/multi-modules/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/build.gradle.kts
@@ -2,10 +2,10 @@ buildscript {
   apply(from = "../../../gradle/dependencies.gradle")
 
   repositories {
-    jcenter()
     maven {
       url = uri("../../../build/localMaven")
     }
+    mavenCentral()
   }
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))

--- a/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
@@ -8,9 +8,7 @@ buildscript {
         maven {
             url = uri("../../../build/localMaven")
         }
-        google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
@@ -25,7 +23,6 @@ repositories {
     maven {
         url = uri("../../../build/localMaven")
     }
-    jcenter()
     mavenCentral()
 }
 

--- a/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
@@ -10,9 +10,7 @@ buildscript {
     maven {
       url = uri("../../../build/localMaven")
     }
-    google()
     mavenCentral()
-    jcenter()
   }
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
@@ -27,7 +25,6 @@ repositories {
   maven {
     url = uri("../../../build/localMaven")
   }
-  jcenter()
   mavenCentral()
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,11 @@ subprojects {
   repositories {
     google()
     mavenCentral()
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
 
   group = property("GROUP")!!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,7 +104,7 @@ fun Project.configurePublishing() {
   if (javadocTask == null && android != null) {
     // create the Android javadoc if needed
     javadocTask = tasks.create("javadoc", Javadoc::class.java) {
-      source = android.sourceSets["main"].java.getSourceFiles()
+      source = android.sourceSets["main"].java.sourceFiles
       classpath += project.files(android.bootClasspath.joinToString(File.pathSeparator))
 
       (android as? com.android.build.gradle.LibraryExtension)?.libraryVariants?.configureEach {
@@ -132,7 +132,7 @@ fun Project.configurePublishing() {
         from(javaPluginConvention.sourceSets.get("main").allSource)
       }
       android != null -> {
-        from(android.sourceSets["main"].java.getSourceFiles())
+        from(android.sourceSets["main"].java.sourceFiles)
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,11 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter() // for trove4j
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
 
   group = property("GROUP")!!
@@ -100,8 +104,8 @@ fun Project.configurePublishing() {
   if (javadocTask == null && android != null) {
     // create the Android javadoc if needed
     javadocTask = tasks.create("javadoc", Javadoc::class.java) {
-      source = android.sourceSets["main"].java.sourceFiles
-      classpath += project.files(android.getBootClasspath().joinToString(File.pathSeparator))
+      source = android.sourceSets["main"].java.getSourceFiles()
+      classpath += project.files(android.bootClasspath.joinToString(File.pathSeparator))
 
       (android as? com.android.build.gradle.LibraryExtension)?.libraryVariants?.configureEach {
         if (name != "release") {
@@ -128,7 +132,7 @@ fun Project.configurePublishing() {
         from(javaPluginConvention.sourceSets.get("main").allSource)
       }
       android != null -> {
-        from(android.sourceSets["main"].java.sourceFiles)
+        from(android.sourceSets["main"].java.getSourceFiles())
       }
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,11 +54,6 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter {
-      content {
-        includeGroup("org.jetbrains.trove4j")
-      }
-    }
   }
 
   group = property("GROUP")!!

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,7 +9,6 @@ project.apply {
 repositories {
   gradlePluginPortal()
   google()
-  jcenter()
   mavenCentral()
 }
 

--- a/composite/build.gradle.kts
+++ b/composite/build.gradle.kts
@@ -20,6 +20,5 @@ subprojects {
   repositories {
     google()
     mavenCentral()
-    jcenter()
   }
 }

--- a/composite/build.gradle.kts
+++ b/composite/build.gradle.kts
@@ -20,5 +20,10 @@ subprojects {
   repositories {
     google()
     mavenCentral()
+    jcenter {
+      content {
+        includeGroup("org.jetbrains.trove4j")
+      }
+    }
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     minAndroidPlugin      : '3.4.2',
-    androidPlugin         : '4.1.1',
+    androidPlugin         : '3.6.2',
     androidxSqlite        : '2.1.0',
     apollo                : '2.4.5-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     minAndroidPlugin      : '3.4.2',
-    androidPlugin         : '3.6.2',
+    androidPlugin         : '4.1.1',
     androidxSqlite        : '2.1.0',
     apollo                : '2.4.5-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.5.3',


### PR DESCRIPTION
only download org.jetbrains.trove4j:trove4j:20160824 from jcenter. It is needed in the buildscript classpath for the android plugin and also in the android lint classpath.