### PR TITLE
[Gradle Plugin] make convertApolloSchema never up-to-date 

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloConvertSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloConvertSchemaTask.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo.compiler.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -16,15 +17,25 @@ import org.gradle.api.tasks.options.Option
 import java.io.File
 
 abstract class ApolloConvertSchemaTask: DefaultTask() {
-  @get:Input
   @get:Option(option = "from", description = "schema to convert from")
   abstract val from: Property<String>
 
-  @get:OutputFile
   @get:Option(option = "to", description = "schema to convert to")
   abstract val to: Property<String>
 
+  init {
+    /**
+     * This task is really meant to be called from the command line so don't do any up-to-date checks
+     * If someone wants to register its own conversion task, it should be easy to do using the
+     * compiler APIs directly (see [convert] below)
+     * This code actually redundant because the task has no output but adding it make it explicit.
+     */
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
+  }
+
   private fun File.isIntrospection() = extension == "json"
+
   fun convert(from: File, to: File) {
     check (from.isIntrospection() && !to.isIntrospection() || !from.isIntrospection() && to.isIntrospection()) {
       "Cannot convert from ${from.name} to ${to.name}, they are already the same format"

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloConvertSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloConvertSchemaTask.kt
@@ -17,9 +17,12 @@ import org.gradle.api.tasks.options.Option
 import java.io.File
 
 abstract class ApolloConvertSchemaTask: DefaultTask() {
+  @get:Input
   @get:Option(option = "from", description = "schema to convert from")
   abstract val from: Property<String>
 
+  // Even if this is points to an output file, for the purpose of the task this is seen as an input
+  @get:Input
   @get:Option(option = "to", description = "schema to convert to")
   abstract val to: Property<String>
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConvertSchemaTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ConvertSchemaTests.kt
@@ -26,6 +26,31 @@ class ConvertSchemaTests {
   }
 
   @Test
+  fun `convert is never up-to-date`() {
+    TestUtils.withTestProject("convertSchema") { dir ->
+      val from = File(dir, "schemas/schema.sdl")
+      val to = File(dir, "schema.json")
+      var result = TestUtils.executeTask("convertApolloSchema",
+          dir,
+          "--from",
+          from.absolutePath,
+          "--to",
+          to.absolutePath
+      )
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":convertApolloSchema")!!.outcome)
+      result = TestUtils.executeTask("convertApolloSchema",
+          dir,
+          "--from",
+          from.absolutePath,
+          "--to",
+          to.absolutePath
+      )
+      // even if inputs are the same,
+      Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":convertApolloSchema")!!.outcome)
+    }
+  }
+
+  @Test
   fun `convert from Json to SDL works`() {
     TestUtils.withTestProject("convertSchema") { dir ->
       val from = File(dir, "schemas/schema.json")


### PR DESCRIPTION
Since it's intended to be used from the command line, it doesn't really make sense to use the up-to-date checks