### PR TITLE
[Kotlin Runtime] revert to okhttp 3 to support older versions of Android

### DIFF
--- a/apollo-runtime-kotlin/build.gradle.kts
+++ b/apollo-runtime-kotlin/build.gradle.kts
@@ -60,7 +60,7 @@ kotlin {
       dependencies {
         implementation(kotlin("test-junit"))
         implementation(groovy.util.Eval.x(project, "x.dep.truth"))
-        implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4"))
+        implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
       }
     }
 


### PR DESCRIPTION
There's no strict requirement for okhttp 4 so stick with okhttp 3 for now