### PR TITLE
[Publishing] publish sha256 and sha512 signatures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,9 +17,6 @@ BINTRAY_POM_REPO=android
 
 org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
-
-# https://github.com/gradle/gradle/issues/11412
-systemProp.org.gradle.internal.publish.checksums.insecure=true
-
+        
 # silence the "multiplatform alpha" warning
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
there was a bug in bintray/sonatype that made it not work but it looks
like it's working now (see
https://github.com/gradle/gradle/issues/11412#issuecomment-733655244)

