### PR TITLE
Open lru normalized cache class

### DIFF
--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/lru/LruNormalizedCache.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  *
  * A common configuration is to have secondary SQL cache.
  */
-class LruNormalizedCache internal constructor(evictionPolicy: EvictionPolicy) : NormalizedCache() {
+open class LruNormalizedCache constructor(evictionPolicy: EvictionPolicy) : NormalizedCache() {
 
   private val lruCache: Cache<String, Record> =
       CacheBuilder.newBuilder().apply {


### PR DESCRIPTION
I have a specific requirement that I would like to address using the LruNormalized Cache. I would be overriding the just the merge method to address a specific case. You can see the issue in this [slack thread](https://kotlinlang.slack.com/archives/C01A6KM1SBZ/p1605834318015400). Currently we are going to pull the whole class into our code base and put in the feature, although it's a working solution it does mean we have to maintain the said class and might miss out on any bug fixes/changes on it from future releases. 

Not a show stopper by any means but I would love to keep our code clean as well.