### PR TITLE
Update Metalava Gradle Plugin to 0.1.5

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -55,7 +55,7 @@ ext.dep = [
     kotlinCompileTesting  : "com.github.tschuchortdev:kotlin-compile-testing:1.2.10",
     cache                 : "com.nytimes.android:cache:$versions.cache",
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
-    gradleMetalavaPlugin  : "me.tylerbwong.gradle:metalava-gradle:0.1.4",
+    gradleMetalavaPlugin  : "me.tylerbwong.gradle:metalava-gradle:0.1.5",
     vanniktechPlugin      : "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
     gradlePublishPlugin   : "com.gradle.publish:plugin-publish-plugin:0.12.0",
     guavaJre              : "com.google.guava:guava:$versions.guava",


### PR DESCRIPTION
This version contains a [fix](https://github.com/tylerbwong/metalava-gradle/commit/ea4432dcd7690fcf5498e9223b2fc98a0fcd8ff6) for platform-specific file path separators (specifically to address the issues found when running on Windows in #2771).