### PR TITLE
Add interface for classes generated for enum types and fix sealed classes json representation

### DIFF
--- a/apollo-api/api.txt
+++ b/apollo-api/api.txt
@@ -130,6 +130,11 @@ package com.apollographql.apollo.api {
     method public int hashCode();
   }
 
+  public interface EnumValue {
+    method public String getRawValue();
+    property public abstract String rawValue;
+  }
+
   public final class Error {
     ctor public Error(String message, java.util.List<com.apollographql.apollo.api.Error.Location> locations, java.util.Map<java.lang.String,?> customAttributes);
     method @Deprecated public java.util.Map<java.lang.String,java.lang.Object> customAttributes();

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/EnumValue.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/EnumValue.kt
@@ -1,0 +1,8 @@
+package com.apollographql.apollo.api
+
+/**
+ * Represents an enum value
+ */
+interface EnumValue {
+  val rawValue: String
+}

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/Utils.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/Utils.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api.internal.json
 
+import com.apollographql.apollo.api.EnumValue
 import com.apollographql.apollo.api.internal.Throws
 import okio.IOException
 import kotlin.jvm.JvmStatic
@@ -31,6 +32,7 @@ object Utils {
 
       is Boolean -> jsonWriter.value(value as Boolean?)
       is Number -> jsonWriter.value(value as Number?)
+      is EnumValue -> jsonWriter.value(value.rawValue)
       else -> jsonWriter.value(value.toString())
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.arguments_complex.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 sealed class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.arguments_simple.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 sealed class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.deprecation.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/type/Episode.kt
@@ -5,14 +5,15 @@
 //
 package com.example.enum_type.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.String
 
 /**
  * The episodes in the Star Wars trilogy (with special symbol $S)
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977. (with special symbol $S)
    */

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.fragment_with_inline_fragment.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/type/Hero_type.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/type/Hero_type.kt
@@ -5,14 +5,15 @@
 //
 package com.example.hero_details.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.String
 
 /**
  * Lower case enum type name
  */
 enum class Hero_type(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   HUMAN("human"),
 
   DROID("droid"),

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.hero_name_query_long_name.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.hero_with_review.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.inline_fragments_with_friends.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.input_object_type.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/java_beans_semantic_naming/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.java_beans_semantic_naming.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.mutation_create_review.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 internal enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.mutation_create_review_semantic_naming.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.nested_conditional_inline.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.union_inline_fragments.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/type/Episode.kt
@@ -5,6 +5,7 @@
 //
 package com.example.unique_type_name.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.Deprecated
 import kotlin.String
 
@@ -12,8 +13,8 @@ import kotlin.String
  * The episodes in the Star Wars trilogy
  */
 enum class Episode(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * Star Wars Episode IV: A New Hope, released in 1977.
    */

--- a/apollo-compiler/src/test/graphql/com/example/variable_default_value/type/LengthUnit.kt
+++ b/apollo-compiler/src/test/graphql/com/example/variable_default_value/type/LengthUnit.kt
@@ -5,14 +5,15 @@
 //
 package com.example.variable_default_value.type
 
+import com.apollographql.apollo.api.EnumValue
 import kotlin.String
 
 /**
  * Units of height
  */
 enum class LengthUnit(
-  val rawValue: String
-) {
+  override val rawValue: String
+) : EnumValue {
   /**
    * The standard unit around the world
    */

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -57,6 +57,12 @@ configure<ApolloExtension> {
     rootPackageName.set("com.apollographql.apollo.integration.directives")
     generateKotlinModels.set(true)
   }
+  service("sealedclasses") {
+    sealedClassesForEnumsMatching.set(listOf(".*"))
+    generateKotlinModels.set(true)
+    sourceFolder.set("com/apollographql/apollo/integration/sealedclasses")
+    rootPackageName.set("com.apollographql.apollo.integration.sealedclasses")
+  }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/sealedclasses/EpisodeHeroName.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/sealedclasses/EpisodeHeroName.graphql
@@ -1,0 +1,4 @@
+#this query is only needed to reference the Direction enum
+query SealedClass($direction: Direction) {
+  path(direction: $direction)
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/sealedclasses/schema.sdl
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/sealedclasses/schema.sdl
@@ -1,0 +1,8 @@
+type Query {
+    path(direction: Direction): String
+}
+
+enum Direction {
+    SOUTH
+    NORTH
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/SealedClassesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/SealedClassesTest.kt
@@ -1,0 +1,38 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.cache.normalized.internal.RealCacheKeyBuilder
+import com.apollographql.apollo.integration.sealedclasses.type.Direction
+import com.google.common.truth.Truth
+import org.junit.Test
+
+
+class SealedClassesTest {
+
+  // see https://github.com/apollographql/apollo-android/issues/2775
+  @Test
+  fun `cache keys are correct for sealed classes`() {
+
+    val arguments = mapOf("direction" to
+        mapOf(
+            "kind" to "Variable",
+            "variableName" to "direction"
+        )
+    )
+
+    val field = ResponseField.forString(
+        "path",
+        "path",
+        arguments,
+        false,
+        emptyList())
+
+
+    val variables = object : Operation.Variables() {
+      override fun valueMap() = mapOf("direction" to Direction.NORTH)
+    }
+    val cacheKey = RealCacheKeyBuilder().build(field, variables)
+    Truth.assertThat(cacheKey).isEqualTo("path({\"direction\":\"NORTH\"})")
+  }
+}


### PR DESCRIPTION
Objects representing enums in sealed classes don't have stable toString() implementation: instead, they'll return the class name along with memory address for that object. This breaks SQLite-based caching for queries that accept enum parameters, as toString() is used to generate the query key, so it would change between app restarts. This commit fixes this behavior by adding an EnumValue interface to types representing enums, and using its `rawValue` property to build proper cache key.

Fixes https://github.com/apollographql/apollo-android/issues/2775