### PR TITLE
Fix NSURLSession configuration

### DIFF
--- a/apollo-runtime-kotlin/src/iosMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
+++ b/apollo-runtime-kotlin/src/iosMain/kotlin/com/apollographql/apollo/network/http/ApolloHttpNetworkTransport.kt
@@ -81,7 +81,7 @@ actual class ApolloHttpNetworkTransport(
   )
 
   private class DefaultDataTaskFactory(readTimeoutMillis: Long) : DataTaskFactory {
-    private val nsurlSession = NSURLSession.sessionWithConfiguration(NSURLSessionConfiguration().apply {
+    private val nsurlSession = NSURLSession.sessionWithConfiguration(NSURLSessionConfiguration.defaultSessionConfiguration().apply {
       timeoutIntervalForRequest = readTimeoutMillis.toDouble()/1000
     })
 


### PR DESCRIPTION
Use `defaultSessionConfiguration`. I was afraid that changing this would change the configuration globally but the documentation explicitely states that it's not the case:

```
Modifying the returned session configuration object does not affect any configuration objects returned by future calls
 to this method, and does not change the default behavior for existing sessions. It is therefore always safe to use the 
returned object as a starting point for additional customization.
```