### PR TITLE
Revert "publish sha256 and sha512 signatures (#2772)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,9 @@ BINTRAY_POM_REPO=android
 
 org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
-        
+
+# https://github.com/gradle/gradle/issues/11412
+systemProp.org.gradle.internal.publish.checksums.insecure=true
+
 # silence the "multiplatform alpha" warning
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
Somehow, bintray still generates wrong versions...

This reverts commit 81d742ac6e3a344d6aa3d4f0c08cfdce8865ed08.