### PR TITLE
do not choke on "repeated" directive.

### DIFF
--- a/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphSDL.g4
+++ b/apollo-compiler/src/main/antlr/com/apollographql/apollo/compiler/parser/antlr/GraphSDL.g4
@@ -105,7 +105,7 @@ inputValueDefinition
   ;
 
 directiveDefinition
-  : description? DIRECTIVE '@' name argumentsDefinition? ON_KEYWORD directiveLocations
+  : description? DIRECTIVE '@' name argumentsDefinition? REPEATABLE? ON_KEYWORD directiveLocations
   ;
 
 directiveLocations
@@ -289,6 +289,7 @@ UNION: 'union';
 SCALAR: 'scalar';
 INPUT: 'input';
 DIRECTIVE: 'directive';
+REPEATABLE: 'repeatable';
 ON_KEYWORD: 'on';
 EXTEND: 'extend';
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/GraphSdlParseTest.kt
@@ -67,6 +67,11 @@ class GraphSdlParseTest() {
   }
 
   @Test
+  fun `repeatable directive does not throw`() {
+    GraphSdlSchema(File("src/test/sdl/repeated-directive.sdl"))
+  }
+
+  @Test
   fun `writing SDL and parsing again yields identical schemas`() {
     val initialSchema = IntrospectionSchema(File("src/test/sdl/schema.json")).normalize()
     val sdlFile = File("build/sdl-test/schema.sdl")

--- a/apollo-compiler/src/test/sdl/repeated-directive.sdl
+++ b/apollo-compiler/src/test/sdl/repeated-directive.sdl
@@ -1,0 +1,6 @@
+
+type Query {
+  random: Int!
+}
+
+directive @testDirective repeatable on OBJECT


### PR DESCRIPTION
We don't do anything with them but them not being in the grammar made
the parser fail for recent schemas