### PR TITLE
Fix the example arguments for downloadApolloSchema

### DIFF
--- a/docs/source/tutorial/02-add-the-graphql-schema.mdx
+++ b/docs/source/tutorial/02-add-the-graphql-schema.mdx
@@ -21,7 +21,7 @@ From the root of the project, run the following:
 
 ```shell:title=(shell)
 mkdir -p app/src/main/graphql/com/example/rocketreserver/
-./gradlew :app:downloadApolloSchema -Pcom.apollographql.apollo.endpoint='https://apollo-fullstack-tutorial.herokuapp.com/' -Pcom.apollographql.apollo.schema='src/main/graphql/com/example/rocketreserver/schema.json'
+./gradlew :app:downloadApolloSchema --endpoint='https://apollo-fullstack-tutorial.herokuapp.com/' --schema='src/main/graphql/com/example/rocketreserver/schema.json'
 ```
 
 This will download a `schema.json` file from your endpoint to `app/src/main/graphql/com/example/rocketserver/schema.json`.


### PR DESCRIPTION
Using the `-P` parameters have been deprecated