### PR TITLE
Ignore Android modules during Gradle sync.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,8 @@ include("apollo-normalized-cache")
 include("apollo-normalized-cache-api")
 include("apollo-runtime-kotlin")
 
-include("apollo-idling-resource")
-include("apollo-normalized-cache-sqlite")
-include("apollo-android-support")
+if (System.getProperty("idea.sync.active") == null) {
+  include("apollo-idling-resource")
+  include("apollo-normalized-cache-sqlite")
+  include("apollo-android-support")
+}


### PR DESCRIPTION
This improves autocomplete in IntelliJ/Android Studio