### PR TITLE
Ignore Android modules during Gradle sync

### DIFF
--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -1,6 +1,4 @@
-val skipAndroidModule = findProperty("apollographql_skipAndroidModules") == "true"
-
-if (!skipAndroidModule) {
+if (System.getProperty("idea.sync.active") == null) {
   apply(plugin = "com.android.library")
 }
 apply(plugin = "org.jetbrains.kotlin.multiplatform")
@@ -29,7 +27,7 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
     }
   }
 
-  if (!skipAndroidModule) {
+  if (System.getProperty("idea.sync.active") == null) {
     android {
       publishAllLibraryVariants()
     }
@@ -52,7 +50,7 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
       }
     }
 
-    if (!skipAndroidModule) {
+    if (System.getProperty("idea.sync.active") == null) {
       val androidMain by getting {
         dependsOn(commonMain)
         dependencies {
@@ -91,7 +89,7 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
       }
     }
 
-    if (!skipAndroidModule) {
+    if (System.getProperty("idea.sync.active") == null) {
       val androidTest by getting {
         dependsOn(jvmTest)
       }
@@ -107,7 +105,7 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
   }
 }
 
-if (!skipAndroidModule) {
+if (System.getProperty("idea.sync.active") == null) {
   configure<com.android.build.gradle.LibraryExtension> {
     compileSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.compileSdkVersion").toString().toInt())
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,16 +172,6 @@ fun Project.configurePublishing() {
     }
   }
 
-  tasks.all {
-    doFirst {
-      if (name.contains("publish")
-          && (name.contains("OssStagingRepository")
-              || name.contains("BintrayRepository"))
-          && findProperty("apollographql_skipAndroidModules") == "true"
-      ) throw kotlin.IllegalStateException("Cannot publish a version without android modules. Set -Papollographql_skipAndroidModules=false to publish a version")
-    }
-  }
-
   configure<SigningExtension> {
     // GPG_PRIVATE_KEY should contain the armoured private key that starts with -----BEGIN PGP PRIVATE KEY BLOCK-----
     // It can be obtained with gpg --armour --export-secret-keys KEY_ID

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,9 +15,7 @@ include("apollo-runtime-kotlin")
 
 include("apollo-normalized-cache-sqlite")
 
-val skipAndroidModules = extra.properties.get("apollographql_skipAndroidModules") == "true"
-
-if (!skipAndroidModules) {
+if (System.getProperty("idea.sync.active") == null) {
   include("apollo-idling-resource")
   include("apollo-android-support")
 }


### PR DESCRIPTION
Same as https://github.com/apollographql/apollo-android/pull/2811 but for `dev-3.x`

use `System.getProperty("idea.sync.active")` to make autocomplete work better in the IDE instead of relying on a global gradle property