### PR TITLE
Better UP-TO-DATE checks

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -57,4 +57,6 @@ tasks.withType<Checkstyle> {
 }
 
 // since test/graphql is not an input to Test tasks, they're not run with the changes made in there.
-tasks.withType<Test>().configureEach { outputs.upToDateWhen { false } }
+tasks.withType<Test>().configureEach {
+  inputs.dir("src/test/graphql")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,7 +146,6 @@ fun Project.configurePublishing() {
       manifest {
         attributes["Built-By"] = findProperty("POM_DEVELOPER_ID") as String?
         attributes["Build-Jdk"] = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")} ${System.getProperty("java.vm.version")})"
-        attributes["Build-Timestamp"] = java.time.Instant.now().toString()
         attributes["Created-By"] = "Gradle ${gradle.gradleVersion}"
         attributes["Implementation-Title"] = findProperty("POM_NAME") as String?
         attributes["Implementation-Version"] = findProperty("VERSION_NAME") as String?


### PR DESCRIPTION
Remove the "Build-Timestamp" Manifest property, this makes the builds never up-to-date and compiling things over and over again

Also tweak the inputs of the codegen tests