### PR TITLE
Cleanup the custom scalar APIs 3/3: Fail on unknown scalar type

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/GraphQLCompiler.kt
@@ -135,10 +135,15 @@ class GraphQLCompiler(val logger: Logger = NoOpLogger) {
      *
      * If the user specified a mapping, use it, else fallback to [Any]
      */
-    val customScalarsMapping = introspectionSchema.types
+    val schemaScalars = introspectionSchema.types
         .values
         .filter { type -> type is IntrospectionSchema.Type.Scalar && !GQLTypeDefinition.builtInTypes.contains(type.name) }
         .map { type -> type.name }
+    val unknownScalars = userScalarTypesMap.keys.subtract(schemaScalars.toSet())
+    check (unknownScalars.isEmpty()) {
+      "ApolloGraphQL: unknown custom scalar(s): ${unknownScalars.joinToString(",")}"
+    }
+    val customScalarsMapping = schemaScalars
         .map {
           it to (userScalarTypesMap[it] ?: anyClassName(generateKotlinModels))
         }.toMap()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -65,8 +65,14 @@ class CodegenTest(private val folder: File) {
 
   companion object {
     fun arguments(folder: File): GraphQLCompiler.Arguments {
-      val customScalarsMapping = if (folder.name in listOf("custom_scalar_type", "input_object_type", "mutation_create_review")) {
-        mapOf("Date" to "java.util.Date", "URL" to "java.lang.String", "ID" to "java.lang.Integer")
+      val customScalarsMapping = if (folder.name in listOf(
+              "custom_scalar_type",
+              "input_object_type",
+              "mutation_create_review")) {
+        mapOf(
+            "Date" to "java.util.Date",
+            "URL" to "java.lang.String",
+        )
       } else {
         emptyMap()
       }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ServiceTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo/gradle/test/ServiceTests.kt
@@ -1,12 +1,15 @@
 package com.apollographql.apollo.gradle.test
 
 
+import com.apollographql.apollo.gradle.internal.DefaultApolloExtension
 import com.apollographql.apollo.gradle.util.TestUtils
 import com.apollographql.apollo.gradle.util.TestUtils.fixturesDirectory
 import com.apollographql.apollo.gradle.util.TestUtils.withSimpleProject
 import com.apollographql.apollo.gradle.util.TestUtils.withTestProject
 import com.apollographql.apollo.gradle.util.generatedChild
 import com.apollographql.apollo.gradle.util.replaceInText
+import com.google.common.truth.Truth
+import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.hamcrest.CoreMatchers.containsString
@@ -15,6 +18,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
@@ -31,6 +35,23 @@ class ServiceTests {
       TestUtils.assertFileContains(dir, "service/com/example/type/CustomScalars.kt", "\"java.util.Date\"")
     }
   }
+
+  @Test
+  fun `registering an unknown custom scalar fails`() {
+    withSimpleProject("""
+      apollo {
+        customScalarsMapping = ["UnknownScalar": "java.util.Date"]
+      }
+    """.trimIndent()) { dir ->
+      try {
+        TestUtils.executeTask("generateApolloSources", dir)
+        fail("Registering an unknown scalar should fail")
+      } catch (e: UnexpectedBuildFailure) {
+        Truth.assertThat(e.message).contains("unknown custom scalar(s)")
+      }
+    }
+  }
+
 
   @Test
   fun `customScalarsMapping put is working`() {

--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -43,7 +43,6 @@ configure<ApolloExtension> {
   }
   service("upload") {
     customScalarsMapping.set(mapOf(
-        "Date" to "java.util.Date",
         "Upload" to "com.apollographql.apollo.api.FileUpload"
     ))
     sourceFolder.set("com/apollographql/apollo/integration/upload")


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/issues/2486