### PR TITLE
Adding ApolloAndroidLogger to apollo-android-support. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ dependencies {
   implementation("com.apollographql.apollo:apollo-coroutines-support:x.y.z")
   // optional: for RxJava3 support  
   implementation("com.apollographql.apollo:apollo-rx3-support:x.y.z")
+  // optional: for additional Android utilities
+  implementation("com.apollographql.apollo:apollo-android-support:x.y.z")
   // optional: if you just want the generated models and parsers and write your own HTTP code/cache code, you can remove apollo-runtime
   // and use apollo-api instead  
   implementation("com.apollographql.apollo:apollo-api:x.y.z")

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dependencies {
   implementation("com.apollographql.apollo:apollo-coroutines-support:x.y.z")
   // optional: for RxJava3 support  
   implementation("com.apollographql.apollo:apollo-rx3-support:x.y.z")
-  // optional: for additional Android utilities
+  // optional: Most of apollo-android does not depend on Android in practice and runs on any JVM or on Kotlin native. apollo-android-support contains a few Android-only helper classes. For an example to send logs to logcat or run callbacks on the main thread.
   implementation("com.apollographql.apollo:apollo-android-support:x.y.z")
   // optional: if you just want the generated models and parsers and write your own HTTP code/cache code, you can remove apollo-runtime
   // and use apollo-api instead  
@@ -109,4 +109,3 @@ If you'd like to contribute, please see [Contributing.md](https://github.com/apo
 - [apollographql.com](http://www.apollographql.com/) to learn about Apollo open-source and commercial tools.
 - [The Apollo blog](https://www.apollographql.com/blog/) for long-form articles about GraphQL, feature announcements for Apollo, and guest articles from the community.
 - [The Apollo Twitter account](https://twitter.com/apollographql) for in-the-moment news.
-

--- a/apollo-android-support/api.txt
+++ b/apollo-android-support/api.txt
@@ -1,6 +1,11 @@
 // Signature format: 3.0
 package com.apollographql.apollo {
 
+  public final class ApolloAndroidLogger implements com.apollographql.apollo.Logger {
+    ctor public ApolloAndroidLogger();
+    method public void log(int priority, String message, Throwable? t, java.lang.Object... args);
+  }
+
   public final class ApolloCallback<T> extends com.apollographql.apollo.ApolloCall.Callback<T> {
     ctor public ApolloCallback(com.apollographql.apollo.ApolloCall.Callback<T!>, android.os.Handler);
     method public void onFailure(com.apollographql.apollo.exception.ApolloException);

--- a/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloAndroidLogger.kt
+++ b/apollo-android-support/src/main/java/com/apollographql/apollo/ApolloAndroidLogger.kt
@@ -1,0 +1,23 @@
+package com.apollographql.apollo
+
+import android.util.Log
+import com.apollographql.apollo.Logger
+
+/**
+ * This is an Android wrapper around [Logger] that will take any messages Apollo wants
+ * to print and log them in the Android logcat.
+ */
+class ApolloAndroidLogger : Logger {
+
+  override fun log(priority: Int, message: String, t: Throwable?, vararg args: Any) {
+    val formattedMessage = message.format(*args)
+    val tag = ApolloAndroidLogger::class.java.simpleName
+
+    when (priority) {
+      Logger.DEBUG -> Log.d(tag, formattedMessage)
+      Logger.WARN -> Log.w(tag, formattedMessage)
+      Logger.ERROR -> Log.e(tag, formattedMessage, t)
+      else -> Log.d(tag, formattedMessage)
+    }
+  }
+}

--- a/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
+++ b/samples/kotlin-sample/src/main/java/com/apollographql/apollo/kotlinsample/KotlinSampleApp.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.kotlinsample
 
 import android.app.Application
 import android.util.Log
+import com.apollographql.apollo.ApolloAndroidLogger
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
@@ -59,11 +60,12 @@ class KotlinSampleApp : Application() {
 
     // Create the http response cache store
     val cacheStore = DiskLruHttpCacheStore(File(cacheDir, "apolloCache"), 1024 * 1024)
+    val logger = ApolloAndroidLogger()
 
     ApolloClient.builder()
         .serverUrl(baseUrl)
         .normalizedCache(sqlNormalizedCacheFactory, cacheKeyResolver)
-        .httpCache(ApolloHttpCache(cacheStore))
+        .httpCache(ApolloHttpCache(cacheStore, logger))
         .defaultHttpCachePolicy(HttpCachePolicy.CACHE_FIRST)
         .okHttpClient(okHttpClient)
         .build()


### PR DESCRIPTION
This introduces a helpful wrapper for the `apollo-android-support` module that implements the `Logger` interface from Apollo to output to the logcat. 

I've also added this logger to the KotlinSampleApp to log hits and misses to the `HttpCache`. 

Here is a sample screenshot from the logcat:
<img width="1051" alt="Screen Shot 2020-12-29 at 3 52 52 PM" src="https://user-images.githubusercontent.com/9515997/103313610-9a9da980-49ee-11eb-83ab-cac162a84707.png">
