### PR TITLE
remove the <V> type parameter

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/GraphqlFragment.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/GraphqlFragment.kt
@@ -1,3 +1,6 @@
 package com.apollographql.apollo.api
 
+/**
+ * Represents a GraphQL fragment
+ */
 interface GraphqlFragment

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Mutation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Mutation.kt
@@ -3,4 +3,4 @@ package com.apollographql.apollo.api
 /**
  * Represents a GraphQL mutation operation that will be sent to the server.
  */
-interface Mutation<D : Operation.Data, V : Operation.Variables> : Operation<D, V>
+interface Mutation<D : Operation.Data> : Operation<D>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Operation.kt
@@ -14,7 +14,7 @@ import kotlin.jvm.JvmField
 /**
  * Represents a GraphQL operation (mutation or query).
  */
-interface Operation<D : Operation.Data, V : Operation.Variables> {
+interface Operation<D : Operation.Data> {
   /**
    * Returns the raw GraphQL operation String.
    */
@@ -23,7 +23,7 @@ interface Operation<D : Operation.Data, V : Operation.Variables> {
   /**
    * Returns the variables associated with this GraphQL operation.
    */
-  fun variables(): V
+  fun variables(): Operation.Variables
 
   /**
    * Returns an Adapter that maps the server response data to/from generated model class [D].

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OperationExtensions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OperationExtensions.kt
@@ -37,7 +37,7 @@ import kotlin.jvm.JvmOverloads
  * param is not provided.
  */
 @JvmOverloads
-fun <D : Operation.Data> Operation<D, *>.toJson(value: D, indent: String = "", customScalarAdapters: CustomScalarAdapters = DEFAULT): String {
+fun <D : Operation.Data> Operation<D>.toJson(value: D, indent: String = "", customScalarAdapters: CustomScalarAdapters = DEFAULT): String {
   return try {
     SimpleResponseWriter(customScalarAdapters).let { writer ->
       adapter().toResponse(writer, value)
@@ -73,7 +73,7 @@ fun <D : Operation.Data> Operation<D, *>.toJson(value: D, indent: String = "", c
  * ```
  */
 @JvmOverloads
-fun Operation<*, *>.composeRequestBody(
+fun Operation<*>.composeRequestBody(
     autoPersistQueries: Boolean,
     withQueryDocument: Boolean,
     customScalarAdapters: CustomScalarAdapters = DEFAULT
@@ -99,7 +99,7 @@ fun Operation<*, *>.composeRequestBody(
  * ```
  */
 @JvmOverloads
-fun Operation<*, *>.composeRequestBody(
+fun Operation<*>.composeRequestBody(
     customScalarAdapters: CustomScalarAdapters = DEFAULT
 ): ByteString {
   return OperationRequestBodyComposer.compose(
@@ -114,7 +114,7 @@ fun Operation<*, *>.composeRequestBody(
  * Parses GraphQL operation raw response from the [source] with provided [customScalarAdapters] and returns result [Response]
  */
 @JvmOverloads
-fun <D : Operation.Data> Operation<D, *>.parse(
+fun <D : Operation.Data> Operation<D>.parse(
     source: BufferedSource,
     customScalarAdapters: CustomScalarAdapters = DEFAULT
 ): Response<D> {
@@ -124,7 +124,7 @@ fun <D : Operation.Data> Operation<D, *>.parse(
 /**
  * Parses GraphQL operation raw response from the [byteString] with provided [customScalarAdapters] and returns result [Response]
  */
-fun <D : Operation.Data> Operation<D, *>.parse(
+fun <D : Operation.Data> Operation<D>.parse(
     byteString: ByteString,
     customScalarAdapters: CustomScalarAdapters = DEFAULT
 ): Response<D> {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Query.kt
@@ -5,4 +5,4 @@ import okio.ByteString
 /**
  * Represents a GraphQL query that will be sent to the server.
  */
-interface Query<D : Operation.Data, V : Operation.Variables> : Operation<D, V>
+interface Query<D : Operation.Data> : Operation<D>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Response.kt
@@ -9,7 +9,7 @@ data class Response<D : Operation.Data>(
     /**
      * GraphQL operation this response represents of
      */
-    val operation: Operation<*, *>,
+    val operation: Operation<*>,
 
     /**
      * Parsed response of GraphQL [operation] execution.
@@ -90,7 +90,7 @@ data class Response<D : Operation.Data>(
     return result
   }
 
-  class Builder<D : Operation.Data> internal constructor(internal val operation: Operation<*, *>) {
+  class Builder<D : Operation.Data> internal constructor(internal val operation: Operation<*>) {
     internal var data: D? = null
     internal var errors: List<Error>? = null
     internal var dependentKeys: Set<String>? = null
@@ -128,6 +128,6 @@ data class Response<D : Operation.Data>(
   companion object {
 
     @JvmStatic
-    fun <D : Operation.Data> builder(operation: Operation<*, *>): Builder<D> = Builder(operation)
+    fun <D : Operation.Data> builder(operation: Operation<*>): Builder<D> = Builder(operation)
   }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Subscription.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Subscription.kt
@@ -3,4 +3,4 @@ package com.apollographql.apollo.api
 /**
  * Represents a GraphQL subscription.
  */
-interface Subscription<D : Operation.Data, V : Operation.Variables> : Operation<D, V>
+interface Subscription<D : Operation.Data> : Operation<D>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/NoOpResolveDelegate.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/NoOpResolveDelegate.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
 
 class NoOpResolveDelegate<T>: ResolveDelegate<T> {
-  override fun willResolveRootQuery(operation: Operation<*, *>) {
+  override fun willResolveRootQuery(operation: Operation<*>) {
   }
 
   override fun willResolve(field: ResponseField, variables: Operation.Variables, value: Any?) {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/OperationRequestBodyComposer.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/OperationRequestBodyComposer.kt
@@ -12,7 +12,7 @@ object OperationRequestBodyComposer {
 
   @JvmStatic
   fun compose(
-      operation: Operation<*, *>,
+      operation: Operation<*>,
       autoPersistQueries: Boolean,
       withQueryDocument: Boolean,
       customScalarAdapters: CustomScalarAdapters

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResolveDelegate.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/ResolveDelegate.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
 
 interface ResolveDelegate<R> {
-  fun willResolveRootQuery(operation: Operation<*, *>)
+  fun willResolveRootQuery(operation: Operation<*>)
   fun willResolve(field: ResponseField, variables: Operation.Variables, value: Any?)
   fun didResolve(field: ResponseField, variables: Operation.Variables)
   fun didResolveScalar(value: Any?)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
@@ -18,7 +18,7 @@ object SimpleOperationResponseParser {
   @Throws(IOException::class)
   fun <D : Operation.Data> parse(
       source: BufferedSource,
-      operation: Operation<D, *>,
+      operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters
   ): Response<D> {
     return BufferedSourceJsonReader(source).use { jsonReader ->

--- a/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
+++ b/apollo-api/src/commonTest/kotlin/com/apollographql/apollo/api/TestUtils.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo.api
 
 import com.apollographql.apollo.api.internal.ResponseAdapter
 
-val EMPTY_OPERATION: Operation<*, *> = object : Operation<Operation.Data, Operation.Variables> {
+val EMPTY_OPERATION: Operation<*> = object : Operation<Operation.Data> {
   override fun variables(): Operation.Variables {
     return Operation.EMPTY_VARIABLES
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/backend/codegen/OperationType.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/backend/codegen/OperationType.kt
@@ -120,7 +120,7 @@ private fun CodeGenerationAst.OperationType.superInterfaceType(targetPackage: St
     CodeGenerationAst.OperationType.Type.QUERY -> Query::class.asClassName()
     CodeGenerationAst.OperationType.Type.MUTATION -> Mutation::class.asClassName()
     CodeGenerationAst.OperationType.Type.SUBSCRIPTION -> Subscription::class.asClassName()
-  }.parameterizedBy(dataTypeName, Operation.Variables::class.asClassName())
+  }.parameterizedBy(dataTypeName)
 }
 
 private val CodeGenerationAst.OperationType.primaryConstructorSpec: FunSpec

--- a/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/antlr_tokens/TestQuery.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val operation: Input<String> = Input.absent()
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/TestQuery.kt
@@ -29,7 +29,7 @@ data class TestQuery(
   val episode: Input<Episode> = Input.absent(),
   val stars: Int,
   val greenValue: Double
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt
@@ -32,7 +32,7 @@ data class TestQuery(
   val includeName: Boolean,
   val friendsCount: Int,
   val listOfListOfStringArgs: List<List<String?>>
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/TestQuery.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val episode: Input<Episode> = Input.absent()
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/TestQuery.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.Transient
 data class TestQuery(
   val withDetails: Boolean,
   val skipHumanDetails: Boolean
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/TestQuery.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.Transient
 data class TestQuery(
   val withDetails: Boolean,
   val skipHumanDetails: Boolean
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/TestQuery.kt
@@ -26,7 +26,7 @@ import kotlin.jvm.Transient
 data class TestQuery(
   val includeName: Boolean,
   val skipFriends: Boolean
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarship.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/AllStarship.kt
@@ -21,7 +21,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class AllStarship : Query<AllStarship.Data, Operation.Variables> {
+class AllStarship : Query<AllStarship.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/TestQuery.kt
@@ -21,7 +21,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetail.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/HeroDetail.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetail : Query<HeroDetail.Data, Operation.Variables> {
+class HeroDetail : Query<HeroDetail.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/HeroDetailsQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetailsQuery : Query<HeroDetailsQuery.Data, Operation.Variables> {
+class HeroDetailsQuery : Query<HeroDetailsQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/TestQuery.kt
@@ -17,7 +17,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.kt
@@ -27,8 +27,8 @@ data class TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryA
   val episodeAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName:
       Input<Episode> = Input.absent()
 ) :
-    Query<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data,
-    Operation.Variables> {
+    Query<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data>
+    {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/TestQuery.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val ep: Episode
-) : Mutation<TestQuery.Data, Operation.Variables> {
+) : Mutation<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/TestQuery.kt
@@ -17,7 +17,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/inline_frgament_intersection/TestOperation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_frgament_intersection/TestOperation.kt
@@ -21,7 +21,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestOperation : Query<TestOperation.Data, Operation.Variables> {
+class TestOperation : Query<TestOperation.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/TestQuery.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.Transient
 data class TestQuery(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<TestQuery.Data, Operation.Variables> {
+) : Mutation<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/merged_include/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/merged_include/TestQuery.kt
@@ -17,7 +17,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/CreateReviewForEpisode.kt
@@ -29,7 +29,7 @@ import kotlin.jvm.Transient
 internal data class CreateReviewForEpisode(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<CreateReviewForEpisode.Data, Operation.Variables> {
+) : Mutation<CreateReviewForEpisode.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/CreateReviewForEpisodeMutation.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.Transient
 data class CreateReviewForEpisodeMutation(
   val ep: Episode,
   val review: ReviewInput
-) : Mutation<CreateReviewForEpisodeMutation.Data, Operation.Variables> {
+) : Mutation<CreateReviewForEpisodeMutation.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/TestQuery.kt
@@ -21,7 +21,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/TestQuery.kt
@@ -27,7 +27,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val episode: Input<Episode> = Input.absent()
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/TestQuery.kt
@@ -17,7 +17,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/recursive_selection/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/TestQuery.kt
@@ -23,7 +23,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-internal class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+internal class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/TestQuery.kt
@@ -20,7 +20,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/TestQuery.kt
@@ -25,7 +25,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val id: String
-) : Query<TestQuery.Data, Operation.Variables> {
+) : Query<TestQuery.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/TestSubscription.kt
@@ -24,7 +24,7 @@ import kotlin.jvm.Transient
     "RemoveRedundantQualifierName")
 data class TestSubscription(
   val repo: String
-) : Subscription<TestSubscription.Data, Operation.Variables> {
+) : Subscription<TestSubscription.Data> {
   @Transient
   private val variables: Operation.Variables = object : Operation.Variables() {
     override fun valueMap(): Map<String, Any?> = mutableMapOf<String, Any?>().apply {

--- a/apollo-compiler/src/test/graphql/com/example/test_inline/GetPage.kt
+++ b/apollo-compiler/src/test/graphql/com/example/test_inline/GetPage.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class GetPage : Query<GetPage.Data, Operation.Variables> {
+class GetPage : Query<GetPage.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/TestQuery.kt
@@ -17,7 +17,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.Suppress
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/TestQuery.kt
@@ -18,7 +18,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/TestQuery.kt
@@ -19,7 +19,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class TestQuery : Query<TestQuery.Data, Operation.Variables> {
+class TestQuery : Query<TestQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/HeroDetailQuery.kt
@@ -22,7 +22,7 @@ import kotlin.collections.List
 @Suppress("NAME_SHADOWING", "UNUSED_ANONYMOUS_PARAMETER", "LocalVariableName",
     "RemoveExplicitTypeArguments", "NestedLambdaShadowedImplicitParameter", "PropertyName",
     "RemoveRedundantQualifierName")
-class HeroDetailQuery : Query<HeroDetailQuery.Data, Operation.Variables> {
+class HeroDetailQuery : Query<HeroDetailQuery.Data> {
   override fun operationId(): String = OPERATION_ID
 
   override fun queryDocument(): String = QUERY_DOCUMENT

--- a/apollo-idling-resource/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.kt
+++ b/apollo-idling-resource/src/test/java/com/apollographql/apollo/test/espresso/ApolloIdlingResourceTest.kt
@@ -144,7 +144,7 @@ class ApolloIdlingResourceTest {
   companion object {
     private const val TIME_OUT_SECONDS: Long = 3
     private const val IDLING_RESOURCE_NAME = "apolloIdlingResource"
-    private val EMPTY_QUERY: Query<Operation.Data, Operation.Variables> = object : Query<Operation.Data, Operation.Variables> {
+    private val EMPTY_QUERY: Query<Operation.Data> = object : Query<Operation.Data> {
       var operationName: OperationName = object : OperationName {
         override fun name(): String {
           return "EmptyQuery"

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
@@ -241,7 +241,7 @@ class ResponseNormalizationTest {
   }
 
   @Throws(Exception::class)
-  private fun <D: Operation.Data> assertHasNoErrors(mockResponse: String, query: Query<D, *>) {
+  private fun <D: Operation.Data> assertHasNoErrors(mockResponse: String, query: Query<D>) {
     enqueueAndAssertResponse(
         server,
         mockResponse,

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseWriteTestCase.kt
@@ -444,7 +444,7 @@ class ResponseWriteTestCase {
   }
 
   @Throws(Exception::class)
-  private fun <D: Operation.Data> assertCachedQueryResponse(query: Query<D, *>, predicate: Predicate<Response<D>>) {
+  private fun <D: Operation.Data> assertCachedQueryResponse(query: Query<D>, predicate: Predicate<Response<D>>) {
     assertResponse(
         apolloClient!!.query(query).responseFetcher(ApolloResponseFetchers.CACHE_ONLY),
         predicate

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptorFileUploadTest.kt
@@ -223,7 +223,7 @@ class ApolloServerInterceptorFileUploadTest {
     interceptor.httpPostCall(mutationSingle, CacheHeaders.NONE, requestHeaders, true, false)
   }
 
-  private fun assertDefaultRequestHeaders(request: Request, mutation: Operation<*, *>) {
+  private fun assertDefaultRequestHeaders(request: Request, mutation: Operation<*>) {
     Truth.assertThat(request.url()).isEqualTo(serverUrl)
     Truth.assertThat(request.method()).isEqualTo("POST")
     Truth.assertThat(request.header(ApolloServerInterceptor.HEADER_ACCEPT_TYPE)).isEqualTo(ApolloServerInterceptor.ACCEPT_TYPE)

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/CacheKeyResolver.kt
@@ -32,7 +32,7 @@ abstract class CacheKeyResolver {
 
     @JvmStatic
     @Suppress("UNUSED_PARAMETER")
-    fun rootKeyForOperation(operation: Operation<*, *>): CacheKey {
+    fun rootKeyForOperation(operation: Operation<*>): CacheKey {
       return ROOT_CACHE_KEY
     }
   }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ResponseNormalizer.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ResponseNormalizer.kt
@@ -28,7 +28,7 @@ abstract class ResponseNormalizer<R> : ResolveDelegate<R> {
     return dependentKeys
   }
 
-  override fun willResolveRootQuery(operation: Operation<*, *>) {
+  override fun willResolveRootQuery(operation: Operation<*>) {
     willResolveRecord(rootKeyForOperation(operation))
   }
 
@@ -131,7 +131,7 @@ abstract class ResponseNormalizer<R> : ResolveDelegate<R> {
   companion object {
     @JvmField
     val NO_OP_NORMALIZER: ResponseNormalizer<*> = object : ResponseNormalizer<Any?>() {
-      override fun willResolveRootQuery(operation: Operation<*, *>) {}
+      override fun willResolveRootQuery(operation: Operation<*>) {}
       override fun willResolve(field: ResponseField, variables: Operation.Variables, value: Any?) {}
       override fun didResolve(field: ResponseField, variables: Operation.Variables) {}
       override fun didResolveScalar(value: Any?) {}

--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
@@ -120,8 +120,8 @@ interface ApolloStore {
    * @param <V>       type of operation variables
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with cached data for specified operation
   </V></T></D> */
-  fun <D : Operation.Data, V : Operation.Variables> read(
-      operation: Operation<D, V>
+  fun <D : Operation.Data> read(
+      operation: Operation<D>
   ): ApolloStoreOperation<D>
 
   /**
@@ -135,8 +135,8 @@ interface ApolloStore {
    * @param <V>                 type of operation variables
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with cached response for specified operation
   </V></T></D> */
-  fun <D : Operation.Data, V : Operation.Variables> read(
-      operation: Operation<D, V>,
+  fun <D : Operation.Data> read(
+      operation: Operation<D>,
       responseNormalizer: ResponseNormalizer<Record>,
       cacheHeaders: CacheHeaders
   ): ApolloStoreOperation<Response<D>>
@@ -166,8 +166,8 @@ interface ApolloStore {
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of [Record] which
    * have changed
   </V></T></D> */
-  fun <D : Operation.Data, V : Operation.Variables> write(
-      operation: Operation<D, V>,
+  fun <D : Operation.Data> write(
+      operation: Operation<D>,
       operationData: D
   ): ApolloStoreOperation<Set<String>>
 
@@ -181,8 +181,8 @@ interface ApolloStore {
    * @param <V>           type of operation variables
    * @return {@ApolloStoreOperation} to be performed
   </V></T></D> */
-  fun <D : Operation.Data, V : Operation.Variables> writeAndPublish(
-      operation: Operation<D, V>,
+  fun <D : Operation.Data> writeAndPublish(
+      operation: Operation<D>,
       operationData: D
   ): ApolloStoreOperation<Boolean>
 
@@ -225,8 +225,8 @@ interface ApolloStore {
    * @return {@ApolloStoreOperation} to be performed, that will be resolved with set of keys of [Record] which
    * have changed
    */
-  fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdates(
-      operation: Operation<D, V>,
+  fun <D : Operation.Data> writeOptimisticUpdates(
+      operation: Operation<D>,
       operationData: D,
       mutationId: UUID
   ): ApolloStoreOperation<Set<String>>
@@ -240,8 +240,8 @@ interface ApolloStore {
    * @param mutationId    mutation unique identifier
    * @return {@ApolloStoreOperation} to be performed
    */
-  fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdatesAndPublish(
-      operation: Operation<D, V>,
+  fun <D : Operation.Data> writeOptimisticUpdatesAndPublish(
+      operation: Operation<D>,
       operationData: D,
       mutationId: UUID
   ): ApolloStoreOperation<Boolean>

--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/NoOpApolloStore.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/NoOpApolloStore.kt
@@ -80,13 +80,13 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     error("Cannot get cacheKeyResolver: no cache configured")
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> read(
-      operation: Operation<D, V>): ApolloStoreOperation<D> {
+  override fun <D : Operation.Data> read(
+      operation: Operation<D>): ApolloStoreOperation<D> {
     error("Cannot read operation: no cache configured")
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> read(
-      operation: Operation<D, V>,
+  override fun <D : Operation.Data> read(
+      operation: Operation<D>,
       responseNormalizer: ResponseNormalizer<Record>,
       cacheHeaders: CacheHeaders
   ): ApolloStoreOperation<Response<D>> {
@@ -102,14 +102,14 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     error("Cannot read fragment: no cache configured")
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> write(
-      operation: Operation<D, V>, operationData: D): ApolloStoreOperation<Set<String>> {
+  override fun <D : Operation.Data> write(
+      operation: Operation<D>, operationData: D): ApolloStoreOperation<Set<String>> {
     // Should we throw here instead?
     return emptyOperation(emptySet())
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> writeAndPublish(
-      operation: Operation<D, V>, operationData: D): ApolloStoreOperation<Boolean> {
+  override fun <D : Operation.Data> writeAndPublish(
+      operation: Operation<D>, operationData: D): ApolloStoreOperation<Boolean> {
     // Should we throw here instead?
     return emptyOperation(false)
   }
@@ -126,12 +126,12 @@ class NoOpApolloStore : ApolloStore, ReadableStore, WriteableStore {
     return emptyOperation(false)
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdates(operation: Operation<D, V>, operationData: D, mutationId: UUID): ApolloStoreOperation<Set<String>> {
+  override fun <D : Operation.Data> writeOptimisticUpdates(operation: Operation<D>, operationData: D, mutationId: UUID): ApolloStoreOperation<Set<String>> {
     // Should we throw here instead?
     return emptyOperation(emptySet())
   }
 
-  override fun <D : Operation.Data, V : Operation.Variables> writeOptimisticUpdatesAndPublish(operation: Operation<D, V>, operationData: D,
+  override fun <D : Operation.Data> writeOptimisticUpdatesAndPublish(operation: Operation<D>, operationData: D,
                                                                                               mutationId: UUID): ApolloStoreOperation<Boolean> {
     // Should we throw here instead?
     return emptyOperation(java.lang.Boolean.FALSE)

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
@@ -31,19 +31,19 @@ class ApolloClient private constructor(
   private val coroutineDispatcherContext = executionContext[ApolloCoroutineDispatcherContext]
       ?: ApolloCoroutineDispatcherContext(Dispatchers.Default)
 
-  fun <D : Operation.Data, V : Operation.Variables> mutate(mutation: Mutation<D, V>): ApolloMutationCall<D> {
+  fun <D : Operation.Data> mutate(mutation: Mutation<D>): ApolloMutationCall<D> {
     return mutation.prepareCall()
   }
 
-  fun <D : Operation.Data, V : Operation.Variables> query(query: Query<D, V>): ApolloQueryCall<D> {
+  fun <D : Operation.Data> query(query: Query<D>): ApolloQueryCall<D> {
     return query.prepareCall()
   }
 
-  fun <D : Operation.Data, V : Operation.Variables> subscribe(query: Subscription<D, V>): ApolloQueryCall<D> {
+  fun <D : Operation.Data> subscribe(query: Subscription<D>): ApolloQueryCall<D> {
     return query.prepareCall()
   }
 
-  private fun <D : Operation.Data, V : Operation.Variables> Operation<D, V>.prepareCall(): RealApolloCall<D> {
+  private fun <D : Operation.Data> Operation<D>.prepareCall(): RealApolloCall<D> {
     return RealApolloCall(
         operation = this,
         customScalarAdapters = customScalarAdapters,

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/interceptor/ApolloRequest.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/interceptor/ApolloRequest.kt
@@ -8,7 +8,7 @@ import com.benasher44.uuid.uuid4
 
 @ApolloExperimental
 class ApolloRequest<D : Operation.Data>(
-    val operation: Operation<D, *>,
+    val operation: Operation<D>,
     val customScalarAdapters: CustomScalarAdapters,
     val executionContext: ExecutionContext
 ) {

--- a/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/internal/RealApolloCall.kt
+++ b/apollo-runtime-kotlin/src/commonMain/kotlin/com/apollographql/apollo/internal/RealApolloCall.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.map
 @ApolloExperimental
 @OptIn(ExperimentalCoroutinesApi::class)
 class RealApolloCall<D : Operation.Data> constructor(
-    private val operation: Operation<D, *>,
+    private val operation: Operation<D>,
     private val customScalarAdapters: CustomScalarAdapters,
     private val interceptors: List<ApolloRequestInterceptor>,
     private val executionContext: ExecutionContext

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloCall.java
@@ -58,7 +58,7 @@ public interface ApolloCall<D extends Operation.Data> extends Cancelable {
    *
    * @return {@link Operation}
    */
-  @NotNull Operation<D, ?> operation();
+  @NotNull Operation<D> operation();
 
   /**
    * Cancels this {@link ApolloCall}. If the call was started with {@link #enqueue(Callback)}, the

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -142,34 +142,34 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   }
 
   @Override
-  public <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
-      @NotNull Mutation<D, V> mutation) {
+  public <D extends Mutation.Data> ApolloMutationCall<D> mutate(
+      @NotNull Mutation<D> mutation) {
     return newCall(mutation).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY);
   }
 
   @Override
-  public <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
-      @NotNull Mutation<D, V> mutation, @NotNull D withOptimisticUpdates) {
+  public <D extends Mutation.Data> ApolloMutationCall<D> mutate(
+      @NotNull Mutation<D> mutation, @NotNull D withOptimisticUpdates) {
     checkNotNull(withOptimisticUpdates, "withOptimisticUpdate == null");
     return newCall(mutation).toBuilder().responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .optimisticUpdates(Optional.<Operation.Data>fromNullable(withOptimisticUpdates)).build();
   }
 
   @Override
-  public <D extends Query.Data, V extends Query.Variables> ApolloQueryCall<D> query(@NotNull Query<D, V> query) {
+  public <D extends Query.Data> ApolloQueryCall<D> query(@NotNull Query<D> query) {
     return newCall(query);
   }
 
   @Override
-  public <D extends Operation.Data, V extends Operation.Variables> ApolloPrefetch prefetch(
-      @NotNull Operation<D, V> operation) {
+  public <D extends Operation.Data> ApolloPrefetch prefetch(
+      @NotNull Operation<D> operation) {
     return new RealApolloPrefetch(operation, serverUrl, httpCallFactory, customScalarAdapters, dispatcher, logger,
         tracker);
   }
 
   @Override
-  public <D extends Subscription.Data, V extends Subscription.Variables> ApolloSubscriptionCall<D> subscribe(
-      @NotNull Subscription<D, V> subscription) {
+  public <D extends Subscription.Data> ApolloSubscriptionCall<D> subscribe(
+      @NotNull Subscription<D> subscription) {
     return new RealApolloSubscriptionCall<>(subscription, subscriptionManager, apolloStore, ApolloSubscriptionCall.CachePolicy.NO_CACHE,
         dispatcher, logger);
   }
@@ -340,8 +340,8 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
     }
   }
 
-  private <D extends Operation.Data, V extends Operation.Variables> RealApolloCall<D> newCall(
-      @NotNull Operation<D, V> operation) {
+  private <D extends Operation.Data> RealApolloCall<D> newCall(
+      @NotNull Operation<D> operation) {
     return RealApolloCall.<D>builder()
         .operation(operation)
         .serverUrl(serverUrl)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloMutationCall.java
@@ -101,8 +101,8 @@ public interface ApolloMutationCall<D extends Operation.Data> extends ApolloCall
      * @param mutation the {@link Mutation} which needs to be performed
      * @return prepared {@link ApolloMutationCall} call to be executed at some point in the future
      */
-    <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
-        @NotNull Mutation<D, V> mutation);
+    <D extends Mutation.Data> ApolloMutationCall<D> mutate(
+        @NotNull Mutation<D> mutation);
 
     /**
      * <p>Creates and prepares a new {@link ApolloMutationCall} call with optimistic updates.</p>
@@ -115,7 +115,7 @@ public interface ApolloMutationCall<D extends Operation.Data> extends ApolloCall
      * @param withOptimisticUpdates optimistic updates for this mutation
      * @return prepared {@link ApolloMutationCall} call to be executed at some point in the future
      */
-    <D extends Mutation.Data, V extends Mutation.Variables> ApolloMutationCall<D> mutate(
-        @NotNull Mutation<D, V> mutation, @NotNull D withOptimisticUpdates);
+    <D extends Mutation.Data> ApolloMutationCall<D> mutate(
+        @NotNull Mutation<D> mutation, @NotNull D withOptimisticUpdates);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloPrefetch.java
@@ -112,8 +112,8 @@ public interface ApolloPrefetch extends Cancelable {
      * @param operation the operation which needs to be performed
      * @return The ApolloPrefetch object with the wrapped operation object
      */
-    <D extends Operation.Data, V extends Operation.Variables> ApolloPrefetch prefetch(
-        @NotNull Operation<D, V> operation);
+    <D extends Operation.Data> ApolloPrefetch prefetch(
+        @NotNull Operation<D> operation);
 
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloQueryCall.java
@@ -121,6 +121,6 @@ public interface ApolloQueryCall<D extends Operation.Data> extends ApolloCall<D>
      * @param query the operation which needs to be performed
      * @return prepared {@link ApolloQueryCall} call to be executed at some point in the future
      */
-    <D extends Query.Data, V extends Query.Variables> ApolloQueryCall<D> query(@NotNull Query<D, V> query);
+    <D extends Query.Data> ApolloQueryCall<D> query(@NotNull Query<D> query);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloSubscriptionCall.java
@@ -53,8 +53,8 @@ public interface ApolloSubscriptionCall<D extends Subscription.Data> extends Can
      * @param subscription to be sent to the subscription server to start listening pushed updates
      * @return prepared {@link ApolloSubscriptionCall} call to be executed
      */
-    <D extends Subscription.Data, V extends Subscription.Variables> ApolloSubscriptionCall<D> subscribe(
-        @NotNull Subscription<D, V> subscription);
+    <D extends Subscription.Data> ApolloSubscriptionCall<D> subscribe(
+        @NotNull Subscription<D> subscription);
   }
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloAutoPersistedOperationInterceptor.java
@@ -131,7 +131,7 @@ public class ApolloAutoPersistedOperationInterceptor implements ApolloIntercepto
       this(false, true, true);
     }
 
-    @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?, ?> operation) {
+    @Nullable @Override public ApolloInterceptor newInterceptor(@NotNull ApolloLogger logger, @NotNull Operation<?> operation) {
       if (operation instanceof Query && !persistQueries) {
         return null;
       }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/interceptor/ApolloInterceptorFactory.kt
@@ -12,5 +12,5 @@ interface ApolloInterceptorFactory {
    *
    * @return the interceptor or null if no interceptor is needed for this operation
    */
-  fun newInterceptor(logger: ApolloLogger, operation: Operation<*, *>): ApolloInterceptor?
+  fun newInterceptor(logger: ApolloLogger, operation: Operation<*>): ApolloInterceptor?
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -50,7 +50,7 @@ import static java.util.Collections.emptyList;
 
 @SuppressWarnings("WeakerAccess")
 public final class RealApolloCall<D extends Query.Data> implements ApolloQueryCall<D>, ApolloMutationCall<D> {
-  final Operation<D, ?> operation;
+  final Operation<D> operation;
   final HttpUrl serverUrl;
   final Call.Factory httpCallFactory;
   final HttpCache httpCache;
@@ -230,7 +230,7 @@ public final class RealApolloCall<D extends Query.Data> implements ApolloQueryCa
         .build();
   }
 
-  @NotNull @Override public Operation<D, ?> operation() {
+  @NotNull @Override public Operation<D> operation() {
     return operation;
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
@@ -31,7 +31,7 @@ import static com.apollographql.apollo.internal.CallState.IDLE;
 import static com.apollographql.apollo.internal.CallState.TERMINATED;
 
 public class RealApolloSubscriptionCall<D extends Operation.Data> implements ApolloSubscriptionCall<D> {
-  private final Subscription<D, ?> subscription;
+  private final Subscription<D> subscription;
   private final SubscriptionManager subscriptionManager;
   private final ApolloStore apolloStore;
   private final CachePolicy cachePolicy;
@@ -41,7 +41,7 @@ public class RealApolloSubscriptionCall<D extends Operation.Data> implements Apo
   private SubscriptionManagerCallback<D> subscriptionCallback;
 
   public RealApolloSubscriptionCall(
-      @NotNull Subscription<D, ?> subscription,
+      @NotNull Subscription<D> subscription,
       @NotNull SubscriptionManager subscriptionManager,
       @NotNull ApolloStore apolloStore,
       @NotNull CachePolicy cachePolicy,

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloServerInterceptor.kt
@@ -74,7 +74,7 @@ class ApolloServerInterceptor(
     callBack.onFetch(FetchSourceType.NETWORK)
     val httpCall: Call
     httpCall = try {
-      if (request.useHttpGetMethodForQueries && request.operation is Query<*, *>) {
+      if (request.useHttpGetMethodForQueries && request.operation is Query<*>) {
         httpGetCall(request.operation, request.cacheHeaders, request.requestHeaders,
             request.sendQueryDocument, request.autoPersistQueries)
       } else {
@@ -112,7 +112,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun httpGetCall(operation: Operation<*, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
+  fun httpGetCall(operation: Operation<*>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
                   writeQueryDocument: Boolean, autoPersistQueries: Boolean): Call {
     val requestBuilder = Request.Builder()
         .url(httpGetUrl(serverUrl, operation, customScalarAdapters, writeQueryDocument, autoPersistQueries))
@@ -122,7 +122,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun httpPostCall(operation: Operation<*, *>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
+  fun httpPostCall(operation: Operation<*>, cacheHeaders: CacheHeaders, requestHeaders: RequestHeaders,
                    writeQueryDocument: Boolean, autoPersistQueries: Boolean): Call {
     var requestBody = RequestBody.create(MEDIA_TYPE, httpPostRequestBody(operation, customScalarAdapters,
         writeQueryDocument, autoPersistQueries))
@@ -136,7 +136,7 @@ class ApolloServerInterceptor(
   }
 
   @Throws(IOException::class)
-  fun decorateRequest(requestBuilder: Request.Builder, operation: Operation<*, *>, cacheHeaders: CacheHeaders,
+  fun decorateRequest(requestBuilder: Request.Builder, operation: Operation<*>, cacheHeaders: CacheHeaders,
                       requestHeaders: RequestHeaders) {
     requestBuilder
         .header(HEADER_ACCEPT_TYPE, ACCEPT_TYPE)
@@ -172,18 +172,18 @@ class ApolloServerInterceptor(
     val MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8")
 
     @Throws(IOException::class)
-    fun cacheKey(operation: Operation<*, *>, customScalarAdapters: CustomScalarAdapters?): String {
+    fun cacheKey(operation: Operation<*>, customScalarAdapters: CustomScalarAdapters?): String {
       return httpPostRequestBody(operation, customScalarAdapters, true, true).md5().hex()
     }
 
     @Throws(IOException::class)
-    fun httpPostRequestBody(operation: Operation<*, *>, customScalarAdapters: CustomScalarAdapters?,
+    fun httpPostRequestBody(operation: Operation<*>, customScalarAdapters: CustomScalarAdapters?,
                             writeQueryDocument: Boolean, autoPersistQueries: Boolean): ByteString {
       return operation.composeRequestBody(autoPersistQueries, writeQueryDocument, customScalarAdapters!!)
     }
 
     @Throws(IOException::class)
-    fun httpGetUrl(serverUrl: HttpUrl, operation: Operation<*, *>,
+    fun httpGetUrl(serverUrl: HttpUrl, operation: Operation<*>,
                    customScalarAdapters: CustomScalarAdapters?, writeQueryDocument: Boolean,
                    autoPersistQueries: Boolean): HttpUrl {
       val urlBuilder = serverUrl.newBuilder()
@@ -201,7 +201,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun addVariablesUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *>,
+    fun addVariablesUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*>,
                                       customScalarAdapters: CustomScalarAdapters?) {
       val buffer = Buffer()
       val jsonWriter = of(buffer)
@@ -214,7 +214,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun addExtensionsUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*, *>) {
+    fun addExtensionsUrlQueryParameter(urlBuilder: HttpUrl.Builder, operation: Operation<*>) {
       val buffer = Buffer()
       val jsonWriter = of(buffer)
       jsonWriter.serializeNulls = true
@@ -272,7 +272,7 @@ class ApolloServerInterceptor(
     }
 
     @Throws(IOException::class)
-    fun transformToMultiPartIfUploadExists(originalBody: RequestBody?, operation: Operation<*, *>): RequestBody? {
+    fun transformToMultiPartIfUploadExists(originalBody: RequestBody?, operation: Operation<*>): RequestBody? {
       val allUploads = ArrayList<FileUploadMeta>()
       for (variableName in operation.variables().valueMap().keys) {
         val value = operation.variables().valueMap()[variableName]

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/NoOpSubscriptionManager.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/NoOpSubscriptionManager.kt
@@ -8,11 +8,11 @@ import com.apollographql.apollo.subscription.SubscriptionManagerState
 class NoOpSubscriptionManager : SubscriptionManager {
   val errorMessage = "No `SubscriptionTransport.Factory` found, please add one to your `ApolloClient` with `ApolloClient.Builder.subscriptionTransportFactory`"
 
-  override fun <D : Operation.Data> subscribe(subscription: Subscription<D, *>, callback: SubscriptionManager.Callback<D>) {
+  override fun <D : Operation.Data> subscribe(subscription: Subscription<D>, callback: SubscriptionManager.Callback<D>) {
     throw IllegalStateException(errorMessage)
   }
 
-  override fun unsubscribe(subscription: Subscription<*, *>) {
+  override fun unsubscribe(subscription: Subscription<*>) {
     throw IllegalStateException(errorMessage)
   }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -92,7 +92,7 @@ public final class RealSubscriptionManager implements SubscriptionManager {
   }
 
   @Override
-  public <D extends Operation.Data> void subscribe(@NotNull final Subscription<D, ?> subscription, @NotNull final SubscriptionManager.Callback<D> callback) {
+  public <D extends Operation.Data> void subscribe(@NotNull final Subscription<D> subscription, @NotNull final SubscriptionManager.Callback<D> callback) {
     checkNotNull(subscription, "subscription == null");
     checkNotNull(callback, "callback == null");
     dispatcher.execute(new Runnable() {
@@ -506,10 +506,10 @@ public final class RealSubscriptionManager implements SubscriptionManager {
 
   private static class SubscriptionRecord {
     final UUID id;
-    final Subscription<?, ?> subscription;
+    final Subscription<?> subscription;
     final SubscriptionManager.Callback<?> callback;
 
-    SubscriptionRecord(UUID id, Subscription<?, ?> subscription, SubscriptionManager.Callback<?> callback) {
+    SubscriptionRecord(UUID id, Subscription<?> subscription, SubscriptionManager.Callback<?> callback) {
       this.id = id;
       this.subscription = subscription;
       this.callback = callback;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionManager.java
@@ -14,14 +14,14 @@ public interface SubscriptionManager {
    * @param subscription to start
    * @param callback to be called on result
    */
-  <D extends Operation.Data> void subscribe(@NotNull Subscription<D, ?> subscription, @NotNull RealSubscriptionManager.Callback<D> callback);
+  <D extends Operation.Data> void subscribe(@NotNull Subscription<D> subscription, @NotNull RealSubscriptionManager.Callback<D> callback);
 
   /**
    * Stops provided subscription. If there are no active subscriptions left, disconnects from the subscription server.
    *
    * @param subscription to stop
    */
-  void unsubscribe(@NotNull Subscription<?, ?> subscription);
+  void unsubscribe(@NotNull Subscription<?> subscription);
 
   /**
    * Returns the current state of subscription manager.

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/SubscriptionResponse.java
@@ -8,11 +8,11 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Collection;
 
 public final class SubscriptionResponse<D extends Subscription.Data> {
-  @NotNull public final Subscription<D, ?> subscription;
+  @NotNull public final Subscription<D> subscription;
   @NotNull public final Response<D> response;
   @NotNull public final Collection<Record> cacheRecords;
 
-  public SubscriptionResponse(@NotNull Subscription<D, ?> subscription, @NotNull Response<D> response,
+  public SubscriptionResponse(@NotNull Subscription<D> subscription, @NotNull Response<D> response,
       @NotNull Collection<Record> cacheRecords) {
     this.subscription = subscription;
     this.response = response;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -22,15 +22,15 @@ import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
 @SuppressWarnings("WeakerAccess")
 public final class OperationResponseParser<D extends Operation.Data> {
-  final Operation<D, ?> operation;
+  final Operation<D> operation;
   final CustomScalarAdapters customScalarAdapters;
   final ResponseNormalizer<Map<String, Object>> responseNormalizer;
 
-  @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D, ?> operation, CustomScalarAdapters customScalarAdapters) {
+  @SuppressWarnings("unchecked") public OperationResponseParser(Operation<D> operation, CustomScalarAdapters customScalarAdapters) {
     this(operation, customScalarAdapters, (ResponseNormalizer<Map<String, Object>>) ResponseNormalizer.NO_OP_NORMALIZER);
   }
 
-  public OperationResponseParser(Operation<D, ?> operation,
+  public OperationResponseParser(Operation<D> operation,
       CustomScalarAdapters customScalarAdapters, ResponseNormalizer<Map<String, Object>> responseNormalizer) {
     this.operation = operation;
     this.customScalarAdapters = customScalarAdapters;

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/OperationClientMessage.kt
@@ -34,7 +34,7 @@ sealed class OperationClientMessage {
       @JvmField
       val subscriptionId: String,
       @JvmField
-      val subscription: Subscription<*, *>,
+      val subscription: Subscription<*>,
       @JvmField
       val customScalarAdapters: CustomScalarAdapters,
       @JvmField

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/ApolloExceptionTest.kt
@@ -25,7 +25,7 @@ class ApolloExceptionTest {
   
   private lateinit var apolloClient: ApolloClient
 
-  private val emptyQuery = object : Query<Operation.Data, Operation.Variables> {
+  private val emptyQuery = object : Query<Operation.Data> {
     var operationName: OperationName = object : OperationName {
       override fun name(): String {
         return "emptyQuery"
@@ -90,7 +90,7 @@ class ApolloExceptionTest {
   fun httpExceptionPrefetch() {
     server.enqueue(MockResponse().setResponseCode(401).setBody("Unauthorized request!"))
     Rx2Apollo
-        .from(apolloClient.prefetch<Operation.Data, Operation.Variables>(emptyQuery))
+        .from(apolloClient.prefetch<Operation.Data>(emptyQuery))
         .test()
         .awaitDone(timeoutSeconds, TimeUnit.SECONDS)
         .assertNoValues()
@@ -101,7 +101,7 @@ class ApolloExceptionTest {
   @Throws(Exception::class)
   fun testTimeoutException() {
     Rx2Apollo
-        .from(apolloClient.query<Operation.Data, Operation.Variables>(emptyQuery))
+        .from(apolloClient.query<Operation.Data>(emptyQuery))
         .test()
         .awaitDone(timeoutSeconds * 2, TimeUnit.SECONDS)
         .assertNoValues()
@@ -117,7 +117,7 @@ class ApolloExceptionTest {
   @Throws(Exception::class)
   fun testTimeoutExceptionPrefetch() {
     Rx2Apollo
-        .from(apolloClient.prefetch<Operation.Data, Operation.Variables>(emptyQuery))
+        .from(apolloClient.prefetch<Operation.Data>(emptyQuery))
         .test()
         .awaitDone(timeoutSeconds * 2, TimeUnit.SECONDS)
         .assertNoValues()
@@ -134,7 +134,7 @@ class ApolloExceptionTest {
   fun testParseException() {
     server.enqueue(MockResponse().setBody("Noise"))
     Rx2Apollo
-        .from(apolloClient.query<Operation.Data, Operation.Variables>(emptyQuery))
+        .from(apolloClient.query<Operation.Data>(emptyQuery))
         .test()
         .awaitDone(timeoutSeconds, TimeUnit.SECONDS)
         .assertNoValues()

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/ResponseFetcherTest.kt
@@ -13,7 +13,7 @@ import org.junit.Test
 
 class ResponseFetcherTest {
 
-  private val emptyQuery = object : Query<Operation.Data, Operation.Variables> {
+  private val emptyQuery = object : Query<Operation.Data> {
     var operationName: OperationName = object : OperationName {
       override fun name(): String {
         return "emptyQuery"
@@ -58,7 +58,7 @@ class ResponseFetcherTest {
         .serverUrl("http://google.com")
         .okHttpClient(OkHttpClient())
         .build()
-    val realApolloCall = apolloClient.query<Operation.Data, Operation.Variables>(emptyQuery) as RealApolloCall<*>
+    val realApolloCall = apolloClient.query<Operation.Data>(emptyQuery) as RealApolloCall<*>
     Truth.assertThat(realApolloCall.httpCachePolicy.fetchStrategy).isEqualTo(FetchStrategy.NETWORK_ONLY)
     Truth.assertThat(realApolloCall.responseFetcher).isEqualTo(ApolloResponseFetchers.CACHE_FIRST)
   }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
@@ -270,7 +270,7 @@ public class ApolloAutoPersistedOperationInterceptorTest {
         .build();
   }
 
-  static class MockOperation implements Operation<MockOperation.Data, Operation.Variables> {
+  static class MockOperation implements Operation<MockOperation.Data> {
 
     @Override public String queryDocument() {
       throw new UnsupportedOperationException();

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -77,7 +77,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testCachesErrorResponseWhenStorePartialResponsesCacheHeaderPresent() {
-    Operation<?, ?> operation = mock(Operation.class);
+    Operation<?> operation = mock(Operation.class);
     Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
@@ -102,7 +102,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testDoesCachesNonErrorResponse() {
-    Operation<?, ?> operation = mock(Operation.class);
+    Operation<?> operation = mock(Operation.class);
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
         com.apollographql.apollo.api.Response.builder(operation).build(),

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -60,7 +60,7 @@ public class ApolloCacheInterceptorTest {
 
   @Test
   public void testDoesNotCacheErrorResponse() {
-    Operation<?,?> operation = mock(Operation.class);
+    Operation<?> operation = mock(Operation.class);
     Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/reader/ApolloCallTrackerTest.kt
@@ -119,7 +119,7 @@ class ApolloCallTrackerTest {
   companion object {
     private const val SERVER_URL = "http://localhost:1234"
     private const val TIMEOUT_SECONDS = 2
-    private val EMPTY_QUERY: Query<QueryData, Operation.Variables> = object : Query<QueryData, Operation.Variables> {
+    private val EMPTY_QUERY: Query<QueryData> = object : Query<QueryData> {
       var operationName: OperationName = object : OperationName {
         override fun name(): String {
           return "EmptyQuery"

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionAutoPersistTest.java
@@ -151,7 +151,7 @@ public class SubscriptionAutoPersistTest {
     }
   }
 
-  private static final class MockSubscription implements Subscription<Operation.Data, Operation.Variables> {
+  private static final class MockSubscription implements Subscription<Operation.Data> {
     final String operationId;
 
     MockSubscription(String operationId) {

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/subscription/SubscriptionManagerTest.kt
@@ -345,7 +345,7 @@ class SubscriptionManagerTest {
     }
   }
 
-  private class MockSubscription(val operationId: String) : Subscription<Operation.Data, Operation.Variables> {
+  private class MockSubscription(val operationId: String) : Subscription<Operation.Data> {
     override fun queryDocument(): String {
       return "subscription {\n  commentAdded(repoFullName: \"repo\") {\n    __typename\n    id\n    content\n  }\n}"
     }

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/MockSubscription.kt
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/subscription/MockSubscription.kt
@@ -10,7 +10,7 @@ class MockSubscription(
     private val variables: Map<String, Any?> = emptyMap(),
     private val name: String = "SomeSubscription",
     private val operationId: String = "someId"
-) : Subscription<Operation.Data, Operation.Variables> {
+) : Subscription<Operation.Data> {
   override fun queryDocument(): String = queryDocument
 
   override fun variables(): Operation.Variables = object : Operation.Variables() {

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo/rx2/RxJavaExtensions.kt
@@ -57,8 +57,8 @@ inline fun <D : Operation.Data> ApolloSubscriptionCall<D>.rx(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
-    query: Query<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxQuery(
+    query: Query<D>,
     configure: ApolloQueryCall<D>.() -> ApolloQueryCall<D> = { this }
 ): Observable<Response<D>> = query(query).configure().rx()
 
@@ -67,8 +67,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxMutate(
+    mutation: Mutation<D>,
     configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
 ): Single<Response<D>> = mutate(mutation).configure().rx().singleOrError()
 
@@ -81,8 +81,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxMutate(
+    mutation: Mutation<D>,
     withOptimisticUpdates: D,
     configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
 ): Single<Response<D>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
@@ -92,8 +92,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch(
-    operation: Operation<D, V>
+inline fun <D : Operation.Data> ApolloClient.rxPrefetch(
+    operation: Operation<D>
 ): Completable = prefetch(operation).rx()
 
 /**
@@ -103,7 +103,7 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxSubscribe(
-    subscription: Subscription<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxSubscribe(
+    subscription: Subscription<D>,
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
 ): Flowable<Response<D>> = subscribe(subscription).rx(backpressureStrategy)

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/RxJavaExtensions.kt
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo/rx3/RxJavaExtensions.kt
@@ -57,8 +57,8 @@ inline fun <D : Operation.Data> ApolloSubscriptionCall<D>.rx(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
-    query: Query<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxQuery(
+    query: Query<D>,
     configure: ApolloQueryCall<D>.() -> ApolloQueryCall<D> = { this }
 ): Observable<Response<D>> = query(query).configure().rx()
 
@@ -67,8 +67,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxQuery(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxMutate(
+    mutation: Mutation<D>,
     configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
 ): Single<Response<D>> = mutate(mutation).configure().rx().singleOrError()
 
@@ -81,8 +81,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
-    mutation: Mutation<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxMutate(
+    mutation: Mutation<D>,
     withOptimisticUpdates: D,
     configure: ApolloMutationCall<D>.() -> ApolloMutationCall<D> = { this }
 ): Single<Response<D>> = mutate(mutation, withOptimisticUpdates).configure().rx().singleOrError()
@@ -92,8 +92,8 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxMutate(
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch(
-    operation: Operation<D, V>
+inline fun <D : Operation.Data> ApolloClient.rxPrefetch(
+    operation: Operation<D>
 ): Completable = prefetch(operation).rx()
 
 /**
@@ -103,7 +103,7 @@ inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxPrefetch
  */
 @JvmSynthetic
 @CheckReturnValue
-inline fun <D : Operation.Data, V : Operation.Variables> ApolloClient.rxSubscribe(
-    subscription: Subscription<D, V>,
+inline fun <D : Operation.Data> ApolloClient.rxSubscribe(
+    subscription: Subscription<D>,
     backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST
 ): Flowable<Response<D>> = subscribe(subscription).rx(backpressureStrategy)

--- a/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo/testing/MockQuery.kt
+++ b/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo/testing/MockQuery.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo.api.internal.ResponseAdapter
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.apollographql.apollo.api.internal.ResponseWriter
 
-class MockQuery : Query<MockQuery.Data, Operation.Variables> {
+class MockQuery : Query<MockQuery.Data> {
 
   override fun queryDocument(): String = "query MockQuery { name }"
 

--- a/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo/testing/MockSubscription.kt
+++ b/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo/testing/MockSubscription.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo.api.internal.ResponseAdapter
 import com.apollographql.apollo.api.internal.ResponseReader
 import com.apollographql.apollo.api.internal.ResponseWriter
 
-class MockSubscription : Subscription<MockSubscription.Data, Operation.Variables> {
+class MockSubscription : Subscription<MockSubscription.Data> {
 
   override fun queryDocument(): String = "subscription MockSubscription { name }"
 


### PR DESCRIPTION
it is not needed since the variables are passed in the constructor and that will make the generated models even easier to read