### PR TITLE
Separate parsing and normalization

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OperationExtensions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OperationExtensions.kt
@@ -112,6 +112,8 @@ fun Operation<*>.composeRequestBody(
 
 /**
  * Parses GraphQL operation raw response from the [source] with provided [customScalarAdapters] and returns result [Response]
+ *
+ * This will consume [source] so you don't need to close it. Also, you cannot reuse it
  */
 @JvmOverloads
 fun <D : Operation.Data> Operation<D>.parse(
@@ -128,5 +130,15 @@ fun <D : Operation.Data> Operation<D>.parse(
     byteString: ByteString,
     customScalarAdapters: CustomScalarAdapters = DEFAULT
 ): Response<D> {
-  return SimpleOperationResponseParser.parse(Buffer().write(byteString), this, customScalarAdapters)
+  return parse(Buffer().write(byteString), customScalarAdapters)
+}
+
+/**
+ * Parses GraphQL operation raw response from the [byteString] with provided [customScalarAdapters] and returns result [Response]
+ */
+fun <D : Operation.Data> Operation<D>.parse(
+    string: String,
+    customScalarAdapters: CustomScalarAdapters = DEFAULT
+): Response<D> {
+  return parse(Buffer().writeUtf8(string), customScalarAdapters)
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseReader.kt
@@ -14,7 +14,6 @@ class RealResponseReader<R : Map<String, Any?>>(
     private val recordSet: R,
     internal val fieldValueResolver: FieldValueResolver<R>,
     internal val customScalarAdapters: CustomScalarAdapters,
-    internal val resolveDelegate: ResolveDelegate<R>
 ) : ResponseReader {
   private val variableValues: Map<String, Any?> = operationVariables.valueMap()
   private var selectedFieldIndex = -1
@@ -31,118 +30,70 @@ class RealResponseReader<R : Map<String, Any?>>(
   override fun readString(field: ResponseField): String? {
     val value = fieldValueResolver.valueFor<String>(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
-    if (value == null) {
-      resolveDelegate.didResolveNull()
-    } else {
-      resolveDelegate.didResolveScalar(value)
-    }
-    didResolve(field)
     return value
   }
 
   override fun readInt(field: ResponseField): Int? {
     val value = fieldValueResolver.valueFor<BigDecimal>(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
-    if (value == null) {
-      resolveDelegate.didResolveNull()
-    } else {
-      resolveDelegate.didResolveScalar(value)
-    }
-    didResolve(field)
+    
     return value?.toNumber()?.toInt()
   }
 
   override fun readDouble(field: ResponseField): Double? {
     val value = fieldValueResolver.valueFor<BigDecimal>(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
-    if (value == null) {
-      resolveDelegate.didResolveNull()
-    } else {
-      resolveDelegate.didResolveScalar(value)
-    }
-    didResolve(field)
+    
     return value?.toNumber()?.toDouble()
   }
 
   override fun readBoolean(field: ResponseField): Boolean? {
     val value = fieldValueResolver.valueFor<Boolean>(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
-    if (value == null) {
-      resolveDelegate.didResolveNull()
-    } else {
-      resolveDelegate.didResolveScalar(value)
-    }
-    didResolve(field)
+    
     return value
   }
 
   override fun <T : Any> readObject(field: ResponseField, block: (ResponseReader) -> T): T? {
     val value: R? = fieldValueResolver.valueFor(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
-    resolveDelegate.willResolveObject(field, value)
-    val parsedValue: T?
-    parsedValue = if (value == null) {
-      resolveDelegate.didResolveNull()
+    val parsedValue: T? = if (value == null) {
       null
     } else {
-      block(RealResponseReader(operationVariables, value, fieldValueResolver, customScalarAdapters, resolveDelegate))
+      block(RealResponseReader(operationVariables, value, fieldValueResolver, customScalarAdapters))
     }
-    resolveDelegate.didResolveObject(field, value)
-    didResolve(field)
     return parsedValue
   }
 
   override fun <T : Any> readList(field: ResponseField, block: (ResponseReader.ListItemReader) -> T): List<T?>? {
     val values = fieldValueResolver.valueFor<List<*>>(recordSet, field)
     checkValue(field, values)
-    willResolve(field, values)
     val result = if (values == null) {
-      resolveDelegate.didResolveNull()
       null
     } else {
       values.mapIndexed { index, value ->
-        resolveDelegate.willResolveElement(index)
         if (value == null) {
-          resolveDelegate.didResolveNull()
           null
         } else {
           block(ListItemReader(field, value))
-        }.also { resolveDelegate.didResolveElement(index) }
-      }.also { resolveDelegate.didResolveList(values) }
+        }
+      }
     }
-    didResolve(field)
     return result
   }
 
   override fun <T : Any> readCustomScalar(field: ResponseField.CustomScalarField): T? {
     val value = fieldValueResolver.valueFor<Any>(recordSet, field)
     checkValue(field, value)
-    willResolve(field, value)
     val result: T?
     if (value == null) {
-      resolveDelegate.didResolveNull()
       result = null
     } else {
       val scalarTypeAdapter: CustomScalarAdapter<T> = customScalarAdapters.adapterFor(field.customScalar)
       result = scalarTypeAdapter.decode(fromRawValue(value))
       checkValue(field, result)
-      resolveDelegate.didResolveScalar(value)
     }
-    didResolve(field)
     return result
-  }
-
-  private fun willResolve(field: ResponseField, value: Any?) {
-    resolveDelegate.willResolve(field, operationVariables, value)
-  }
-
-  private fun didResolve(field: ResponseField) {
-    resolveDelegate.didResolve(field, operationVariables)
   }
 
   private fun checkValue(field: ResponseField, value: Any?) {
@@ -177,52 +128,42 @@ class RealResponseReader<R : Map<String, Any?>>(
   ) : ResponseReader.ListItemReader {
 
     override fun readString(): String {
-      resolveDelegate.didResolveScalar(value)
       return value as String
     }
 
     override fun readInt(): Int {
-      resolveDelegate.didResolveScalar(value)
       return (value as BigDecimal).toNumber().toInt()
     }
 
     override fun readDouble(): Double {
-      resolveDelegate.didResolveScalar(value)
       return (value as BigDecimal).toNumber().toDouble()
     }
 
     override fun readBoolean(): Boolean {
-      resolveDelegate.didResolveScalar(value)
       return value as Boolean
     }
 
     override fun <T : Any> readCustomScalar(customScalar: CustomScalar): T {
       val scalarTypeAdapter: CustomScalarAdapter<T> = customScalarAdapters.adapterFor(customScalar)
-      resolveDelegate.didResolveScalar(value)
       return scalarTypeAdapter.decode(fromRawValue(value))
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Any> readObject(block: (ResponseReader) -> T): T {
       val value = value as R
-      resolveDelegate.willResolveObject(field, value)
-      val item = block(RealResponseReader(operationVariables, value, fieldValueResolver, customScalarAdapters, resolveDelegate))
-      resolveDelegate.didResolveObject(field, value)
+      val item = block(RealResponseReader(operationVariables, value, fieldValueResolver, customScalarAdapters))
       return item
     }
 
     override fun <T : Any> readList(block: (ResponseReader.ListItemReader) -> T): List<T?> {
       val values = value as List<*>
       val result = values.mapIndexed { index, value ->
-        resolveDelegate.willResolveElement(index)
         if (value == null) {
-          resolveDelegate.didResolveNull()
           null
         } else {
           block(ListItemReader(field, value))
-        }.also { resolveDelegate.didResolveElement(index) }
+        }
       }
-      resolveDelegate.didResolveList(values)
       return result
     }
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseWriter.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.internal.ResolveDelegate
 import com.apollographql.apollo.api.internal.ResponseWriter
 import com.apollographql.apollo.api.internal.Utils.shouldSkip
+import com.apollographql.apollo.api.internal.json.JsonWriter.Companion.of
 
 class RealResponseWriter(
     private val operationVariables: Operation.Variables,
@@ -21,15 +22,15 @@ class RealResponseWriter(
   }
 
   override fun writeInt(field: ResponseField, value: Int?) {
-    writeScalarFieldValue(field, if (value != null) BigDecimal(value.toLong()) else null)
+    writeScalarFieldValue(field, if (value != null) BigDecimal(value.toString()) else null)
   }
 
   override fun writeLong(field: ResponseField, value: Long?) {
-    writeScalarFieldValue(field, if (value != null) BigDecimal(value) else null)
+    writeScalarFieldValue(field, if (value != null) BigDecimal(value.toString()) else null)
   }
 
   override fun writeDouble(field: ResponseField, value: Double?) {
-    writeScalarFieldValue(field, if (value != null) BigDecimal(value) else null)
+    writeScalarFieldValue(field, if (value != null) BigDecimal(value.toString()) else null)
   }
 
   override fun writeBoolean(field: ResponseField, value: Boolean?) {
@@ -193,15 +194,15 @@ class RealResponseWriter(
     }
 
     override fun writeInt(value: Int?) {
-      accumulator.add(if (value != null) BigDecimal(value.toLong()) else null)
+      accumulator.add(if (value != null) BigDecimal(value.toString()) else null)
     }
 
     override fun writeLong(value: Long?) {
-      accumulator.add(if (value != null) BigDecimal(value) else null)
+      accumulator.add(if (value != null) BigDecimal(value.toString()) else null)
     }
 
     override fun writeDouble(value: Double?) {
-      accumulator.add(if (value != null) BigDecimal(value) else null)
+      accumulator.add(if (value != null) BigDecimal(value.toString()) else null)
     }
 
     override fun writeBoolean(value: Boolean?) {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/RealResponseWriter.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo.internal.response
+package com.apollographql.apollo.api.internal.response
 
 import com.apollographql.apollo.api.BigDecimal
 import com.apollographql.apollo.api.Operation
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.CustomScalar
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.internal.ResolveDelegate
 import com.apollographql.apollo.api.internal.ResponseWriter
+import com.apollographql.apollo.api.internal.Utils.shouldSkip
 
 class RealResponseWriter(
     private val operationVariables: Operation.Variables,
@@ -41,7 +42,11 @@ class RealResponseWriter(
   }
 
   override fun writeObject(field: ResponseField, block: ((ResponseWriter) -> Unit)?) {
+    if (field.shouldSkip(variableValues = operationVariables.valueMap())) {
+      return
+    }
     checkFieldValue(field, block)
+
     if (block == null) {
       buffer[field.responseName] = FieldDescriptor(field, null)
       return
@@ -55,7 +60,11 @@ class RealResponseWriter(
       field: ResponseField, values: List<T>?,
       block: (items: List<T>?, listItemWriter: ResponseWriter.ListItemWriter) -> Unit
   ) {
+    if (field.shouldSkip(variableValues = operationVariables.valueMap())) {
+      return
+    }
     checkFieldValue(field, values)
+
     if (values == null) {
       buffer[field.responseName] = FieldDescriptor(field, null)
       return
@@ -70,6 +79,9 @@ class RealResponseWriter(
   }
 
   private fun writeScalarFieldValue(field: ResponseField, value: Any?) {
+    if (field.shouldSkip(variableValues = operationVariables.valueMap())) {
+      return
+    }
     checkFieldValue(field, value)
     buffer[field.responseName] = FieldDescriptor(field, value)
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
@@ -55,7 +55,11 @@ object SimpleOperationResponseParser {
       adapter: ResponseAdapter<D>,
       variables: Operation.Variables,
       customScalarAdapters: CustomScalarAdapters,
-  ): D {
+  ): D? {
+    if (peek() == JsonReader.Token.NULL) {
+      return nextNull<D>()
+    }
+
     beginObject()
     val data = adapter.fromResponse(
         StreamResponseReader(

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/Utils.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/Utils.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api.internal
 
+import com.apollographql.apollo.api.ResponseField
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
@@ -43,5 +44,25 @@ object Utils {
       throw NullPointerException()
     }
     return reference
+  }
+
+  internal fun ResponseField.shouldSkip(variableValues: Map<String, Any?>): Boolean {
+    for (condition in conditions) {
+      if (condition is ResponseField.BooleanCondition) {
+        val conditionValue = variableValues[condition.variableName] as Boolean
+        if (condition.isInverted) {
+          // means it's a skip directive
+          if (conditionValue) {
+            return true
+          }
+        } else {
+          // means it's an include directive
+          if (!conditionValue) {
+            return true
+          }
+        }
+      }
+    }
+    return false
   }
 }

--- a/apollo-cache-interceptor/src/commonMain/kotlin/com/apollographql/apollo/interceptor/cache/ApolloCacheInterceptor.kt
+++ b/apollo-cache-interceptor/src/commonMain/kotlin/com/apollographql/apollo/interceptor/cache/ApolloCacheInterceptor.kt
@@ -20,7 +20,7 @@ import com.apollographql.apollo.interceptor.ApolloRequest
 import com.apollographql.apollo.interceptor.ApolloRequestInterceptor
 import com.apollographql.apollo.interceptor.ApolloResponse
 import com.apollographql.apollo.api.internal.RealResponseReader
-import com.apollographql.apollo.internal.response.RealResponseWriter
+import com.apollographql.apollo.api.internal.response.RealResponseWriter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow

--- a/apollo-cache-interceptor/src/commonMain/kotlin/com/apollographql/apollo/interceptor/cache/ApolloCacheInterceptor.kt
+++ b/apollo-cache-interceptor/src/commonMain/kotlin/com/apollographql/apollo/interceptor/cache/ApolloCacheInterceptor.kt
@@ -69,7 +69,7 @@ class ApolloCacheInterceptor<S>(private val store: S) : ApolloRequestInterceptor
     responseNormalizer.willResolveRootQuery(operation);
     writer.resolveFields(responseNormalizer)
 
-    store.merge(responseNormalizer.records()?.filterNotNull() ?: emptySet(), CacheHeaders.NONE)
+    store.merge(responseNormalizer.records().toList(), CacheHeaders.NONE)
   }
 
   private fun <D : Operation.Data> readFromCache(request: ApolloRequest<D>): Response<D>? {
@@ -82,7 +82,7 @@ class ApolloCacheInterceptor<S>(private val store: S) : ApolloRequestInterceptor
         CacheHeaders.NONE,
         RealCacheKeyBuilder()
     )
-    val responseReader = RealResponseReader(operation.variables(), rootRecord, fieldValueResolver, request.customScalarAdapters, NoOpResolveDelegate())
+    val responseReader = RealResponseReader(operation.variables(), rootRecord, fieldValueResolver, request.customScalarAdapters)
     val data = operation.adapter().fromResponse(responseReader)
     return builder<D>(operation)
         .data(data)

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroNameWithId.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/normalizer/EpisodeHeroNameWithId.graphql
@@ -1,0 +1,6 @@
+query EpisodeHeroNameWithId($episode: Episode) {
+  hero(episode: $episode) {
+    id
+    name
+  }
+}

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
@@ -86,9 +86,9 @@ class ApolloWatcherTest {
         { response -> !response.hasErrors() }
     )
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList[1]).isEqualTo("Artoo")
-    Truth.assertThat(heroNameList.size).isEqualTo(2)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList[1]).isEqualTo("Artoo")
+    assertThat(heroNameList.size).isEqualTo(2)
   }
 
   @Test
@@ -108,7 +108,7 @@ class ApolloWatcherTest {
             Assert.fail(e.message)
           }
         })
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
 
     // Someone writes to the store directly
     val changedKeys: Set<String> = apolloClient.apolloStore.writeTransaction(object : Transaction<WriteableStore, Set<String>> {
@@ -120,7 +120,7 @@ class ApolloWatcherTest {
       }
     })
     apolloClient.apolloStore.publish(changedKeys)
-    Truth.assertThat(heroNameList[1]).isEqualTo("Artoo")
+    assertThat(heroNameList[1]).isEqualTo("Artoo")
     watcher.cancel()
   }
 
@@ -143,8 +143,8 @@ class ApolloWatcherTest {
     server.enqueue(Utils.mockResponse("EpisodeHeroNameResponseWithId.json"))
     apolloClient.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY).enqueue(null)
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList.size).isEqualTo(1)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList.size).isEqualTo(1)
   }
 
   @Test
@@ -172,8 +172,8 @@ class ApolloWatcherTest {
         { response -> !response.hasErrors() }
     )
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList[1]).isEqualTo("Artoo")
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList[1]).isEqualTo("Artoo")
   }
 
   @Test
@@ -196,15 +196,15 @@ class ApolloWatcherTest {
     server.enqueue(Utils.mockResponse("HeroAndFriendsNameWithIdsResponse.json"))
     apolloClient.query(friendsQuery).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY).enqueue(null)
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList.size).isEqualTo(1)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList.size).isEqualTo(1)
   }
 
   @Test
   fun testRefetchCacheControl() {
     val heroNameList: MutableList<String> = ArrayList()
     server.enqueue(Utils.mockResponse("EpisodeHeroNameResponseWithId.json"))
-    val query: EpisodeHeroNameQuery = EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))
+    val query = EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))
     val watcher: ApolloQueryWatcher<EpisodeHeroNameQuery.Data> = apolloClient.query(query).watcher()
     watcher.refetchResponseFetcher(ApolloResponseFetchers.NETWORK_ONLY) //Force network instead of CACHE_FIRST default
         .enqueueAndWatch(
@@ -226,15 +226,15 @@ class ApolloWatcherTest {
     server.enqueue(Utils.mockResponse("EpisodeHeroNameResponseNameChangeTwo.json"))
     apolloClient.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY).enqueue(null)
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList[1]).isEqualTo("ArTwo")
-    Truth.assertThat(heroNameList.size).isEqualTo(2)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList[1]).isEqualTo("ArTwo")
+    assertThat(heroNameList.size).isEqualTo(2)
   }
 
   @Test
   fun testQueryWatcherUpdated_SameQuery_DifferentResults_cacheOnly() {
     val heroNameList: MutableList<String> = ArrayList()
-    val query: EpisodeHeroNameQuery = EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))
+    val query = EpisodeHeroNameQuery(Input.fromNullable(Episode.EMPIRE))
     server.enqueue(Utils.mockResponse("EpisodeHeroNameResponseWithId.json"))
     apolloClient.query(query).enqueue(object : Callback<EpisodeHeroNameQuery.Data>() {
       override fun onResponse(response: Response<EpisodeHeroNameQuery.Data>) {}
@@ -259,9 +259,9 @@ class ApolloWatcherTest {
     server.enqueue(Utils.mockResponse("EpisodeHeroNameResponseNameChange.json"))
     apolloClient.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY).enqueue(null)
     watcher.cancel()
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList[1]).isEqualTo("Artoo")
-    Truth.assertThat(heroNameList.size).isEqualTo(2)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList[1]).isEqualTo("Artoo")
+    assertThat(heroNameList.size).isEqualTo(2)
   }
 
   @Test
@@ -287,8 +287,8 @@ class ApolloWatcherTest {
         apolloClient.query(query).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY),
         { response -> !response.hasErrors() }
     )
-    Truth.assertThat(heroNameList[0]).isEqualTo("R2-D2")
-    Truth.assertThat(heroNameList.size).isEqualTo(1)
+    assertThat(heroNameList[0]).isEqualTo("R2-D2")
+    assertThat(heroNameList.size).isEqualTo(1)
   }
 
   @Test

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/IntegrationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/IntegrationTest.kt
@@ -201,13 +201,12 @@ class IntegrationTest {
   fun dataNull() {
     server.enqueue(mockResponse("ResponseDataNull.json"))
     assertResponse(
-        apolloClient.query(HeroNameQuery()),
-        Predicate<Response<HeroNameQuery.Data>> { response ->
-          assertThat(response.data).isNull()
-          assertThat(response.hasErrors()).isFalse()
-          true
-        }
-    )
+        apolloClient.query(HeroNameQuery())
+    ) { response ->
+      assertThat(response.data).isNull()
+      assertThat(response.hasErrors()).isFalse()
+      true
+    }
   }
 
   @Test
@@ -239,8 +238,7 @@ class IntegrationTest {
   fun operationResponseParser() {
     val json = readFileToString(javaClass, "/HeroNameResponse.json")
     val query = HeroNameQuery()
-    val (_, data) = OperationResponseParser(query, CustomScalarAdapters(emptyMap()))
-        .parse(Buffer().writeUtf8(json))
+    val data = query.parse(json).data
     assertThat(data!!.hero?.name).isEqualTo("R2-D2")
   }
 
@@ -249,8 +247,7 @@ class IntegrationTest {
   fun operationJsonWriter() {
     val expected = readFileToString(javaClass, "/OperationJsonWriter.json")
     val query = AllPlanetsQuery()
-    val (_, data) = OperationResponseParser(query, CustomScalarAdapters.DEFAULT)
-        .parse(Buffer().writeUtf8(expected))
+    val data = query.parse(expected).data
     val actual = query.toJson(data!!, "  ")
     assertThat(actual).isEqualTo(expected)
   }
@@ -303,7 +300,7 @@ class IntegrationTest {
   fun operationResponseParserParseResponseWithExtensions() {
     val source = Buffer().readFrom(javaClass.getResourceAsStream("/HeroNameResponse.json"))
     val query = HeroNameQuery()
-    val (_, _, _, _, _, extensions) = OperationResponseParser(query, CustomScalarAdapters(emptyMap())).parse(source)
+    val extensions = query.parse(source).extensions
     assertThat(extensions.toString()).isEqualTo("{cost={requestedQueryCost=3, actualQueryCost=3, throttleStatus={maximumAvailable=1000, currentlyAvailable=997, restoreRate=50}}}")
   }
 

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
@@ -209,9 +209,9 @@ class ResponseNormalizationTest {
     Truth.assertThat(lukeRecord.field("height({\"unit\":\"METER\"})")).isEqualTo(BigDecimal.valueOf(1.72))
     val friends = normalizedCache
         .loadRecord(TEST_FIELD_KEY_JEDI, CacheHeaders.NONE)!!.field("friends") as List<Any>?
-    Truth.assertThat(friends!![0]).isEqualTo(CacheReference(TEST_FIELD_KEY_JEDI + ".friends.0"))
-    Truth.assertThat(friends[1]).isEqualTo(CacheReference(TEST_FIELD_KEY_JEDI + ".friends.1"))
-    Truth.assertThat(friends[2]).isEqualTo(CacheReference(TEST_FIELD_KEY_JEDI + ".friends.2"))
+    Truth.assertThat(friends!![0]).isEqualTo(CacheReference("$TEST_FIELD_KEY_JEDI.friends.0"))
+    Truth.assertThat(friends[1]).isEqualTo(CacheReference("$TEST_FIELD_KEY_JEDI.friends.1"))
+    Truth.assertThat(friends[2]).isEqualTo(CacheReference("$TEST_FIELD_KEY_JEDI.friends.2"))
   }
 
   @Test

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ResponseNormalizationTest.kt
@@ -217,10 +217,12 @@ class ResponseNormalizationTest {
   @Test
   @Throws(Exception::class)
   fun testHeroParentTypeDependentFieldHuman() {
-    assertHasNoErrors("HeroParentTypeDependentFieldHumanResponse.json",
-        HeroParentTypeDependentFieldQuery(fromNullable(Episode.EMPIRE)))
+    assertHasNoErrors(
+        "HeroParentTypeDependentFieldHumanResponse.json",
+        HeroParentTypeDependentFieldQuery(fromNullable(Episode.EMPIRE))
+    )
     val lukeRecord = normalizedCache
-        .loadRecord(TEST_FIELD_KEY_EMPIRE + ".friends.0", CacheHeaders.NONE)
+        .loadRecord("$TEST_FIELD_KEY_EMPIRE.friends.0", CacheHeaders.NONE)
     Truth.assertThat(lukeRecord!!.field("name")).isEqualTo("Han Solo")
     Truth.assertThat(lukeRecord.field("height({\"unit\":\"FOOT\"})")).isEqualTo(BigDecimal.valueOf(5.905512))
   }

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/Rx3ApolloTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/Rx3ApolloTest.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory
 import com.apollographql.apollo.cache.normalized.NormalizedCacheFactory
 import com.apollographql.apollo.fetcher.ApolloResponseFetchers.NETWORK_ONLY
 import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameQuery
+import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameWithIdQuery
 import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo.integration.normalizer.type.Episode.EMPIRE
 import com.apollographql.apollo.integration.normalizer.type.Episode.NEWHOPE
@@ -112,13 +113,13 @@ class Rx3ApolloTest {
   @Throws(Exception::class)
   fun queryWatcherUpdatedSameQueryDifferentResults() {
     server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
-    val observer: TestObserver<EpisodeHeroNameQuery.Data> = TestObserver<EpisodeHeroNameQuery.Data>()
+    val observer = TestObserver<EpisodeHeroNameWithIdQuery.Data>()
     Rx3Apollo
-        .from(apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(EMPIRE))).watcher())
-        .map({ response -> response.data })
+        .from(apolloClient.query(EpisodeHeroNameWithIdQuery(Input.fromNullable(EMPIRE))).watcher())
+        .map { response -> response.data }
         .subscribeWith(observer)
     server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_CHANGE))
-    apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(EMPIRE)))
+    apolloClient.query(EpisodeHeroNameWithIdQuery(Input.fromNullable(EMPIRE)))
         .responseFetcher(NETWORK_ONLY)
         .enqueue(null)
     observer.assertValueCount(2)
@@ -174,10 +175,10 @@ class Rx3ApolloTest {
   @Throws(Exception::class)
   fun queryWatcherUpdatedDifferentQueryDifferentResults() {
     server.enqueue(mockResponse(FILE_EPISODE_HERO_NAME_WITH_ID))
-    val observer: TestObserver<EpisodeHeroNameQuery.Data> = TestObserver<EpisodeHeroNameQuery.Data>()
+    val observer = TestObserver<EpisodeHeroNameWithIdQuery.Data>()
     Rx3Apollo
-        .from(apolloClient.query(EpisodeHeroNameQuery(Input.fromNullable(EMPIRE))).watcher())
-        .map({ response -> response.data })
+        .from(apolloClient.query(EpisodeHeroNameWithIdQuery(Input.fromNullable(EMPIRE))).watcher())
+        .map { response -> response.data }
         .subscribeWith(observer)
     server.enqueue(mockResponse("HeroAndFriendsNameWithIdsNameChange.json"))
     apolloClient.query(HeroAndFriendsNamesWithIDsQuery(Input.fromNullable(NEWHOPE))).enqueue(null)

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/Utils.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/Utils.kt
@@ -7,6 +7,8 @@ import com.apollographql.apollo.fetcher.ApolloResponseFetchers.NETWORK_ONLY
 import com.apollographql.apollo.rx2.Rx2Apollo
 import com.google.common.io.CharStreams
 import io.reactivex.functions.Predicate
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import java.io.File
@@ -129,5 +131,9 @@ object Utils {
         }
       }
     }
+  }
+
+  suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 500) = withTimeout(timeoutMillis) {
+    receive()
   }
 }

--- a/apollo-integration/src/test/resources/HeroParentTypeDependentFieldDroidResponse.json
+++ b/apollo-integration/src/test/resources/HeroParentTypeDependentFieldDroidResponse.json
@@ -1,8 +1,8 @@
 {
   "data": {
     "hero": {
-      "name": "R2-D2",
       "__typename": "Droid",
+      "name": "R2-D2",
       "friends": [
         {
           "__typename": "Human",

--- a/apollo-integration/src/test/resources/HeroParentTypeDependentFieldHumanResponse.json
+++ b/apollo-integration/src/test/resources/HeroParentTypeDependentFieldHumanResponse.json
@@ -1,8 +1,8 @@
 {
   "data": {
     "hero": {
-      "name": "Luke Skywalker",
       "__typename": "Human",
+      "name": "Luke Skywalker",
       "friends": [
         {
           "__typename": "Human",

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo.cache.normalized.internal
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.cache.normalized.Record
-import com.apollographql.apollo.internal.response.RealResponseWriter
+import com.apollographql.apollo.api.internal.response.RealResponseWriter
 
 fun <D: Operation.Data> Operation<D>.normalize(
     data: D,

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
@@ -12,6 +12,7 @@ fun <D: Operation.Data> Operation<D>.normalize(
 ): Set<Record> {
   val writer = RealResponseWriter(variables(), customScalarAdapters)
   adapter().toResponse(writer, data)
+  normalizer.willResolveRootQuery(this)
   writer.resolveFields(normalizer)
   return normalizer.records().toSet()
 }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/OperationResponseNormalizer.kt
@@ -1,0 +1,23 @@
+package com.apollographql.apollo.cache.normalized.internal
+
+import com.apollographql.apollo.api.CustomScalarAdapters
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.cache.normalized.Record
+import com.apollographql.apollo.internal.response.RealResponseWriter
+
+fun <D: Operation.Data> Operation<D>.normalize(
+    data: D,
+    customScalarAdapters: CustomScalarAdapters,
+    normalizer: ResponseNormalizer<Map<String, Any>?>
+): Set<Record> {
+  val writer = RealResponseWriter(variables(), customScalarAdapters)
+  adapter().toResponse(writer, data)
+  writer.resolveFields(normalizer)
+  return normalizer.records().toSet()
+}
+
+fun Set<Record>?.dependentKeys(): Set<String> {
+  return this?.flatMap {
+    it.keys() + it.key
+  }?.toSet() ?: emptySet()
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.kt
@@ -28,7 +28,7 @@ import com.apollographql.apollo.cache.normalized.internal.RealCacheKeyBuilder
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer
 import com.apollographql.apollo.cache.normalized.internal.Transaction
 import com.apollographql.apollo.cache.normalized.internal.WriteableStore
-import com.apollographql.apollo.internal.response.RealResponseWriter
+import com.apollographql.apollo.api.internal.response.RealResponseWriter
 import java.util.ArrayList
 import java.util.Collections
 import java.util.LinkedHashSet

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.kt
@@ -29,6 +29,8 @@ import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer
 import com.apollographql.apollo.cache.normalized.internal.Transaction
 import com.apollographql.apollo.cache.normalized.internal.WriteableStore
 import com.apollographql.apollo.api.internal.response.RealResponseWriter
+import com.apollographql.apollo.cache.normalized.internal.dependentKeys
+import com.apollographql.apollo.cache.normalized.internal.normalize
 import java.util.ArrayList
 import java.util.Collections
 import java.util.LinkedHashSet
@@ -328,8 +330,12 @@ class RealApolloStore(normalizedCache: NormalizedCache, cacheKeyResolver: CacheK
             cacheKeyResolver(),
             CacheHeaders.NONE,
             cacheKeyBuilder)
-        val responseReader = RealResponseReader<Record>(operation.variables(), rootRecord,
-            fieldValueResolver, customScalarAdapters, ResponseNormalizer.NO_OP_NORMALIZER as ResolveDelegate<Record>)
+        val responseReader = RealResponseReader(
+            operation.variables(),
+            rootRecord,
+            fieldValueResolver,
+            customScalarAdapters
+        )
         return operation.adapter().fromResponse(responseReader, null)
       }
     })
@@ -349,15 +355,19 @@ class RealApolloStore(normalizedCache: NormalizedCache, cacheKeyResolver: CacheK
             cacheKeyResolver(),
             cacheHeaders,
             cacheKeyBuilder)
-        val responseReader = RealResponseReader(operation.variables(), rootRecord,
-            fieldValueResolver, customScalarAdapters, responseNormalizer)
+        val responseReader = RealResponseReader(
+            operation.variables(),
+            rootRecord,
+            fieldValueResolver,
+            customScalarAdapters
+        )
         return try {
-          responseNormalizer.willResolveRootQuery(operation)
           val data = operation.adapter().fromResponse(responseReader, null)
+          val records = operation.normalize(data, customScalarAdapters, networkResponseNormalizer() as ResponseNormalizer<Map<String, Any>?>)
           builder<D>(operation)
               .data(data)
               .fromCache(true)
-              .dependentKeys(responseNormalizer.dependentKeys())
+              .dependentKeys(records.dependentKeys()) // Do we need the dependentKeys here?
               .build()
         } catch (e: Exception) {
           logger.e(e, "Failed to read cache response")
@@ -374,8 +384,12 @@ class RealApolloStore(normalizedCache: NormalizedCache, cacheKeyResolver: CacheK
         val rootRecord = cache.read(cacheKey.key, CacheHeaders.NONE) ?: return null
         val fieldValueResolver = CacheFieldValueResolver(cache, variables,
             cacheKeyResolver(), CacheHeaders.NONE, cacheKeyBuilder)
-        val responseReader = RealResponseReader<Record>(variables, rootRecord,
-            fieldValueResolver, customScalarAdapters, ResponseNormalizer.NO_OP_NORMALIZER as ResolveDelegate<Record>)
+        val responseReader = RealResponseReader(
+            variables,
+            rootRecord,
+            fieldValueResolver,
+            customScalarAdapters,
+        )
         return adapter.fromResponse(responseReader, null)
       }
     })

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloParseInterceptor.kt
@@ -4,7 +4,11 @@ import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.cache.http.HttpCache
 import com.apollographql.apollo.api.internal.ApolloLogger
+import com.apollographql.apollo.api.internal.ResolveDelegate
+import com.apollographql.apollo.api.parse
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer
+import com.apollographql.apollo.cache.normalized.internal.dependentKeys
+import com.apollographql.apollo.cache.normalized.internal.normalize
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloParseException
@@ -70,18 +74,21 @@ class ApolloParseInterceptor(private val httpCache: HttpCache?,
     val cacheKey = httpResponse.request().header(HttpCache.CACHE_KEY_HEADER)
     return if (httpResponse.isSuccessful) {
       try {
-        val parser: OperationResponseParser<Operation.Data> = OperationResponseParser(operation, customScalarAdapters, normalizer as ResponseNormalizer<Map<String, Any?>?>)
         val httpExecutionContext = OkHttpExecutionContext(httpResponse)
-        var parsedResponse = parser.parse(httpResponse.body()!!.source())
+        var parsedResponse = operation.parse(httpResponse.body()!!.source(), customScalarAdapters)
+
+        val records = parsedResponse.data?.let { operation.normalize(it, customScalarAdapters, normalizer as ResponseNormalizer<Map<String, Any>?>) }
         parsedResponse = parsedResponse
             .toBuilder()
             .fromCache(httpResponse.cacheResponse() != null)
+            .dependentKeys(records.dependentKeys())
             .executionContext(parsedResponse.executionContext.plus(httpExecutionContext))
             .build()
         if (parsedResponse.hasErrors() && httpCache != null) {
           httpCache.removeQuietly(cacheKey!!)
         }
-        InterceptorResponse(httpResponse, parsedResponse, normalizer.records())
+
+        InterceptorResponse(httpResponse, parsedResponse, records)
       } catch (rethrown: Exception) {
         logger.e(rethrown, "Failed to parse network response for operation: %s", operation.name().name())
         closeQuietly(httpResponse)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
@@ -54,17 +54,6 @@ class OperationResponseParser<D : Operation.Data> @JvmOverloads constructor(
         .build()
   }
 
-  @Throws(IOException::class)
-  fun parse(source: BufferedSource): Response<D> {
-    var jsonReader: BufferedSourceJsonReader? = null
-    return try {
-      jsonReader = BufferedSourceJsonReader(source!!)
-      parse((jsonReader.readRecursively() as Map<String, Any?>?)!!)
-    } finally {
-      jsonReader?.close()
-    }
-  }
-
   companion object {
     fun parseError(payload: Map<String, Any?>): Error {
       var message = ""

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
@@ -20,10 +20,8 @@ import java.util.HashMap
 
 class OperationResponseParser<D : Operation.Data> @JvmOverloads constructor(
     val operation: Operation<D>,
-    val customScalarAdapters: CustomScalarAdapters,
-    val responseNormalizer: ResponseNormalizer<Map<String, Any?>?> = ResponseNormalizer.NO_OP_NORMALIZER as ResponseNormalizer<Map<String, Any?>?>) {
+    val customScalarAdapters: CustomScalarAdapters) {
   fun parse(payload: Map<String, Any?>): Response<D> {
-    responseNormalizer.willResolveRootQuery(operation)
     var data: D? = null
     val buffer = payload["data"] as Map<String, Any?>?
     if (buffer != null) {
@@ -32,7 +30,6 @@ class OperationResponseParser<D : Operation.Data> @JvmOverloads constructor(
           buffer,
           MapFieldValueResolver() as FieldValueResolver<Map<String, Any?>>,
           customScalarAdapters,
-          responseNormalizer as ResolveDelegate<Map<String, Any?>>
       )
       data = operation.adapter().fromResponse(realResponseReader, null)
     }
@@ -49,7 +46,6 @@ class OperationResponseParser<D : Operation.Data> @JvmOverloads constructor(
     return builder<D>(operation)
         .data(data)
         .errors(errors)
-        .dependentKeys(responseNormalizer.dependentKeys())
         .extensions(payload["extensions"] as Map<String, Any?>?)
         .build()
   }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.kt
@@ -55,7 +55,7 @@ class OperationResponseParser<D : Operation.Data> @JvmOverloads constructor(
   }
 
   @Throws(IOException::class)
-  fun parse(source: BufferedSource?): Response<D> {
+  fun parse(source: BufferedSource): Response<D> {
     var jsonReader: BufferedSourceJsonReader? = null
     return try {
       jsonReader = BufferedSourceJsonReader(source!!)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,8 +12,6 @@ You can run the tests from Android Studio by clicking the "run" icon in the gutt
 
 Run on a Pixel 3 XL. Feel free to update/commit new results and we can get the history using `git annotate`
 
-benchmark:    13,642,293 ns Benchmark.moshi
-benchmark:    14,921,928 ns Benchmark.apollo
-benchmark:    24,562,346 ns Benchmark.apolloParsingWithMapParser
-benchmark:    37,406,150 ns Benchmark.apolloComputeRecordsDuringParsing
-benchmark:    41,032,713 ns Benchmark.apolloComputeRecordsAfterParsing
+benchmark:    12,915,106 ns Benchmark.moshi
+benchmark:    14,606,511 ns Benchmark.apollo
+benchmark:    30,442,868 ns Benchmark.apolloParseAndNormalize

--- a/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Benchmark.kt
+++ b/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Benchmark.kt
@@ -1,14 +1,13 @@
 package com.apollographql.apollo.benchmark
 
+import Utils
 import Utils.bufferedSource
-import Utils.parseAndNormalizeAfter
-import Utils.parseWithInlinedNormalizer
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
 import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.parse
 import com.apollographql.apollo.benchmark.moshi.Query
-import com.apollographql.apollo.response.OperationResponseParser
+import com.apollographql.apollo.cache.normalized.internal.normalize
 import com.squareup.moshi.Moshi
 import org.junit.Rule
 import org.junit.Test
@@ -39,33 +38,14 @@ class Benchmark {
     moshiAdapter.fromJson(bufferedSource)
   }
 
+
   @Test
-  fun apolloParsingWithMapParser() = benchmarkRule.measureRepeated {
+  fun apolloParseAndNormalize() = benchmarkRule.measureRepeated {
     val bufferedSource = runWithTimingDisabled {
       bufferedSource()
     }
 
-    OperationResponseParser(
-        operation,
-        CustomScalarAdapters.DEFAULT
-    ).parse(bufferedSource)
-  }
-
-  @Test
-  fun apolloComputeRecordsDuringParsing() = benchmarkRule.measureRepeated {
-    val bufferedSource = runWithTimingDisabled {
-      bufferedSource()
-    }
-
-    parseWithInlinedNormalizer(operation, bufferedSource)
-  }
-
-  @Test
-  fun apolloComputeRecordsAfterParsing() = benchmarkRule.measureRepeated {
-    val bufferedSource = runWithTimingDisabled {
-      bufferedSource()
-    }
-
-    parseAndNormalizeAfter(operation, bufferedSource)
+    val data = operation.parse(bufferedSource).data!!
+    val records = operation.normalize(data, CustomScalarAdapters.DEFAULT, Utils.responseNormalizer)
   }
 }

--- a/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Utils.kt
+++ b/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Utils.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo.cache.normalized.CacheKey
 import com.apollographql.apollo.cache.normalized.Record
 import com.apollographql.apollo.cache.normalized.internal.RealCacheKeyBuilder
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer
-import com.apollographql.apollo.internal.response.RealResponseWriter
+import com.apollographql.apollo.api.internal.response.RealResponseWriter
 import com.apollographql.apollo.response.OperationResponseParser
 import okio.BufferedSource
 import okio.buffer

--- a/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Utils.kt
+++ b/benchmark/src/androidTest/java/com/apollographql/apollo/benchmark/Utils.kt
@@ -8,9 +8,6 @@ import com.apollographql.apollo.cache.normalized.CacheKey
 import com.apollographql.apollo.cache.normalized.Record
 import com.apollographql.apollo.cache.normalized.internal.RealCacheKeyBuilder
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer
-import com.apollographql.apollo.api.internal.response.RealResponseWriter
-import com.apollographql.apollo.response.OperationResponseParser
-import okio.BufferedSource
 import okio.buffer
 import okio.source
 
@@ -19,36 +16,9 @@ object Utils {
       .source()
       .buffer()
 
-  private val responseNormalizer = object : ResponseNormalizer<Map<String, Any?>>() {
+  val responseNormalizer = object : ResponseNormalizer<Map<String, Any>?>() {
     override fun cacheKeyBuilder() = RealCacheKeyBuilder()
 
-    override fun resolveCacheKey(field: ResponseField, record: Map<String, Any?>) = CacheKey.NO_KEY
-  }
-
-  fun <D : Operation.Data> parseWithInlinedNormalizer(operation: Operation<D>, bufferedSource: BufferedSource) {
-    OperationResponseParser(
-        operation,
-        CustomScalarAdapters.DEFAULT,
-        responseNormalizer
-    ).parse(bufferedSource)
-
-    responseNormalizer.records()
-  }
-
-  /**
-   * Contrary to [parseWithInlinedNormalizer], this normalizes after parsing, using the generated models
-   */
-  fun <D : Operation.Data> parseAndNormalizeAfter(operation: Operation<D>, bufferedSource: BufferedSource) {
-    val response = OperationResponseParser(
-        operation,
-        CustomScalarAdapters.DEFAULT,
-        ResponseNormalizer.NO_OP_NORMALIZER as ResponseNormalizer<MutableMap<String, Any>>?
-    ).parse(bufferedSource)
-
-    val writer = RealResponseWriter(operation.variables(), CustomScalarAdapters.DEFAULT)
-    operation.adapter().toResponse(writer, response.data!!)
-    responseNormalizer.willResolveRootQuery(operation);
-    writer.resolveFields(responseNormalizer as ResolveDelegate<Map<String, Any>?>)
-    responseNormalizer.records()
+    override fun resolveCacheKey(field: ResponseField, record: Map<String, Any>?) = CacheKey.NO_KEY
   }
 }


### PR DESCRIPTION
Remove normalization from the parsing step. Normalization is now done from the models, like it is done when using the cache write APIs.

Advantages:
- Normalizing network response now uses the same path as when writing to the cache using the imperative cache write API. This ensures the results will be identical (see apollographql#2818)
- Normalization can be better decoupled from the parsing and not applied at all if no cache is configured. This also means we can make normalization "async" and send a model to the UI without having to wait

This also enables the streaming parser in `ApolloParseInterceptor`, which is the main use case, which is something like ~25% faster on the whole parsing + normalization path, potentially event faster without normalization 🎉  (see the README.md in the benchmarks for actual numbers)