### PR TITLE
Copy `configurations` before flatmapping in `getDeps`

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloPlugin.kt
@@ -287,7 +287,7 @@ open class ApolloPlugin : Plugin<Project> {
     data class Dep(val name: String, val version: String?)
 
     fun getDeps(configurations: ConfigurationContainer): List<Dep> {
-      return configurations.flatMap { configuration ->
+      return configurations.toList().flatMap { configuration ->
         configuration.incoming.dependencies
             .filter {
               it.group == "com.apollographql.apollo"


### PR DESCRIPTION
It seems like some other gradle plugins may do something with
configurations during resolving dependencies, causing
`java.util.ConcurrentModificationException` when `apollo-gradle-plugin`
is flatmapping over the list of configurations in the getDeps function.

Copying `configurations` via `toList()` before flatmapping solves the
issue.

Fixes #2864