### PR TITLE
Use Okio's base64 implementation

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/AppSyncOperationMessageSerializer.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/subscription/AppSyncOperationMessageSerializer.kt
@@ -9,7 +9,6 @@ import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
 import okio.IOException
-import java.util.Base64
 
 /**
  * An [OperationMessageSerializer] that uses the format used by
@@ -112,7 +111,7 @@ class AppSyncOperationMessageSerializer(
     private fun Map<String, Any?>.base64Encode(): String {
       val buffer = Buffer()
       Utils.writeToJson(this, JsonWriter.of(buffer))
-      return Base64.getUrlEncoder().encodeToString(buffer.readByteArray())
+      return buffer.readByteString().base64Url()
     }
   }
 }


### PR DESCRIPTION
java.util.Base64 is only available on API 26+ on Android while
Okio's implementation works on all API levels.

This fixes #2857