### PR TITLE
configure the Kotlin compiler options for multiplatform projects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,15 @@ subprojects {
       freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
     }
   }
+  (project.extensions.findByName("kotlin")
+   as? org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension)?.run {
+    sourceSets.all {
+      languageSettings.apply {
+        apiVersion = "1.3"
+        this.useExperimentalAnnotation("kotlin.RequiresOptIn")
+      }
+    }
+  }
 
   tasks.withType<Test> {
     testLogging {


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-44348, for multiplatform projects, the kotlin compiler was missing some options