### PR TITLE
[3.x] Remove extra adapter class

### DIFF
--- a/apollo-compiler/src/test/graphql/com/example/antlr_tokens/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/antlr_tokens/adapter/TestQuery_ResponseAdapter.kt
@@ -23,87 +23,72 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var typeWithGraphQLKeywords: TestQuery.Data.TypeWithGraphQLKeywords? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> typeWithGraphQLKeywords = readObject<TestQuery.Data.TypeWithGraphQLKeywords>(RESPONSE_FIELDS[0]) { reader ->
+            TypeWithGraphQLKeywords.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        typeWithGraphQLKeywords = typeWithGraphQLKeywords
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.typeWithGraphQLKeywords == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        TypeWithGraphQLKeywords.toResponse(writer, value.typeWithGraphQLKeywords)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object TypeWithGraphQLKeywords : ResponseAdapter<TestQuery.Data.TypeWithGraphQLKeywords> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("typeWithGraphQLKeywords", "typeWithGraphQLKeywords", null, true, null)
+      ResponseField.forString("on", "on", null, true, null),
+      ResponseField.forString("null", "null", mapOf<String, Any?>(
+        "fragment" to mapOf<String, Any?>(
+          "kind" to "Variable",
+          "variableName" to "operation")), true, null),
+      ResponseField.forString("alias", "null", mapOf<String, Any?>(
+        "fragment" to """
+        |A string
+        |with a new line
+        """.trimMargin()), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.TypeWithGraphQLKeywords {
       return reader.run {
-        var typeWithGraphQLKeywords: TestQuery.Data.TypeWithGraphQLKeywords? = null
+        var on: String? = null
+        var null_: String? = null
+        var alias: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> typeWithGraphQLKeywords = readObject<TestQuery.Data.TypeWithGraphQLKeywords>(RESPONSE_FIELDS[0]) { reader ->
-              TypeWithGraphQLKeywords.fromResponse(reader)
-            }
+            0 -> on = readString(RESPONSE_FIELDS[0])
+            1 -> null_ = readString(RESPONSE_FIELDS[1])
+            2 -> alias = readString(RESPONSE_FIELDS[2])
             else -> break
           }
         }
-        TestQuery.Data(
-          typeWithGraphQLKeywords = typeWithGraphQLKeywords
+        TestQuery.Data.TypeWithGraphQLKeywords(
+          on = on,
+          null_ = null_,
+          alias = alias
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.typeWithGraphQLKeywords == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          TypeWithGraphQLKeywords.toResponse(writer, value.typeWithGraphQLKeywords)
-        }
-      }
-    }
-
-    object TypeWithGraphQLKeywords : ResponseAdapter<TestQuery.Data.TypeWithGraphQLKeywords> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("on", "on", null, true, null),
-        ResponseField.forString("null", "null", mapOf<String, Any?>(
-          "fragment" to mapOf<String, Any?>(
-            "kind" to "Variable",
-            "variableName" to "operation")), true, null),
-        ResponseField.forString("alias", "null", mapOf<String, Any?>(
-          "fragment" to """
-          |A string
-          |with a new line
-          """.trimMargin()), true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.TypeWithGraphQLKeywords {
-        return reader.run {
-          var on: String? = null
-          var null_: String? = null
-          var alias: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> on = readString(RESPONSE_FIELDS[0])
-              1 -> null_ = readString(RESPONSE_FIELDS[1])
-              2 -> alias = readString(RESPONSE_FIELDS[2])
-              else -> break
-            }
-          }
-          TestQuery.Data.TypeWithGraphQLKeywords(
-            on = on,
-            null_ = null_,
-            alias = alias
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter,
-          value: TestQuery.Data.TypeWithGraphQLKeywords) {
-        writer.writeString(RESPONSE_FIELDS[0], value.on)
-        writer.writeString(RESPONSE_FIELDS[1], value.null_)
-        writer.writeString(RESPONSE_FIELDS[2], value.alias)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.TypeWithGraphQLKeywords) {
+      writer.writeString(RESPONSE_FIELDS[0], value.on)
+      writer.writeString(RESPONSE_FIELDS[1], value.null_)
+      writer.writeString(RESPONSE_FIELDS[2], value.alias)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_complex/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_complex/adapter/TestQuery_ResponseAdapter.kt
@@ -46,97 +46,61 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var heroWithReview: TestQuery.Data.HeroWithReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> heroWithReview = readObject<TestQuery.Data.HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
+            HeroWithReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        heroWithReview = heroWithReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.heroWithReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        HeroWithReview.toResponse(writer, value.heroWithReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object HeroWithReview : ResponseAdapter<TestQuery.Data.HeroWithReview> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("heroWithReview", "heroWithReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "episode"),
-        "review" to mapOf<String, Any?>(
-          "stars" to mapOf<String, Any?>(
-            "kind" to "Variable",
-            "variableName" to "stars"),
-          "favoriteColor" to mapOf<String, Any?>(
-            "red" to 0,
-            "green" to mapOf<String, Any?>(
-              "kind" to "Variable",
-              "variableName" to "greenValue"),
-            "blue" to 0.0),
-          "booleanNonOptional" to false,
-          "listOfStringNonOptional" to emptyList<Any?>()),
-        "listOfInts" to listOf<Any?>(
-          mapOf<String, Any?>(
-            "kind" to "Variable",
-            "variableName" to "stars"),
-          mapOf<String, Any?>(
-            "kind" to "Variable",
-            "variableName" to "stars"))), true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forDouble("height", "height", mapOf<String, Any?>(
+        "unit" to "FOOT"), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.HeroWithReview {
       return reader.run {
-        var heroWithReview: TestQuery.Data.HeroWithReview? = null
+        var name: String? = null
+        var height: Double? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> heroWithReview = readObject<TestQuery.Data.HeroWithReview>(RESPONSE_FIELDS[0]) { reader ->
-              HeroWithReview.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> height = readDouble(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          heroWithReview = heroWithReview
+        TestQuery.Data.HeroWithReview(
+          name = name!!,
+          height = height
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.heroWithReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          HeroWithReview.toResponse(writer, value.heroWithReview)
-        }
-      }
-    }
-
-    object HeroWithReview : ResponseAdapter<TestQuery.Data.HeroWithReview> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forDouble("height", "height", mapOf<String, Any?>(
-          "unit" to "FOOT"), true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.HeroWithReview {
-        return reader.run {
-          var name: String? = null
-          var height: Double? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> height = readDouble(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.HeroWithReview(
-            name = name!!,
-            height = height
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.HeroWithReview) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeDouble(RESPONSE_FIELDS[1], value.height)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.HeroWithReview) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeDouble(RESPONSE_FIELDS[1], value.height)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/adapter/TestQuery_ResponseAdapter.kt
@@ -36,89 +36,63 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var reviews: List<TestQuery.Data.Review?>? = null
+      var testNullableArguments: Int? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> reviews = readList<TestQuery.Data.Review>(RESPONSE_FIELDS[0]) { reader ->
+            reader.readObject<TestQuery.Data.Review> { reader ->
+              Review.fromResponse(reader)
+            }
+          }
+          1 -> testNullableArguments = readInt(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        reviews = reviews,
+        testNullableArguments = testNullableArguments!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeList(RESPONSE_FIELDS[0], value.reviews) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Review.toResponse(writer, value)
+      }
+    }
+    writer.writeInt(RESPONSE_FIELDS[1], value.testNullableArguments)
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Review : ResponseAdapter<TestQuery.Data.Review> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forList("reviews", "reviews", mapOf<String, Any?>(
-        "episode" to "JEDI",
-        "starsInt" to 10,
-        "starsFloat" to 9.9), true, null),
-      ResponseField.forInt("testNullableArguments", "testNullableArguments", mapOf<String, Any?>(
-        "int" to null,
-        "string" to null,
-        "float" to null,
-        "review" to null,
-        "episode" to null,
-        "boolean" to null,
-        "list" to null), false, null)
+      ResponseField.forInt("stars", "stars", null, false, null),
+      ResponseField.forString("commentary", "commentary", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Review {
       return reader.run {
-        var reviews: List<TestQuery.Data.Review?>? = null
-        var testNullableArguments: Int? = null
+        var stars: Int? = null
+        var commentary: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> reviews = readList<TestQuery.Data.Review>(RESPONSE_FIELDS[0]) { reader ->
-              reader.readObject<TestQuery.Data.Review> { reader ->
-                Review.fromResponse(reader)
-              }
-            }
-            1 -> testNullableArguments = readInt(RESPONSE_FIELDS[1])
+            0 -> stars = readInt(RESPONSE_FIELDS[0])
+            1 -> commentary = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          reviews = reviews,
-          testNullableArguments = testNullableArguments!!
+        TestQuery.Data.Review(
+          stars = stars!!,
+          commentary = commentary
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      writer.writeList(RESPONSE_FIELDS[0], value.reviews) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Review.toResponse(writer, value)
-        }
-      }
-      writer.writeInt(RESPONSE_FIELDS[1], value.testNullableArguments)
-    }
-
-    object Review : ResponseAdapter<TestQuery.Data.Review> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("stars", "stars", null, false, null),
-        ResponseField.forString("commentary", "commentary", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Review {
-        return reader.run {
-          var stars: Int? = null
-          var commentary: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> stars = readInt(RESPONSE_FIELDS[0])
-              1 -> commentary = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.Review(
-            stars = stars!!,
-            commentary = commentary
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Review) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.stars)
-        writer.writeString(RESPONSE_FIELDS[1], value.commentary)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Review) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.stars)
+      writer.writeString(RESPONSE_FIELDS[1], value.commentary)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/adapter/TestQuery_ResponseAdapter.kt
@@ -41,74 +41,220 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      var heroWithReview: TestQuery.Data.HeroWithReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          1 -> heroWithReview = readObject<TestQuery.Data.HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
+            HeroWithReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero,
+        heroWithReview = heroWithReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
+    if(value.heroWithReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        HeroWithReview.toResponse(writer, value.heroWithReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "episode"),
-        "listOfListOfStringArgs" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "listOfListOfStringArgs")), true, null),
-      ResponseField.forObject("heroWithReview", "heroWithReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "episode"),
-        "review" to mapOf<String, Any?>(
-          "stars" to 5,
-          "favoriteColor" to mapOf<String, Any?>(
-            "red" to 1,
-            "blue" to 1.0),
-          "listOfStringNonOptional" to emptyList<Any?>())), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, true, listOf(
+        ResponseField.Condition.booleanCondition("IncludeName", false)
+      ))
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        var heroWithReview: TestQuery.Data.HeroWithReview? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, true, listOf(
+          ResponseField.Condition.booleanCondition("IncludeName", false)
+        )),
+        ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any?>(
+          "first" to mapOf<String, Any?>(
+            "kind" to "Variable",
+            "variableName" to "friendsCount")), false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              else -> break
             }
-            1 -> heroWithReview = readObject<TestQuery.Data.HeroWithReview>(RESPONSE_FIELDS[1]) { reader ->
-              HeroWithReview.fromResponse(reader)
+          }
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name,
+            friendsConnection = friendsConnection!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
+        }
+      }
+
+      object FriendsConnection :
+          ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forInt("totalCount", "totalCount", null, true, null),
+          ResponseField.forList("edges", "edges", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection {
+          return reader.run {
+            var totalCount: Int? = null
+            var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+                1 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
+                }
+                else -> break
+              }
             }
-            else -> break
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection(
+              totalCount = totalCount,
+              edges = edges
+            )
           }
         }
-        TestQuery.Data(
-          hero = hero,
-          heroWithReview = heroWithReview
-        )
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
+          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
+          }
+        }
+
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forObject("node", "node", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
+            return reader.run {
+              var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
+                node = node
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
+              }
+            }
+          }
+
+          object Node :
+              ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("name", "name", null, true, listOf(
+                ResponseField.Condition.booleanCondition("IncludeName", false)
+              ))
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
+              return reader.run {
+                var name: String? = null
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> name = readString(RESPONSE_FIELDS[0])
+                    else -> break
+                  }
+                }
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
+                  name = name
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
+            }
+          }
+        }
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-      if(value.heroWithReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          HeroWithReview.toResponse(writer, value.heroWithReview)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, true, listOf(
@@ -116,231 +262,55 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
         ))
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, true, listOf(
-            ResponseField.Condition.booleanCondition("IncludeName", false)
-          )),
-          ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any?>(
-            "first" to mapOf<String, Any?>(
-              "kind" to "Variable",
-              "variableName" to "friendsCount")), false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                  FriendsConnection.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name,
-              friendsConnection = friendsConnection!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-        }
-
-        object FriendsConnection :
-            ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forInt("totalCount", "totalCount", null, true, null),
-            ResponseField.forList("edges", "edges", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection {
-            return reader.run {
-              var totalCount: Int? = null
-              var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                  1 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection(
-                totalCount = totalCount,
-                edges = edges
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
-            writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-            writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
-              }
-            }
-          }
-
-          object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
-              return reader.run {
-                var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
-                  node = node
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node :
-                ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, true, listOf(
-                  ResponseField.Condition.booleanCondition("IncludeName", false)
-                ))
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
-                    name = name
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
-            }
-          }
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, true, listOf(
-            ResponseField.Condition.booleanCondition("IncludeName", false)
-          ))
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
-      }
-    }
-
-    object HeroWithReview : ResponseAdapter<TestQuery.Data.HeroWithReview> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.HeroWithReview {
+          TestQuery.Data.Hero.OtherHero {
         return reader.run {
+          var __typename: String? = __typename
           var name: String? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
               else -> break
             }
           }
-          TestQuery.Data.HeroWithReview(
-            name = name!!
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.HeroWithReview) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
+    }
+  }
+
+  object HeroWithReview : ResponseAdapter<TestQuery.Data.HeroWithReview> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("name", "name", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.HeroWithReview {
+      return reader.run {
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            else -> break
+          }
+        }
+        TestQuery.Data.HeroWithReview(
+          name = name!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.HeroWithReview) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -29,149 +29,130 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
+            FriendsConnection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HeroDetailsImpl.Data(
+        __typename = __typename!!,
+        friendsConnection = friendsConnection!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+      FriendsConnection.toResponse(writer, value.friendsConnection)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forObject("friendsConnection", "friendsConnection", mapOf<String, Any?>(
-        "first" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "friendsCount")), false, null)
+      ResponseField.forInt("totalCount", "totalCount", null, true, null),
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.FriendsConnection {
       return reader.run {
-        var __typename: String? = __typename
-        var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+        var totalCount: Int? = null
+        var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
-              FriendsConnection.fromResponse(reader)
+            0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+            1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        HeroDetailsImpl.Data(
-          __typename = __typename!!,
-          friendsConnection = friendsConnection!!
+        HeroDetailsImpl.Data.FriendsConnection(
+          totalCount = totalCount,
+          edges = edges
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-        FriendsConnection.toResponse(writer, value.friendsConnection)
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.FriendsConnection) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+      writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
+        }
       }
     }
 
-    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
+    object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("totalCount", "totalCount", null, true, null),
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.FriendsConnection {
+          HeroDetailsImpl.Data.FriendsConnection.Edge {
         return reader.run {
-          var totalCount: Int? = null
-          var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
+          var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-              1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          HeroDetailsImpl.Data.FriendsConnection(
-            totalCount = totalCount,
-            edges = edges
+          HeroDetailsImpl.Data.FriendsConnection.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: HeroDetailsImpl.Data.FriendsConnection) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
+      object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("name", "name", null, true, listOf(
+            ResponseField.Condition.booleanCondition("IncludeName", false)
+          ))
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.FriendsConnection.Edge {
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
           return reader.run {
-            var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
+            var name: String? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
+                0 -> name = readString(RESPONSE_FIELDS[0])
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.FriendsConnection.Edge(
-              node = node
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
+              name = name
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
-          }
-        }
-
-        object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, true, listOf(
-              ResponseField.Condition.booleanCondition("IncludeName", false)
-            ))
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
-            return reader.run {
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
-                name = name
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
+            value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/adapter/TestQuery_ResponseAdapter.kt
@@ -27,99 +27,85 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null),
+      ResponseField.forList("appearanceDates", "appearanceDates", null, false, null),
+      ResponseField.forCustomScalar("fieldWithUnsupportedType", "fieldWithUnsupportedType", null, false, CustomScalars.UnsupportedType, null),
+      ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null),
+      ResponseField.forList("links", "links", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
+        var birthDate: Date? = null
+        var appearanceDates: List<Date>? = null
+        var fieldWithUnsupportedType: Any? = null
+        var profileLink: java.lang.String? = null
+        var links: List<java.lang.String>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> birthDate = readCustomScalar<Date>(RESPONSE_FIELDS[1] as ResponseField.CustomScalarField)
+            2 -> appearanceDates = readList<Date>(RESPONSE_FIELDS[2]) { reader ->
+              reader.readCustomScalar<Date>(CustomScalars.Date)
+            }?.map { it!! }
+            3 -> fieldWithUnsupportedType = readCustomScalar<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField)
+            4 -> profileLink = readCustomScalar<java.lang.String>(RESPONSE_FIELDS[4] as ResponseField.CustomScalarField)
+            5 -> links = readList<java.lang.String>(RESPONSE_FIELDS[5]) { reader ->
+              reader.readCustomScalar<java.lang.String>(CustomScalars.URL)
+            }?.map { it!! }
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name!!,
+          birthDate = birthDate!!,
+          appearanceDates = appearanceDates!!,
+          fieldWithUnsupportedType = fieldWithUnsupportedType!!,
+          profileLink = profileLink!!,
+          links = links!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null),
-        ResponseField.forList("appearanceDates", "appearanceDates", null, false, null),
-        ResponseField.forCustomScalar("fieldWithUnsupportedType", "fieldWithUnsupportedType", null, false, CustomScalars.UnsupportedType, null),
-        ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null),
-        ResponseField.forList("links", "links", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          var birthDate: Date? = null
-          var appearanceDates: List<Date>? = null
-          var fieldWithUnsupportedType: Any? = null
-          var profileLink: java.lang.String? = null
-          var links: List<java.lang.String>? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> birthDate = readCustomScalar<Date>(RESPONSE_FIELDS[1] as ResponseField.CustomScalarField)
-              2 -> appearanceDates = readList<Date>(RESPONSE_FIELDS[2]) { reader ->
-                reader.readCustomScalar<Date>(CustomScalars.Date)
-              }?.map { it!! }
-              3 -> fieldWithUnsupportedType = readCustomScalar<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField)
-              4 -> profileLink = readCustomScalar<java.lang.String>(RESPONSE_FIELDS[4] as ResponseField.CustomScalarField)
-              5 -> links = readList<java.lang.String>(RESPONSE_FIELDS[5]) { reader ->
-                reader.readCustomScalar<java.lang.String>(CustomScalars.URL)
-              }?.map { it!! }
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            name = name!!,
-            birthDate = birthDate!!,
-            appearanceDates = appearanceDates!!,
-            fieldWithUnsupportedType = fieldWithUnsupportedType!!,
-            profileLink = profileLink!!,
-            links = links!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomScalarField, value.birthDate)
-        writer.writeList(RESPONSE_FIELDS[2], value.appearanceDates) { value, listItemWriter ->
-          listItemWriter.writeCustom(CustomScalars.Date, value)}
-        writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField, value.fieldWithUnsupportedType)
-        writer.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomScalarField, value.profileLink)
-        writer.writeList(RESPONSE_FIELDS[5], value.links) { value, listItemWriter ->
-          listItemWriter.writeCustom(CustomScalars.URL, value)}
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeCustom(RESPONSE_FIELDS[1] as ResponseField.CustomScalarField, value.birthDate)
+      writer.writeList(RESPONSE_FIELDS[2], value.appearanceDates) { value, listItemWriter ->
+        listItemWriter.writeCustom(CustomScalars.Date, value)}
+      writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField, value.fieldWithUnsupportedType)
+      writer.writeCustom(RESPONSE_FIELDS[4] as ResponseField.CustomScalarField, value.profileLink)
+      writer.writeList(RESPONSE_FIELDS[5], value.links) { value, listItemWriter ->
+        listItemWriter.writeCustom(CustomScalars.URL, value)}
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type_warnings/adapter/TestQuery_ResponseAdapter.kt
@@ -26,71 +26,57 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forList("links", "links", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var links: List<Any>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> links = readList<Any>(RESPONSE_FIELDS[0]) { reader ->
+              reader.readCustomScalar<Any>(CustomScalars.URL)
+            }?.map { it!! }
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          links = links!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forList("links", "links", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var links: List<Any>? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> links = readList<Any>(RESPONSE_FIELDS[0]) { reader ->
-                reader.readCustomScalar<Any>(CustomScalars.URL)
-              }?.map { it!! }
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            links = links!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeList(RESPONSE_FIELDS[0], value.links) { value, listItemWriter ->
-          listItemWriter.writeCustom(CustomScalars.URL, value)}
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeList(RESPONSE_FIELDS[0], value.links) { value, listItemWriter ->
+        listItemWriter.writeCustom(CustomScalars.URL, value)}
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/deprecation/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/deprecation/adapter/TestQuery_ResponseAdapter.kt
@@ -27,81 +27,64 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "episode")), true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forString("deprecated", "deprecated", null, false, null),
+      ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
+        var deprecated: String? = null
+        var deprecatedBool: Boolean? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> deprecated = readString(RESPONSE_FIELDS[1])
+            2 -> deprecatedBool = readBoolean(RESPONSE_FIELDS[2])
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name!!,
+          deprecated = deprecated!!,
+          deprecatedBool = deprecatedBool!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forString("deprecated", "deprecated", null, false, null),
-        ResponseField.forBoolean("deprecatedBool", "deprecatedBool", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          var deprecated: String? = null
-          var deprecatedBool: Boolean? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> deprecated = readString(RESPONSE_FIELDS[1])
-              2 -> deprecatedBool = readBoolean(RESPONSE_FIELDS[2])
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            name = name!!,
-            deprecated = deprecated!!,
-            deprecatedBool = deprecatedBool!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeString(RESPONSE_FIELDS[1], value.deprecated)
-        writer.writeBoolean(RESPONSE_FIELDS[2], value.deprecatedBool)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeString(RESPONSE_FIELDS[1], value.deprecated)
+      writer.writeBoolean(RESPONSE_FIELDS[2], value.deprecatedBool)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -23,175 +23,161 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("id", "id", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("homePlanet", "homePlanet", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> homePlanet = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.CharacterHumanHero(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterHumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
+        writer.writeString(RESPONSE_FIELDS[3], value.homePlanet)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("id", "id", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            id = id!!
+          )
         }
       }
 
-      object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            var homePlanet: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                3 -> homePlanet = readString(RESPONSE_FIELDS[3])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.CharacterHumanHero(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!,
-              homePlanet = homePlanet
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterHumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
-          writer.writeString(RESPONSE_FIELDS[3], value.homePlanet)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              id = id!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      HeroDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        HeroDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var homePlanet: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> homePlanet = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      HumanDetailsImpl.Data(
+        __typename = __typename!!,
+        homePlanet = homePlanet
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var homePlanet: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> homePlanet = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        HumanDetailsImpl.Data(
-          __typename = __typename!!,
-          homePlanet = homePlanet
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.homePlanet)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.homePlanet)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directive_with_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -23,181 +23,167 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("id", "id", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanCharacterHero.fromResponse(reader, typename)
+        "Droid" -> DroidCharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.HumanCharacterHero -> HumanCharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.DroidCharacterHero -> DroidCharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanCharacterHero : ResponseAdapter<TestQuery.Data.Hero.HumanCharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("homePlanet", "homePlanet", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanCharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> homePlanet = readString(RESPONSE_FIELDS[3])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.HumanCharacterHero(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.HumanCharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
+        writer.writeString(RESPONSE_FIELDS[3], value.homePlanet)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object DroidCharacterHero : ResponseAdapter<TestQuery.Data.Hero.DroidCharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidCharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidCharacterHero(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.DroidCharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
+        writer.writeString(RESPONSE_FIELDS[3], value.primaryFunction)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("id", "id", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanCharacterHero.fromResponse(reader, typename)
-          "Droid" -> DroidCharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.HumanCharacterHero -> HumanCharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.DroidCharacterHero -> DroidCharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanCharacterHero : ResponseAdapter<TestQuery.Data.Hero.HumanCharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanCharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            var homePlanet: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                3 -> homePlanet = readString(RESPONSE_FIELDS[3])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Hero.HumanCharacterHero(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!,
-              homePlanet = homePlanet
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.HumanCharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
-          writer.writeString(RESPONSE_FIELDS[3], value.homePlanet)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            id = id!!
+          )
         }
       }
 
-      object DroidCharacterHero : ResponseAdapter<TestQuery.Data.Hero.DroidCharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidCharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.DroidCharacterHero(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.DroidCharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
-          writer.writeString(RESPONSE_FIELDS[3], value.primaryFunction)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              id = id!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/directives/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/directives/adapter/TestQuery_ResponseAdapter.kt
@@ -24,111 +24,97 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, true, listOf(
+        ResponseField.Condition.booleanCondition("includeName", false)
+      )),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, true, listOf(
+        ResponseField.Condition.booleanCondition("skipFriends", true)
+      ))
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
+        var friendsConnection: TestQuery.Data.Hero.FriendsConnection? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> friendsConnection = readObject<TestQuery.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
+              FriendsConnection.fromResponse(reader)
             }
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name,
+          friendsConnection = friendsConnection
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      if(value.friendsConnection == null) {
+        writer.writeObject(RESPONSE_FIELDS[1], null)
       } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
         }
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, true, listOf(
-          ResponseField.Condition.booleanCondition("includeName", false)
-        )),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, true, listOf(
-          ResponseField.Condition.booleanCondition("skipFriends", true)
-        ))
+        ResponseField.forInt("totalCount", "totalCount", null, true, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.FriendsConnection {
         return reader.run {
-          var name: String? = null
-          var friendsConnection: TestQuery.Data.Hero.FriendsConnection? = null
+          var totalCount: Int? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> friendsConnection = readObject<TestQuery.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
-                FriendsConnection.fromResponse(reader)
-              }
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
               else -> break
             }
           }
-          TestQuery.Data.Hero(
-            name = name,
-            friendsConnection = friendsConnection
+          TestQuery.Data.Hero.FriendsConnection(
+            totalCount = totalCount
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        if(value.friendsConnection == null) {
-          writer.writeObject(RESPONSE_FIELDS[1], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-        }
-      }
-
-      object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.FriendsConnection> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.FriendsConnection {
-          return reader.run {
-            var totalCount: Int? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.FriendsConnection(
-              totalCount = totalCount
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-        }
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/enum_type/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/enum_type/adapter/TestQuery_ResponseAdapter.kt
@@ -25,81 +25,67 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forList("appearsIn", "appearsIn", null, false, null),
+      ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
+        var appearsIn: List<Episode?>? = null
+        var firstAppearsIn: Episode? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
+              Episode.safeValueOf(reader.readString())
             }
+            2 -> firstAppearsIn = readString(RESPONSE_FIELDS[2])?.let { Episode.safeValueOf(it) }
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name!!,
+          appearsIn = appearsIn!!,
+          firstAppearsIn = firstAppearsIn!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forList("appearsIn", "appearsIn", null, false, null),
-        ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          var appearsIn: List<Episode?>? = null
-          var firstAppearsIn: Episode? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
-                Episode.safeValueOf(reader.readString())
-              }
-              2 -> firstAppearsIn = readString(RESPONSE_FIELDS[2])?.let { Episode.safeValueOf(it) }
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            name = name!!,
-            appearsIn = appearsIn!!,
-            firstAppearsIn = firstAppearsIn!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeList(RESPONSE_FIELDS[1], value.appearsIn) { value, listItemWriter ->
-          listItemWriter.writeString(value?.rawValue)}
-        writer.writeString(RESPONSE_FIELDS[2], value.firstAppearsIn.rawValue)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeList(RESPONSE_FIELDS[1], value.appearsIn) { value, listItemWriter ->
+        listItemWriter.writeString(value?.rawValue)}
+      writer.writeString(RESPONSE_FIELDS[2], value.firstAppearsIn.rawValue)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/adapter/TestQuery_ResponseAdapter.kt
@@ -25,234 +25,220 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        TestQuery.Data(
-          hero = hero
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
         }
       }
 
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      object FriendsConnection :
+          ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+          ResponseField.forInt("totalCount", "totalCount", null, true, null),
+          ResponseField.forList("edges", "edges", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection {
           return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
+            var totalCount: Int? = null
+            var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                  FriendsConnection.fromResponse(reader)
+                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+                1 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
                 }
                 else -> break
               }
             }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name!!,
-              friendsConnection = friendsConnection!!
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection(
+              totalCount = totalCount,
+              edges = edges
             )
           }
         }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
+          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
           }
         }
 
-        object FriendsConnection :
-            ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forInt("totalCount", "totalCount", null, true, null),
-            ResponseField.forList("edges", "edges", null, true, null)
+            ResponseField.forObject("node", "node", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection {
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
             return reader.run {
-              var totalCount: Int? = null
-              var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
+              var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                  1 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
+                  0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
                   }
                   else -> break
                 }
               }
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection(
-                totalCount = totalCount,
-                edges = edges
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
+                node = node
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
-            writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-            writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
+              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
               }
             }
           }
 
-          object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
+          object Node :
+              ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
+              ResponseField.forString("name", "name", null, false, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
               return reader.run {
-                var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
+                var name: String? = null
                 while(true) {
                   when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
+                    0 -> name = readString(RESPONSE_FIELDS[0])
                     else -> break
                   }
                 }
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
-                  node = node
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
+                  name = name!!
                 )
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node :
-                ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
+                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
             }
           }
         }
       }
+    }
 
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
           }
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
+      }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_friends_connection/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -27,149 +27,132 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+            FriendsConnection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HeroDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        friendsConnection = friendsConnection!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+      FriendsConnection.toResponse(writer, value.friendsConnection)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+      ResponseField.forInt("totalCount", "totalCount", null, true, null),
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.FriendsConnection {
       return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+        var totalCount: Int? = null
+        var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-              FriendsConnection.fromResponse(reader)
+            0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+            1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        HeroDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          friendsConnection = friendsConnection!!
+        HeroDetailsImpl.Data.FriendsConnection(
+          totalCount = totalCount,
+          edges = edges
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-        FriendsConnection.toResponse(writer, value.friendsConnection)
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.FriendsConnection) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+      writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
+        }
       }
     }
 
-    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
+    object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("totalCount", "totalCount", null, true, null),
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.FriendsConnection {
+          HeroDetailsImpl.Data.FriendsConnection.Edge {
         return reader.run {
-          var totalCount: Int? = null
-          var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
+          var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-              1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          HeroDetailsImpl.Data.FriendsConnection(
-            totalCount = totalCount,
-            edges = edges
+          HeroDetailsImpl.Data.FriendsConnection.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: HeroDetailsImpl.Data.FriendsConnection) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
+      object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("name", "name", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.FriendsConnection.Edge {
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
           return reader.run {
-            var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
+            var name: String? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
+                0 -> name = readString(RESPONSE_FIELDS[0])
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.FriendsConnection.Edge(
-              node = node
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
+              name = name!!
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
-          }
-        }
-
-        object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
-            return reader.run {
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
+            value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/adapter/AllStarships_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/adapter/AllStarships_ResponseAdapter.kt
@@ -24,485 +24,470 @@ object AllStarships_ResponseAdapter : ResponseAdapter<AllStarships.Data> {
       "first" to 7), true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): AllStarships.Data {
-    return Data.fromResponse(reader, __typename)
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      com.example.fragment_in_fragment.AllStarships.Data {
+    return reader.run {
+      var allStarships: com.example.fragment_in_fragment.AllStarships.Data.AllStarships? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> allStarships = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships>(RESPONSE_FIELDS[0]) { reader ->
+            AllStarships.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      com.example.fragment_in_fragment.AllStarships.Data(
+        allStarships = allStarships
+      )
+    }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: AllStarships.Data) {
-    Data.toResponse(writer, value)
+  override fun toResponse(writer: ResponseWriter,
+      value: com.example.fragment_in_fragment.AllStarships.Data) {
+    if(value.allStarships == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        AllStarships.toResponse(writer, value.allStarships)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<AllStarships.Data> {
+  object AllStarships :
+      ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("allStarships", "allStarships", mapOf<String, Any?>(
-        "first" to 7), true, null)
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        com.example.fragment_in_fragment.AllStarships.Data {
+        com.example.fragment_in_fragment.AllStarships.Data.AllStarships {
       return reader.run {
-        var allStarships: com.example.fragment_in_fragment.AllStarships.Data.AllStarships? = null
+        var edges: List<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> allStarships = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships>(RESPONSE_FIELDS[0]) { reader ->
-              AllStarships.fromResponse(reader)
+            0 -> edges = readList<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge>(RESPONSE_FIELDS[0]) { reader ->
+              reader.readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        com.example.fragment_in_fragment.AllStarships.Data(
-          allStarships = allStarships
+        com.example.fragment_in_fragment.AllStarships.Data.AllStarships(
+          edges = edges
         )
       }
     }
 
     override fun toResponse(writer: ResponseWriter,
-        value: com.example.fragment_in_fragment.AllStarships.Data) {
-      if(value.allStarships == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          AllStarships.toResponse(writer, value.allStarships)
+        value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships) {
+      writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
         }
       }
     }
 
-    object AllStarships :
-        ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships> {
+    object Edge :
+        ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          com.example.fragment_in_fragment.AllStarships.Data.AllStarships {
+          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge {
         return reader.run {
-          var edges: List<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge?>? = null
+          var node: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> edges = readList<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                reader.readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          com.example.fragment_in_fragment.AllStarships.Data.AllStarships(
-            edges = edges
+          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships) {
-        writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge :
-          ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge> {
+      object Node :
+          ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node>
+          {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge {
-          return reader.run {
-            var node: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge(
-              node = node
-            )
+            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Starship" -> StarshipNode.fromResponse(reader, typename)
+            else -> OtherNode.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
+            value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node) {
+          when(value) {
+            is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode -> StarshipNode.toResponse(writer, value)
+            is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
           }
         }
 
-        object Node :
-            ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node>
+        object StarshipNode :
+            ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode>
             {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("id", "id", null, false, null),
+            ResponseField.forString("name", "name", null, true, null),
+            ResponseField.forObject("pilotConnection", "pilotConnection", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Starship" -> StarshipNode.fromResponse(reader, typename)
-              else -> OtherNode.fromResponse(reader, typename)
+              com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode {
+            return reader.run {
+              var __typename: String? = __typename
+              var id: String? = null
+              var name: String? = null
+              var pilotConnection: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> id = readString(RESPONSE_FIELDS[1])
+                  2 -> name = readString(RESPONSE_FIELDS[2])
+                  3 -> pilotConnection = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
+                    PilotConnection.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode(
+                __typename = __typename!!,
+                id = id!!,
+                name = name,
+                pilotConnection = pilotConnection
+              )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node) {
-            when(value) {
-              is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode -> StarshipNode.toResponse(writer, value)
-              is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
+              value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.id)
+            writer.writeString(RESPONSE_FIELDS[2], value.name)
+            if(value.pilotConnection == null) {
+              writer.writeObject(RESPONSE_FIELDS[3], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+                PilotConnection.toResponse(writer, value.pilotConnection)
+              }
             }
           }
 
-          object StarshipNode :
-              ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode>
+          object PilotConnection :
+              ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection>
               {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("id", "id", null, false, null),
-              ResponseField.forString("name", "name", null, true, null),
-              ResponseField.forObject("pilotConnection", "pilotConnection", null, true, null)
+              ResponseField.forList("edges", "edges", null, true, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode {
+                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection {
               return reader.run {
-                var __typename: String? = __typename
-                var id: String? = null
-                var name: String? = null
-                var pilotConnection: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection? = null
+                var edges: List<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge?>? = null
                 while(true) {
                   when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> id = readString(RESPONSE_FIELDS[1])
-                    2 -> name = readString(RESPONSE_FIELDS[2])
-                    3 -> pilotConnection = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
-                      PilotConnection.fromResponse(reader)
+                    0 -> edges = readList<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+                      reader.readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge> { reader ->
+                        Edge.fromResponse(reader)
+                      }
                     }
                     else -> break
                   }
                 }
-                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode(
-                  __typename = __typename!!,
-                  id = id!!,
-                  name = name,
-                  pilotConnection = pilotConnection
+                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection(
+                  edges = edges
                 )
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.id)
-              writer.writeString(RESPONSE_FIELDS[2], value.name)
-              if(value.pilotConnection == null) {
-                writer.writeObject(RESPONSE_FIELDS[3], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-                  PilotConnection.toResponse(writer, value.pilotConnection)
+                value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection) {
+              writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+                listItemWriter.writeObject { writer ->
+                  Edge.toResponse(writer, value)
                 }
               }
             }
 
-            object PilotConnection :
-                ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection>
+            object Edge :
+                ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge>
                 {
               private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forList("edges", "edges", null, true, null)
+                ResponseField.forObject("node", "node", null, true, null)
               )
 
               override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection {
+                  com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge {
                 return reader.run {
-                  var edges: List<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge?>? = null
+                  var node: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node? = null
                   while(true) {
                     when (selectField(RESPONSE_FIELDS)) {
-                      0 -> edges = readList<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                        reader.readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge> { reader ->
-                          Edge.fromResponse(reader)
-                        }
+                      0 -> node = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                        Node.fromResponse(reader)
                       }
                       else -> break
                     }
                   }
-                  com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection(
-                    edges = edges
+                  com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge(
+                    node = node
                   )
                 }
               }
 
               override fun toResponse(writer: ResponseWriter,
-                  value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection) {
-                writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-                  listItemWriter.writeObject { writer ->
-                    Edge.toResponse(writer, value)
+                  value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge) {
+                if(value.node == null) {
+                  writer.writeObject(RESPONSE_FIELDS[0], null)
+                } else {
+                  writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                    Node.toResponse(writer, value.node)
                   }
                 }
               }
 
-              object Edge :
-                  ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge>
+              object Node :
+                  ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node>
                   {
                 private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forObject("node", "node", null, true, null)
+                  ResponseField.forString("__typename", "__typename", null, false, null)
                 )
 
                 override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge {
-                  return reader.run {
-                    var node: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node? = null
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> node = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                          Node.fromResponse(reader)
-                        }
-                        else -> break
-                      }
-                    }
-                    com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge(
-                      node = node
-                    )
+                    com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node {
+                  val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+                  return when(typename) {
+                    "Person" -> PersonNode.fromResponse(reader, typename)
+                    else -> OtherNode.fromResponse(reader, typename)
                   }
                 }
 
                 override fun toResponse(writer: ResponseWriter,
-                    value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge) {
-                  if(value.node == null) {
-                    writer.writeObject(RESPONSE_FIELDS[0], null)
-                  } else {
-                    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                      Node.toResponse(writer, value.node)
-                    }
+                    value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node) {
+                  when(value) {
+                    is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode -> PersonNode.toResponse(writer, value)
+                    is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
                   }
                 }
 
-                object Node :
-                    ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node>
+                object PersonNode :
+                    ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode>
                     {
                   private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                    ResponseField.forString("__typename", "__typename", null, false, null)
+                    ResponseField.forString("__typename", "__typename", null, false, null),
+                    ResponseField.forString("name", "name", null, true, null),
+                    ResponseField.forObject("homeworld", "homeworld", null, true, null)
                   )
 
                   override fun fromResponse(reader: ResponseReader, __typename: String?):
-                      com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node {
-                    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-                    return when(typename) {
-                      "Person" -> PersonNode.fromResponse(reader, typename)
-                      else -> OtherNode.fromResponse(reader, typename)
+                      com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode {
+                    return reader.run {
+                      var __typename: String? = __typename
+                      var name: String? = null
+                      var homeworld: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld? = null
+                      while(true) {
+                        when (selectField(RESPONSE_FIELDS)) {
+                          0 -> __typename = readString(RESPONSE_FIELDS[0])
+                          1 -> name = readString(RESPONSE_FIELDS[1])
+                          2 -> homeworld = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+                            Homeworld.fromResponse(reader)
+                          }
+                          else -> break
+                        }
+                      }
+                      com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode(
+                        __typename = __typename!!,
+                        name = name,
+                        homeworld = homeworld
+                      )
                     }
                   }
 
                   override fun toResponse(writer: ResponseWriter,
-                      value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node) {
-                    when(value) {
-                      is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode -> PersonNode.toResponse(writer, value)
-                      is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
-                    }
-                  }
-
-                  object PersonNode :
-                      ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode>
-                      {
-                    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                      ResponseField.forString("__typename", "__typename", null, false, null),
-                      ResponseField.forString("name", "name", null, true, null),
-                      ResponseField.forObject("homeworld", "homeworld", null, true, null)
-                    )
-
-                    override fun fromResponse(reader: ResponseReader, __typename: String?):
-                        com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode {
-                      return reader.run {
-                        var __typename: String? = __typename
-                        var name: String? = null
-                        var homeworld: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld? = null
-                        while(true) {
-                          when (selectField(RESPONSE_FIELDS)) {
-                            0 -> __typename = readString(RESPONSE_FIELDS[0])
-                            1 -> name = readString(RESPONSE_FIELDS[1])
-                            2 -> homeworld = readObject<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
-                              Homeworld.fromResponse(reader)
-                            }
-                            else -> break
-                          }
-                        }
-                        com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode(
-                          __typename = __typename!!,
-                          name = name,
-                          homeworld = homeworld
-                        )
-                      }
-                    }
-
-                    override fun toResponse(writer: ResponseWriter,
-                        value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode) {
-                      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                      writer.writeString(RESPONSE_FIELDS[1], value.name)
-                      if(value.homeworld == null) {
-                        writer.writeObject(RESPONSE_FIELDS[2], null)
-                      } else {
-                        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-                          Homeworld.toResponse(writer, value.homeworld)
-                        }
-                      }
-                    }
-
-                    object Homeworld :
-                        ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld>
-                        {
-                      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                        ResponseField.forString("__typename", "__typename", null, false, null)
-                      )
-
-                      override fun fromResponse(reader: ResponseReader, __typename: String?):
-                          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld {
-                        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-                        return when(typename) {
-                          "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
-                          else -> OtherHomeworld.fromResponse(reader, typename)
-                        }
-                      }
-
-                      override fun toResponse(writer: ResponseWriter,
-                          value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld) {
-                        when(value) {
-                          is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
-                          is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
-                        }
-                      }
-
-                      object PlanetHomeworld :
-                          ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld>
-                          {
-                        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                          ResponseField.forString("__typename", "__typename", null, false, null),
-                          ResponseField.forString("name", "name", null, true, null)
-                        )
-
-                        override fun fromResponse(reader: ResponseReader, __typename: String?):
-                            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld {
-                          return reader.run {
-                            var __typename: String? = __typename
-                            var name: String? = null
-                            while(true) {
-                              when (selectField(RESPONSE_FIELDS)) {
-                                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                                1 -> name = readString(RESPONSE_FIELDS[1])
-                                else -> break
-                              }
-                            }
-                            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld(
-                              __typename = __typename!!,
-                              name = name
-                            )
-                          }
-                        }
-
-                        override fun toResponse(writer: ResponseWriter,
-                            value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld) {
-                          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                          writer.writeString(RESPONSE_FIELDS[1], value.name)
-                        }
-                      }
-
-                      object OtherHomeworld :
-                          ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld>
-                          {
-                        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                          ResponseField.forString("__typename", "__typename", null, false, null)
-                        )
-
-                        override fun fromResponse(reader: ResponseReader, __typename: String?):
-                            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld {
-                          return reader.run {
-                            var __typename: String? = __typename
-                            while(true) {
-                              when (selectField(RESPONSE_FIELDS)) {
-                                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                                else -> break
-                              }
-                            }
-                            com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld(
-                              __typename = __typename!!
-                            )
-                          }
-                        }
-
-                        override fun toResponse(writer: ResponseWriter,
-                            value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld) {
-                          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                        }
+                      value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode) {
+                    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                    writer.writeString(RESPONSE_FIELDS[1], value.name)
+                    if(value.homeworld == null) {
+                      writer.writeObject(RESPONSE_FIELDS[2], null)
+                    } else {
+                      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+                        Homeworld.toResponse(writer, value.homeworld)
                       }
                     }
                   }
 
-                  object OtherNode :
-                      ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode>
+                  object Homeworld :
+                      ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld>
                       {
                     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
                       ResponseField.forString("__typename", "__typename", null, false, null)
                     )
 
                     override fun fromResponse(reader: ResponseReader, __typename: String?):
-                        com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode {
-                      return reader.run {
-                        var __typename: String? = __typename
-                        while(true) {
-                          when (selectField(RESPONSE_FIELDS)) {
-                            0 -> __typename = readString(RESPONSE_FIELDS[0])
-                            else -> break
-                          }
-                        }
-                        com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode(
-                          __typename = __typename!!
-                        )
+                        com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld {
+                      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+                      return when(typename) {
+                        "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
+                        else -> OtherHomeworld.fromResponse(reader, typename)
                       }
                     }
 
                     override fun toResponse(writer: ResponseWriter,
-                        value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode) {
-                      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                        value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld) {
+                      when(value) {
+                        is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
+                        is com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
+                      }
                     }
+
+                    object PlanetHomeworld :
+                        ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld>
+                        {
+                      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                        ResponseField.forString("__typename", "__typename", null, false, null),
+                        ResponseField.forString("name", "name", null, true, null)
+                      )
+
+                      override fun fromResponse(reader: ResponseReader, __typename: String?):
+                          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld {
+                        return reader.run {
+                          var __typename: String? = __typename
+                          var name: String? = null
+                          while(true) {
+                            when (selectField(RESPONSE_FIELDS)) {
+                              0 -> __typename = readString(RESPONSE_FIELDS[0])
+                              1 -> name = readString(RESPONSE_FIELDS[1])
+                              else -> break
+                            }
+                          }
+                          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld(
+                            __typename = __typename!!,
+                            name = name
+                          )
+                        }
+                      }
+
+                      override fun toResponse(writer: ResponseWriter,
+                          value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld) {
+                        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                        writer.writeString(RESPONSE_FIELDS[1], value.name)
+                      }
+                    }
+
+                    object OtherHomeworld :
+                        ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld>
+                        {
+                      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                        ResponseField.forString("__typename", "__typename", null, false, null)
+                      )
+
+                      override fun fromResponse(reader: ResponseReader, __typename: String?):
+                          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld {
+                        return reader.run {
+                          var __typename: String? = __typename
+                          while(true) {
+                            when (selectField(RESPONSE_FIELDS)) {
+                              0 -> __typename = readString(RESPONSE_FIELDS[0])
+                              else -> break
+                            }
+                          }
+                          com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld(
+                            __typename = __typename!!
+                          )
+                        }
+                      }
+
+                      override fun toResponse(writer: ResponseWriter,
+                          value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld) {
+                        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                      }
+                    }
+                  }
+                }
+
+                object OtherNode :
+                    ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode>
+                    {
+                  private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                    ResponseField.forString("__typename", "__typename", null, false, null)
+                  )
+
+                  override fun fromResponse(reader: ResponseReader, __typename: String?):
+                      com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode {
+                    return reader.run {
+                      var __typename: String? = __typename
+                      while(true) {
+                        when (selectField(RESPONSE_FIELDS)) {
+                          0 -> __typename = readString(RESPONSE_FIELDS[0])
+                          else -> break
+                        }
+                      }
+                      com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode(
+                        __typename = __typename!!
+                      )
+                    }
+                  }
+
+                  override fun toResponse(writer: ResponseWriter,
+                      value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.StarshipNode.PilotConnection.Edge.Node.OtherNode) {
+                    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
                   }
                 }
               }
             }
           }
+        }
 
-          object OtherNode :
-              ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
+        object OtherNode :
+            ResponseAdapter<com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode>
+            {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null)
+          )
 
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode {
-              return reader.run {
-                var __typename: String? = __typename
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode {
+            return reader.run {
+              var __typename: String? = __typename
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  else -> break
                 }
-                com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode(
-                  __typename = __typename!!
-                )
               }
+              com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode(
+                __typename = __typename!!
+              )
             }
+          }
 
-            override fun toResponse(writer: ResponseWriter,
-                value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            }
+          override fun toResponse(writer: ResponseWriter,
+              value: com.example.fragment_in_fragment.AllStarships.Data.AllStarships.Edge.Node.OtherNode) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/PilotFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/PilotFragmentImpl_ResponseAdapter.kt
@@ -25,133 +25,117 @@ object PilotFragmentImpl_ResponseAdapter : ResponseAdapter<PilotFragmentImpl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): PilotFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var homeworld: PilotFragmentImpl.Data.Homeworld? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> homeworld = readObject<PilotFragmentImpl.Data.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+            Homeworld.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      PilotFragmentImpl.Data(
+        __typename = __typename!!,
+        name = name,
+        homeworld = homeworld
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: PilotFragmentImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    if(value.homeworld == null) {
+      writer.writeObject(RESPONSE_FIELDS[2], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        Homeworld.toResponse(writer, value.homeworld)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<PilotFragmentImpl.Data> {
+  object Homeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, true, null),
-      ResponseField.forObject("homeworld", "homeworld", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): PilotFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var homeworld: PilotFragmentImpl.Data.Homeworld? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> homeworld = readObject<PilotFragmentImpl.Data.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
-              Homeworld.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        PilotFragmentImpl.Data.Homeworld {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
+        else -> OtherHomeworld.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: PilotFragmentImpl.Data.Homeworld) {
+      when(value) {
+        is PilotFragmentImpl.Data.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
+        is PilotFragmentImpl.Data.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
+      }
+    }
+
+    object PlanetHomeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld.PlanetHomeworld> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          PilotFragmentImpl.Data.Homeworld.PlanetHomeworld {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            else -> break
           }
+          PilotFragmentImpl.Data.Homeworld.PlanetHomeworld(
+            __typename = __typename!!,
+            name = name
+          )
         }
-        PilotFragmentImpl.Data(
-          __typename = __typename!!,
-          name = name,
-          homeworld = homeworld
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: PilotFragmentImpl.Data.Homeworld.PlanetHomeworld) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: PilotFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      if(value.homeworld == null) {
-        writer.writeObject(RESPONSE_FIELDS[2], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          Homeworld.toResponse(writer, value.homeworld)
-        }
-      }
-    }
-
-    object Homeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld> {
+    object OtherHomeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld.OtherHomeworld> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          PilotFragmentImpl.Data.Homeworld {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
-          else -> OtherHomeworld.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: PilotFragmentImpl.Data.Homeworld) {
-        when(value) {
-          is PilotFragmentImpl.Data.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
-          is PilotFragmentImpl.Data.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
-        }
-      }
-
-      object PlanetHomeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld.PlanetHomeworld> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            PilotFragmentImpl.Data.Homeworld.PlanetHomeworld {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+          PilotFragmentImpl.Data.Homeworld.OtherHomeworld {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            PilotFragmentImpl.Data.Homeworld.PlanetHomeworld(
-              __typename = __typename!!,
-              name = name
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: PilotFragmentImpl.Data.Homeworld.PlanetHomeworld) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          PilotFragmentImpl.Data.Homeworld.OtherHomeworld(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherHomeworld : ResponseAdapter<PilotFragmentImpl.Data.Homeworld.OtherHomeworld> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            PilotFragmentImpl.Data.Homeworld.OtherHomeworld {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            PilotFragmentImpl.Data.Homeworld.OtherHomeworld(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: PilotFragmentImpl.Data.Homeworld.OtherHomeworld) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter,
+          value: PilotFragmentImpl.Data.Homeworld.OtherHomeworld) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/PlanetFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/PlanetFragmentImpl_ResponseAdapter.kt
@@ -24,41 +24,25 @@ object PlanetFragmentImpl_ResponseAdapter : ResponseAdapter<PlanetFragmentImpl.D
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): PlanetFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      PlanetFragmentImpl.Data(
+        __typename = __typename!!,
+        name = name
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: PlanetFragmentImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<PlanetFragmentImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        PlanetFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        PlanetFragmentImpl.Data(
-          __typename = __typename!!,
-          name = name
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: PlanetFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/StarshipFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_in_fragment/fragment/adapter/StarshipFragmentImpl_ResponseAdapter.kt
@@ -28,311 +28,293 @@ object StarshipFragmentImpl_ResponseAdapter : ResponseAdapter<StarshipFragmentIm
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
       StarshipFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var id: String? = null
+      var name: String? = null
+      var pilotConnection: StarshipFragmentImpl.Data.PilotConnection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> id = readString(RESPONSE_FIELDS[1])
+          2 -> name = readString(RESPONSE_FIELDS[2])
+          3 -> pilotConnection = readObject<StarshipFragmentImpl.Data.PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
+            PilotConnection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      StarshipFragmentImpl.Data(
+        __typename = __typename!!,
+        id = id!!,
+        name = name,
+        pilotConnection = pilotConnection
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: StarshipFragmentImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.id)
+    writer.writeString(RESPONSE_FIELDS[2], value.name)
+    if(value.pilotConnection == null) {
+      writer.writeObject(RESPONSE_FIELDS[3], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+        PilotConnection.toResponse(writer, value.pilotConnection)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<StarshipFragmentImpl.Data> {
+  object PilotConnection : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("id", "id", null, false, null),
-      ResponseField.forString("name", "name", null, true, null),
-      ResponseField.forObject("pilotConnection", "pilotConnection", null, true, null)
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        StarshipFragmentImpl.Data {
+        StarshipFragmentImpl.Data.PilotConnection {
       return reader.run {
-        var __typename: String? = __typename
-        var id: String? = null
-        var name: String? = null
-        var pilotConnection: StarshipFragmentImpl.Data.PilotConnection? = null
+        var edges: List<StarshipFragmentImpl.Data.PilotConnection.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> id = readString(RESPONSE_FIELDS[1])
-            2 -> name = readString(RESPONSE_FIELDS[2])
-            3 -> pilotConnection = readObject<StarshipFragmentImpl.Data.PilotConnection>(RESPONSE_FIELDS[3]) { reader ->
-              PilotConnection.fromResponse(reader)
+            0 -> edges = readList<StarshipFragmentImpl.Data.PilotConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+              reader.readObject<StarshipFragmentImpl.Data.PilotConnection.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        StarshipFragmentImpl.Data(
-          __typename = __typename!!,
-          id = id!!,
-          name = name,
-          pilotConnection = pilotConnection
+        StarshipFragmentImpl.Data.PilotConnection(
+          edges = edges
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: StarshipFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.id)
-      writer.writeString(RESPONSE_FIELDS[2], value.name)
-      if(value.pilotConnection == null) {
-        writer.writeObject(RESPONSE_FIELDS[3], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-          PilotConnection.toResponse(writer, value.pilotConnection)
+    override fun toResponse(writer: ResponseWriter,
+        value: StarshipFragmentImpl.Data.PilotConnection) {
+      writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
         }
       }
     }
 
-    object PilotConnection : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection> {
+    object Edge : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          StarshipFragmentImpl.Data.PilotConnection {
+          StarshipFragmentImpl.Data.PilotConnection.Edge {
         return reader.run {
-          var edges: List<StarshipFragmentImpl.Data.PilotConnection.Edge?>? = null
+          var node: StarshipFragmentImpl.Data.PilotConnection.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> edges = readList<StarshipFragmentImpl.Data.PilotConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                reader.readObject<StarshipFragmentImpl.Data.PilotConnection.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<StarshipFragmentImpl.Data.PilotConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          StarshipFragmentImpl.Data.PilotConnection(
-            edges = edges
+          StarshipFragmentImpl.Data.PilotConnection.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: StarshipFragmentImpl.Data.PilotConnection) {
-        writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: StarshipFragmentImpl.Data.PilotConnection.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge> {
+      object Node : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            StarshipFragmentImpl.Data.PilotConnection.Edge {
-          return reader.run {
-            var node: StarshipFragmentImpl.Data.PilotConnection.Edge.Node? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<StarshipFragmentImpl.Data.PilotConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            StarshipFragmentImpl.Data.PilotConnection.Edge(
-              node = node
-            )
+            StarshipFragmentImpl.Data.PilotConnection.Edge.Node {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Person" -> PersonNode.fromResponse(reader, typename)
+            else -> OtherNode.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: StarshipFragmentImpl.Data.PilotConnection.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
+            value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node) {
+          when(value) {
+            is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode -> PersonNode.toResponse(writer, value)
+            is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
           }
         }
 
-        object Node : ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node> {
+        object PersonNode :
+            ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, true, null),
+            ResponseField.forObject("homeworld", "homeworld", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              StarshipFragmentImpl.Data.PilotConnection.Edge.Node {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Person" -> PersonNode.fromResponse(reader, typename)
-              else -> OtherNode.fromResponse(reader, typename)
+              StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var homeworld: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> homeworld = readObject<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
+                    Homeworld.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode(
+                __typename = __typename!!,
+                name = name,
+                homeworld = homeworld
+              )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node) {
-            when(value) {
-              is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode -> PersonNode.toResponse(writer, value)
-              is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode -> OtherNode.toResponse(writer, value)
+              value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            if(value.homeworld == null) {
+              writer.writeObject(RESPONSE_FIELDS[2], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+                Homeworld.toResponse(writer, value.homeworld)
+              }
             }
           }
 
-          object PersonNode :
-              ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode> {
+          object Homeworld :
+              ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld>
+              {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, true, null),
-              ResponseField.forObject("homeworld", "homeworld", null, true, null)
+              ResponseField.forString("__typename", "__typename", null, false, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var homeworld: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> homeworld = readObject<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld>(RESPONSE_FIELDS[2]) { reader ->
-                      Homeworld.fromResponse(reader)
-                    }
-                    else -> break
-                  }
-                }
-                StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode(
-                  __typename = __typename!!,
-                  name = name,
-                  homeworld = homeworld
-                )
+                StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld {
+              val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+              return when(typename) {
+                "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
+                else -> OtherHomeworld.fromResponse(reader, typename)
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              if(value.homeworld == null) {
-                writer.writeObject(RESPONSE_FIELDS[2], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-                  Homeworld.toResponse(writer, value.homeworld)
-                }
+                value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld) {
+              when(value) {
+                is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
+                is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
               }
             }
 
-            object Homeworld :
-                ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld>
+            object PlanetHomeworld :
+                ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld>
+                {
+              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                ResponseField.forString("__typename", "__typename", null, false, null),
+                ResponseField.forString("name", "name", null, true, null)
+              )
+
+              override fun fromResponse(reader: ResponseReader, __typename: String?):
+                  StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld {
+                return reader.run {
+                  var __typename: String? = __typename
+                  var name: String? = null
+                  while(true) {
+                    when (selectField(RESPONSE_FIELDS)) {
+                      0 -> __typename = readString(RESPONSE_FIELDS[0])
+                      1 -> name = readString(RESPONSE_FIELDS[1])
+                      else -> break
+                    }
+                  }
+                  StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld(
+                    __typename = __typename!!,
+                    name = name
+                  )
+                }
+              }
+
+              override fun toResponse(writer: ResponseWriter,
+                  value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld) {
+                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                writer.writeString(RESPONSE_FIELDS[1], value.name)
+              }
+            }
+
+            object OtherHomeworld :
+                ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld>
                 {
               private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
                 ResponseField.forString("__typename", "__typename", null, false, null)
               )
 
               override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld {
-                val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-                return when(typename) {
-                  "Planet" -> PlanetHomeworld.fromResponse(reader, typename)
-                  else -> OtherHomeworld.fromResponse(reader, typename)
+                  StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld {
+                return reader.run {
+                  var __typename: String? = __typename
+                  while(true) {
+                    when (selectField(RESPONSE_FIELDS)) {
+                      0 -> __typename = readString(RESPONSE_FIELDS[0])
+                      else -> break
+                    }
+                  }
+                  StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld(
+                    __typename = __typename!!
+                  )
                 }
               }
 
               override fun toResponse(writer: ResponseWriter,
-                  value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld) {
-                when(value) {
-                  is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld -> PlanetHomeworld.toResponse(writer, value)
-                  is StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld -> OtherHomeworld.toResponse(writer, value)
-                }
-              }
-
-              object PlanetHomeworld :
-                  ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld>
-                  {
-                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forString("__typename", "__typename", null, false, null),
-                  ResponseField.forString("name", "name", null, true, null)
-                )
-
-                override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld {
-                  return reader.run {
-                    var __typename: String? = __typename
-                    var name: String? = null
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> __typename = readString(RESPONSE_FIELDS[0])
-                        1 -> name = readString(RESPONSE_FIELDS[1])
-                        else -> break
-                      }
-                    }
-                    StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld(
-                      __typename = __typename!!,
-                      name = name
-                    )
-                  }
-                }
-
-                override fun toResponse(writer: ResponseWriter,
-                    value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.PlanetHomeworld) {
-                  writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                  writer.writeString(RESPONSE_FIELDS[1], value.name)
-                }
-              }
-
-              object OtherHomeworld :
-                  ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld>
-                  {
-                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forString("__typename", "__typename", null, false, null)
-                )
-
-                override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld {
-                  return reader.run {
-                    var __typename: String? = __typename
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> __typename = readString(RESPONSE_FIELDS[0])
-                        else -> break
-                      }
-                    }
-                    StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld(
-                      __typename = __typename!!
-                    )
-                  }
-                }
-
-                override fun toResponse(writer: ResponseWriter,
-                    value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld) {
-                  writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                }
+                  value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.PersonNode.Homeworld.OtherHomeworld) {
+                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
               }
             }
           }
+        }
 
-          object OtherNode :
-              ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
+        object OtherNode :
+            ResponseAdapter<StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null)
+          )
 
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode {
-              return reader.run {
-                var __typename: String? = __typename
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode {
+            return reader.run {
+              var __typename: String? = __typename
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  else -> break
                 }
-                StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode(
-                  __typename = __typename!!
-                )
               }
+              StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode(
+                __typename = __typename!!
+              )
             }
+          }
 
-            override fun toResponse(writer: ResponseWriter,
-                value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            }
+          override fun toResponse(writer: ResponseWriter,
+              value: StarshipFragmentImpl.Data.PilotConnection.Edge.Node.OtherNode) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/adapter/TestQuery_ResponseAdapter.kt
@@ -25,164 +25,150 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var birthDate: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.CharacterHumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            birthDate = birthDate!!
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterHumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var birthDate: Any? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name!!,
-              birthDate = birthDate!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var birthDate: Any? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.CharacterHumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              birthDate = birthDate!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterHumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/CharacterDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/CharacterDetailsImpl_ResponseAdapter.kt
@@ -28,46 +28,29 @@ object CharacterDetailsImpl_ResponseAdapter : ResponseAdapter<CharacterDetailsIm
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
       CharacterDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var birthDate: Any? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+          else -> break
+        }
+      }
+      CharacterDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        birthDate = birthDate!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: CharacterDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<CharacterDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?):
-        CharacterDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var birthDate: Any? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-            else -> break
-          }
-        }
-        CharacterDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          birthDate = birthDate!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: CharacterDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -25,99 +25,85 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Droid" -> CharacterData.fromResponse(reader, typename)
+      "Human" -> CharacterData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is HeroDetailsImpl.Data.CharacterData -> CharacterData.toResponse(writer, value)
+      is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object CharacterData : ResponseAdapter<HeroDetailsImpl.Data.CharacterData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Droid" -> CharacterData.fromResponse(reader, typename)
-        "Human" -> CharacterData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      when(value) {
-        is HeroDetailsImpl.Data.CharacterData -> CharacterData.toResponse(writer, value)
-        is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object CharacterData : ResponseAdapter<HeroDetailsImpl.Data.CharacterData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.CharacterData {
-        return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          var birthDate: Any? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-              else -> break
-            }
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.CharacterData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        var birthDate: Any? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+            else -> break
           }
-          HeroDetailsImpl.Data.CharacterData(
-            __typename = __typename!!,
-            name = name!!,
-            birthDate = birthDate!!
-          )
         }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.CharacterData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
+        HeroDetailsImpl.Data.CharacterData(
+          __typename = __typename!!,
+          name = name!!,
+          birthDate = birthDate!!
+        )
       }
     }
 
-    object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null)
-      )
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.CharacterData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
+    }
+  }
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
+  object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            else -> break
           }
-          HeroDetailsImpl.Data.OtherData(
-            __typename = __typename!!,
-            name = name!!
-          )
         }
+        HeroDetailsImpl.Data.OtherData(
+          __typename = __typename!!,
+          name = name!!
+        )
       }
+    }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -25,98 +25,84 @@ object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Human" -> CharacterData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is HumanDetailsImpl.Data.CharacterData -> CharacterData.toResponse(writer, value)
+      is HumanDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
+  object CharacterData : ResponseAdapter<HumanDetailsImpl.Data.CharacterData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Human" -> CharacterData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      when(value) {
-        is HumanDetailsImpl.Data.CharacterData -> CharacterData.toResponse(writer, value)
-        is HumanDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object CharacterData : ResponseAdapter<HumanDetailsImpl.Data.CharacterData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forCustomScalar("birthDate", "birthDate", null, false, CustomScalars.Date, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HumanDetailsImpl.Data.CharacterData {
-        return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          var birthDate: Any? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-              else -> break
-            }
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HumanDetailsImpl.Data.CharacterData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        var birthDate: Any? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> birthDate = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+            else -> break
           }
-          HumanDetailsImpl.Data.CharacterData(
-            __typename = __typename!!,
-            name = name!!,
-            birthDate = birthDate!!
-          )
         }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data.CharacterData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
+        HumanDetailsImpl.Data.CharacterData(
+          __typename = __typename!!,
+          name = name!!,
+          birthDate = birthDate!!
+        )
       }
     }
 
-    object OtherData : ResponseAdapter<HumanDetailsImpl.Data.OtherData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null)
-      )
+    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data.CharacterData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.birthDate)
+    }
+  }
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HumanDetailsImpl.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
+  object OtherData : ResponseAdapter<HumanDetailsImpl.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HumanDetailsImpl.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            else -> break
           }
-          HumanDetailsImpl.Data.OtherData(
-            __typename = __typename!!,
-            name = name!!
-          )
         }
+        HumanDetailsImpl.Data.OtherData(
+          __typename = __typename!!,
+          name = name!!
+        )
       }
+    }
 
-      override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -26,421 +26,405 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forList("appearsIn", "appearsIn", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterDroidHero.fromResponse(reader, typename)
+        "Human" -> CharacterHumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterDroidHero -> CharacterDroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterDroidHero : ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("appearsIn", "appearsIn", null, false, null),
+        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterDroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          var friendsConnection: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              3 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              4 -> primaryFunction = readString(RESPONSE_FIELDS[4])
+              else -> break
             }
-            else -> break
+          }
+          TestQuery.Data.Hero.CharacterDroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!,
+            friendsConnection = friendsConnection!!,
+            primaryFunction = primaryFunction
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterDroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
+          listItemWriter.writeString(value?.rawValue)}
+        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
+        }
+        writer.writeString(RESPONSE_FIELDS[4], value.primaryFunction)
+      }
+
+      object FriendsConnection :
+          ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forInt("totalCount", "totalCount", null, true, null),
+          ResponseField.forList("edges", "edges", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection {
+          return reader.run {
+            var totalCount: Int? = null
+            var edges: List<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+                1 -> edges = readList<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
+                }
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection(
+              totalCount = totalCount,
+              edges = edges
+            )
           }
         }
-        TestQuery.Data(
-          hero = hero
-        )
-      }
-    }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection) {
+          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
+          }
+        }
+
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge>
+            {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forObject("node", "node", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge {
+            return reader.run {
+              var node: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> node = readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge(
+                node = node
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
+              }
+            }
+          }
+
+          object Node :
+              ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node> {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("name", "name", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node {
+              return reader.run {
+                var name: String? = null
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> name = readString(RESPONSE_FIELDS[0])
+                    else -> break
+                  }
+                }
+                TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node(
+                  name = name!!
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
+            }
+          }
         }
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("appearsIn", "appearsIn", null, false, null),
+        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          var friendsConnection: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
+              }
+              3 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.CharacterHumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterHumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
+          listItemWriter.writeString(value?.rawValue)}
+        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
+        }
+      }
+
+      object FriendsConnection :
+          ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forInt("totalCount", "totalCount", null, true, null),
+          ResponseField.forList("edges", "edges", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection {
+          return reader.run {
+            var totalCount: Int? = null
+            var edges: List<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+                1 -> edges = readList<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
+                }
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection(
+              totalCount = totalCount,
+              edges = edges
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection) {
+          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
+          }
+        }
+
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge>
+            {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forObject("node", "node", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge {
+            return reader.run {
+              var node: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> node = readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge(
+                node = node
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
+              }
+            }
+          }
+
+          object Node :
+              ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node> {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("name", "name", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node {
+              return reader.run {
+                var name: String? = null
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> name = readString(RESPONSE_FIELDS[0])
+                    else -> break
+                  }
+                }
+                TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node(
+                  name = name!!
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
+            }
+          }
+        }
+      }
+    }
+
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null),
         ResponseField.forList("appearsIn", "appearsIn", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterDroidHero.fromResponse(reader, typename)
-          "Human" -> CharacterHumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterDroidHero -> CharacterDroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterDroidHero : ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("appearsIn", "appearsIn", null, false, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterDroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var appearsIn: List<Episode?>? = null
-            var friendsConnection: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-                  Episode.safeValueOf(reader.readString())
-                }
-                3 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
-                  FriendsConnection.fromResponse(reader)
-                }
-                4 -> primaryFunction = readString(RESPONSE_FIELDS[4])
-                else -> break
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var appearsIn: List<Episode?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                Episode.safeValueOf(reader.readString())
               }
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterDroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              appearsIn = appearsIn!!,
-              friendsConnection = friendsConnection!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterDroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
-            listItemWriter.writeString(value?.rawValue)}
-          writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-          writer.writeString(RESPONSE_FIELDS[4], value.primaryFunction)
-        }
-
-        object FriendsConnection :
-            ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forInt("totalCount", "totalCount", null, true, null),
-            ResponseField.forList("edges", "edges", null, true, null)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name!!,
+            appearsIn = appearsIn!!
           )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection {
-            return reader.run {
-              var totalCount: Int? = null
-              var edges: List<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                  1 -> edges = readList<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection(
-                totalCount = totalCount,
-                edges = edges
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection) {
-            writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-            writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
-              }
-            }
-          }
-
-          object Edge :
-              ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge {
-              return reader.run {
-                var node: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge(
-                  node = node
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node :
-                ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.CharacterDroidHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
-            }
-          }
         }
       }
 
-      object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("appearsIn", "appearsIn", null, false, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var appearsIn: List<Episode?>? = null
-            var friendsConnection: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-                  Episode.safeValueOf(reader.readString())
-                }
-                3 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
-                  FriendsConnection.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.CharacterHumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              appearsIn = appearsIn!!,
-              friendsConnection = friendsConnection!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterHumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
-            listItemWriter.writeString(value?.rawValue)}
-          writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-        }
-
-        object FriendsConnection :
-            ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forInt("totalCount", "totalCount", null, true, null),
-            ResponseField.forList("edges", "edges", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection {
-            return reader.run {
-              var totalCount: Int? = null
-              var edges: List<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                  1 -> edges = readList<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection(
-                totalCount = totalCount,
-                edges = edges
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection) {
-            writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-            writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
-              }
-            }
-          }
-
-          object Edge :
-              ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge {
-              return reader.run {
-                var node: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge(
-                  node = node
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node :
-                ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.CharacterHumanHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
-            }
-          }
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("appearsIn", "appearsIn", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var appearsIn: List<Episode?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-                  Episode.safeValueOf(reader.readString())
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name!!,
-              appearsIn = appearsIn!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
-            listItemWriter.writeString(value?.rawValue)}
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
+          listItemWriter.writeString(value?.rawValue)}
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
@@ -25,45 +25,29 @@ object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<DroidDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var primaryFunction: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+          else -> break
+        }
+      }
+      DroidDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        primaryFunction = primaryFunction
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<DroidDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var primaryFunction: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-            else -> break
-          }
-        }
-        DroidDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          primaryFunction = primaryFunction
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -25,464 +25,447 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Droid" -> DroidData.fromResponse(reader, typename)
+      "Human" -> HumanData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is HeroDetailsImpl.Data.DroidData -> DroidData.toResponse(writer, value)
+      is HeroDetailsImpl.Data.HumanData -> HumanData.toResponse(writer, value)
+      is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object DroidData : ResponseAdapter<HeroDetailsImpl.Data.DroidData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
+      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Droid" -> DroidData.fromResponse(reader, typename)
-        "Human" -> HumanData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.DroidData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        var friendsConnection: HeroDetailsImpl.Data.DroidData.FriendsConnection? = null
+        var primaryFunction: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> friendsConnection = readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+              FriendsConnection.fromResponse(reader)
+            }
+            3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
+            else -> break
+          }
+        }
+        HeroDetailsImpl.Data.DroidData(
+          __typename = __typename!!,
+          name = name!!,
+          friendsConnection = friendsConnection!!,
+          primaryFunction = primaryFunction
+        )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      when(value) {
-        is HeroDetailsImpl.Data.DroidData -> DroidData.toResponse(writer, value)
-        is HeroDetailsImpl.Data.HumanData -> HumanData.toResponse(writer, value)
-        is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.DroidData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
       }
+      writer.writeString(RESPONSE_FIELDS[3], value.primaryFunction)
     }
 
-    object DroidData : ResponseAdapter<HeroDetailsImpl.Data.DroidData> {
+    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
-        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.DroidData {
+          HeroDetailsImpl.Data.DroidData.FriendsConnection {
         return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          var friendsConnection: HeroDetailsImpl.Data.DroidData.FriendsConnection? = null
-          var primaryFunction: String? = null
+          var totalCount: Int? = null
+          var edges: List<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> friendsConnection = readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
-              3 -> primaryFunction = readString(RESPONSE_FIELDS[3])
               else -> break
             }
           }
-          HeroDetailsImpl.Data.DroidData(
-            __typename = __typename!!,
-            name = name!!,
-            friendsConnection = friendsConnection!!,
-            primaryFunction = primaryFunction
+          HeroDetailsImpl.Data.DroidData.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.DroidData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.DroidData.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
-        writer.writeString(RESPONSE_FIELDS[3], value.primaryFunction)
       }
 
-      object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection> {
+      object Edge : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.DroidData.FriendsConnection {
+            HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge?>? = null
+            var node: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.DroidData.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.DroidData.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge {
+              HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge(
-                node = node
+              HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: HeroDetailsImpl.Data.DroidData.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }
     }
+  }
 
-    object HumanData : ResponseAdapter<HeroDetailsImpl.Data.HumanData> {
+  object HumanData : ResponseAdapter<HeroDetailsImpl.Data.HumanData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.HumanData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        var friendsConnection: HeroDetailsImpl.Data.HumanData.FriendsConnection? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> friendsConnection = readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+              FriendsConnection.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        HeroDetailsImpl.Data.HumanData(
+          __typename = __typename!!,
+          name = name!!,
+          friendsConnection = friendsConnection!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.HumanData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
+      }
+    }
+
+    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.HumanData {
+          HeroDetailsImpl.Data.HumanData.FriendsConnection {
         return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          var friendsConnection: HeroDetailsImpl.Data.HumanData.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> friendsConnection = readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          HeroDetailsImpl.Data.HumanData(
-            __typename = __typename!!,
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          HeroDetailsImpl.Data.HumanData.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.HumanData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.HumanData.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection> {
+      object Edge : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.HumanData.FriendsConnection {
+            HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge?>? = null
+            var node: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.HumanData.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.HumanData.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge {
+              HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge(
-                node = node
+              HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: HeroDetailsImpl.Data.HumanData.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }
     }
+  }
 
-    object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
+  object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        var friendsConnection: HeroDetailsImpl.Data.OtherData.FriendsConnection? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> friendsConnection = readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+              FriendsConnection.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        HeroDetailsImpl.Data.OtherData(
+          __typename = __typename!!,
+          name = name!!,
+          friendsConnection = friendsConnection!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
+      }
+    }
+
+    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.OtherData {
+          HeroDetailsImpl.Data.OtherData.FriendsConnection {
         return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          var friendsConnection: HeroDetailsImpl.Data.OtherData.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> friendsConnection = readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          HeroDetailsImpl.Data.OtherData(
-            __typename = __typename!!,
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          HeroDetailsImpl.Data.OtherData.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.OtherData.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection> {
+      object Edge : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.OtherData.FriendsConnection {
+            HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge?>? = null
+            var node: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.OtherData.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.OtherData.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge {
+              HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge(
-                node = node
+              HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: HeroDetailsImpl.Data.OtherData.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      HumanDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        HumanDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/adapter/TestQuery_ResponseAdapter.kt
@@ -23,125 +23,111 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/fragment/adapter/DroidDetails1Impl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/fragment/adapter/DroidDetails1Impl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object DroidDetails1Impl_ResponseAdapter : ResponseAdapter<DroidDetails1Impl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails1Impl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      DroidDetails1Impl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidDetails1Impl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<DroidDetails1Impl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails1Impl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        DroidDetails1Impl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: DroidDetails1Impl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/fragment/adapter/DroidDetails2Impl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/fragment/adapter/DroidDetails2Impl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object DroidDetails2Impl_ResponseAdapter : ResponseAdapter<DroidDetails2Impl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails2Impl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var primaryFunction: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> primaryFunction = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      DroidDetails2Impl.Data(
+        __typename = __typename!!,
+        primaryFunction = primaryFunction
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidDetails2Impl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<DroidDetails2Impl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetails2Impl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var primaryFunction: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> primaryFunction = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        DroidDetails2Impl.Data(
-          __typename = __typename!!,
-          primaryFunction = primaryFunction
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: DroidDetails2Impl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.primaryFunction)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.primaryFunction)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/adapter/TestQuery_ResponseAdapter.kt
@@ -25,297 +25,282 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var r2: TestQuery.Data.R2? = null
+      var luke: TestQuery.Data.Luke? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
+            R2.fromResponse(reader)
+          }
+          1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
+            Luke.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        r2 = r2,
+        luke = luke
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.r2 == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        R2.toResponse(writer, value.r2)
+      }
+    }
+    if(value.luke == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Luke.toResponse(writer, value.luke)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object R2 : ResponseAdapter<TestQuery.Data.R2> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("r2", "hero", null, true, null),
-      ResponseField.forObject("luke", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var r2: TestQuery.Data.R2? = null
-        var luke: TestQuery.Data.Luke? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
-              R2.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanR2.fromResponse(reader, typename)
+        "Droid" -> DroidR2.fromResponse(reader, typename)
+        else -> OtherR2.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
+      when(value) {
+        is TestQuery.Data.R2.HumanR2 -> HumanR2.toResponse(writer, value)
+        is TestQuery.Data.R2.DroidR2 -> DroidR2.toResponse(writer, value)
+        is TestQuery.Data.R2.OtherR2 -> OtherR2.toResponse(writer, value)
+      }
+    }
+
+    object HumanR2 : ResponseAdapter<TestQuery.Data.R2.HumanR2> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.R2.HumanR2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
             }
-            1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
-              Luke.fromResponse(reader)
-            }
-            else -> break
           }
+          TestQuery.Data.R2.HumanR2(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
         }
-        TestQuery.Data(
-          r2 = r2,
-          luke = luke
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.HumanR2) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.r2 == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          R2.toResponse(writer, value.r2)
+    object DroidR2 : ResponseAdapter<TestQuery.Data.R2.DroidR2> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.R2.DroidR2 {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.R2.DroidR2(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
       }
-      if(value.luke == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Luke.toResponse(writer, value.luke)
-        }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.DroidR2) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
       }
     }
 
-    object R2 : ResponseAdapter<TestQuery.Data.R2> {
+    object OtherR2 : ResponseAdapter<TestQuery.Data.R2.OtherR2> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanR2.fromResponse(reader, typename)
-          "Droid" -> DroidR2.fromResponse(reader, typename)
-          else -> OtherR2.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
-        when(value) {
-          is TestQuery.Data.R2.HumanR2 -> HumanR2.toResponse(writer, value)
-          is TestQuery.Data.R2.DroidR2 -> DroidR2.toResponse(writer, value)
-          is TestQuery.Data.R2.OtherR2 -> OtherR2.toResponse(writer, value)
-        }
-      }
-
-      object HumanR2 : ResponseAdapter<TestQuery.Data.R2.HumanR2> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.R2.HumanR2 {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.R2.OtherR2 {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.R2.HumanR2(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.HumanR2) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          TestQuery.Data.R2.OtherR2(
+            __typename = __typename!!
+          )
         }
       }
 
-      object DroidR2 : ResponseAdapter<TestQuery.Data.R2.DroidR2> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.R2.DroidR2 {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.R2.DroidR2(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.DroidR2) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.OtherR2) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
+    }
+  }
 
-      object OtherR2 : ResponseAdapter<TestQuery.Data.R2.OtherR2> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+  object Luke : ResponseAdapter<TestQuery.Data.Luke> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.R2.OtherR2 {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.R2.OtherR2(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.OtherR2) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanLuke.fromResponse(reader, typename)
+        "Droid" -> DroidLuke.fromResponse(reader, typename)
+        else -> OtherLuke.fromResponse(reader, typename)
       }
     }
 
-    object Luke : ResponseAdapter<TestQuery.Data.Luke> {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
+      when(value) {
+        is TestQuery.Data.Luke.HumanLuke -> HumanLuke.toResponse(writer, value)
+        is TestQuery.Data.Luke.DroidLuke -> DroidLuke.toResponse(writer, value)
+        is TestQuery.Data.Luke.OtherLuke -> OtherLuke.toResponse(writer, value)
+      }
+    }
+
+    object HumanLuke : ResponseAdapter<TestQuery.Data.Luke.HumanLuke> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Luke.HumanLuke {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Luke.HumanLuke(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.HumanLuke) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+      }
+    }
+
+    object DroidLuke : ResponseAdapter<TestQuery.Data.Luke.DroidLuke> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Luke.DroidLuke {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Luke.DroidLuke(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.DroidLuke) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+      }
+    }
+
+    object OtherLuke : ResponseAdapter<TestQuery.Data.Luke.OtherLuke> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanLuke.fromResponse(reader, typename)
-          "Droid" -> DroidLuke.fromResponse(reader, typename)
-          else -> OtherLuke.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
-        when(value) {
-          is TestQuery.Data.Luke.HumanLuke -> HumanLuke.toResponse(writer, value)
-          is TestQuery.Data.Luke.DroidLuke -> DroidLuke.toResponse(writer, value)
-          is TestQuery.Data.Luke.OtherLuke -> OtherLuke.toResponse(writer, value)
-        }
-      }
-
-      object HumanLuke : ResponseAdapter<TestQuery.Data.Luke.HumanLuke> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Luke.HumanLuke {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Luke.OtherLuke {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Luke.HumanLuke(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.HumanLuke) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          TestQuery.Data.Luke.OtherLuke(
+            __typename = __typename!!
+          )
         }
       }
 
-      object DroidLuke : ResponseAdapter<TestQuery.Data.Luke.DroidLuke> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Luke.DroidLuke {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.Luke.DroidLuke(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.DroidLuke) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-        }
-      }
-
-      object OtherLuke : ResponseAdapter<TestQuery.Data.Luke.OtherLuke> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Luke.OtherLuke {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Luke.OtherLuke(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.OtherLuke) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke.OtherLuke) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
@@ -25,45 +25,29 @@ object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<DroidDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var primaryFunction: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+          else -> break
+        }
+      }
+      DroidDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        primaryFunction = primaryFunction
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<DroidDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var primaryFunction: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-            else -> break
-          }
-        }
-        DroidDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          primaryFunction = primaryFunction
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -26,45 +26,29 @@ object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var height: Double? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> height = readDouble(RESPONSE_FIELDS[2])
+          else -> break
+        }
+      }
+      HumanDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        height = height
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forDouble("height", "height", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var height: Double? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> height = readDouble(RESPONSE_FIELDS[2])
-            else -> break
-          }
-        }
-        HumanDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          height = height
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeDouble(RESPONSE_FIELDS[2], value.height)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details/adapter/HeroDetails_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details/adapter/HeroDetails_ResponseAdapter.kt
@@ -26,182 +26,167 @@ object HeroDetails_ResponseAdapter : ResponseAdapter<HeroDetails.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: HeroDetails.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<HeroDetails.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HeroDetails.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetails.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetails.Data> {
+  object Hero : ResponseAdapter<HeroDetails.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forEnum("type", "type", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetails.Data.Hero {
       return reader.run {
-        var hero: HeroDetails.Data.Hero? = null
+        var type: Hero_type? = null
+        var name: String? = null
+        var friendsConnection: HeroDetails.Data.Hero.FriendsConnection? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<HeroDetails.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+            0 -> type = readString(RESPONSE_FIELDS[0])?.let { Hero_type.safeValueOf(it) }
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> friendsConnection = readObject<HeroDetails.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+              FriendsConnection.fromResponse(reader)
             }
             else -> break
           }
         }
-        HeroDetails.Data(
-          hero = hero
+        HeroDetails.Data.Hero(
+          type = type!!,
+          name = name!!,
+          friendsConnection = friendsConnection!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetails.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: HeroDetails.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.type.rawValue)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
       }
     }
 
-    object Hero : ResponseAdapter<HeroDetails.Data.Hero> {
+    object FriendsConnection : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forEnum("type", "type", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetails.Data.Hero {
+          HeroDetails.Data.Hero.FriendsConnection {
         return reader.run {
-          var type: Hero_type? = null
-          var name: String? = null
-          var friendsConnection: HeroDetails.Data.Hero.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<HeroDetails.Data.Hero.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> type = readString(RESPONSE_FIELDS[0])?.let { Hero_type.safeValueOf(it) }
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> friendsConnection = readObject<HeroDetails.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<HeroDetails.Data.Hero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<HeroDetails.Data.Hero.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          HeroDetails.Data.Hero(
-            type = type!!,
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          HeroDetails.Data.Hero.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetails.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.type.rawValue)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetails.Data.Hero.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection> {
+      object Edge : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetails.Data.Hero.FriendsConnection {
+            HeroDetails.Data.Hero.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<HeroDetails.Data.Hero.FriendsConnection.Edge?>? = null
+            var node: HeroDetails.Data.Hero.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<HeroDetails.Data.Hero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<HeroDetails.Data.Hero.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<HeroDetails.Data.Hero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            HeroDetails.Data.Hero.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            HeroDetails.Data.Hero.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetails.Data.Hero.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: HeroDetails.Data.Hero.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetails.Data.Hero.FriendsConnection.Edge {
+              HeroDetails.Data.Hero.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: HeroDetails.Data.Hero.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<HeroDetails.Data.Hero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              HeroDetails.Data.Hero.FriendsConnection.Edge(
-                node = node
+              HeroDetails.Data.Hero.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: HeroDetails.Data.Hero.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<HeroDetails.Data.Hero.FriendsConnection.Edge.Node> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                HeroDetails.Data.Hero.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                HeroDetails.Data.Hero.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: HeroDetails.Data.Hero.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: HeroDetails.Data.Hero.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/adapter/HeroDetailsQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/adapter/HeroDetailsQuery_ResponseAdapter.kt
@@ -25,177 +25,163 @@ object HeroDetailsQuery_ResponseAdapter : ResponseAdapter<HeroDetailsQuery.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: HeroDetailsQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<HeroDetailsQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HeroDetailsQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsQuery.Data> {
+  object Hero : ResponseAdapter<HeroDetailsQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsQuery.Data.Hero {
       return reader.run {
-        var hero: HeroDetailsQuery.Data.Hero? = null
+        var name: String? = null
+        var friendsConnection: HeroDetailsQuery.Data.Hero.FriendsConnection? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<HeroDetailsQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> friendsConnection = readObject<HeroDetailsQuery.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
+              FriendsConnection.fromResponse(reader)
             }
             else -> break
           }
         }
-        HeroDetailsQuery.Data(
-          hero = hero
+        HeroDetailsQuery.Data.Hero(
+          name = name!!,
+          friendsConnection = friendsConnection!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
       }
     }
 
-    object Hero : ResponseAdapter<HeroDetailsQuery.Data.Hero> {
+    object FriendsConnection : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsQuery.Data.Hero {
+          HeroDetailsQuery.Data.Hero.FriendsConnection {
         return reader.run {
-          var name: String? = null
-          var friendsConnection: HeroDetailsQuery.Data.Hero.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> friendsConnection = readObject<HeroDetailsQuery.Data.Hero.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          HeroDetailsQuery.Data.Hero(
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          HeroDetailsQuery.Data.Hero.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsQuery.Data.Hero.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection> {
+      object Edge : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsQuery.Data.Hero.FriendsConnection {
+            HeroDetailsQuery.Data.Hero.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge?>? = null
+            var node: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            HeroDetailsQuery.Data.Hero.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            HeroDetailsQuery.Data.Hero.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsQuery.Data.Hero.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsQuery.Data.Hero.FriendsConnection.Edge {
+              HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              HeroDetailsQuery.Data.Hero.FriendsConnection.Edge(
-                node = node
+              HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: HeroDetailsQuery.Data.Hero.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name/adapter/TestQuery_ResponseAdapter.kt
@@ -23,73 +23,59 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forString("id", "id", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
+        var id: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> id = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name!!,
+          id = id!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forString("id", "id", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          var id: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> id = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            name = name!!,
-            id = id!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeString(RESPONSE_FIELDS[1], value.id)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeString(RESPONSE_FIELDS[1], value.id)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/adapter/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/adapter/TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName_ResponseAdapter.kt
@@ -32,81 +32,59 @@ object
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
       TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var heroAVeryAVeryAVeryAVeryAVeryAVeryAV: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> heroAVeryAVeryAVeryAVeryAVeryAVeryAV = readObject<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>(RESPONSE_FIELDS[0]) { reader ->
+            HeroAVeryAVeryAVeryAVeryAVeryAVeryAV.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data(
+        heroAVeryAVeryAVeryAVeryAVeryAVeryAV = heroAVeryAVeryAVeryAVeryAVeryAVeryAV
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter,
       value: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data) {
-    Data.toResponse(writer, value)
+    if(value.heroAVeryAVeryAVeryAVeryAVeryAVeryAV == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        HeroAVeryAVeryAVeryAVeryAVeryAVeryAV.toResponse(writer, value.heroAVeryAVeryAVeryAVeryAVeryAVeryAV)
+      }
+    }
   }
 
-  object Data :
-      ResponseAdapter<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data>
+  object HeroAVeryAVeryAVeryAVeryAVeryAVeryAV :
+      ResponseAdapter<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>
       {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("heroAVeryAVeryAVeryAVeryAVeryAVeryAV", "hero", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to
-              "episodeAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName")), true, null)
+      ResponseField.forString("nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName", "name", null, false, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data {
+        TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV {
       return reader.run {
-        var heroAVeryAVeryAVeryAVeryAVeryAVeryAV: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV? = null
+        var nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> heroAVeryAVeryAVeryAVeryAVeryAVeryAV = readObject<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>(RESPONSE_FIELDS[0]) { reader ->
-              HeroAVeryAVeryAVeryAVeryAVeryAVeryAV.fromResponse(reader)
-            }
+            0 -> nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName = readString(RESPONSE_FIELDS[0])
             else -> break
           }
         }
-        TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data(
-          heroAVeryAVeryAVeryAVeryAVeryAVeryAV = heroAVeryAVeryAVeryAVeryAVeryAVeryAV
+        TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(
+          nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName = nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName!!
         )
       }
     }
 
     override fun toResponse(writer: ResponseWriter,
-        value: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data) {
-      if(value.heroAVeryAVeryAVeryAVeryAVeryAVeryAV == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          HeroAVeryAVeryAVeryAVeryAVeryAVeryAV.toResponse(writer, value.heroAVeryAVeryAVeryAVeryAVeryAVeryAV)
-        }
-      }
-    }
-
-    object HeroAVeryAVeryAVeryAVeryAVeryAVeryAV :
-        ResponseAdapter<TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV>
-        {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV {
-        return reader.run {
-          var nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV(
-            nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName = nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter,
-          value: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV) {
-        writer.writeString(RESPONSE_FIELDS[0], value.nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName)
-      }
+        value: TestQueryWithAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName.Data.HeroAVeryAVeryAVeryAVeryAVeryAVeryAV) {
+      writer.writeString(RESPONSE_FIELDS[0], value.nameAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryAVeryLongName)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/adapter/TestQuery_ResponseAdapter.kt
@@ -40,90 +40,60 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var createReview: TestQuery.Data.CreateReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> createReview = readObject<TestQuery.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+            CreateReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        createReview = createReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.createReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        CreateReview.toResponse(writer, value.createReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object CreateReview : ResponseAdapter<TestQuery.Data.CreateReview> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("createReview", "createReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "ep"),
-        "review" to mapOf<String, Any?>(
-          "stars" to 5,
-          "listOfEnums" to listOf<Any?>(
-            "JEDI",
-            "EMPIRE",
-            "NEWHOPE"),
-          "listOfStringNonOptional" to listOf<Any?>(
-            "1",
-            "2",
-            "3"),
-          "favoriteColor" to mapOf<String, Any?>(
-            "red" to 1,
-            "blue" to 1.0))), true, null)
+      ResponseField.forInt("stars", "stars", null, false, null),
+      ResponseField.forString("commentary", "commentary", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.CreateReview {
       return reader.run {
-        var createReview: TestQuery.Data.CreateReview? = null
+        var stars: Int? = null
+        var commentary: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> createReview = readObject<TestQuery.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-              CreateReview.fromResponse(reader)
-            }
+            0 -> stars = readInt(RESPONSE_FIELDS[0])
+            1 -> commentary = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          createReview = createReview
+        TestQuery.Data.CreateReview(
+          stars = stars!!,
+          commentary = commentary
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.createReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          CreateReview.toResponse(writer, value.createReview)
-        }
-      }
-    }
-
-    object CreateReview : ResponseAdapter<TestQuery.Data.CreateReview> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("stars", "stars", null, false, null),
-        ResponseField.forString("commentary", "commentary", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.CreateReview {
-        return reader.run {
-          var stars: Int? = null
-          var commentary: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> stars = readInt(RESPONSE_FIELDS[0])
-              1 -> commentary = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.CreateReview(
-            stars = stars!!,
-            commentary = commentary
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.CreateReview) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.stars)
-        writer.writeString(RESPONSE_FIELDS[1], value.commentary)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.CreateReview) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.stars)
+      writer.writeString(RESPONSE_FIELDS[1], value.commentary)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/adapter/TestQuery_ResponseAdapter.kt
@@ -25,133 +25,118 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var nonOptionalHero: TestQuery.Data.NonOptionalHero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> nonOptionalHero = readObject<TestQuery.Data.NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
+            NonOptionalHero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        nonOptionalHero = nonOptionalHero!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+      NonOptionalHero.toResponse(writer, value.nonOptionalHero)
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object NonOptionalHero : ResponseAdapter<TestQuery.Data.NonOptionalHero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("nonOptionalHero", "nonOptionalHero", mapOf<String, Any?>(
-        "episode" to "EMPIRE"), false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var nonOptionalHero: TestQuery.Data.NonOptionalHero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> nonOptionalHero = readObject<TestQuery.Data.NonOptionalHero>(RESPONSE_FIELDS[0]) { reader ->
-              NonOptionalHero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.NonOptionalHero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanNonOptionalHero.fromResponse(reader, typename)
+        else -> OtherNonOptionalHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.NonOptionalHero) {
+      when(value) {
+        is TestQuery.Data.NonOptionalHero.HumanNonOptionalHero -> HumanNonOptionalHero.toResponse(writer, value)
+        is TestQuery.Data.NonOptionalHero.OtherNonOptionalHero -> OtherNonOptionalHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanNonOptionalHero :
+        ResponseAdapter<TestQuery.Data.NonOptionalHero.HumanNonOptionalHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.NonOptionalHero.HumanNonOptionalHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.NonOptionalHero.HumanNonOptionalHero(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
         }
-        TestQuery.Data(
-          nonOptionalHero = nonOptionalHero!!
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.NonOptionalHero.HumanNonOptionalHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-        NonOptionalHero.toResponse(writer, value.nonOptionalHero)
-      }
-    }
-
-    object NonOptionalHero : ResponseAdapter<TestQuery.Data.NonOptionalHero> {
+    object OtherNonOptionalHero :
+        ResponseAdapter<TestQuery.Data.NonOptionalHero.OtherNonOptionalHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.NonOptionalHero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanNonOptionalHero.fromResponse(reader, typename)
-          else -> OtherNonOptionalHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.NonOptionalHero) {
-        when(value) {
-          is TestQuery.Data.NonOptionalHero.HumanNonOptionalHero -> HumanNonOptionalHero.toResponse(writer, value)
-          is TestQuery.Data.NonOptionalHero.OtherNonOptionalHero -> OtherNonOptionalHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanNonOptionalHero :
-          ResponseAdapter<TestQuery.Data.NonOptionalHero.HumanNonOptionalHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.NonOptionalHero.HumanNonOptionalHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          TestQuery.Data.NonOptionalHero.OtherNonOptionalHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.NonOptionalHero.HumanNonOptionalHero(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.NonOptionalHero.HumanNonOptionalHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          TestQuery.Data.NonOptionalHero.OtherNonOptionalHero(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
       }
 
-      object OtherNonOptionalHero :
-          ResponseAdapter<TestQuery.Data.NonOptionalHero.OtherNonOptionalHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.NonOptionalHero.OtherNonOptionalHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.NonOptionalHero.OtherNonOptionalHero(
-              __typename = __typename!!,
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.NonOptionalHero.OtherNonOptionalHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.NonOptionalHero.OtherNonOptionalHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -25,167 +25,151 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var search: List<TestQuery.Data.Search?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
+            reader.readObject<TestQuery.Data.Search> { reader ->
+              Search.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        search = search
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Search.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Search : ResponseAdapter<TestQuery.Data.Search> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forList("search", "search", mapOf<String, Any?>(
-        "text" to "bla-bla"), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var search: List<TestQuery.Data.Search?>? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
-              reader.readObject<TestQuery.Data.Search> { reader ->
-                Search.fromResponse(reader)
-              }
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Search {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterDroidSearch.fromResponse(reader, typename)
+        "Human" -> CharacterHumanSearch.fromResponse(reader, typename)
+        else -> OtherSearch.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
+      when(value) {
+        is TestQuery.Data.Search.CharacterDroidSearch -> CharacterDroidSearch.toResponse(writer, value)
+        is TestQuery.Data.Search.CharacterHumanSearch -> CharacterHumanSearch.toResponse(writer, value)
+        is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
+      }
+    }
+
+    object CharacterDroidSearch : ResponseAdapter<TestQuery.Data.Search.CharacterDroidSearch> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Search.CharacterDroidSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Search.CharacterDroidSearch(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
-        TestQuery.Data(
-          search = search
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Search.CharacterDroidSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Search.toResponse(writer, value)
+    object CharacterHumanSearch : ResponseAdapter<TestQuery.Data.Search.CharacterHumanSearch> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("homePlanet", "homePlanet", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Search.CharacterHumanSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Search.CharacterHumanSearch(
+            __typename = __typename!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Search.CharacterHumanSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
       }
     }
 
-    object Search : ResponseAdapter<TestQuery.Data.Search> {
+    object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Search {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterDroidSearch.fromResponse(reader, typename)
-          "Human" -> CharacterHumanSearch.fromResponse(reader, typename)
-          else -> OtherSearch.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
-        when(value) {
-          is TestQuery.Data.Search.CharacterDroidSearch -> CharacterDroidSearch.toResponse(writer, value)
-          is TestQuery.Data.Search.CharacterHumanSearch -> CharacterHumanSearch.toResponse(writer, value)
-          is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
-        }
-      }
-
-      object CharacterDroidSearch : ResponseAdapter<TestQuery.Data.Search.CharacterDroidSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.CharacterDroidSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          TestQuery.Data.Search.OtherSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Search.CharacterDroidSearch(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Search.CharacterDroidSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          TestQuery.Data.Search.OtherSearch(
+            __typename = __typename!!
+          )
         }
       }
 
-      object CharacterHumanSearch : ResponseAdapter<TestQuery.Data.Search.CharacterHumanSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.CharacterHumanSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var homePlanet: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> homePlanet = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.Search.CharacterHumanSearch(
-              __typename = __typename!!,
-              name = name!!,
-              homePlanet = homePlanet
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Search.CharacterHumanSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
-        }
-      }
-
-      object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.OtherSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Search.OtherSearch(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/adapter/TestQuery_ResponseAdapter.kt
@@ -26,346 +26,330 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
+        ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
+          var profileLink: Any? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              3 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField)
+              else -> break
             }
-            else -> break
+          }
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!,
+            profileLink = profileLink!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
+        }
+        writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField, value.profileLink)
+      }
+
+      object FriendsConnection :
+          ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forList("edges", "edges", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection {
+          return reader.run {
+            var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
+                }
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.CharacterHero.FriendsConnection(
+              edges = edges
+            )
           }
         }
-        TestQuery.Data(
-          hero = hero
-        )
-      }
-    }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
+          writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
+          }
+        }
+
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forObject("node", "node", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
+            return reader.run {
+              var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
+                  }
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
+                node = node
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
+              }
+            }
+          }
+
+          object Node :
+              ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("name", "name", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
+              return reader.run {
+                var name: String? = null
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> name = readString(RESPONSE_FIELDS[0])
+                    else -> break
+                  }
+                }
+                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
+                  name = name!!
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
+            }
+          }
         }
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null),
         ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friendsConnection: TestQuery.Data.Hero.OtherHero.FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friendsConnection = readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name!!,
+            friendsConnection = friendsConnection!!
+          )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
         }
       }
 
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
+      object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null),
-          ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null)
+          ResponseField.forList("edges", "edges", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
+            TestQuery.Data.Hero.OtherHero.FriendsConnection {
           return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friendsConnection: TestQuery.Data.Hero.CharacterHero.FriendsConnection? = null
-            var profileLink: Any? = null
+            var edges: List<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge?>? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friendsConnection = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                  FriendsConnection.fromResponse(reader)
+                0 -> edges = readList<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
+                  }
                 }
-                3 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField)
                 else -> break
               }
             }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name!!,
-              friendsConnection = friendsConnection!!,
-              profileLink = profileLink!!
+            TestQuery.Data.Hero.OtherHero.FriendsConnection(
+              edges = edges
             )
           }
         }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.OtherHero.FriendsConnection) {
+          writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Edge.toResponse(writer, value)
+            }
           }
-          writer.writeCustom(RESPONSE_FIELDS[3] as ResponseField.CustomScalarField, value.profileLink)
         }
 
-        object FriendsConnection :
-            ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection> {
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forList("edges", "edges", null, true, null)
+            ResponseField.forObject("node", "node", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection {
+              TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge {
             return reader.run {
-              var edges: List<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge?>? = null
+              var node: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> edges = readList<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
+                  0 -> node = readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
                   }
                   else -> break
                 }
               }
-              TestQuery.Data.Hero.CharacterHero.FriendsConnection(
-                edges = edges
+              TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge(
+                node = node
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterHero.FriendsConnection) {
-            writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
+              value: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
               }
             }
           }
 
-          object Edge : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge> {
+          object Node : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node> {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
+              ResponseField.forString("name", "name", null, false, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge {
+                TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node {
               return reader.run {
-                var node: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node? = null
+                var name: String? = null
                 while(true) {
                   when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
+                    0 -> name = readString(RESPONSE_FIELDS[0])
                     else -> break
                   }
                 }
-                TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge(
-                  node = node
+                TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node(
+                  name = name!!
                 )
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node :
-                ResponseAdapter<TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node> {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.CharacterHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
-            }
-          }
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friendsConnection: TestQuery.Data.Hero.OtherHero.FriendsConnection? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friendsConnection = readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                  FriendsConnection.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name!!,
-              friendsConnection = friendsConnection!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-        }
-
-        object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection>
-            {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forList("edges", "edges", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.OtherHero.FriendsConnection {
-            return reader.run {
-              var edges: List<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> edges = readList<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.OtherHero.FriendsConnection(
-                edges = edges
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.OtherHero.FriendsConnection) {
-            writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
-              }
-            }
-          }
-
-          object Edge : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge {
-              return reader.run {
-                var node: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge(
-                  node = node
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node : ResponseAdapter<TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
+                value: TestQuery.Data.Hero.OtherHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
             }
           }
         }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/adapter/TestQuery_ResponseAdapter.kt
@@ -23,131 +23,117 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var foo: TestQuery.Data.Foo? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> foo = readObject<TestQuery.Data.Foo>(RESPONSE_FIELDS[0]) { reader ->
+            Foo.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        foo = foo
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.foo == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Foo.toResponse(writer, value.foo)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Foo : ResponseAdapter<TestQuery.Data.Foo> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("foo", "foo", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("foo", "foo", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var foo: TestQuery.Data.Foo? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> foo = readObject<TestQuery.Data.Foo>(RESPONSE_FIELDS[0]) { reader ->
-              Foo.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Foo {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "FooBar" -> BarFoo.fromResponse(reader, typename)
+        else -> OtherFoo.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo) {
+      when(value) {
+        is TestQuery.Data.Foo.BarFoo -> BarFoo.toResponse(writer, value)
+        is TestQuery.Data.Foo.OtherFoo -> OtherFoo.toResponse(writer, value)
+      }
+    }
+
+    object BarFoo : ResponseAdapter<TestQuery.Data.Foo.BarFoo> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("foo", "foo", null, false, null),
+        ResponseField.forString("bar", "bar", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Foo.BarFoo {
+        return reader.run {
+          var __typename: String? = __typename
+          var foo: String? = null
+          var bar: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> foo = readString(RESPONSE_FIELDS[1])
+              2 -> bar = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Foo.BarFoo(
+            __typename = __typename!!,
+            foo = foo!!,
+            bar = bar!!
+          )
         }
-        TestQuery.Data(
-          foo = foo
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo.BarFoo) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.foo)
+        writer.writeString(RESPONSE_FIELDS[2], value.bar)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.foo == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Foo.toResponse(writer, value.foo)
-        }
-      }
-    }
-
-    object Foo : ResponseAdapter<TestQuery.Data.Foo> {
+    object OtherFoo : ResponseAdapter<TestQuery.Data.Foo.OtherFoo> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("foo", "foo", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Foo {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "FooBar" -> BarFoo.fromResponse(reader, typename)
-          else -> OtherFoo.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo) {
-        when(value) {
-          is TestQuery.Data.Foo.BarFoo -> BarFoo.toResponse(writer, value)
-          is TestQuery.Data.Foo.OtherFoo -> OtherFoo.toResponse(writer, value)
-        }
-      }
-
-      object BarFoo : ResponseAdapter<TestQuery.Data.Foo.BarFoo> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("foo", "foo", null, false, null),
-          ResponseField.forString("bar", "bar", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Foo.BarFoo {
-          return reader.run {
-            var __typename: String? = __typename
-            var foo: String? = null
-            var bar: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> foo = readString(RESPONSE_FIELDS[1])
-                2 -> bar = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Foo.OtherFoo {
+        return reader.run {
+          var __typename: String? = __typename
+          var foo: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> foo = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Foo.BarFoo(
-              __typename = __typename!!,
-              foo = foo!!,
-              bar = bar!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo.BarFoo) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.foo)
-          writer.writeString(RESPONSE_FIELDS[2], value.bar)
+          TestQuery.Data.Foo.OtherFoo(
+            __typename = __typename!!,
+            foo = foo!!
+          )
         }
       }
 
-      object OtherFoo : ResponseAdapter<TestQuery.Data.Foo.OtherFoo> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("foo", "foo", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Foo.OtherFoo {
-          return reader.run {
-            var __typename: String? = __typename
-            var foo: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> foo = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Foo.OtherFoo(
-              __typename = __typename!!,
-              foo = foo!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo.OtherFoo) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.foo)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Foo.OtherFoo) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.foo)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/adapter/TestQuery_ResponseAdapter.kt
@@ -26,252 +26,238 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHero.fromResponse(reader, typename)
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null),
+        ResponseField.forList("friends", "friends", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          var friends: List<TestQuery.Data.Hero.HumanHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              3 -> friends = readList<TestQuery.Data.Hero.HumanHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.HumanHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
             }
-            else -> break
+          }
+          TestQuery.Data.Hero.HumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            height = height,
+            friends = friends
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+        writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
           }
         }
-        TestQuery.Data(
-          hero = hero
-        )
       }
-    }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forList("appearsIn", "appearsIn", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.HumanHero.Friend {
+          return reader.run {
+            var appearsIn: List<Episode?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[0]) { reader ->
+                  Episode.safeValueOf(reader.readString())
+                }
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.HumanHero.Friend(
+              appearsIn = appearsIn!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.HumanHero.Friend) {
+          writer.writeList(RESPONSE_FIELDS[0], value.appearsIn) { value, listItemWriter ->
+            listItemWriter.writeString(value?.rawValue)}
         }
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
+        ResponseField.forList("friends", "friends", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction,
+            friends = friends
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+        writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
+        }
+      }
+
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("id", "id", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.DroidHero.Friend {
+          return reader.run {
+            var id: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> id = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.DroidHero.Friend(
+              id = id!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.DroidHero.Friend) {
+          writer.writeString(RESPONSE_FIELDS[0], value.id)
+        }
+      }
+    }
+
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHero.fromResponse(reader, typename)
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            var friends: List<TestQuery.Data.Hero.HumanHero.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                3 -> friends = readList<TestQuery.Data.Hero.HumanHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.HumanHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.HumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              height = height,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-          writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
           }
-        }
-
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forList("appearsIn", "appearsIn", null, false, null)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name!!
           )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.HumanHero.Friend {
-            return reader.run {
-              var appearsIn: List<Episode?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[0]) { reader ->
-                    Episode.safeValueOf(reader.readString())
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.HumanHero.Friend(
-                appearsIn = appearsIn!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.HumanHero.Friend) {
-            writer.writeList(RESPONSE_FIELDS[0], value.appearsIn) { value, listItemWriter ->
-              listItemWriter.writeString(value?.rawValue)}
-          }
         }
       }
 
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                3 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-          writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
-          }
-        }
-
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("id", "id", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.DroidHero.Friend {
-            return reader.run {
-              var id: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> id = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.DroidHero.Friend(
-                id = id!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.DroidHero.Friend) {
-            writer.writeString(RESPONSE_FIELDS[0], value.id)
-          }
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/inline_frgament_intersection/adapter/TestOperation_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/inline_frgament_intersection/adapter/TestOperation_ResponseAdapter.kt
@@ -27,397 +27,383 @@ object TestOperation_ResponseAdapter : ResponseAdapter<TestOperation.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestOperation.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var random: TestOperation.Data.Random? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> random = readObject<TestOperation.Data.Random>(RESPONSE_FIELDS[0]) { reader ->
+            Random.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestOperation.Data(
+        random = random!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestOperation.Data) {
-    Data.toResponse(writer, value)
+    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+      Random.toResponse(writer, value.random)
+    }
   }
 
-  object Data : ResponseAdapter<TestOperation.Data> {
+  object Random : ResponseAdapter<TestOperation.Data.Random> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("random", "random", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestOperation.Data {
-      return reader.run {
-        var random: TestOperation.Data.Random? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> random = readObject<TestOperation.Data.Random>(RESPONSE_FIELDS[0]) { reader ->
-              Random.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        TestOperation.Data(
-          random = random!!
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestOperation.Data.Random {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> BeingHumanRandom.fromResponse(reader, typename)
+        "Wookie" -> BeingWookieRandom.fromResponse(reader, typename)
+        else -> OtherRandom.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestOperation.Data) {
-      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-        Random.toResponse(writer, value.random)
+    override fun toResponse(writer: ResponseWriter, value: TestOperation.Data.Random) {
+      when(value) {
+        is TestOperation.Data.Random.BeingHumanRandom -> BeingHumanRandom.toResponse(writer, value)
+        is TestOperation.Data.Random.BeingWookieRandom -> BeingWookieRandom.toResponse(writer, value)
+        is TestOperation.Data.Random.OtherRandom -> OtherRandom.toResponse(writer, value)
       }
     }
 
-    object Random : ResponseAdapter<TestOperation.Data.Random> {
+    object BeingHumanRandom : ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, false, null),
+        ResponseField.forString("profilePictureUrl", "profilePictureUrl", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestOperation.Data.Random {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> BeingHumanRandom.fromResponse(reader, typename)
-          "Wookie" -> BeingWookieRandom.fromResponse(reader, typename)
-          else -> OtherRandom.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestOperation.Data.Random) {
-        when(value) {
-          is TestOperation.Data.Random.BeingHumanRandom -> BeingHumanRandom.toResponse(writer, value)
-          is TestOperation.Data.Random.BeingWookieRandom -> BeingWookieRandom.toResponse(writer, value)
-          is TestOperation.Data.Random.OtherRandom -> OtherRandom.toResponse(writer, value)
-        }
-      }
-
-      object BeingHumanRandom : ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, false, null),
-          ResponseField.forString("profilePictureUrl", "profilePictureUrl", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestOperation.Data.Random.BeingHumanRandom {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<TestOperation.Data.Random.BeingHumanRandom.Friend>? = null
-            var profilePictureUrl: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<TestOperation.Data.Random.BeingHumanRandom.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<TestOperation.Data.Random.BeingHumanRandom.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }?.map { it!! }
-                3 -> profilePictureUrl = readString(RESPONSE_FIELDS[3])
-                else -> break
-              }
-            }
-            TestOperation.Data.Random.BeingHumanRandom(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends!!,
-              profilePictureUrl = profilePictureUrl
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestOperation.Data.Random.BeingHumanRandom) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
+          TestOperation.Data.Random.BeingHumanRandom {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<TestOperation.Data.Random.BeingHumanRandom.Friend>? = null
+          var profilePictureUrl: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<TestOperation.Data.Random.BeingHumanRandom.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<TestOperation.Data.Random.BeingHumanRandom.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }?.map { it!! }
+              3 -> profilePictureUrl = readString(RESPONSE_FIELDS[3])
+              else -> break
             }
           }
-          writer.writeString(RESPONSE_FIELDS[3], value.profilePictureUrl)
-        }
-
-        object Friend : ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+          TestOperation.Data.Random.BeingHumanRandom(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends!!,
+            profilePictureUrl = profilePictureUrl
           )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestOperation.Data.Random.BeingHumanRandom.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Wookie" -> WookieFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestOperation.Data.Random.BeingHumanRandom.Friend) {
-            when(value) {
-              is TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend -> WookieFriend.toResponse(writer, value)
-              is TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-            }
-          }
-
-          object WookieFriend :
-              ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forBoolean("isFamous", "isFamous", null, true, null),
-              ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null),
-              ResponseField.forEnum("race", "race", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var isFamous: Boolean? = null
-                var lifeExpectancy: Double? = null
-                var race: Race? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> isFamous = readBoolean(RESPONSE_FIELDS[2])
-                    3 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[3])
-                    4 -> race = readString(RESPONSE_FIELDS[4])?.let { Race.safeValueOf(it) }
-                    else -> break
-                  }
-                }
-                TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  isFamous = isFamous,
-                  lifeExpectancy = lifeExpectancy,
-                  race = race!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeBoolean(RESPONSE_FIELDS[2], value.isFamous)
-              writer.writeDouble(RESPONSE_FIELDS[3], value.lifeExpectancy)
-              writer.writeString(RESPONSE_FIELDS[4], value.race.rawValue)
-            }
-          }
-
-          object OtherFriend :
-              ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forBoolean("isFamous", "isFamous", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var isFamous: Boolean? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> isFamous = readBoolean(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  isFamous = isFamous
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeBoolean(RESPONSE_FIELDS[2], value.isFamous)
-            }
-          }
         }
       }
 
-      object BeingWookieRandom : ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, false, null),
-          ResponseField.forEnum("race", "race", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestOperation.Data.Random.BeingWookieRandom {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<TestOperation.Data.Random.BeingWookieRandom.Friend>? = null
-            var race: Race? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<TestOperation.Data.Random.BeingWookieRandom.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<TestOperation.Data.Random.BeingWookieRandom.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }?.map { it!! }
-                3 -> race = readString(RESPONSE_FIELDS[3])?.let { Race.safeValueOf(it) }
-                else -> break
-              }
-            }
-            TestOperation.Data.Random.BeingWookieRandom(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends!!,
-              race = race!!
-            )
+      override fun toResponse(writer: ResponseWriter,
+          value: TestOperation.Data.Random.BeingHumanRandom) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
           }
         }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestOperation.Data.Random.BeingWookieRandom) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
-          }
-          writer.writeString(RESPONSE_FIELDS[3], value.race.rawValue)
-        }
-
-        object Friend : ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestOperation.Data.Random.BeingWookieRandom.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Wookie" -> WookieFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestOperation.Data.Random.BeingWookieRandom.Friend) {
-            when(value) {
-              is TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend -> WookieFriend.toResponse(writer, value)
-              is TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-            }
-          }
-
-          object WookieFriend :
-              ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var lifeExpectancy: Double? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  lifeExpectancy = lifeExpectancy
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeDouble(RESPONSE_FIELDS[2], value.lifeExpectancy)
-            }
-          }
-
-          object OtherFriend :
-              ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var lifeExpectancy: Double? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  lifeExpectancy = lifeExpectancy
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeDouble(RESPONSE_FIELDS[2], value.lifeExpectancy)
-            }
-          }
-        }
+        writer.writeString(RESPONSE_FIELDS[3], value.profilePictureUrl)
       }
 
-      object OtherRandom : ResponseAdapter<TestOperation.Data.Random.OtherRandom> {
+      object Friend : ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
           ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestOperation.Data.Random.OtherRandom {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestOperation.Data.Random.OtherRandom(
-              __typename = __typename!!
-            )
+            TestOperation.Data.Random.BeingHumanRandom.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Wookie" -> WookieFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: TestOperation.Data.Random.OtherRandom) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            value: TestOperation.Data.Random.BeingHumanRandom.Friend) {
+          when(value) {
+            is TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend -> WookieFriend.toResponse(writer, value)
+            is TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+          }
         }
+
+        object WookieFriend :
+            ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forBoolean("isFamous", "isFamous", null, true, null),
+            ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null),
+            ResponseField.forEnum("race", "race", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var isFamous: Boolean? = null
+              var lifeExpectancy: Double? = null
+              var race: Race? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> isFamous = readBoolean(RESPONSE_FIELDS[2])
+                  3 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[3])
+                  4 -> race = readString(RESPONSE_FIELDS[4])?.let { Race.safeValueOf(it) }
+                  else -> break
+                }
+              }
+              TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend(
+                __typename = __typename!!,
+                name = name!!,
+                isFamous = isFamous,
+                lifeExpectancy = lifeExpectancy,
+                race = race!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestOperation.Data.Random.BeingHumanRandom.Friend.WookieFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeBoolean(RESPONSE_FIELDS[2], value.isFamous)
+            writer.writeDouble(RESPONSE_FIELDS[3], value.lifeExpectancy)
+            writer.writeString(RESPONSE_FIELDS[4], value.race.rawValue)
+          }
+        }
+
+        object OtherFriend :
+            ResponseAdapter<TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forBoolean("isFamous", "isFamous", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var isFamous: Boolean? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> isFamous = readBoolean(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend(
+                __typename = __typename!!,
+                name = name!!,
+                isFamous = isFamous
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestOperation.Data.Random.BeingHumanRandom.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeBoolean(RESPONSE_FIELDS[2], value.isFamous)
+          }
+        }
+      }
+    }
+
+    object BeingWookieRandom : ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, false, null),
+        ResponseField.forEnum("race", "race", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestOperation.Data.Random.BeingWookieRandom {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<TestOperation.Data.Random.BeingWookieRandom.Friend>? = null
+          var race: Race? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<TestOperation.Data.Random.BeingWookieRandom.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<TestOperation.Data.Random.BeingWookieRandom.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }?.map { it!! }
+              3 -> race = readString(RESPONSE_FIELDS[3])?.let { Race.safeValueOf(it) }
+              else -> break
+            }
+          }
+          TestOperation.Data.Random.BeingWookieRandom(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends!!,
+            race = race!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestOperation.Data.Random.BeingWookieRandom) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
+        }
+        writer.writeString(RESPONSE_FIELDS[3], value.race.rawValue)
+      }
+
+      object Friend : ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestOperation.Data.Random.BeingWookieRandom.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Wookie" -> WookieFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestOperation.Data.Random.BeingWookieRandom.Friend) {
+          when(value) {
+            is TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend -> WookieFriend.toResponse(writer, value)
+            is TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+          }
+        }
+
+        object WookieFriend :
+            ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var lifeExpectancy: Double? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend(
+                __typename = __typename!!,
+                name = name!!,
+                lifeExpectancy = lifeExpectancy
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestOperation.Data.Random.BeingWookieRandom.Friend.WookieFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeDouble(RESPONSE_FIELDS[2], value.lifeExpectancy)
+          }
+        }
+
+        object OtherFriend :
+            ResponseAdapter<TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forDouble("lifeExpectancy", "lifeExpectancy", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var lifeExpectancy: Double? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> lifeExpectancy = readDouble(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend(
+                __typename = __typename!!,
+                name = name!!,
+                lifeExpectancy = lifeExpectancy
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestOperation.Data.Random.BeingWookieRandom.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeDouble(RESPONSE_FIELDS[2], value.lifeExpectancy)
+          }
+        }
+      }
+    }
+
+    object OtherRandom : ResponseAdapter<TestOperation.Data.Random.OtherRandom> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestOperation.Data.Random.OtherRandom {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          TestOperation.Data.Random.OtherRandom(
+            __typename = __typename!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestOperation.Data.Random.OtherRandom) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/adapter/TestQuery_ResponseAdapter.kt
@@ -30,80 +30,60 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var createReview: TestQuery.Data.CreateReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> createReview = readObject<TestQuery.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+            CreateReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        createReview = createReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.createReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        CreateReview.toResponse(writer, value.createReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object CreateReview : ResponseAdapter<TestQuery.Data.CreateReview> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("createReview", "createReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "ep"),
-        "review" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "review")), true, null)
+      ResponseField.forInt("stars", "stars", null, false, null),
+      ResponseField.forString("commentary", "commentary", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.CreateReview {
       return reader.run {
-        var createReview: TestQuery.Data.CreateReview? = null
+        var stars: Int? = null
+        var commentary: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> createReview = readObject<TestQuery.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-              CreateReview.fromResponse(reader)
-            }
+            0 -> stars = readInt(RESPONSE_FIELDS[0])
+            1 -> commentary = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          createReview = createReview
+        TestQuery.Data.CreateReview(
+          stars = stars!!,
+          commentary = commentary
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.createReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          CreateReview.toResponse(writer, value.createReview)
-        }
-      }
-    }
-
-    object CreateReview : ResponseAdapter<TestQuery.Data.CreateReview> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("stars", "stars", null, false, null),
-        ResponseField.forString("commentary", "commentary", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.CreateReview {
-        return reader.run {
-          var stars: Int? = null
-          var commentary: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> stars = readInt(RESPONSE_FIELDS[0])
-              1 -> commentary = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.CreateReview(
-            stars = stars!!,
-            commentary = commentary
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.CreateReview) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.stars)
-        writer.writeString(RESPONSE_FIELDS[1], value.commentary)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.CreateReview) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.stars)
+      writer.writeString(RESPONSE_FIELDS[1], value.commentary)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/interface_on_interface/adapter/GetHuman_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/interface_on_interface/adapter/GetHuman_ResponseAdapter.kt
@@ -25,160 +25,145 @@ object GetHuman_ResponseAdapter : ResponseAdapter<GetHuman.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var human: GetHuman.Data.Human? = null
+      var node: GetHuman.Data.Node? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> human = readObject<GetHuman.Data.Human>(RESPONSE_FIELDS[0]) { reader ->
+            Human.fromResponse(reader)
+          }
+          1 -> node = readObject<GetHuman.Data.Node>(RESPONSE_FIELDS[1]) { reader ->
+            Node.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      GetHuman.Data(
+        human = human!!,
+        node = node!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: GetHuman.Data) {
-    Data.toResponse(writer, value)
+    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+      Human.toResponse(writer, value.human)
+    }
+    writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+      Node.toResponse(writer, value.node)
+    }
   }
 
-  object Data : ResponseAdapter<GetHuman.Data> {
+  object Human : ResponseAdapter<GetHuman.Data.Human> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("human", "human", null, false, null),
-      ResponseField.forObject("node", "node", null, false, null)
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forDouble("height", "height", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data.Human {
       return reader.run {
-        var human: GetHuman.Data.Human? = null
-        var node: GetHuman.Data.Node? = null
+        var id: String? = null
+        var name: String? = null
+        var height: Double? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> human = readObject<GetHuman.Data.Human>(RESPONSE_FIELDS[0]) { reader ->
-              Human.fromResponse(reader)
-            }
-            1 -> node = readObject<GetHuman.Data.Node>(RESPONSE_FIELDS[1]) { reader ->
-              Node.fromResponse(reader)
-            }
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> height = readDouble(RESPONSE_FIELDS[2])
             else -> break
           }
         }
-        GetHuman.Data(
-          human = human!!,
-          node = node!!
+        GetHuman.Data.Human(
+          id = id!!,
+          name = name!!,
+          height = height!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: GetHuman.Data) {
-      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-        Human.toResponse(writer, value.human)
-      }
-      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-        Node.toResponse(writer, value.node)
+    override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Human) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+    }
+  }
+
+  object Node : ResponseAdapter<GetHuman.Data.Node> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data.Node {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanNode.fromResponse(reader, typename)
+        else -> OtherNode.fromResponse(reader, typename)
       }
     }
 
-    object Human : ResponseAdapter<GetHuman.Data.Human> {
+    override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node) {
+      when(value) {
+        is GetHuman.Data.Node.HumanNode -> HumanNode.toResponse(writer, value)
+        is GetHuman.Data.Node.OtherNode -> OtherNode.toResponse(writer, value)
+      }
+    }
+
+    object HumanNode : ResponseAdapter<GetHuman.Data.Node.HumanNode> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forDouble("height", "height", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data.Human {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          GetHuman.Data.Node.HumanNode {
         return reader.run {
-          var id: String? = null
-          var name: String? = null
+          var __typename: String? = __typename
           var height: Double? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> height = readDouble(RESPONSE_FIELDS[1])
               else -> break
             }
           }
-          GetHuman.Data.Human(
-            id = id!!,
-            name = name!!,
+          GetHuman.Data.Node.HumanNode(
+            __typename = __typename!!,
             height = height!!
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Human) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+      override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node.HumanNode) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeDouble(RESPONSE_FIELDS[1], value.height)
       }
     }
 
-    object Node : ResponseAdapter<GetHuman.Data.Node> {
+    object OtherNode : ResponseAdapter<GetHuman.Data.Node.OtherNode> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): GetHuman.Data.Node {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanNode.fromResponse(reader, typename)
-          else -> OtherNode.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node) {
-        when(value) {
-          is GetHuman.Data.Node.HumanNode -> HumanNode.toResponse(writer, value)
-          is GetHuman.Data.Node.OtherNode -> OtherNode.toResponse(writer, value)
-        }
-      }
-
-      object HumanNode : ResponseAdapter<GetHuman.Data.Node.HumanNode> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forDouble("height", "height", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            GetHuman.Data.Node.HumanNode {
-          return reader.run {
-            var __typename: String? = __typename
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> height = readDouble(RESPONSE_FIELDS[1])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          GetHuman.Data.Node.OtherNode {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            GetHuman.Data.Node.HumanNode(
-              __typename = __typename!!,
-              height = height!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node.HumanNode) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeDouble(RESPONSE_FIELDS[1], value.height)
+          GetHuman.Data.Node.OtherNode(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherNode : ResponseAdapter<GetHuman.Data.Node.OtherNode> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            GetHuman.Data.Node.OtherNode {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            GetHuman.Data.Node.OtherNode(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node.OtherNode) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: GetHuman.Data.Node.OtherNode) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/introspection_query/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/introspection_query/adapter/TestQuery_ResponseAdapter.kt
@@ -26,153 +26,85 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __schema: TestQuery.Data.__Schema? = null
+      var __type: TestQuery.Data.__Type? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __schema = readObject<TestQuery.Data.__Schema>(RESPONSE_FIELDS[0]) { reader ->
+            __Schema.fromResponse(reader)
+          }
+          1 -> __type = readObject<TestQuery.Data.__Type>(RESPONSE_FIELDS[1]) { reader ->
+            __Type.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        __schema = __schema!!,
+        __type = __type!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+      __Schema.toResponse(writer, value.__schema)
+    }
+    writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+      __Type.toResponse(writer, value.__type)
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object __Schema : ResponseAdapter<TestQuery.Data.__Schema> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("__schema", "__schema", null, false, null),
-      ResponseField.forObject("__type", "__type", mapOf<String, Any?>(
-        "name" to "Vehicle"), false, null)
+      ResponseField.forObject("queryType", "queryType", null, false, null),
+      ResponseField.forList("types", "types", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.__Schema {
       return reader.run {
-        var __schema: TestQuery.Data.__Schema? = null
-        var __type: TestQuery.Data.__Type? = null
+        var queryType: TestQuery.Data.__Schema.QueryType? = null
+        var types: List<TestQuery.Data.__Schema.Type>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __schema = readObject<TestQuery.Data.__Schema>(RESPONSE_FIELDS[0]) { reader ->
-              __Schema.fromResponse(reader)
+            0 -> queryType = readObject<TestQuery.Data.__Schema.QueryType>(RESPONSE_FIELDS[0]) { reader ->
+              QueryType.fromResponse(reader)
             }
-            1 -> __type = readObject<TestQuery.Data.__Type>(RESPONSE_FIELDS[1]) { reader ->
-              __Type.fromResponse(reader)
-            }
+            1 -> types = readList<TestQuery.Data.__Schema.Type>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<TestQuery.Data.__Schema.Type> { reader ->
+                Type.fromResponse(reader)
+              }
+            }?.map { it!! }
             else -> break
           }
         }
-        TestQuery.Data(
-          __schema = __schema!!,
-          __type = __type!!
+        TestQuery.Data.__Schema(
+          queryType = queryType!!,
+          types = types!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema) {
       writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-        __Schema.toResponse(writer, value.__schema)
+        QueryType.toResponse(writer, value.queryType)
       }
-      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-        __Type.toResponse(writer, value.__type)
-      }
-    }
-
-    object __Schema : ResponseAdapter<TestQuery.Data.__Schema> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forObject("queryType", "queryType", null, false, null),
-        ResponseField.forList("types", "types", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.__Schema {
-        return reader.run {
-          var queryType: TestQuery.Data.__Schema.QueryType? = null
-          var types: List<TestQuery.Data.__Schema.Type>? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> queryType = readObject<TestQuery.Data.__Schema.QueryType>(RESPONSE_FIELDS[0]) { reader ->
-                QueryType.fromResponse(reader)
-              }
-              1 -> types = readList<TestQuery.Data.__Schema.Type>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<TestQuery.Data.__Schema.Type> { reader ->
-                  Type.fromResponse(reader)
-                }
-              }?.map { it!! }
-              else -> break
-            }
-          }
-          TestQuery.Data.__Schema(
-            queryType = queryType!!,
-            types = types!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema) {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          QueryType.toResponse(writer, value.queryType)
-        }
-        writer.writeList(RESPONSE_FIELDS[1], value.types) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Type.toResponse(writer, value)
-          }
-        }
-      }
-
-      object QueryType : ResponseAdapter<TestQuery.Data.__Schema.QueryType> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.__Schema.QueryType {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.__Schema.QueryType(
-              name = name
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema.QueryType) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
-        }
-      }
-
-      object Type : ResponseAdapter<TestQuery.Data.__Schema.Type> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.__Schema.Type {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.__Schema.Type(
-              name = name
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema.Type) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeList(RESPONSE_FIELDS[1], value.types) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Type.toResponse(writer, value)
         }
       }
     }
 
-    object __Type : ResponseAdapter<TestQuery.Data.__Type> {
+    object QueryType : ResponseAdapter<TestQuery.Data.__Schema.QueryType> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("name", "name", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.__Type {
+          TestQuery.Data.__Schema.QueryType {
         return reader.run {
           var name: String? = null
           while(true) {
@@ -181,15 +113,66 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
               else -> break
             }
           }
-          TestQuery.Data.__Type(
+          TestQuery.Data.__Schema.QueryType(
             name = name
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Type) {
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema.QueryType) {
         writer.writeString(RESPONSE_FIELDS[0], value.name)
       }
+    }
+
+    object Type : ResponseAdapter<TestQuery.Data.__Schema.Type> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("name", "name", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.__Schema.Type {
+        return reader.run {
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> name = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          TestQuery.Data.__Schema.Type(
+            name = name
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Schema.Type) {
+        writer.writeString(RESPONSE_FIELDS[0], value.name)
+      }
+    }
+  }
+
+  object __Type : ResponseAdapter<TestQuery.Data.__Type> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("name", "name", null, true, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.__Type {
+      return reader.run {
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            else -> break
+          }
+        }
+        TestQuery.Data.__Type(
+          name = name
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.__Type) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/merged_include/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/merged_include/adapter/TestQuery_ResponseAdapter.kt
@@ -23,68 +23,54 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var name: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/adapter/CreateReviewForEpisode_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/adapter/CreateReviewForEpisode_ResponseAdapter.kt
@@ -36,162 +36,141 @@ internal object CreateReviewForEpisode_ResponseAdapter :
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
       CreateReviewForEpisode.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var createReview: CreateReviewForEpisode.Data.CreateReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> createReview = readObject<CreateReviewForEpisode.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+            CreateReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      CreateReviewForEpisode.Data(
+        createReview = createReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: CreateReviewForEpisode.Data) {
-    Data.toResponse(writer, value)
+    if(value.createReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        CreateReview.toResponse(writer, value.createReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<CreateReviewForEpisode.Data> {
+  object CreateReview : ResponseAdapter<CreateReviewForEpisode.Data.CreateReview> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("createReview", "createReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "ep"),
-        "review" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "review")), true, null)
+      ResponseField.forInt("stars", "stars", null, false, null),
+      ResponseField.forString("commentary", "commentary", null, true, null),
+      ResponseField.forList("listOfListOfString", "listOfListOfString", null, true, null),
+      ResponseField.forList("listOfListOfEnum", "listOfListOfEnum", null, true, null),
+      ResponseField.forList("listOfListOfCustom", "listOfListOfCustom", null, true, null),
+      ResponseField.forList("listOfListOfObject", "listOfListOfObject", null, true, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        CreateReviewForEpisode.Data {
+        CreateReviewForEpisode.Data.CreateReview {
       return reader.run {
-        var createReview: CreateReviewForEpisode.Data.CreateReview? = null
+        var stars: Int? = null
+        var commentary: String? = null
+        var listOfListOfString: List<List<String>>? = null
+        var listOfListOfEnum: List<List<Episode>>? = null
+        var listOfListOfCustom: List<List<Date>>? = null
+        var listOfListOfObject: List<List<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject>>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> createReview = readObject<CreateReviewForEpisode.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-              CreateReview.fromResponse(reader)
-            }
+            0 -> stars = readInt(RESPONSE_FIELDS[0])
+            1 -> commentary = readString(RESPONSE_FIELDS[1])
+            2 -> listOfListOfString = readList<List<String>>(RESPONSE_FIELDS[2]) { reader ->
+              reader.readList<String> { reader ->
+                reader.readString()
+              }.map { it!! }
+            }?.map { it!! }
+            3 -> listOfListOfEnum = readList<List<Episode>>(RESPONSE_FIELDS[3]) { reader ->
+              reader.readList<Episode> { reader ->
+                Episode.safeValueOf(reader.readString())
+              }.map { it!! }
+            }?.map { it!! }
+            4 -> listOfListOfCustom = readList<List<Date>>(RESPONSE_FIELDS[4]) { reader ->
+              reader.readList<Date> { reader ->
+                reader.readCustomScalar<Date>(CustomScalars.Date)
+              }.map { it!! }
+            }?.map { it!! }
+            5 -> listOfListOfObject = readList<List<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject>>(RESPONSE_FIELDS[5]) { reader ->
+              reader.readList<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> { reader ->
+                reader.readObject<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> { reader ->
+                  ListOfListOfObject.fromResponse(reader)
+                }
+              }.map { it!! }
+            }?.map { it!! }
             else -> break
           }
         }
-        CreateReviewForEpisode.Data(
-          createReview = createReview
+        CreateReviewForEpisode.Data.CreateReview(
+          stars = stars!!,
+          commentary = commentary,
+          listOfListOfString = listOfListOfString,
+          listOfListOfEnum = listOfListOfEnum,
+          listOfListOfCustom = listOfListOfCustom,
+          listOfListOfObject = listOfListOfObject
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: CreateReviewForEpisode.Data) {
-      if(value.createReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          CreateReview.toResponse(writer, value.createReview)
+    override fun toResponse(writer: ResponseWriter,
+        value: CreateReviewForEpisode.Data.CreateReview) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.stars)
+      writer.writeString(RESPONSE_FIELDS[1], value.commentary)
+      writer.writeList(RESPONSE_FIELDS[2], value.listOfListOfString) { value, listItemWriter ->
+        listItemWriter.writeList(value) { value, listItemWriter ->
+          listItemWriter.writeString(value)}
+      }
+      writer.writeList(RESPONSE_FIELDS[3], value.listOfListOfEnum) { value, listItemWriter ->
+        listItemWriter.writeList(value) { value, listItemWriter ->
+          listItemWriter.writeString(value.rawValue)}
+      }
+      writer.writeList(RESPONSE_FIELDS[4], value.listOfListOfCustom) { value, listItemWriter ->
+        listItemWriter.writeList(value) { value, listItemWriter ->
+          listItemWriter.writeCustom(CustomScalars.Date, value)}
+      }
+      writer.writeList(RESPONSE_FIELDS[5], value.listOfListOfObject) { value, listItemWriter ->
+        listItemWriter.writeList(value) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            ListOfListOfObject.toResponse(writer, value)
+          }
         }
       }
     }
 
-    object CreateReview : ResponseAdapter<CreateReviewForEpisode.Data.CreateReview> {
+    object ListOfListOfObject :
+        ResponseAdapter<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("stars", "stars", null, false, null),
-        ResponseField.forString("commentary", "commentary", null, true, null),
-        ResponseField.forList("listOfListOfString", "listOfListOfString", null, true, null),
-        ResponseField.forList("listOfListOfEnum", "listOfListOfEnum", null, true, null),
-        ResponseField.forList("listOfListOfCustom", "listOfListOfCustom", null, true, null),
-        ResponseField.forList("listOfListOfObject", "listOfListOfObject", null, true, null)
+        ResponseField.forString("name", "name", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          CreateReviewForEpisode.Data.CreateReview {
+          CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject {
         return reader.run {
-          var stars: Int? = null
-          var commentary: String? = null
-          var listOfListOfString: List<List<String>>? = null
-          var listOfListOfEnum: List<List<Episode>>? = null
-          var listOfListOfCustom: List<List<Date>>? = null
-          var listOfListOfObject: List<List<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject>>? = null
+          var name: String? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> stars = readInt(RESPONSE_FIELDS[0])
-              1 -> commentary = readString(RESPONSE_FIELDS[1])
-              2 -> listOfListOfString = readList<List<String>>(RESPONSE_FIELDS[2]) { reader ->
-                reader.readList<String> { reader ->
-                  reader.readString()
-                }.map { it!! }
-              }?.map { it!! }
-              3 -> listOfListOfEnum = readList<List<Episode>>(RESPONSE_FIELDS[3]) { reader ->
-                reader.readList<Episode> { reader ->
-                  Episode.safeValueOf(reader.readString())
-                }.map { it!! }
-              }?.map { it!! }
-              4 -> listOfListOfCustom = readList<List<Date>>(RESPONSE_FIELDS[4]) { reader ->
-                reader.readList<Date> { reader ->
-                  reader.readCustomScalar<Date>(CustomScalars.Date)
-                }.map { it!! }
-              }?.map { it!! }
-              5 -> listOfListOfObject = readList<List<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject>>(RESPONSE_FIELDS[5]) { reader ->
-                reader.readList<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> { reader ->
-                  reader.readObject<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> { reader ->
-                    ListOfListOfObject.fromResponse(reader)
-                  }
-                }.map { it!! }
-              }?.map { it!! }
+              0 -> name = readString(RESPONSE_FIELDS[0])
               else -> break
             }
           }
-          CreateReviewForEpisode.Data.CreateReview(
-            stars = stars!!,
-            commentary = commentary,
-            listOfListOfString = listOfListOfString,
-            listOfListOfEnum = listOfListOfEnum,
-            listOfListOfCustom = listOfListOfCustom,
-            listOfListOfObject = listOfListOfObject
+          CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject(
+            name = name!!
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: CreateReviewForEpisode.Data.CreateReview) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.stars)
-        writer.writeString(RESPONSE_FIELDS[1], value.commentary)
-        writer.writeList(RESPONSE_FIELDS[2], value.listOfListOfString) { value, listItemWriter ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            listItemWriter.writeString(value)}
-        }
-        writer.writeList(RESPONSE_FIELDS[3], value.listOfListOfEnum) { value, listItemWriter ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            listItemWriter.writeString(value.rawValue)}
-        }
-        writer.writeList(RESPONSE_FIELDS[4], value.listOfListOfCustom) { value, listItemWriter ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            listItemWriter.writeCustom(CustomScalars.Date, value)}
-        }
-        writer.writeList(RESPONSE_FIELDS[5], value.listOfListOfObject) { value, listItemWriter ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              ListOfListOfObject.toResponse(writer, value)
-            }
-          }
-        }
-      }
-
-      object ListOfListOfObject :
-          ResponseAdapter<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject(
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
-        }
+          value: CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject) {
+        writer.writeString(RESPONSE_FIELDS[0], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/adapter/CreateReviewForEpisodeMutation_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/adapter/CreateReviewForEpisodeMutation_ResponseAdapter.kt
@@ -32,82 +32,61 @@ object CreateReviewForEpisodeMutation_ResponseAdapter :
 
   override fun fromResponse(reader: ResponseReader, __typename: String?):
       CreateReviewForEpisodeMutation.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var createReview: CreateReviewForEpisodeMutation.Data.CreateReview? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> createReview = readObject<CreateReviewForEpisodeMutation.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
+            CreateReview.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      CreateReviewForEpisodeMutation.Data(
+        createReview = createReview
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: CreateReviewForEpisodeMutation.Data) {
-    Data.toResponse(writer, value)
+    if(value.createReview == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        CreateReview.toResponse(writer, value.createReview)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<CreateReviewForEpisodeMutation.Data> {
+  object CreateReview : ResponseAdapter<CreateReviewForEpisodeMutation.Data.CreateReview> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("createReview", "createReview", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "ep"),
-        "review" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "review")), true, null)
+      ResponseField.forInt("stars", "stars", null, false, null),
+      ResponseField.forString("commentary", "commentary", null, true, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        CreateReviewForEpisodeMutation.Data {
+        CreateReviewForEpisodeMutation.Data.CreateReview {
       return reader.run {
-        var createReview: CreateReviewForEpisodeMutation.Data.CreateReview? = null
+        var stars: Int? = null
+        var commentary: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> createReview = readObject<CreateReviewForEpisodeMutation.Data.CreateReview>(RESPONSE_FIELDS[0]) { reader ->
-              CreateReview.fromResponse(reader)
-            }
+            0 -> stars = readInt(RESPONSE_FIELDS[0])
+            1 -> commentary = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        CreateReviewForEpisodeMutation.Data(
-          createReview = createReview
+        CreateReviewForEpisodeMutation.Data.CreateReview(
+          stars = stars!!,
+          commentary = commentary
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: CreateReviewForEpisodeMutation.Data) {
-      if(value.createReview == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          CreateReview.toResponse(writer, value.createReview)
-        }
-      }
-    }
-
-    object CreateReview : ResponseAdapter<CreateReviewForEpisodeMutation.Data.CreateReview> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("stars", "stars", null, false, null),
-        ResponseField.forString("commentary", "commentary", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          CreateReviewForEpisodeMutation.Data.CreateReview {
-        return reader.run {
-          var stars: Int? = null
-          var commentary: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> stars = readInt(RESPONSE_FIELDS[0])
-              1 -> commentary = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          CreateReviewForEpisodeMutation.Data.CreateReview(
-            stars = stars!!,
-            commentary = commentary
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter,
-          value: CreateReviewForEpisodeMutation.Data.CreateReview) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.stars)
-        writer.writeString(RESPONSE_FIELDS[1], value.commentary)
-      }
+    override fun toResponse(writer: ResponseWriter,
+        value: CreateReviewForEpisodeMutation.Data.CreateReview) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.stars)
+      writer.writeString(RESPONSE_FIELDS[1], value.commentary)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/adapter/TestQuery_ResponseAdapter.kt
@@ -26,311 +26,295 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        TestQuery.Data(
-          hero = hero
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        "Human" -> HumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
+        ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          "Human" -> HumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction,
+            friends = friends
+          )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+        writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
         }
       }
 
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
-          ResponseField.forList("friends", "friends", null, true, null)
+          ResponseField.forString("name", "name", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
+            TestQuery.Data.Hero.DroidHero.Friend {
           return reader.run {
-            var __typename: String? = __typename
             var name: String? = null
-            var primaryFunction: String? = null
-            var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                3 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
+                0 -> name = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.Hero.DroidHero.Friend(
+              name = name!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.DroidHero.Friend) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
+        }
+      }
+    }
+
+    object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null),
+        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var profileLink: Any? = null
+          var friendsConnection: TestQuery.Data.Hero.HumanHero.FriendsConnection? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+              3 -> friendsConnection = readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
+                FriendsConnection.fromResponse(reader)
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.HumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            profileLink = profileLink!!,
+            friendsConnection = friendsConnection!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.profileLink)
+        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+          FriendsConnection.toResponse(writer, value.friendsConnection)
+        }
+      }
+
+      object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forList("edges", "edges", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.HumanHero.FriendsConnection {
+          return reader.run {
+            var edges: List<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> edges = readList<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+                  reader.readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge> { reader ->
+                    Edge.fromResponse(reader)
                   }
                 }
                 else -> break
               }
             }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction,
-              friends = friends
+            TestQuery.Data.Hero.HumanHero.FriendsConnection(
+              edges = edges
             )
           }
         }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-          writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.HumanHero.FriendsConnection) {
+          writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
             listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
+              Edge.toResponse(writer, value)
             }
           }
         }
 
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
+        object Edge : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null)
+            ResponseField.forObject("node", "node", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.DroidHero.Friend {
+              TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge {
             return reader.run {
-              var name: String? = null
+              var node: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.Hero.DroidHero.Friend(
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.DroidHero.Friend) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
-        }
-      }
-
-      object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null),
-          ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var profileLink: Any? = null
-            var friendsConnection: TestQuery.Data.Hero.HumanHero.FriendsConnection? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-                3 -> friendsConnection = readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
-                  FriendsConnection.fromResponse(reader)
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.HumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              profileLink = profileLink!!,
-              friendsConnection = friendsConnection!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.profileLink)
-          writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-            FriendsConnection.toResponse(writer, value.friendsConnection)
-          }
-        }
-
-        object FriendsConnection : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection>
-            {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forList("edges", "edges", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.HumanHero.FriendsConnection {
-            return reader.run {
-              var edges: List<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> edges = readList<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                    reader.readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge> { reader ->
-                      Edge.fromResponse(reader)
-                    }
+                  0 -> node = readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                    Node.fromResponse(reader)
                   }
                   else -> break
                 }
               }
-              TestQuery.Data.Hero.HumanHero.FriendsConnection(
-                edges = edges
+              TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge(
+                node = node
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.HumanHero.FriendsConnection) {
-            writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Edge.toResponse(writer, value)
+              value: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge) {
+            if(value.node == null) {
+              writer.writeObject(RESPONSE_FIELDS[0], null)
+            } else {
+              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                Node.toResponse(writer, value.node)
               }
             }
           }
 
-          object Edge : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge> {
+          object Node : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node> {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forObject("node", "node", null, true, null)
+              ResponseField.forString("name", "name", null, false, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge {
+                TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node {
               return reader.run {
-                var node: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node? = null
+                var name: String? = null
                 while(true) {
                   when (selectField(RESPONSE_FIELDS)) {
-                    0 -> node = readObject<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                      Node.fromResponse(reader)
-                    }
+                    0 -> name = readString(RESPONSE_FIELDS[0])
                     else -> break
                   }
                 }
-                TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge(
-                  node = node
+                TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node(
+                  name = name!!
                 )
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge) {
-              if(value.node == null) {
-                writer.writeObject(RESPONSE_FIELDS[0], null)
-              } else {
-                writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                  Node.toResponse(writer, value.node)
-                }
-              }
-            }
-
-            object Node : ResponseAdapter<TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("name", "name", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node {
-                return reader.run {
-                  var name: String? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> name = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node(
-                    name = name!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node) {
-                writer.writeString(RESPONSE_FIELDS[0], value.name)
-              }
+                value: TestQuery.Data.Hero.HumanHero.FriendsConnection.Edge.Node) {
+              writer.writeString(RESPONSE_FIELDS[0], value.name)
             }
           }
         }
       }
+    }
 
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
           }
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
+      }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/adapter/DroidDetailsImpl_ResponseAdapter.kt
@@ -27,84 +27,67 @@ object DroidDetailsImpl_ResponseAdapter : ResponseAdapter<DroidDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var primaryFunction: String? = null
+      var friends: List<DroidDetailsImpl.Data.Friend?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+          3 -> friends = readList<DroidDetailsImpl.Data.Friend>(RESPONSE_FIELDS[3]) { reader ->
+            reader.readObject<DroidDetailsImpl.Data.Friend> { reader ->
+              Friend.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      DroidDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        primaryFunction = primaryFunction,
+        friends = friends
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+    writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Friend.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<DroidDetailsImpl.Data> {
+  object Friend : ResponseAdapter<DroidDetailsImpl.Data.Friend> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
-      ResponseField.forList("friends", "friends", null, true, null)
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidDetailsImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        DroidDetailsImpl.Data.Friend {
       return reader.run {
-        var __typename: String? = __typename
         var name: String? = null
-        var primaryFunction: String? = null
-        var friends: List<DroidDetailsImpl.Data.Friend?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-            3 -> friends = readList<DroidDetailsImpl.Data.Friend>(RESPONSE_FIELDS[3]) { reader ->
-              reader.readObject<DroidDetailsImpl.Data.Friend> { reader ->
-                Friend.fromResponse(reader)
-              }
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
             else -> break
           }
         }
-        DroidDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          primaryFunction = primaryFunction,
-          friends = friends
+        DroidDetailsImpl.Data.Friend(
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-      writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Friend.toResponse(writer, value)
-        }
-      }
-    }
-
-    object Friend : ResponseAdapter<DroidDetailsImpl.Data.Friend> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          DroidDetailsImpl.Data.Friend {
-        return reader.run {
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          DroidDetailsImpl.Data.Friend(
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data.Friend) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: DroidDetailsImpl.Data.Friend) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -29,149 +29,132 @@ object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var profileLink: Any? = null
+      var friendsConnection: HumanDetailsImpl.Data.FriendsConnection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
+          3 -> friendsConnection = readObject<HumanDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
+            FriendsConnection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HumanDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        profileLink = profileLink!!,
+        friendsConnection = friendsConnection!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.profileLink)
+    writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+      FriendsConnection.toResponse(writer, value.friendsConnection)
+    }
   }
 
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
+  object FriendsConnection : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forCustomScalar("profileLink", "profileLink", null, false, CustomScalars.URL, null),
-      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HumanDetailsImpl.Data.FriendsConnection {
       return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var profileLink: Any? = null
-        var friendsConnection: HumanDetailsImpl.Data.FriendsConnection? = null
+        var edges: List<HumanDetailsImpl.Data.FriendsConnection.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> profileLink = readCustomScalar<Any>(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField)
-            3 -> friendsConnection = readObject<HumanDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[3]) { reader ->
-              FriendsConnection.fromResponse(reader)
+            0 -> edges = readList<HumanDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
+              reader.readObject<HumanDetailsImpl.Data.FriendsConnection.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        HumanDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          profileLink = profileLink!!,
-          friendsConnection = friendsConnection!!
+        HumanDetailsImpl.Data.FriendsConnection(
+          edges = edges
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeCustom(RESPONSE_FIELDS[2] as ResponseField.CustomScalarField, value.profileLink)
-      writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-        FriendsConnection.toResponse(writer, value.friendsConnection)
+    override fun toResponse(writer: ResponseWriter,
+        value: HumanDetailsImpl.Data.FriendsConnection) {
+      writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
+        }
       }
     }
 
-    object FriendsConnection : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection> {
+    object Edge : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HumanDetailsImpl.Data.FriendsConnection {
+          HumanDetailsImpl.Data.FriendsConnection.Edge {
         return reader.run {
-          var edges: List<HumanDetailsImpl.Data.FriendsConnection.Edge?>? = null
+          var node: HumanDetailsImpl.Data.FriendsConnection.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> edges = readList<HumanDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[0]) { reader ->
-                reader.readObject<HumanDetailsImpl.Data.FriendsConnection.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<HumanDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          HumanDetailsImpl.Data.FriendsConnection(
-            edges = edges
+          HumanDetailsImpl.Data.FriendsConnection.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: HumanDetailsImpl.Data.FriendsConnection) {
-        writer.writeList(RESPONSE_FIELDS[0], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: HumanDetailsImpl.Data.FriendsConnection.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection.Edge> {
+      object Node : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection.Edge.Node> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("name", "name", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HumanDetailsImpl.Data.FriendsConnection.Edge {
+            HumanDetailsImpl.Data.FriendsConnection.Edge.Node {
           return reader.run {
-            var node: HumanDetailsImpl.Data.FriendsConnection.Edge.Node? = null
+            var name: String? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<HumanDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
+                0 -> name = readString(RESPONSE_FIELDS[0])
                 else -> break
               }
             }
-            HumanDetailsImpl.Data.FriendsConnection.Edge(
-              node = node
+            HumanDetailsImpl.Data.FriendsConnection.Edge.Node(
+              name = name!!
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HumanDetailsImpl.Data.FriendsConnection.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
-          }
-        }
-
-        object Node : ResponseAdapter<HumanDetailsImpl.Data.FriendsConnection.Edge.Node> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HumanDetailsImpl.Data.FriendsConnection.Edge.Node {
-            return reader.run {
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              HumanDetailsImpl.Data.FriendsConnection.Edge.Node(
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: HumanDetailsImpl.Data.FriendsConnection.Edge.Node) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
+            value: HumanDetailsImpl.Data.FriendsConnection.Edge.Node) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/adapter/GetUser_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/adapter/GetUser_ResponseAdapter.kt
@@ -24,237 +24,220 @@ object GetUser_ResponseAdapter : ResponseAdapter<GetUser.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): GetUser.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Query" -> QueryData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: GetUser.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is GetUser.Data.QueryData -> QueryData.toResponse(writer, value)
+      is GetUser.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<GetUser.Data> {
+  object QueryData : ResponseAdapter<GetUser.Data.QueryData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forObject("organization", "organization", mapOf<String, Any?>(
+        "id" to mapOf<String, Any?>(
+          "kind" to "Variable",
+          "variableName" to "organizationId")), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): GetUser.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Query" -> QueryData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): GetUser.Data.QueryData {
+      return reader.run {
+        var __typename: String? = __typename
+        var organization: GetUser.Data.QueryData.Organization? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> organization = readObject<GetUser.Data.QueryData.Organization>(RESPONSE_FIELDS[1]) { reader ->
+              Organization.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        GetUser.Data.QueryData(
+          __typename = __typename!!,
+          organization = organization
+        )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: GetUser.Data) {
-      when(value) {
-        is GetUser.Data.QueryData -> QueryData.toResponse(writer, value)
-        is GetUser.Data.OtherData -> OtherData.toResponse(writer, value)
+    override fun toResponse(writer: ResponseWriter, value: GetUser.Data.QueryData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      if(value.organization == null) {
+        writer.writeObject(RESPONSE_FIELDS[1], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+          Organization.toResponse(writer, value.organization)
+        }
       }
     }
 
-    object QueryData : ResponseAdapter<GetUser.Data.QueryData> {
+    object Organization : ResponseAdapter<GetUser.Data.QueryData.Organization> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forObject("organization", "organization", mapOf<String, Any?>(
-          "id" to mapOf<String, Any?>(
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forList("user", "user", mapOf<String, Any?>(
+          "query" to mapOf<String, Any?>(
             "kind" to "Variable",
-            "variableName" to "organizationId")), true, null)
+            "variableName" to "query")), false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          GetUser.Data.QueryData {
+          GetUser.Data.QueryData.Organization {
         return reader.run {
-          var __typename: String? = __typename
-          var organization: GetUser.Data.QueryData.Organization? = null
+          var id: String? = null
+          var user: List<GetUser.Data.QueryData.Organization.User>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> organization = readObject<GetUser.Data.QueryData.Organization>(RESPONSE_FIELDS[1]) { reader ->
-                Organization.fromResponse(reader)
-              }
+              0 -> id = readString(RESPONSE_FIELDS[0])
+              1 -> user = readList<GetUser.Data.QueryData.Organization.User>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<GetUser.Data.QueryData.Organization.User> { reader ->
+                  User.fromResponse(reader)
+                }
+              }?.map { it!! }
               else -> break
             }
           }
-          GetUser.Data.QueryData(
-            __typename = __typename!!,
-            organization = organization
+          GetUser.Data.QueryData.Organization(
+            id = id!!,
+            user = user!!
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: GetUser.Data.QueryData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        if(value.organization == null) {
-          writer.writeObject(RESPONSE_FIELDS[1], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-            Organization.toResponse(writer, value.organization)
+      override fun toResponse(writer: ResponseWriter, value: GetUser.Data.QueryData.Organization) {
+        writer.writeString(RESPONSE_FIELDS[0], value.id)
+        writer.writeList(RESPONSE_FIELDS[1], value.user) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            User.toResponse(writer, value)
           }
         }
       }
 
-      object Organization : ResponseAdapter<GetUser.Data.QueryData.Organization> {
+      object User : ResponseAdapter<GetUser.Data.QueryData.Organization.User> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forList("user", "user", mapOf<String, Any?>(
-            "query" to mapOf<String, Any?>(
-              "kind" to "Variable",
-              "variableName" to "query")), false, null)
+          ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            GetUser.Data.QueryData.Organization {
-          return reader.run {
-            var id: String? = null
-            var user: List<GetUser.Data.QueryData.Organization.User>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> id = readString(RESPONSE_FIELDS[0])
-                1 -> user = readList<GetUser.Data.QueryData.Organization.User>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<GetUser.Data.QueryData.Organization.User> { reader ->
-                    User.fromResponse(reader)
-                  }
-                }?.map { it!! }
-                else -> break
-              }
-            }
-            GetUser.Data.QueryData.Organization(
-              id = id!!,
-              user = user!!
-            )
+            GetUser.Data.QueryData.Organization.User {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "User" -> UserUser.fromResponse(reader, typename)
+            else -> OtherUser.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: GetUser.Data.QueryData.Organization) {
-          writer.writeString(RESPONSE_FIELDS[0], value.id)
-          writer.writeList(RESPONSE_FIELDS[1], value.user) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              User.toResponse(writer, value)
-            }
+            value: GetUser.Data.QueryData.Organization.User) {
+          when(value) {
+            is GetUser.Data.QueryData.Organization.User.UserUser -> UserUser.toResponse(writer, value)
+            is GetUser.Data.QueryData.Organization.User.OtherUser -> OtherUser.toResponse(writer, value)
           }
         }
 
-        object User : ResponseAdapter<GetUser.Data.QueryData.Organization.User> {
+        object UserUser : ResponseAdapter<GetUser.Data.QueryData.Organization.User.UserUser> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("firstName", "firstName", null, false, null),
+            ResponseField.forString("lastName", "lastName", null, false, null),
+            ResponseField.forString("avatar", "avatar", mapOf<String, Any?>(
+              "size" to mapOf<String, Any?>(
+                "kind" to "Variable",
+                "variableName" to "size")), false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              GetUser.Data.QueryData.Organization.User.UserUser {
+            return reader.run {
+              var __typename: String? = __typename
+              var firstName: String? = null
+              var lastName: String? = null
+              var avatar: String? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> firstName = readString(RESPONSE_FIELDS[1])
+                  2 -> lastName = readString(RESPONSE_FIELDS[2])
+                  3 -> avatar = readString(RESPONSE_FIELDS[3])
+                  else -> break
+                }
+              }
+              GetUser.Data.QueryData.Organization.User.UserUser(
+                __typename = __typename!!,
+                firstName = firstName!!,
+                lastName = lastName!!,
+                avatar = avatar!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: GetUser.Data.QueryData.Organization.User.UserUser) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.firstName)
+            writer.writeString(RESPONSE_FIELDS[2], value.lastName)
+            writer.writeString(RESPONSE_FIELDS[3], value.avatar)
+          }
+        }
+
+        object OtherUser : ResponseAdapter<GetUser.Data.QueryData.Organization.User.OtherUser> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
             ResponseField.forString("__typename", "__typename", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              GetUser.Data.QueryData.Organization.User {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "User" -> UserUser.fromResponse(reader, typename)
-              else -> OtherUser.fromResponse(reader, typename)
+              GetUser.Data.QueryData.Organization.User.OtherUser {
+            return reader.run {
+              var __typename: String? = __typename
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  else -> break
+                }
+              }
+              GetUser.Data.QueryData.Organization.User.OtherUser(
+                __typename = __typename!!
+              )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: GetUser.Data.QueryData.Organization.User) {
-            when(value) {
-              is GetUser.Data.QueryData.Organization.User.UserUser -> UserUser.toResponse(writer, value)
-              is GetUser.Data.QueryData.Organization.User.OtherUser -> OtherUser.toResponse(writer, value)
-            }
-          }
-
-          object UserUser : ResponseAdapter<GetUser.Data.QueryData.Organization.User.UserUser> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("firstName", "firstName", null, false, null),
-              ResponseField.forString("lastName", "lastName", null, false, null),
-              ResponseField.forString("avatar", "avatar", mapOf<String, Any?>(
-                "size" to mapOf<String, Any?>(
-                  "kind" to "Variable",
-                  "variableName" to "size")), false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                GetUser.Data.QueryData.Organization.User.UserUser {
-              return reader.run {
-                var __typename: String? = __typename
-                var firstName: String? = null
-                var lastName: String? = null
-                var avatar: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> firstName = readString(RESPONSE_FIELDS[1])
-                    2 -> lastName = readString(RESPONSE_FIELDS[2])
-                    3 -> avatar = readString(RESPONSE_FIELDS[3])
-                    else -> break
-                  }
-                }
-                GetUser.Data.QueryData.Organization.User.UserUser(
-                  __typename = __typename!!,
-                  firstName = firstName!!,
-                  lastName = lastName!!,
-                  avatar = avatar!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: GetUser.Data.QueryData.Organization.User.UserUser) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.firstName)
-              writer.writeString(RESPONSE_FIELDS[2], value.lastName)
-              writer.writeString(RESPONSE_FIELDS[3], value.avatar)
-            }
-          }
-
-          object OtherUser : ResponseAdapter<GetUser.Data.QueryData.Organization.User.OtherUser> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                GetUser.Data.QueryData.Organization.User.OtherUser {
-              return reader.run {
-                var __typename: String? = __typename
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                GetUser.Data.QueryData.Organization.User.OtherUser(
-                  __typename = __typename!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: GetUser.Data.QueryData.Organization.User.OtherUser) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            }
+              value: GetUser.Data.QueryData.Organization.User.OtherUser) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
           }
         }
       }
     }
+  }
 
-    object OtherData : ResponseAdapter<GetUser.Data.OtherData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
-      )
+  object OtherData : ResponseAdapter<GetUser.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          GetUser.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
+    override fun fromResponse(reader: ResponseReader, __typename: String?): GetUser.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            else -> break
           }
-          GetUser.Data.OtherData(
-            __typename = __typename!!
-          )
         }
+        GetUser.Data.OtherData(
+          __typename = __typename!!
+        )
       }
+    }
 
-      override fun toResponse(writer: ResponseWriter, value: GetUser.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      }
+    override fun toResponse(writer: ResponseWriter, value: GetUser.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
@@ -28,186 +28,168 @@ object QueryFragmentImpl_ResponseAdapter : ResponseAdapter<QueryFragmentImpl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var organization: QueryFragmentImpl.Data.Organization? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> organization = readObject<QueryFragmentImpl.Data.Organization>(RESPONSE_FIELDS[1]) { reader ->
+            Organization.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      QueryFragmentImpl.Data(
+        __typename = __typename!!,
+        organization = organization
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    if(value.organization == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Organization.toResponse(writer, value.organization)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<QueryFragmentImpl.Data> {
+  object Organization : ResponseAdapter<QueryFragmentImpl.Data.Organization> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forObject("organization", "organization", mapOf<String, Any?>(
-        "id" to mapOf<String, Any?>(
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forList("user", "user", mapOf<String, Any?>(
+        "query" to mapOf<String, Any?>(
           "kind" to "Variable",
-          "variableName" to "organizationId")), true, null)
+          "variableName" to "query")), false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        QueryFragmentImpl.Data.Organization {
       return reader.run {
-        var __typename: String? = __typename
-        var organization: QueryFragmentImpl.Data.Organization? = null
+        var id: String? = null
+        var user: List<QueryFragmentImpl.Data.Organization.User>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> organization = readObject<QueryFragmentImpl.Data.Organization>(RESPONSE_FIELDS[1]) { reader ->
-              Organization.fromResponse(reader)
-            }
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> user = readList<QueryFragmentImpl.Data.Organization.User>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<QueryFragmentImpl.Data.Organization.User> { reader ->
+                User.fromResponse(reader)
+              }
+            }?.map { it!! }
             else -> break
           }
         }
-        QueryFragmentImpl.Data(
-          __typename = __typename!!,
-          organization = organization
+        QueryFragmentImpl.Data.Organization(
+          id = id!!,
+          user = user!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      if(value.organization == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Organization.toResponse(writer, value.organization)
+    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Organization) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeList(RESPONSE_FIELDS[1], value.user) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          User.toResponse(writer, value)
         }
       }
     }
 
-    object Organization : ResponseAdapter<QueryFragmentImpl.Data.Organization> {
+    object User : ResponseAdapter<QueryFragmentImpl.Data.Organization.User> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forList("user", "user", mapOf<String, Any?>(
-          "query" to mapOf<String, Any?>(
-            "kind" to "Variable",
-            "variableName" to "query")), false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          QueryFragmentImpl.Data.Organization {
-        return reader.run {
-          var id: String? = null
-          var user: List<QueryFragmentImpl.Data.Organization.User>? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> user = readList<QueryFragmentImpl.Data.Organization.User>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<QueryFragmentImpl.Data.Organization.User> { reader ->
-                  User.fromResponse(reader)
-                }
-              }?.map { it!! }
-              else -> break
+          QueryFragmentImpl.Data.Organization.User {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "User" -> UserUser.fromResponse(reader, typename)
+          else -> OtherUser.fromResponse(reader, typename)
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Organization.User) {
+        when(value) {
+          is QueryFragmentImpl.Data.Organization.User.UserUser -> UserUser.toResponse(writer, value)
+          is QueryFragmentImpl.Data.Organization.User.OtherUser -> OtherUser.toResponse(writer, value)
+        }
+      }
+
+      object UserUser : ResponseAdapter<QueryFragmentImpl.Data.Organization.User.UserUser> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("firstName", "firstName", null, false, null),
+          ResponseField.forString("lastName", "lastName", null, false, null),
+          ResponseField.forString("avatar", "avatar", mapOf<String, Any?>(
+            "size" to mapOf<String, Any?>(
+              "kind" to "Variable",
+              "variableName" to "size")), false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            QueryFragmentImpl.Data.Organization.User.UserUser {
+          return reader.run {
+            var __typename: String? = __typename
+            var firstName: String? = null
+            var lastName: String? = null
+            var avatar: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> firstName = readString(RESPONSE_FIELDS[1])
+                2 -> lastName = readString(RESPONSE_FIELDS[2])
+                3 -> avatar = readString(RESPONSE_FIELDS[3])
+                else -> break
+              }
             }
+            QueryFragmentImpl.Data.Organization.User.UserUser(
+              __typename = __typename!!,
+              firstName = firstName!!,
+              lastName = lastName!!,
+              avatar = avatar!!
+            )
           }
-          QueryFragmentImpl.Data.Organization(
-            id = id!!,
-            user = user!!
-          )
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: QueryFragmentImpl.Data.Organization.User.UserUser) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.firstName)
+          writer.writeString(RESPONSE_FIELDS[2], value.lastName)
+          writer.writeString(RESPONSE_FIELDS[3], value.avatar)
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Organization) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeList(RESPONSE_FIELDS[1], value.user) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            User.toResponse(writer, value)
-          }
-        }
-      }
-
-      object User : ResponseAdapter<QueryFragmentImpl.Data.Organization.User> {
+      object OtherUser : ResponseAdapter<QueryFragmentImpl.Data.Organization.User.OtherUser> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
           ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Organization.User {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "User" -> UserUser.fromResponse(reader, typename)
-            else -> OtherUser.fromResponse(reader, typename)
+            QueryFragmentImpl.Data.Organization.User.OtherUser {
+          return reader.run {
+            var __typename: String? = __typename
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            QueryFragmentImpl.Data.Organization.User.OtherUser(
+              __typename = __typename!!
+            )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Organization.User) {
-          when(value) {
-            is QueryFragmentImpl.Data.Organization.User.UserUser -> UserUser.toResponse(writer, value)
-            is QueryFragmentImpl.Data.Organization.User.OtherUser -> OtherUser.toResponse(writer, value)
-          }
-        }
-
-        object UserUser : ResponseAdapter<QueryFragmentImpl.Data.Organization.User.UserUser> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("firstName", "firstName", null, false, null),
-            ResponseField.forString("lastName", "lastName", null, false, null),
-            ResponseField.forString("avatar", "avatar", mapOf<String, Any?>(
-              "size" to mapOf<String, Any?>(
-                "kind" to "Variable",
-                "variableName" to "size")), false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              QueryFragmentImpl.Data.Organization.User.UserUser {
-            return reader.run {
-              var __typename: String? = __typename
-              var firstName: String? = null
-              var lastName: String? = null
-              var avatar: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> firstName = readString(RESPONSE_FIELDS[1])
-                  2 -> lastName = readString(RESPONSE_FIELDS[2])
-                  3 -> avatar = readString(RESPONSE_FIELDS[3])
-                  else -> break
-                }
-              }
-              QueryFragmentImpl.Data.Organization.User.UserUser(
-                __typename = __typename!!,
-                firstName = firstName!!,
-                lastName = lastName!!,
-                avatar = avatar!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: QueryFragmentImpl.Data.Organization.User.UserUser) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.firstName)
-            writer.writeString(RESPONSE_FIELDS[2], value.lastName)
-            writer.writeString(RESPONSE_FIELDS[3], value.avatar)
-          }
-        }
-
-        object OtherUser : ResponseAdapter<QueryFragmentImpl.Data.Organization.User.OtherUser> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              QueryFragmentImpl.Data.Organization.User.OtherUser {
-            return reader.run {
-              var __typename: String? = __typename
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              QueryFragmentImpl.Data.Organization.User.OtherUser(
-                __typename = __typename!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: QueryFragmentImpl.Data.Organization.User.OtherUser) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          }
+            value: QueryFragmentImpl.Data.Organization.User.OtherUser) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/fragment/adapter/UserFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/fragment/adapter/UserFragmentImpl_ResponseAdapter.kt
@@ -29,53 +29,33 @@ object UserFragmentImpl_ResponseAdapter : ResponseAdapter<UserFragmentImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): UserFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var firstName: String? = null
+      var lastName: String? = null
+      var avatar: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> firstName = readString(RESPONSE_FIELDS[1])
+          2 -> lastName = readString(RESPONSE_FIELDS[2])
+          3 -> avatar = readString(RESPONSE_FIELDS[3])
+          else -> break
+        }
+      }
+      UserFragmentImpl.Data(
+        __typename = __typename!!,
+        firstName = firstName!!,
+        lastName = lastName!!,
+        avatar = avatar!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: UserFragmentImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<UserFragmentImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("firstName", "firstName", null, false, null),
-      ResponseField.forString("lastName", "lastName", null, false, null),
-      ResponseField.forString("avatar", "avatar", mapOf<String, Any?>(
-        "size" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "size")), false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): UserFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var firstName: String? = null
-        var lastName: String? = null
-        var avatar: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> firstName = readString(RESPONSE_FIELDS[1])
-            2 -> lastName = readString(RESPONSE_FIELDS[2])
-            3 -> avatar = readString(RESPONSE_FIELDS[3])
-            else -> break
-          }
-        }
-        UserFragmentImpl.Data(
-          __typename = __typename!!,
-          firstName = firstName!!,
-          lastName = lastName!!,
-          avatar = avatar!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: UserFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.firstName)
-      writer.writeString(RESPONSE_FIELDS[2], value.lastName)
-      writer.writeString(RESPONSE_FIELDS[3], value.avatar)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.firstName)
+    writer.writeString(RESPONSE_FIELDS[2], value.lastName)
+    writer.writeString(RESPONSE_FIELDS[3], value.avatar)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/adapter/TestQuery_ResponseAdapter.kt
@@ -24,169 +24,155 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHero.fromResponse(reader, typename)
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.HumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHero.fromResponse(reader, typename)
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Hero.HumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
       }
 
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/adapter/TestQuery_ResponseAdapter.kt
@@ -28,374 +28,357 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", mapOf<String, Any?>(
-        "episode" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "episode")), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHero.fromResponse(reader, typename)
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<TestQuery.Data.Hero.HumanHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<TestQuery.Data.Hero.HumanHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.HumanHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
             }
-            else -> break
+          }
+          TestQuery.Data.Hero.HumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
           }
         }
-        TestQuery.Data(
-          hero = hero
-        )
       }
-    }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.HumanHero.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Human" -> HumanFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.HumanHero.Friend) {
+          when(value) {
+            is TestQuery.Data.Hero.HumanHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
+            is TestQuery.Data.Hero.HumanHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+          }
+        }
+
+        object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend.HumanFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forDouble("height", "height", mapOf<String, Any?>(
+              "unit" to "FOOT"), true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.HumanHero.Friend.HumanFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var height: Double? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> height = readDouble(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.HumanHero.Friend.HumanFriend(
+                __typename = __typename!!,
+                name = name!!,
+                height = height
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.HumanHero.Friend.HumanFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          }
+        }
+
+        object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.HumanHero.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.HumanHero.Friend.OtherFriend(
+                __typename = __typename!!,
+                name = name!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.HumanHero.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+          }
         }
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
+        }
+      }
+
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.Hero.DroidHero.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Human" -> HumanFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.DroidHero.Friend) {
+          when(value) {
+            is TestQuery.Data.Hero.DroidHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
+            is TestQuery.Data.Hero.DroidHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+          }
+        }
+
+        object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend.HumanFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forDouble("height", "height", mapOf<String, Any?>(
+              "unit" to "METER"), true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.DroidHero.Friend.HumanFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var height: Double? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> height = readDouble(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.DroidHero.Friend.HumanFriend(
+                __typename = __typename!!,
+                name = name!!,
+                height = height
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.DroidHero.Friend.HumanFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          }
+        }
+
+        object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.DroidHero.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.DroidHero.Friend.OtherFriend(
+                __typename = __typename!!,
+                name = name!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.DroidHero.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+          }
+        }
+      }
+    }
+
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHero.fromResponse(reader, typename)
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<TestQuery.Data.Hero.HumanHero.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<TestQuery.Data.Hero.HumanHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.HumanHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.HumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
           }
-        }
-
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!,
+            name = name!!
           )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.HumanHero.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Human" -> HumanFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.HumanHero.Friend) {
-            when(value) {
-              is TestQuery.Data.Hero.HumanHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
-              is TestQuery.Data.Hero.HumanHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-            }
-          }
-
-          object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend.HumanFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forDouble("height", "height", mapOf<String, Any?>(
-                "unit" to "FOOT"), true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.HumanHero.Friend.HumanFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var height: Double? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> height = readDouble(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.HumanHero.Friend.HumanFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  height = height
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.HumanHero.Friend.HumanFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-            }
-          }
-
-          object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.HumanHero.Friend.OtherFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.HumanHero.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.HumanHero.Friend.OtherFriend(
-                  __typename = __typename!!,
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.HumanHero.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-            }
-          }
         }
       }
 
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<TestQuery.Data.Hero.DroidHero.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<TestQuery.Data.Hero.DroidHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.DroidHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
-          }
-        }
-
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.DroidHero.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Human" -> HumanFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.DroidHero.Friend) {
-            when(value) {
-              is TestQuery.Data.Hero.DroidHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
-              is TestQuery.Data.Hero.DroidHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-            }
-          }
-
-          object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend.HumanFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forDouble("height", "height", mapOf<String, Any?>(
-                "unit" to "METER"), true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.DroidHero.Friend.HumanFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var height: Double? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> height = readDouble(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.DroidHero.Friend.HumanFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  height = height
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.DroidHero.Friend.HumanFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-            }
-          }
-
-          object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.DroidHero.Friend.OtherFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.DroidHero.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.DroidHero.Friend.OtherFriend(
-                  __typename = __typename!!,
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.DroidHero.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-            }
-          }
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!,
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/operation_id_generator/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/operation_id_generator/adapter/TestQuery_ResponseAdapter.kt
@@ -23,73 +23,59 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
       return reader.run {
-        var hero: TestQuery.Data.Hero? = null
+        var id: String? = null
+        var name: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          hero = hero
+        TestQuery.Data.Hero(
+          id = id!!,
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        return reader.run {
-          var id: String? = null
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.Hero(
-            id = id!!,
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/recursive_selection/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/recursive_selection/adapter/TestQuery_ResponseAdapter.kt
@@ -24,145 +24,131 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var tree: TestQuery.Data.Tree? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> tree = readObject<TestQuery.Data.Tree>(RESPONSE_FIELDS[0]) { reader ->
+            Tree.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        tree = tree
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.tree == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Tree.toResponse(writer, value.tree)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Tree : ResponseAdapter<TestQuery.Data.Tree> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("tree", "tree", null, true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forList("children", "children", null, false, null),
+      ResponseField.forObject("parent", "parent", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Tree {
       return reader.run {
-        var tree: TestQuery.Data.Tree? = null
+        var name: String? = null
+        var children: List<TestQuery.Data.Tree.Child>? = null
+        var parent: TestQuery.Data.Tree.Parent? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> tree = readObject<TestQuery.Data.Tree>(RESPONSE_FIELDS[0]) { reader ->
-              Tree.fromResponse(reader)
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> children = readList<TestQuery.Data.Tree.Child>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<TestQuery.Data.Tree.Child> { reader ->
+                Child.fromResponse(reader)
+              }
+            }?.map { it!! }
+            2 -> parent = readObject<TestQuery.Data.Tree.Parent>(RESPONSE_FIELDS[2]) { reader ->
+              Parent.fromResponse(reader)
             }
             else -> break
           }
         }
-        TestQuery.Data(
-          tree = tree
+        TestQuery.Data.Tree(
+          name = name!!,
+          children = children!!,
+          parent = parent
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.tree == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeList(RESPONSE_FIELDS[1], value.children) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Child.toResponse(writer, value)
+        }
+      }
+      if(value.parent == null) {
+        writer.writeObject(RESPONSE_FIELDS[2], null)
       } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Tree.toResponse(writer, value.tree)
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          Parent.toResponse(writer, value.parent)
         }
       }
     }
 
-    object Tree : ResponseAdapter<TestQuery.Data.Tree> {
+    object Child : ResponseAdapter<TestQuery.Data.Tree.Child> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forList("children", "children", null, false, null),
-        ResponseField.forObject("parent", "parent", null, true, null)
+        ResponseField.forString("name", "name", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Tree {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Tree.Child {
         return reader.run {
           var name: String? = null
-          var children: List<TestQuery.Data.Tree.Child>? = null
-          var parent: TestQuery.Data.Tree.Parent? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
               0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> children = readList<TestQuery.Data.Tree.Child>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<TestQuery.Data.Tree.Child> { reader ->
-                  Child.fromResponse(reader)
-                }
-              }?.map { it!! }
-              2 -> parent = readObject<TestQuery.Data.Tree.Parent>(RESPONSE_FIELDS[2]) { reader ->
-                Parent.fromResponse(reader)
-              }
               else -> break
             }
           }
-          TestQuery.Data.Tree(
-            name = name!!,
-            children = children!!,
-            parent = parent
+          TestQuery.Data.Tree.Child(
+            name = name!!
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree) {
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree.Child) {
         writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeList(RESPONSE_FIELDS[1], value.children) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Child.toResponse(writer, value)
+      }
+    }
+
+    object Parent : ResponseAdapter<TestQuery.Data.Tree.Parent> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Tree.Parent {
+        return reader.run {
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> name = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
           }
-        }
-        if(value.parent == null) {
-          writer.writeObject(RESPONSE_FIELDS[2], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            Parent.toResponse(writer, value.parent)
-          }
+          TestQuery.Data.Tree.Parent(
+            name = name!!
+          )
         }
       }
 
-      object Child : ResponseAdapter<TestQuery.Data.Tree.Child> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Tree.Child {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Tree.Child(
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree.Child) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
-        }
-      }
-
-      object Parent : ResponseAdapter<TestQuery.Data.Tree.Parent> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Tree.Parent {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Tree.Parent(
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree.Parent) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Tree.Parent) {
+        writer.writeString(RESPONSE_FIELDS[0], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/reserved_keywords/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/reserved_keywords/adapter/TestQuery_ResponseAdapter.kt
@@ -26,167 +26,150 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var yield_: TestQuery.Data.Yield? = null
+      var objects: List<TestQuery.Data.Object?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> yield_ = readObject<TestQuery.Data.Yield>(RESPONSE_FIELDS[0]) { reader ->
+            Yield.fromResponse(reader)
+          }
+          1 -> objects = readList<TestQuery.Data.Object>(RESPONSE_FIELDS[1]) { reader ->
+            reader.readObject<TestQuery.Data.Object> { reader ->
+              Object.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        yield_ = yield_,
+        objects = objects
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.yield_ == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Yield.toResponse(writer, value.yield_)
+      }
+    }
+    writer.writeList(RESPONSE_FIELDS[1], value.objects) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Object.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Yield : ResponseAdapter<TestQuery.Data.Yield> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("yield", "hero", null, true, null),
-      ResponseField.forList("objects", "search", mapOf<String, Any?>(
-        "text" to "abc"), true, null)
+      ResponseField.forString("it", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Yield {
       return reader.run {
-        var yield_: TestQuery.Data.Yield? = null
-        var objects: List<TestQuery.Data.Object?>? = null
+        var it_: String? = null
+        var name: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> yield_ = readObject<TestQuery.Data.Yield>(RESPONSE_FIELDS[0]) { reader ->
-              Yield.fromResponse(reader)
-            }
-            1 -> objects = readList<TestQuery.Data.Object>(RESPONSE_FIELDS[1]) { reader ->
-              reader.readObject<TestQuery.Data.Object> { reader ->
-                Object.fromResponse(reader)
-              }
-            }
+            0 -> it_ = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestQuery.Data(
-          yield_ = yield_,
-          objects = objects
+        TestQuery.Data.Yield(
+          it_ = it_!!,
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.yield_ == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Yield.toResponse(writer, value.yield_)
-        }
-      }
-      writer.writeList(RESPONSE_FIELDS[1], value.objects) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Object.toResponse(writer, value)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Yield) {
+      writer.writeString(RESPONSE_FIELDS[0], value.it_)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+    }
+  }
+
+  object Object : ResponseAdapter<TestQuery.Data.Object> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Object {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> CharacterObject.fromResponse(reader, typename)
+        "Droid" -> CharacterObject.fromResponse(reader, typename)
+        else -> OtherObject.fromResponse(reader, typename)
       }
     }
 
-    object Yield : ResponseAdapter<TestQuery.Data.Yield> {
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Object) {
+      when(value) {
+        is TestQuery.Data.Object.CharacterObject -> CharacterObject.toResponse(writer, value)
+        is TestQuery.Data.Object.OtherObject -> OtherObject.toResponse(writer, value)
+      }
+    }
+
+    object CharacterObject : ResponseAdapter<TestQuery.Data.Object.CharacterObject> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("it", "id", null, false, null),
+        ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Yield {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Object.CharacterObject {
         return reader.run {
-          var it_: String? = null
+          var __typename: String? = __typename
           var name: String? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> it_ = readString(RESPONSE_FIELDS[0])
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
               1 -> name = readString(RESPONSE_FIELDS[1])
               else -> break
             }
           }
-          TestQuery.Data.Yield(
-            it_ = it_!!,
+          TestQuery.Data.Object.CharacterObject(
+            __typename = __typename!!,
             name = name!!
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Yield) {
-        writer.writeString(RESPONSE_FIELDS[0], value.it_)
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Object.CharacterObject) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
         writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
 
-    object Object : ResponseAdapter<TestQuery.Data.Object> {
+    object OtherObject : ResponseAdapter<TestQuery.Data.Object.OtherObject> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Object {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> CharacterObject.fromResponse(reader, typename)
-          "Droid" -> CharacterObject.fromResponse(reader, typename)
-          else -> OtherObject.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Object) {
-        when(value) {
-          is TestQuery.Data.Object.CharacterObject -> CharacterObject.toResponse(writer, value)
-          is TestQuery.Data.Object.OtherObject -> OtherObject.toResponse(writer, value)
-        }
-      }
-
-      object CharacterObject : ResponseAdapter<TestQuery.Data.Object.CharacterObject> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Object.CharacterObject {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+          TestQuery.Data.Object.OtherObject {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Object.CharacterObject(
-              __typename = __typename!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Object.CharacterObject) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          TestQuery.Data.Object.OtherObject(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherObject : ResponseAdapter<TestQuery.Data.Object.OtherObject> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Object.OtherObject {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Object.OtherObject(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Object.OtherObject) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Object.OtherObject) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -23,122 +23,108 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Query" -> QueryData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
+      is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forObject("hero", "hero", null, true, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.QueryData {
+      return reader.run {
+        var __typename: String? = __typename
+        var hero: TestQuery.Data.QueryData.Hero? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
+              Hero.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        TestQuery.Data.QueryData(
+          __typename = __typename!!,
+          hero = hero
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      if(value.hero == null) {
+        writer.writeObject(RESPONSE_FIELDS[1], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+          Hero.toResponse(writer, value.hero)
+        }
+      }
+    }
+
+    object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.QueryData.Hero {
+        return reader.run {
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> name = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          TestQuery.Data.QueryData.Hero(
+            name = name!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.name)
+      }
+    }
+  }
+
+  object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Query" -> QueryData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      when(value) {
-        is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
-        is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forObject("hero", "hero", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.QueryData {
-        return reader.run {
-          var __typename: String? = __typename
-          var hero: TestQuery.Data.QueryData.Hero? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
-                Hero.fromResponse(reader)
-              }
-              else -> break
-            }
-          }
-          TestQuery.Data.QueryData(
-            __typename = __typename!!,
-            hero = hero
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        if(value.hero == null) {
-          writer.writeObject(RESPONSE_FIELDS[1], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-            Hero.toResponse(writer, value.hero)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            else -> break
           }
         }
-      }
-
-      object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("name", "name", null, false, null)
+        TestQuery.Data.OtherData(
+          __typename = __typename!!
         )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Hero {
-          return reader.run {
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> name = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.QueryData.Hero(
-              name = name!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.name)
-        }
       }
     }
 
-    object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQuery.Data.OtherData(
-            __typename = __typename!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
@@ -24,74 +24,59 @@ object QueryFragmentImpl_ResponseAdapter : ResponseAdapter<QueryFragmentImpl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var hero: QueryFragmentImpl.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> hero = readObject<QueryFragmentImpl.Data.Hero>(RESPONSE_FIELDS[1]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      QueryFragmentImpl.Data(
+        __typename = __typename!!,
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<QueryFragmentImpl.Data> {
+  object Hero : ResponseAdapter<QueryFragmentImpl.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        QueryFragmentImpl.Data.Hero {
       return reader.run {
-        var __typename: String? = __typename
-        var hero: QueryFragmentImpl.Data.Hero? = null
+        var name: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> hero = readObject<QueryFragmentImpl.Data.Hero>(RESPONSE_FIELDS[1]) { reader ->
-              Hero.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
             else -> break
           }
         }
-        QueryFragmentImpl.Data(
-          __typename = __typename!!,
-          hero = hero
+        QueryFragmentImpl.Data.Hero(
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<QueryFragmentImpl.Data.Hero> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          QueryFragmentImpl.Data.Hero {
-        return reader.run {
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          QueryFragmentImpl.Data.Hero(
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Hero) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Hero) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/adapter/TestQuery_ResponseAdapter.kt
@@ -23,378 +23,364 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Query" -> QueryData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
+      is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forObject("hero", "hero", null, true, null),
+      ResponseField.forObject("droid", "droid", mapOf<String, Any?>(
+        "id" to 1), true, null),
+      ResponseField.forObject("human", "human", mapOf<String, Any?>(
+        "id" to 1), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Query" -> QueryData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.QueryData {
+      return reader.run {
+        var __typename: String? = __typename
+        var hero: TestQuery.Data.QueryData.Hero? = null
+        var droid: TestQuery.Data.QueryData.Droid? = null
+        var human: TestQuery.Data.QueryData.Human? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
+              Hero.fromResponse(reader)
+            }
+            2 -> droid = readObject<TestQuery.Data.QueryData.Droid>(RESPONSE_FIELDS[2]) { reader ->
+              Droid.fromResponse(reader)
+            }
+            3 -> human = readObject<TestQuery.Data.QueryData.Human>(RESPONSE_FIELDS[3]) { reader ->
+              Human.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        TestQuery.Data.QueryData(
+          __typename = __typename!!,
+          hero = hero,
+          droid = droid,
+          human = human
+        )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      when(value) {
-        is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
-        is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forObject("hero", "hero", null, true, null),
-        ResponseField.forObject("droid", "droid", mapOf<String, Any?>(
-          "id" to 1), true, null),
-        ResponseField.forObject("human", "human", mapOf<String, Any?>(
-          "id" to 1), true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.QueryData {
-        return reader.run {
-          var __typename: String? = __typename
-          var hero: TestQuery.Data.QueryData.Hero? = null
-          var droid: TestQuery.Data.QueryData.Droid? = null
-          var human: TestQuery.Data.QueryData.Human? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
-                Hero.fromResponse(reader)
-              }
-              2 -> droid = readObject<TestQuery.Data.QueryData.Droid>(RESPONSE_FIELDS[2]) { reader ->
-                Droid.fromResponse(reader)
-              }
-              3 -> human = readObject<TestQuery.Data.QueryData.Human>(RESPONSE_FIELDS[3]) { reader ->
-                Human.fromResponse(reader)
-              }
-              else -> break
-            }
-          }
-          TestQuery.Data.QueryData(
-            __typename = __typename!!,
-            hero = hero,
-            droid = droid,
-            human = human
-          )
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      if(value.hero == null) {
+        writer.writeObject(RESPONSE_FIELDS[1], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+          Hero.toResponse(writer, value.hero)
         }
       }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        if(value.hero == null) {
-          writer.writeObject(RESPONSE_FIELDS[1], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-            Hero.toResponse(writer, value.hero)
-          }
-        }
-        if(value.droid == null) {
-          writer.writeObject(RESPONSE_FIELDS[2], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            Droid.toResponse(writer, value.droid)
-          }
-        }
-        if(value.human == null) {
-          writer.writeObject(RESPONSE_FIELDS[3], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-            Human.toResponse(writer, value.human)
-          }
+      if(value.droid == null) {
+        writer.writeObject(RESPONSE_FIELDS[2], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          Droid.toResponse(writer, value.droid)
         }
       }
-
-      object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Hero {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "Droid" -> CharacterHero.fromResponse(reader, typename)
-            "Human" -> CharacterHero.fromResponse(reader, typename)
-            else -> OtherHero.fromResponse(reader, typename)
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
-          when(value) {
-            is TestQuery.Data.QueryData.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-            is TestQuery.Data.QueryData.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-          }
-        }
-
-        object CharacterHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.CharacterHero> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Hero.CharacterHero {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Hero.CharacterHero(
-                __typename = __typename!!,
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Hero.CharacterHero) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-          }
-        }
-
-        object OtherHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.OtherHero> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Hero.OtherHero {
-            return reader.run {
-              var __typename: String? = __typename
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Hero.OtherHero(
-                __typename = __typename!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Hero.OtherHero) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          }
-        }
-      }
-
-      object Droid : ResponseAdapter<TestQuery.Data.QueryData.Droid> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Droid {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "Droid" -> DroidDroid.fromResponse(reader, typename)
-            else -> OtherDroid.fromResponse(reader, typename)
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Droid) {
-          when(value) {
-            is TestQuery.Data.QueryData.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
-            is TestQuery.Data.QueryData.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
-          }
-        }
-
-        object DroidDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.DroidDroid> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Droid.DroidDroid {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              var primaryFunction: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Droid.DroidDroid(
-                __typename = __typename!!,
-                name = name!!,
-                primaryFunction = primaryFunction
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Droid.DroidDroid) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-            writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-          }
-        }
-
-        object OtherDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.OtherDroid> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Droid.OtherDroid {
-            return reader.run {
-              var __typename: String? = __typename
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Droid.OtherDroid(
-                __typename = __typename!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Droid.OtherDroid) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          }
-        }
-      }
-
-      object Human : ResponseAdapter<TestQuery.Data.QueryData.Human> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Human {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "Human" -> HumanHuman.fromResponse(reader, typename)
-            else -> OtherHuman.fromResponse(reader, typename)
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Human) {
-          when(value) {
-            is TestQuery.Data.QueryData.Human.HumanHuman -> HumanHuman.toResponse(writer, value)
-            is TestQuery.Data.QueryData.Human.OtherHuman -> OtherHuman.toResponse(writer, value)
-          }
-        }
-
-        object HumanHuman : ResponseAdapter<TestQuery.Data.QueryData.Human.HumanHuman> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Human.HumanHuman {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              var homePlanet: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  2 -> homePlanet = readString(RESPONSE_FIELDS[2])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Human.HumanHuman(
-                __typename = __typename!!,
-                name = name!!,
-                homePlanet = homePlanet
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Human.HumanHuman) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-            writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
-          }
-        }
-
-        object OtherHuman : ResponseAdapter<TestQuery.Data.QueryData.Human.OtherHuman> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Human.OtherHuman {
-            return reader.run {
-              var __typename: String? = __typename
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Human.OtherHuman(
-                __typename = __typename!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Human.OtherHuman) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          }
+      if(value.human == null) {
+        writer.writeObject(RESPONSE_FIELDS[3], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+          Human.toResponse(writer, value.human)
         }
       }
     }
 
-    object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
+    object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQuery.Data.OtherData(
-            __typename = __typename!!
-          )
+          TestQuery.Data.QueryData.Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "Droid" -> CharacterHero.fromResponse(reader, typename)
+          "Human" -> CharacterHero.fromResponse(reader, typename)
+          else -> OtherHero.fromResponse(reader, typename)
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
+        when(value) {
+          is TestQuery.Data.QueryData.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+          is TestQuery.Data.QueryData.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+        }
       }
+
+      object CharacterHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.CharacterHero> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Hero.CharacterHero {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Hero.CharacterHero(
+              __typename = __typename!!,
+              name = name!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Hero.CharacterHero) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+        }
+      }
+
+      object OtherHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.OtherHero> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Hero.OtherHero {
+          return reader.run {
+            var __typename: String? = __typename
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Hero.OtherHero(
+              __typename = __typename!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Hero.OtherHero) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        }
+      }
+    }
+
+    object Droid : ResponseAdapter<TestQuery.Data.QueryData.Droid> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.QueryData.Droid {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "Droid" -> DroidDroid.fromResponse(reader, typename)
+          else -> OtherDroid.fromResponse(reader, typename)
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Droid) {
+        when(value) {
+          is TestQuery.Data.QueryData.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
+          is TestQuery.Data.QueryData.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
+        }
+      }
+
+      object DroidDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.DroidDroid> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Droid.DroidDroid {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            var primaryFunction: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Droid.DroidDroid(
+              __typename = __typename!!,
+              name = name!!,
+              primaryFunction = primaryFunction
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Droid.DroidDroid) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+        }
+      }
+
+      object OtherDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.OtherDroid> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Droid.OtherDroid {
+          return reader.run {
+            var __typename: String? = __typename
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Droid.OtherDroid(
+              __typename = __typename!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Droid.OtherDroid) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        }
+      }
+    }
+
+    object Human : ResponseAdapter<TestQuery.Data.QueryData.Human> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.QueryData.Human {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "Human" -> HumanHuman.fromResponse(reader, typename)
+          else -> OtherHuman.fromResponse(reader, typename)
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Human) {
+        when(value) {
+          is TestQuery.Data.QueryData.Human.HumanHuman -> HumanHuman.toResponse(writer, value)
+          is TestQuery.Data.QueryData.Human.OtherHuman -> OtherHuman.toResponse(writer, value)
+        }
+      }
+
+      object HumanHuman : ResponseAdapter<TestQuery.Data.QueryData.Human.HumanHuman> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forString("homePlanet", "homePlanet", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Human.HumanHuman {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            var homePlanet: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Human.HumanHuman(
+              __typename = __typename!!,
+              name = name!!,
+              homePlanet = homePlanet
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Human.HumanHuman) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
+        }
+      }
+
+      object OtherHuman : ResponseAdapter<TestQuery.Data.QueryData.Human.OtherHuman> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Human.OtherHuman {
+          return reader.run {
+            var __typename: String? = __typename
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Human.OtherHuman(
+              __typename = __typename!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Human.OtherHuman) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        }
+      }
+    }
+  }
+
+  object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            else -> break
+          }
+        }
+        TestQuery.Data.OtherData(
+          __typename = __typename!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/DroidFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/DroidFragmentImpl_ResponseAdapter.kt
@@ -25,45 +25,29 @@ object DroidFragmentImpl_ResponseAdapter : ResponseAdapter<DroidFragmentImpl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): DroidFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var primaryFunction: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+          else -> break
+        }
+      }
+      DroidFragmentImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        primaryFunction = primaryFunction
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: DroidFragmentImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<DroidFragmentImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): DroidFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var primaryFunction: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-            else -> break
-          }
-        }
-        DroidFragmentImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          primaryFunction = primaryFunction
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: DroidFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/HeroFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/HeroFragmentImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object HeroFragmentImpl_ResponseAdapter : ResponseAdapter<HeroFragmentImpl.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      HeroFragmentImpl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroFragmentImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HeroFragmentImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        HeroFragmentImpl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HeroFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/fragment/adapter/QueryFragmentImpl_ResponseAdapter.kt
@@ -28,329 +28,310 @@ object QueryFragmentImpl_ResponseAdapter : ResponseAdapter<QueryFragmentImpl.Dat
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var hero: QueryFragmentImpl.Data.Hero? = null
+      var droid: QueryFragmentImpl.Data.Droid? = null
+      var human: QueryFragmentImpl.Data.Human? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> hero = readObject<QueryFragmentImpl.Data.Hero>(RESPONSE_FIELDS[1]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          2 -> droid = readObject<QueryFragmentImpl.Data.Droid>(RESPONSE_FIELDS[2]) { reader ->
+            Droid.fromResponse(reader)
+          }
+          3 -> human = readObject<QueryFragmentImpl.Data.Human>(RESPONSE_FIELDS[3]) { reader ->
+            Human.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      QueryFragmentImpl.Data(
+        __typename = __typename!!,
+        hero = hero,
+        droid = droid,
+        human = human
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
+    if(value.droid == null) {
+      writer.writeObject(RESPONSE_FIELDS[2], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        Droid.toResponse(writer, value.droid)
+      }
+    }
+    if(value.human == null) {
+      writer.writeObject(RESPONSE_FIELDS[3], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
+        Human.toResponse(writer, value.human)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<QueryFragmentImpl.Data> {
+  object Hero : ResponseAdapter<QueryFragmentImpl.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forObject("hero", "hero", null, true, null),
-      ResponseField.forObject("droid", "droid", mapOf<String, Any?>(
-        "id" to 1), true, null),
-      ResponseField.forObject("human", "human", mapOf<String, Any?>(
-        "id" to 1), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): QueryFragmentImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var hero: QueryFragmentImpl.Data.Hero? = null
-        var droid: QueryFragmentImpl.Data.Droid? = null
-        var human: QueryFragmentImpl.Data.Human? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> hero = readObject<QueryFragmentImpl.Data.Hero>(RESPONSE_FIELDS[1]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        QueryFragmentImpl.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Hero) {
+      when(value) {
+        is QueryFragmentImpl.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is QueryFragmentImpl.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterHero : ResponseAdapter<QueryFragmentImpl.Data.Hero.CharacterHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          QueryFragmentImpl.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            2 -> droid = readObject<QueryFragmentImpl.Data.Droid>(RESPONSE_FIELDS[2]) { reader ->
-              Droid.fromResponse(reader)
-            }
-            3 -> human = readObject<QueryFragmentImpl.Data.Human>(RESPONSE_FIELDS[3]) { reader ->
-              Human.fromResponse(reader)
-            }
-            else -> break
           }
+          QueryFragmentImpl.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
-        QueryFragmentImpl.Data(
-          __typename = __typename!!,
-          hero = hero,
-          droid = droid,
-          human = human
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
-      }
-      if(value.droid == null) {
-        writer.writeObject(RESPONSE_FIELDS[2], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          Droid.toResponse(writer, value.droid)
-        }
-      }
-      if(value.human == null) {
-        writer.writeObject(RESPONSE_FIELDS[3], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[3]) { writer ->
-          Human.toResponse(writer, value.human)
-        }
-      }
-    }
-
-    object Hero : ResponseAdapter<QueryFragmentImpl.Data.Hero> {
+    object OtherHero : ResponseAdapter<QueryFragmentImpl.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          QueryFragmentImpl.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Hero) {
-        when(value) {
-          is QueryFragmentImpl.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is QueryFragmentImpl.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<QueryFragmentImpl.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+          QueryFragmentImpl.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            QueryFragmentImpl.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          QueryFragmentImpl.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherHero : ResponseAdapter<QueryFragmentImpl.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      }
+    }
+  }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            QueryFragmentImpl.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
-          }
-        }
+  object Droid : ResponseAdapter<QueryFragmentImpl.Data.Droid> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
 
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        QueryFragmentImpl.Data.Droid {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> DroidDroid.fromResponse(reader, typename)
+        else -> OtherDroid.fromResponse(reader, typename)
       }
     }
 
-    object Droid : ResponseAdapter<QueryFragmentImpl.Data.Droid> {
+    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Droid) {
+      when(value) {
+        is QueryFragmentImpl.Data.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
+        is QueryFragmentImpl.Data.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
+      }
+    }
+
+    object DroidDroid : ResponseAdapter<QueryFragmentImpl.Data.Droid.DroidDroid> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          QueryFragmentImpl.Data.Droid.DroidDroid {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          QueryFragmentImpl.Data.Droid.DroidDroid(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Droid.DroidDroid) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+      }
+    }
+
+    object OtherDroid : ResponseAdapter<QueryFragmentImpl.Data.Droid.OtherDroid> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          QueryFragmentImpl.Data.Droid {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> DroidDroid.fromResponse(reader, typename)
-          else -> OtherDroid.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Droid) {
-        when(value) {
-          is QueryFragmentImpl.Data.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
-          is QueryFragmentImpl.Data.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
-        }
-      }
-
-      object DroidDroid : ResponseAdapter<QueryFragmentImpl.Data.Droid.DroidDroid> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Droid.DroidDroid {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          QueryFragmentImpl.Data.Droid.OtherDroid {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            QueryFragmentImpl.Data.Droid.DroidDroid(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Droid.DroidDroid) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          QueryFragmentImpl.Data.Droid.OtherDroid(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherDroid : ResponseAdapter<QueryFragmentImpl.Data.Droid.OtherDroid> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Droid.OtherDroid) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      }
+    }
+  }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Droid.OtherDroid {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            QueryFragmentImpl.Data.Droid.OtherDroid(
-              __typename = __typename!!
-            )
-          }
-        }
+  object Human : ResponseAdapter<QueryFragmentImpl.Data.Human> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
 
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Droid.OtherDroid) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        QueryFragmentImpl.Data.Human {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHuman.fromResponse(reader, typename)
+        else -> OtherHuman.fromResponse(reader, typename)
       }
     }
 
-    object Human : ResponseAdapter<QueryFragmentImpl.Data.Human> {
+    override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Human) {
+      when(value) {
+        is QueryFragmentImpl.Data.Human.HumanHuman -> HumanHuman.toResponse(writer, value)
+        is QueryFragmentImpl.Data.Human.OtherHuman -> OtherHuman.toResponse(writer, value)
+      }
+    }
+
+    object HumanHuman : ResponseAdapter<QueryFragmentImpl.Data.Human.HumanHuman> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("homePlanet", "homePlanet", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          QueryFragmentImpl.Data.Human.HumanHuman {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var homePlanet: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          QueryFragmentImpl.Data.Human.HumanHuman(
+            __typename = __typename!!,
+            name = name!!,
+            homePlanet = homePlanet
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Human.HumanHuman) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
+      }
+    }
+
+    object OtherHuman : ResponseAdapter<QueryFragmentImpl.Data.Human.OtherHuman> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          QueryFragmentImpl.Data.Human {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHuman.fromResponse(reader, typename)
-          else -> OtherHuman.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: QueryFragmentImpl.Data.Human) {
-        when(value) {
-          is QueryFragmentImpl.Data.Human.HumanHuman -> HumanHuman.toResponse(writer, value)
-          is QueryFragmentImpl.Data.Human.OtherHuman -> OtherHuman.toResponse(writer, value)
-        }
-      }
-
-      object HumanHuman : ResponseAdapter<QueryFragmentImpl.Data.Human.HumanHuman> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("homePlanet", "homePlanet", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Human.HumanHuman {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var homePlanet: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> homePlanet = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          QueryFragmentImpl.Data.Human.OtherHuman {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            QueryFragmentImpl.Data.Human.HumanHuman(
-              __typename = __typename!!,
-              name = name!!,
-              homePlanet = homePlanet
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Human.HumanHuman) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
+          QueryFragmentImpl.Data.Human.OtherHuman(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherHuman : ResponseAdapter<QueryFragmentImpl.Data.Human.OtherHuman> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            QueryFragmentImpl.Data.Human.OtherHuman {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            QueryFragmentImpl.Data.Human.OtherHuman(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: QueryFragmentImpl.Data.Human.OtherHuman) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter,
+          value: QueryFragmentImpl.Data.Human.OtherHuman) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -26,303 +26,289 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Query" -> QueryData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
+      is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forObject("hero", "hero", null, true, null),
+      ResponseField.forObject("droid", "droid", mapOf<String, Any?>(
+        "id" to 1), true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Query" -> QueryData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      when(value) {
-        is TestQuery.Data.QueryData -> QueryData.toResponse(writer, value)
-        is TestQuery.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object QueryData : ResponseAdapter<TestQuery.Data.QueryData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forObject("hero", "hero", null, true, null),
-        ResponseField.forObject("droid", "droid", mapOf<String, Any?>(
-          "id" to 1), true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.QueryData {
-        return reader.run {
-          var __typename: String? = __typename
-          var hero: TestQuery.Data.QueryData.Hero? = null
-          var droid: TestQuery.Data.QueryData.Droid? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
-                Hero.fromResponse(reader)
-              }
-              2 -> droid = readObject<TestQuery.Data.QueryData.Droid>(RESPONSE_FIELDS[2]) { reader ->
-                Droid.fromResponse(reader)
-              }
-              else -> break
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.QueryData {
+      return reader.run {
+        var __typename: String? = __typename
+        var hero: TestQuery.Data.QueryData.Hero? = null
+        var droid: TestQuery.Data.QueryData.Droid? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> hero = readObject<TestQuery.Data.QueryData.Hero>(RESPONSE_FIELDS[1]) { reader ->
+              Hero.fromResponse(reader)
             }
-          }
-          TestQuery.Data.QueryData(
-            __typename = __typename!!,
-            hero = hero,
-            droid = droid
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        if(value.hero == null) {
-          writer.writeObject(RESPONSE_FIELDS[1], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-            Hero.toResponse(writer, value.hero)
+            2 -> droid = readObject<TestQuery.Data.QueryData.Droid>(RESPONSE_FIELDS[2]) { reader ->
+              Droid.fromResponse(reader)
+            }
+            else -> break
           }
         }
-        if(value.droid == null) {
-          writer.writeObject(RESPONSE_FIELDS[2], null)
-        } else {
-          writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-            Droid.toResponse(writer, value.droid)
-          }
-        }
-      }
-
-      object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
+        TestQuery.Data.QueryData(
+          __typename = __typename!!,
+          hero = hero,
+          droid = droid
         )
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Hero {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "Human" -> HumanHero.fromResponse(reader, typename)
-            else -> OtherHero.fromResponse(reader, typename)
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
-          when(value) {
-            is TestQuery.Data.QueryData.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-            is TestQuery.Data.QueryData.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-          }
-        }
-
-        object HumanHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.HumanHero> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forList("appearsIn", "appearsIn", null, false, null),
-            ResponseField.forDouble("height", "height", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Hero.HumanHero {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              var appearsIn: List<Episode?>? = null
-              var height: Double? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-                    Episode.safeValueOf(reader.readString())
-                  }
-                  3 -> height = readDouble(RESPONSE_FIELDS[3])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Hero.HumanHero(
-                __typename = __typename!!,
-                name = name!!,
-                appearsIn = appearsIn!!,
-                height = height
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Hero.HumanHero) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-            writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
-              listItemWriter.writeString(value?.rawValue)}
-            writer.writeDouble(RESPONSE_FIELDS[3], value.height)
-          }
-        }
-
-        object OtherHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.OtherHero> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forList("appearsIn", "appearsIn", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Hero.OtherHero {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              var appearsIn: List<Episode?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
-                    Episode.safeValueOf(reader.readString())
-                  }
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Hero.OtherHero(
-                __typename = __typename!!,
-                name = name!!,
-                appearsIn = appearsIn!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Hero.OtherHero) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-            writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
-              listItemWriter.writeString(value?.rawValue)}
-          }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      if(value.hero == null) {
+        writer.writeObject(RESPONSE_FIELDS[1], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+          Hero.toResponse(writer, value.hero)
         }
       }
-
-      object Droid : ResponseAdapter<TestQuery.Data.QueryData.Droid> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.QueryData.Droid {
-          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-          return when(typename) {
-            "Droid" -> DroidDroid.fromResponse(reader, typename)
-            else -> OtherDroid.fromResponse(reader, typename)
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Droid) {
-          when(value) {
-            is TestQuery.Data.QueryData.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
-            is TestQuery.Data.QueryData.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
-          }
-        }
-
-        object DroidDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.DroidDroid> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null),
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Droid.DroidDroid {
-            return reader.run {
-              var __typename: String? = __typename
-              var name: String? = null
-              var primaryFunction: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  1 -> name = readString(RESPONSE_FIELDS[1])
-                  2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Droid.DroidDroid(
-                __typename = __typename!!,
-                name = name!!,
-                primaryFunction = primaryFunction
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Droid.DroidDroid) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            writer.writeString(RESPONSE_FIELDS[1], value.name)
-            writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-          }
-        }
-
-        object OtherDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.OtherDroid> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.QueryData.Droid.OtherDroid {
-            return reader.run {
-              var __typename: String? = __typename
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> __typename = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              TestQuery.Data.QueryData.Droid.OtherDroid(
-                __typename = __typename!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.QueryData.Droid.OtherDroid) {
-            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          }
+      if(value.droid == null) {
+        writer.writeObject(RESPONSE_FIELDS[2], null)
+      } else {
+        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+          Droid.toResponse(writer, value.droid)
         }
       }
     }
 
-    object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
+    object Hero : ResponseAdapter<TestQuery.Data.QueryData.Hero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQuery.Data.OtherData(
-            __typename = __typename!!
-          )
+          TestQuery.Data.QueryData.Hero {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "Human" -> HumanHero.fromResponse(reader, typename)
+          else -> OtherHero.fromResponse(reader, typename)
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Hero) {
+        when(value) {
+          is TestQuery.Data.QueryData.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+          is TestQuery.Data.QueryData.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+        }
       }
+
+      object HumanHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.HumanHero> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forList("appearsIn", "appearsIn", null, false, null),
+          ResponseField.forDouble("height", "height", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Hero.HumanHero {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            var appearsIn: List<Episode?>? = null
+            var height: Double? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                  Episode.safeValueOf(reader.readString())
+                }
+                3 -> height = readDouble(RESPONSE_FIELDS[3])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Hero.HumanHero(
+              __typename = __typename!!,
+              name = name!!,
+              appearsIn = appearsIn!!,
+              height = height
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Hero.HumanHero) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
+            listItemWriter.writeString(value?.rawValue)}
+          writer.writeDouble(RESPONSE_FIELDS[3], value.height)
+        }
+      }
+
+      object OtherHero : ResponseAdapter<TestQuery.Data.QueryData.Hero.OtherHero> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forList("appearsIn", "appearsIn", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Hero.OtherHero {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            var appearsIn: List<Episode?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                2 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[2]) { reader ->
+                  Episode.safeValueOf(reader.readString())
+                }
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Hero.OtherHero(
+              __typename = __typename!!,
+              name = name!!,
+              appearsIn = appearsIn!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Hero.OtherHero) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          writer.writeList(RESPONSE_FIELDS[2], value.appearsIn) { value, listItemWriter ->
+            listItemWriter.writeString(value?.rawValue)}
+        }
+      }
+    }
+
+    object Droid : ResponseAdapter<TestQuery.Data.QueryData.Droid> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.QueryData.Droid {
+        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+        return when(typename) {
+          "Droid" -> DroidDroid.fromResponse(reader, typename)
+          else -> OtherDroid.fromResponse(reader, typename)
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.QueryData.Droid) {
+        when(value) {
+          is TestQuery.Data.QueryData.Droid.DroidDroid -> DroidDroid.toResponse(writer, value)
+          is TestQuery.Data.QueryData.Droid.OtherDroid -> OtherDroid.toResponse(writer, value)
+        }
+      }
+
+      object DroidDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.DroidDroid> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null),
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Droid.DroidDroid {
+          return reader.run {
+            var __typename: String? = __typename
+            var name: String? = null
+            var primaryFunction: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                1 -> name = readString(RESPONSE_FIELDS[1])
+                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Droid.DroidDroid(
+              __typename = __typename!!,
+              name = name!!,
+              primaryFunction = primaryFunction
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Droid.DroidDroid) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+        }
+      }
+
+      object OtherDroid : ResponseAdapter<TestQuery.Data.QueryData.Droid.OtherDroid> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("__typename", "__typename", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            TestQuery.Data.QueryData.Droid.OtherDroid {
+          return reader.run {
+            var __typename: String? = __typename
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> __typename = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            TestQuery.Data.QueryData.Droid.OtherDroid(
+              __typename = __typename!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.QueryData.Droid.OtherDroid) {
+          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        }
+      }
+    }
+  }
+
+  object OtherData : ResponseAdapter<TestQuery.Data.OtherData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            else -> break
+          }
+        }
+        TestQuery.Data.OtherData(
+          __typename = __typename!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -23,149 +23,135 @@ internal object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        TestQuery.Data(
-          hero = hero
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+    object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterHumanHero(
-              __typename = __typename!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterHumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          TestQuery.Data.Hero.CharacterHumanHero(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
       }
 
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterHumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
           }
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
+      }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -23,88 +23,74 @@ internal object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImp
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+    return when(typename) {
+      "Human" -> HumanData.fromResponse(reader, typename)
+      else -> OtherData.fromResponse(reader, typename)
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    when(value) {
+      is HeroDetailsImpl.Data.HumanData -> HumanData.toResponse(writer, value)
+      is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object HumanData : ResponseAdapter<HeroDetailsImpl.Data.HumanData> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.HumanData {
+      return reader.run {
+        var __typename: String? = __typename
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            else -> break
+          }
+        }
+        HeroDetailsImpl.Data.HumanData(
+          __typename = __typename!!,
+          name = name!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.HumanData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+    }
+  }
+
+  object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
       ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-      return when(typename) {
-        "Human" -> HumanData.fromResponse(reader, typename)
-        else -> OtherData.fromResponse(reader, typename)
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      when(value) {
-        is HeroDetailsImpl.Data.HumanData -> HumanData.toResponse(writer, value)
-        is HeroDetailsImpl.Data.OtherData -> OtherData.toResponse(writer, value)
-      }
-    }
-
-    object HumanData : ResponseAdapter<HeroDetailsImpl.Data.HumanData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null),
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.HumanData {
-        return reader.run {
-          var __typename: String? = __typename
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.OtherData {
+      return reader.run {
+        var __typename: String? = __typename
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> __typename = readString(RESPONSE_FIELDS[0])
+            else -> break
           }
-          HeroDetailsImpl.Data.HumanData(
-            __typename = __typename!!,
-            name = name!!
-          )
         }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.HumanData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        HeroDetailsImpl.Data.OtherData(
+          __typename = __typename!!
+        )
       }
     }
 
-    object OtherData : ResponseAdapter<HeroDetailsImpl.Data.OtherData> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.OtherData {
-        return reader.run {
-          var __typename: String? = __typename
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> __typename = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          HeroDetailsImpl.Data.OtherData(
-            __typename = __typename!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
-        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      }
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.OtherData) {
+      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment/fragment/adapter/HumanDetailsImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ internal object HumanDetailsImpl_ResponseAdapter : ResponseAdapter<HumanDetailsI
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      HumanDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<HumanDetailsImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HumanDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        HumanDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: HumanDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/adapter/TestQuery_ResponseAdapter.kt
@@ -25,268 +25,251 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        TestQuery.Data(
-          hero = hero
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterHero.fromResponse(reader, typename)
+        "Human" -> CharacterHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, true, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterHero.fromResponse(reader, typename)
-          "Human" -> CharacterHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterHero -> CharacterHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<TestQuery.Data.Hero.CharacterHero.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<TestQuery.Data.Hero.CharacterHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<TestQuery.Data.Hero.CharacterHero.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<TestQuery.Data.Hero.CharacterHero.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<TestQuery.Data.Hero.CharacterHero.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<TestQuery.Data.Hero.CharacterHero.Friend> { reader ->
+                  Friend.fromResponse(reader)
                 }
-                else -> break
               }
-            }
-            TestQuery.Data.Hero.CharacterHero(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
+              else -> break
             }
           }
-        }
-
-        object Friend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+          TestQuery.Data.Hero.CharacterHero(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
           )
+        }
+      }
 
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Hero.CharacterHero.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Human" -> HumanFriend.fromResponse(reader, typename)
-              "Droid" -> DroidFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Hero.CharacterHero.Friend) {
-            when(value) {
-              is TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
-              is TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend -> DroidFriend.toResponse(writer, value)
-              is TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-            }
-          }
-
-          object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forDouble("height", "height", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var height: Double? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> height = readDouble(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  height = height
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-            }
-          }
-
-          object DroidFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var primaryFunction: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  primaryFunction = primaryFunction
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-            }
-          }
-
-          object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend(
-                  __typename = __typename!!,
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-            }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.CharacterHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
           }
         }
       }
 
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
+      object Friend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
           ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
+            TestQuery.Data.Hero.CharacterHero.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Human" -> HumanFriend.fromResponse(reader, typename)
+            "Droid" -> DroidFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
           }
         }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        override fun toResponse(writer: ResponseWriter,
+            value: TestQuery.Data.Hero.CharacterHero.Friend) {
+          when(value) {
+            is TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
+            is TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend -> DroidFriend.toResponse(writer, value)
+            is TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+          }
         }
+
+        object HumanFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forDouble("height", "height", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var height: Double? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> height = readDouble(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend(
+                __typename = __typename!!,
+                name = name!!,
+                height = height
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHero.Friend.HumanFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          }
+        }
+
+        object DroidFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var primaryFunction: String? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend(
+                __typename = __typename!!,
+                name = name!!,
+                primaryFunction = primaryFunction
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHero.Friend.DroidFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          }
+        }
+
+        object OtherFriend : ResponseAdapter<TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  else -> break
+                }
+              }
+              TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend(
+                __typename = __typename!!,
+                name = name!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Hero.CharacterHero.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+          }
+        }
+      }
+    }
+
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -27,182 +27,166 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var friends: List<HeroDetailsImpl.Data.Friend?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> friends = readList<HeroDetailsImpl.Data.Friend>(RESPONSE_FIELDS[2]) { reader ->
+            reader.readObject<HeroDetailsImpl.Data.Friend> { reader ->
+              Friend.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      HeroDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        friends = friends
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Friend.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object Friend : ResponseAdapter<HeroDetailsImpl.Data.Friend> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forList("friends", "friends", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var friends: List<HeroDetailsImpl.Data.Friend?>? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> friends = readList<HeroDetailsImpl.Data.Friend>(RESPONSE_FIELDS[2]) { reader ->
-              reader.readObject<HeroDetailsImpl.Data.Friend> { reader ->
-                Friend.fromResponse(reader)
-              }
-            }
-            else -> break
-          }
-        }
-        HeroDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          friends = friends
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.Friend {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanFriend.fromResponse(reader, typename)
+        "Droid" -> DroidFriend.fromResponse(reader, typename)
+        else -> OtherFriend.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Friend.toResponse(writer, value)
-        }
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.Friend) {
+      when(value) {
+        is HeroDetailsImpl.Data.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
+        is HeroDetailsImpl.Data.Friend.DroidFriend -> DroidFriend.toResponse(writer, value)
+        is HeroDetailsImpl.Data.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
       }
     }
 
-    object Friend : ResponseAdapter<HeroDetailsImpl.Data.Friend> {
+    object HumanFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.HumanFriend> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.Friend {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanFriend.fromResponse(reader, typename)
-          "Droid" -> DroidFriend.fromResponse(reader, typename)
-          else -> OtherFriend.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.Friend) {
-        when(value) {
-          is HeroDetailsImpl.Data.Friend.HumanFriend -> HumanFriend.toResponse(writer, value)
-          is HeroDetailsImpl.Data.Friend.DroidFriend -> DroidFriend.toResponse(writer, value)
-          is HeroDetailsImpl.Data.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-        }
-      }
-
-      object HumanFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.HumanFriend> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.Friend.HumanFriend {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          HeroDetailsImpl.Data.Friend.HumanFriend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
             }
-            HeroDetailsImpl.Data.Friend.HumanFriend(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.Friend.HumanFriend) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+          HeroDetailsImpl.Data.Friend.HumanFriend(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
         }
       }
 
-      object DroidFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.DroidFriend> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.Friend.HumanFriend) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.Friend.DroidFriend {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+    object DroidFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.DroidFriend> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          HeroDetailsImpl.Data.Friend.DroidFriend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            HeroDetailsImpl.Data.Friend.DroidFriend(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.Friend.DroidFriend) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          HeroDetailsImpl.Data.Friend.DroidFriend(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
       }
 
-      object OtherFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.OtherFriend> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.Friend.DroidFriend) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.Friend.OtherFriend {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+    object OtherFriend : ResponseAdapter<HeroDetailsImpl.Data.Friend.OtherFriend> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          HeroDetailsImpl.Data.Friend.OtherFriend {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            HeroDetailsImpl.Data.Friend.OtherFriend(
-              __typename = __typename!!,
-              name = name!!
-            )
           }
+          HeroDetailsImpl.Data.Friend.OtherFriend(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
+      }
 
-        override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.Friend.OtherFriend) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-        }
+      override fun toResponse(writer: ResponseWriter,
+          value: HeroDetailsImpl.Data.Friend.OtherFriend) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -24,165 +24,151 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Droid" -> CharacterDroidHero.fromResponse(reader, typename)
+        "Human" -> CharacterHumanHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.CharacterDroidHero -> CharacterDroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object CharacterDroidHero : ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterDroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Hero.CharacterDroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
-        TestQuery.Data(
-          hero = hero
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterDroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.CharacterHumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> height = readDouble(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.CharacterHumanHero(
+            __typename = __typename!!,
+            name = name!!,
+            height = height
+          )
         }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Hero.CharacterHumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeDouble(RESPONSE_FIELDS[2], value.height)
       }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Droid" -> CharacterDroidHero.fromResponse(reader, typename)
-          "Human" -> CharacterHumanHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.CharacterDroidHero -> CharacterDroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.CharacterHumanHero -> CharacterHumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object CharacterDroidHero : ResponseAdapter<TestQuery.Data.Hero.CharacterDroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterDroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.CharacterDroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterDroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object CharacterHumanHero : ResponseAdapter<TestQuery.Data.Hero.CharacterHumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.CharacterHumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> height = readDouble(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.CharacterHumanHero(
-              __typename = __typename!!,
-              name = name!!,
-              height = height
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Hero.CharacterHumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeDouble(RESPONSE_FIELDS[2], value.height)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/starships/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/starships/adapter/TestQuery_ResponseAdapter.kt
@@ -28,88 +28,71 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var starship: TestQuery.Data.Starship? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> starship = readObject<TestQuery.Data.Starship>(RESPONSE_FIELDS[0]) { reader ->
+            Starship.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        starship = starship
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.starship == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Starship.toResponse(writer, value.starship)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Starship : ResponseAdapter<TestQuery.Data.Starship> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("starship", "starship", mapOf<String, Any?>(
-        "id" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "id")), true, null)
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forList("coordinates", "coordinates", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestQuery.Data.Starship {
       return reader.run {
-        var starship: TestQuery.Data.Starship? = null
+        var id: String? = null
+        var name: String? = null
+        var coordinates: List<List<Double>>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> starship = readObject<TestQuery.Data.Starship>(RESPONSE_FIELDS[0]) { reader ->
-              Starship.fromResponse(reader)
-            }
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> coordinates = readList<List<Double>>(RESPONSE_FIELDS[2]) { reader ->
+              reader.readList<Double> { reader ->
+                reader.readDouble()
+              }.map { it!! }
+            }?.map { it!! }
             else -> break
           }
         }
-        TestQuery.Data(
-          starship = starship
+        TestQuery.Data.Starship(
+          id = id!!,
+          name = name!!,
+          coordinates = coordinates
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.starship == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Starship.toResponse(writer, value.starship)
-        }
-      }
-    }
-
-    object Starship : ResponseAdapter<TestQuery.Data.Starship> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forList("coordinates", "coordinates", null, true, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Starship {
-        return reader.run {
-          var id: String? = null
-          var name: String? = null
-          var coordinates: List<List<Double>>? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> coordinates = readList<List<Double>>(RESPONSE_FIELDS[2]) { reader ->
-                reader.readList<Double> { reader ->
-                  reader.readDouble()
-                }.map { it!! }
-              }?.map { it!! }
-              else -> break
-            }
-          }
-          TestQuery.Data.Starship(
-            id = id!!,
-            name = name!!,
-            coordinates = coordinates
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Starship) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeList(RESPONSE_FIELDS[2], value.coordinates) { value, listItemWriter ->
-          listItemWriter.writeList(value) { value, listItemWriter ->
-            listItemWriter.writeDouble(value)}
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Starship) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeList(RESPONSE_FIELDS[2], value.coordinates) { value, listItemWriter ->
+        listItemWriter.writeList(value) { value, listItemWriter ->
+          listItemWriter.writeDouble(value)}
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/subscriptions/adapter/TestSubscription_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/subscriptions/adapter/TestSubscription_ResponseAdapter.kt
@@ -27,77 +27,60 @@ object TestSubscription_ResponseAdapter : ResponseAdapter<TestSubscription.Data>
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestSubscription.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var commentAdded: TestSubscription.Data.CommentAdded? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> commentAdded = readObject<TestSubscription.Data.CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
+            CommentAdded.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestSubscription.Data(
+        commentAdded = commentAdded
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestSubscription.Data) {
-    Data.toResponse(writer, value)
+    if(value.commentAdded == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        CommentAdded.toResponse(writer, value.commentAdded)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestSubscription.Data> {
+  object CommentAdded : ResponseAdapter<TestSubscription.Data.CommentAdded> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("commentAdded", "commentAdded", mapOf<String, Any?>(
-        "repoFullName" to mapOf<String, Any?>(
-          "kind" to "Variable",
-          "variableName" to "repo")), true, null)
+      ResponseField.forInt("id", "id", null, false, null),
+      ResponseField.forString("content", "content", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestSubscription.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        TestSubscription.Data.CommentAdded {
       return reader.run {
-        var commentAdded: TestSubscription.Data.CommentAdded? = null
+        var id: Int? = null
+        var content: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> commentAdded = readObject<TestSubscription.Data.CommentAdded>(RESPONSE_FIELDS[0]) { reader ->
-              CommentAdded.fromResponse(reader)
-            }
+            0 -> id = readInt(RESPONSE_FIELDS[0])
+            1 -> content = readString(RESPONSE_FIELDS[1])
             else -> break
           }
         }
-        TestSubscription.Data(
-          commentAdded = commentAdded
+        TestSubscription.Data.CommentAdded(
+          id = id!!,
+          content = content!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestSubscription.Data) {
-      if(value.commentAdded == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          CommentAdded.toResponse(writer, value.commentAdded)
-        }
-      }
-    }
-
-    object CommentAdded : ResponseAdapter<TestSubscription.Data.CommentAdded> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("id", "id", null, false, null),
-        ResponseField.forString("content", "content", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestSubscription.Data.CommentAdded {
-        return reader.run {
-          var id: Int? = null
-          var content: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readInt(RESPONSE_FIELDS[0])
-              1 -> content = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestSubscription.Data.CommentAdded(
-            id = id!!,
-            content = content!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestSubscription.Data.CommentAdded) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.content)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestSubscription.Data.CommentAdded) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.content)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/test_inline/adapter/GetPage_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/test_inline/adapter/GetPage_ResponseAdapter.kt
@@ -24,264 +24,249 @@ object GetPage_ResponseAdapter : ResponseAdapter<GetPage.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): GetPage.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var collection: GetPage.Data.Collection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> collection = readObject<GetPage.Data.Collection>(RESPONSE_FIELDS[0]) { reader ->
+            Collection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      GetPage.Data(
+        collection = collection!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: GetPage.Data) {
-    Data.toResponse(writer, value)
+    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+      Collection.toResponse(writer, value.collection)
+    }
   }
 
-  object Data : ResponseAdapter<GetPage.Data> {
+  object Collection : ResponseAdapter<GetPage.Data.Collection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("collection", "collection", null, false, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forList("items", "items", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): GetPage.Data {
-      return reader.run {
-        var collection: GetPage.Data.Collection? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> collection = readObject<GetPage.Data.Collection>(RESPONSE_FIELDS[0]) { reader ->
-              Collection.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        GetPage.Data(
-          collection = collection!!
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        GetPage.Data.Collection {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "ParticularCollection" -> ParticularCollectionCollection.fromResponse(reader, typename)
+        else -> OtherCollection.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: GetPage.Data) {
-      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-        Collection.toResponse(writer, value.collection)
+    override fun toResponse(writer: ResponseWriter, value: GetPage.Data.Collection) {
+      when(value) {
+        is GetPage.Data.Collection.ParticularCollectionCollection -> ParticularCollectionCollection.toResponse(writer, value)
+        is GetPage.Data.Collection.OtherCollection -> OtherCollection.toResponse(writer, value)
       }
     }
 
-    object Collection : ResponseAdapter<GetPage.Data.Collection> {
+    object ParticularCollectionCollection :
+        ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forList("items", "items", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          GetPage.Data.Collection {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "ParticularCollection" -> ParticularCollectionCollection.fromResponse(reader, typename)
-          else -> OtherCollection.fromResponse(reader, typename)
+          GetPage.Data.Collection.ParticularCollectionCollection {
+        return reader.run {
+          var __typename: String? = __typename
+          var items: List<GetPage.Data.Collection.ParticularCollectionCollection.Item>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> items = readList<GetPage.Data.Collection.ParticularCollectionCollection.Item>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<GetPage.Data.Collection.ParticularCollectionCollection.Item> { reader ->
+                  Item.fromResponse(reader)
+                }
+              }?.map { it!! }
+              else -> break
+            }
+          }
+          GetPage.Data.Collection.ParticularCollectionCollection(
+            __typename = __typename!!,
+            items = items!!
+          )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: GetPage.Data.Collection) {
-        when(value) {
-          is GetPage.Data.Collection.ParticularCollectionCollection -> ParticularCollectionCollection.toResponse(writer, value)
-          is GetPage.Data.Collection.OtherCollection -> OtherCollection.toResponse(writer, value)
+      override fun toResponse(writer: ResponseWriter,
+          value: GetPage.Data.Collection.ParticularCollectionCollection) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeList(RESPONSE_FIELDS[1], value.items) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Item.toResponse(writer, value)
+          }
         }
       }
 
-      object ParticularCollectionCollection :
-          ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection> {
+      object Item : ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forList("items", "items", null, false, null)
+          ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            GetPage.Data.Collection.ParticularCollectionCollection {
-          return reader.run {
-            var __typename: String? = __typename
-            var items: List<GetPage.Data.Collection.ParticularCollectionCollection.Item>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> items = readList<GetPage.Data.Collection.ParticularCollectionCollection.Item>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<GetPage.Data.Collection.ParticularCollectionCollection.Item> { reader ->
-                    Item.fromResponse(reader)
-                  }
-                }?.map { it!! }
-                else -> break
-              }
-            }
-            GetPage.Data.Collection.ParticularCollectionCollection(
-              __typename = __typename!!,
-              items = items!!
-            )
+            GetPage.Data.Collection.ParticularCollectionCollection.Item {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "ParticularItem" -> ParticularItemItem.fromResponse(reader, typename)
+            else -> OtherItem.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: GetPage.Data.Collection.ParticularCollectionCollection) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeList(RESPONSE_FIELDS[1], value.items) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Item.toResponse(writer, value)
-            }
+            value: GetPage.Data.Collection.ParticularCollectionCollection.Item) {
+          when(value) {
+            is GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem -> ParticularItemItem.toResponse(writer, value)
+            is GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem -> OtherItem.toResponse(writer, value)
           }
         }
 
-        object Item : ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item> {
+        object ParticularItemItem :
+            ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem>
+            {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+            ResponseField.forString("title", "title", null, false, null),
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("image", "image", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              GetPage.Data.Collection.ParticularCollectionCollection.Item {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "ParticularItem" -> ParticularItemItem.fromResponse(reader, typename)
-              else -> OtherItem.fromResponse(reader, typename)
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: GetPage.Data.Collection.ParticularCollectionCollection.Item) {
-            when(value) {
-              is GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem -> ParticularItemItem.toResponse(writer, value)
-              is GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem -> OtherItem.toResponse(writer, value)
-            }
-          }
-
-          object ParticularItemItem :
-              ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("title", "title", null, false, null),
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("image", "image", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem {
-              return reader.run {
-                var title: String? = null
-                var __typename: String? = __typename
-                var image: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> title = readString(RESPONSE_FIELDS[0])
-                    1 -> __typename = readString(RESPONSE_FIELDS[1])
-                    2 -> image = readString(RESPONSE_FIELDS[2])
-                    else -> break
-                  }
-                }
-                GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem(
-                  title = title!!,
-                  __typename = __typename!!,
-                  image = image!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem) {
-              writer.writeString(RESPONSE_FIELDS[0], value.title)
-              writer.writeString(RESPONSE_FIELDS[1], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[2], value.image)
-            }
-          }
-
-          object OtherItem :
-              ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("title", "title", null, false, null),
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem {
-              return reader.run {
-                var title: String? = null
-                var __typename: String? = __typename
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> title = readString(RESPONSE_FIELDS[0])
-                    1 -> __typename = readString(RESPONSE_FIELDS[1])
-                    else -> break
-                  }
-                }
-                GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem(
-                  title = title!!,
-                  __typename = __typename!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem) {
-              writer.writeString(RESPONSE_FIELDS[0], value.title)
-              writer.writeString(RESPONSE_FIELDS[1], value.__typename)
-            }
-          }
-        }
-      }
-
-      object OtherCollection : ResponseAdapter<GetPage.Data.Collection.OtherCollection> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forList("items", "items", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            GetPage.Data.Collection.OtherCollection {
-          return reader.run {
-            var __typename: String? = __typename
-            var items: List<GetPage.Data.Collection.OtherCollection.Item>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> items = readList<GetPage.Data.Collection.OtherCollection.Item>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<GetPage.Data.Collection.OtherCollection.Item> { reader ->
-                    Item.fromResponse(reader)
-                  }
-                }?.map { it!! }
-                else -> break
-              }
-            }
-            GetPage.Data.Collection.OtherCollection(
-              __typename = __typename!!,
-              items = items!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: GetPage.Data.Collection.OtherCollection) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeList(RESPONSE_FIELDS[1], value.items) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Item.toResponse(writer, value)
-            }
-          }
-        }
-
-        object Item : ResponseAdapter<GetPage.Data.Collection.OtherCollection.Item> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("title", "title", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              GetPage.Data.Collection.OtherCollection.Item {
+              GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem {
             return reader.run {
               var title: String? = null
+              var __typename: String? = __typename
+              var image: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
                   0 -> title = readString(RESPONSE_FIELDS[0])
+                  1 -> __typename = readString(RESPONSE_FIELDS[1])
+                  2 -> image = readString(RESPONSE_FIELDS[2])
                   else -> break
                 }
               }
-              GetPage.Data.Collection.OtherCollection.Item(
-                title = title!!
+              GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem(
+                title = title!!,
+                __typename = __typename!!,
+                image = image!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: GetPage.Data.Collection.OtherCollection.Item) {
+              value: GetPage.Data.Collection.ParticularCollectionCollection.Item.ParticularItemItem) {
             writer.writeString(RESPONSE_FIELDS[0], value.title)
+            writer.writeString(RESPONSE_FIELDS[1], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[2], value.image)
           }
+        }
+
+        object OtherItem :
+            ResponseAdapter<GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("title", "title", null, false, null),
+            ResponseField.forString("__typename", "__typename", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem {
+            return reader.run {
+              var title: String? = null
+              var __typename: String? = __typename
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> title = readString(RESPONSE_FIELDS[0])
+                  1 -> __typename = readString(RESPONSE_FIELDS[1])
+                  else -> break
+                }
+              }
+              GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem(
+                title = title!!,
+                __typename = __typename!!
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: GetPage.Data.Collection.ParticularCollectionCollection.Item.OtherItem) {
+            writer.writeString(RESPONSE_FIELDS[0], value.title)
+            writer.writeString(RESPONSE_FIELDS[1], value.__typename)
+          }
+        }
+      }
+    }
+
+    object OtherCollection : ResponseAdapter<GetPage.Data.Collection.OtherCollection> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forList("items", "items", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          GetPage.Data.Collection.OtherCollection {
+        return reader.run {
+          var __typename: String? = __typename
+          var items: List<GetPage.Data.Collection.OtherCollection.Item>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> items = readList<GetPage.Data.Collection.OtherCollection.Item>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<GetPage.Data.Collection.OtherCollection.Item> { reader ->
+                  Item.fromResponse(reader)
+                }
+              }?.map { it!! }
+              else -> break
+            }
+          }
+          GetPage.Data.Collection.OtherCollection(
+            __typename = __typename!!,
+            items = items!!
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: GetPage.Data.Collection.OtherCollection) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeList(RESPONSE_FIELDS[1], value.items) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Item.toResponse(writer, value)
+          }
+        }
+      }
+
+      object Item : ResponseAdapter<GetPage.Data.Collection.OtherCollection.Item> {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("title", "title", null, false, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            GetPage.Data.Collection.OtherCollection.Item {
+          return reader.run {
+            var title: String? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> title = readString(RESPONSE_FIELDS[0])
+                else -> break
+              }
+            }
+            GetPage.Data.Collection.OtherCollection.Item(
+              title = title!!
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: GetPage.Data.Collection.OtherCollection.Item) {
+          writer.writeString(RESPONSE_FIELDS[0], value.title)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/adapter/TestQuery_ResponseAdapter.kt
@@ -25,112 +25,96 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var r2: TestQuery.Data.R2? = null
+      var luke: TestQuery.Data.Luke? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
+            R2.fromResponse(reader)
+          }
+          1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
+            Luke.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        r2 = r2,
+        luke = luke
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.r2 == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        R2.toResponse(writer, value.r2)
+      }
+    }
+    if(value.luke == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Luke.toResponse(writer, value.luke)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object R2 : ResponseAdapter<TestQuery.Data.R2> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("r2", "hero", null, true, null),
-      ResponseField.forObject("luke", "hero", mapOf<String, Any?>(
-        "episode" to "EMPIRE"), true, null)
+      ResponseField.forString("name", "name", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
       return reader.run {
-        var r2: TestQuery.Data.R2? = null
-        var luke: TestQuery.Data.Luke? = null
+        var name: String? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
-              R2.fromResponse(reader)
-            }
-            1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
-              Luke.fromResponse(reader)
-            }
+            0 -> name = readString(RESPONSE_FIELDS[0])
             else -> break
           }
         }
-        TestQuery.Data(
-          r2 = r2,
-          luke = luke
+        TestQuery.Data.R2(
+          name = name!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.r2 == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          R2.toResponse(writer, value.r2)
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+    }
+  }
+
+  object Luke : ResponseAdapter<TestQuery.Data.Luke> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
+      return reader.run {
+        var id: String? = null
+        var name: String? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            else -> break
+          }
         }
-      }
-      if(value.luke == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Luke.toResponse(writer, value.luke)
-        }
+        TestQuery.Data.Luke(
+          id = id!!,
+          name = name!!
+        )
       }
     }
 
-    object R2 : ResponseAdapter<TestQuery.Data.R2> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
-        return reader.run {
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              else -> break
-            }
-          }
-          TestQuery.Data.R2(
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-      }
-    }
-
-    object Luke : ResponseAdapter<TestQuery.Data.Luke> {
-      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forString("name", "name", null, false, null)
-      )
-
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
-        return reader.run {
-          var id: String? = null
-          var name: String? = null
-          while(true) {
-            when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              else -> break
-            }
-          }
-          TestQuery.Data.Luke(
-            id = id!!,
-            name = name!!
-          )
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-      }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
     }
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/adapter/TestQuery_ResponseAdapter.kt
@@ -27,331 +27,314 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var r2: TestQuery.Data.R2? = null
+      var luke: TestQuery.Data.Luke? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
+            R2.fromResponse(reader)
+          }
+          1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
+            Luke.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        r2 = r2,
+        luke = luke
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.r2 == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        R2.toResponse(writer, value.r2)
+      }
+    }
+    if(value.luke == null) {
+      writer.writeObject(RESPONSE_FIELDS[1], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        Luke.toResponse(writer, value.luke)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object R2 : ResponseAdapter<TestQuery.Data.R2> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("r2", "hero", null, true, null),
-      ResponseField.forObject("luke", "hero", mapOf<String, Any?>(
-        "episode" to "EMPIRE"), true, null)
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
       return reader.run {
-        var r2: TestQuery.Data.R2? = null
-        var luke: TestQuery.Data.Luke? = null
+        var name: String? = null
+        var friendsConnection: TestQuery.Data.R2.FriendsConnection? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> r2 = readObject<TestQuery.Data.R2>(RESPONSE_FIELDS[0]) { reader ->
-              R2.fromResponse(reader)
-            }
-            1 -> luke = readObject<TestQuery.Data.Luke>(RESPONSE_FIELDS[1]) { reader ->
-              Luke.fromResponse(reader)
+            0 -> name = readString(RESPONSE_FIELDS[0])
+            1 -> friendsConnection = readObject<TestQuery.Data.R2.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
+              FriendsConnection.fromResponse(reader)
             }
             else -> break
           }
         }
-        TestQuery.Data(
-          r2 = r2,
-          luke = luke
+        TestQuery.Data.R2(
+          name = name!!,
+          friendsConnection = friendsConnection!!
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.r2 == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          R2.toResponse(writer, value.r2)
-        }
-      }
-      if(value.luke == null) {
-        writer.writeObject(RESPONSE_FIELDS[1], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          Luke.toResponse(writer, value.luke)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
+      writer.writeString(RESPONSE_FIELDS[0], value.name)
+      writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
       }
     }
 
-    object R2 : ResponseAdapter<TestQuery.Data.R2> {
+    object FriendsConnection : ResponseAdapter<TestQuery.Data.R2.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.R2 {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.R2.FriendsConnection {
         return reader.run {
-          var name: String? = null
-          var friendsConnection: TestQuery.Data.R2.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<TestQuery.Data.R2.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> name = readString(RESPONSE_FIELDS[0])
-              1 -> friendsConnection = readObject<TestQuery.Data.R2.FriendsConnection>(RESPONSE_FIELDS[1]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<TestQuery.Data.R2.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<TestQuery.Data.R2.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          TestQuery.Data.R2(
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          TestQuery.Data.R2.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2) {
-        writer.writeString(RESPONSE_FIELDS[0], value.name)
-        writer.writeObject(RESPONSE_FIELDS[1]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.R2.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<TestQuery.Data.R2.FriendsConnection> {
+      object Edge : ResponseAdapter<TestQuery.Data.R2.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.R2.FriendsConnection {
+            TestQuery.Data.R2.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<TestQuery.Data.R2.FriendsConnection.Edge?>? = null
+            var node: TestQuery.Data.R2.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<TestQuery.Data.R2.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<TestQuery.Data.R2.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<TestQuery.Data.R2.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            TestQuery.Data.R2.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            TestQuery.Data.R2.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.R2.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: TestQuery.Data.R2.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<TestQuery.Data.R2.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<TestQuery.Data.R2.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.R2.FriendsConnection.Edge {
+              TestQuery.Data.R2.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: TestQuery.Data.R2.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<TestQuery.Data.R2.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              TestQuery.Data.R2.FriendsConnection.Edge(
-                node = node
+              TestQuery.Data.R2.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.R2.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<TestQuery.Data.R2.FriendsConnection.Edge.Node> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.R2.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.R2.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.R2.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: TestQuery.Data.R2.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }
     }
+  }
 
-    object Luke : ResponseAdapter<TestQuery.Data.Luke> {
+  object Luke : ResponseAdapter<TestQuery.Data.Luke> {
+    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+      ResponseField.forString("id", "id", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+    )
+
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
+      return reader.run {
+        var id: String? = null
+        var name: String? = null
+        var friendsConnection: TestQuery.Data.Luke.FriendsConnection? = null
+        while(true) {
+          when (selectField(RESPONSE_FIELDS)) {
+            0 -> id = readString(RESPONSE_FIELDS[0])
+            1 -> name = readString(RESPONSE_FIELDS[1])
+            2 -> friendsConnection = readObject<TestQuery.Data.Luke.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+              FriendsConnection.fromResponse(reader)
+            }
+            else -> break
+          }
+        }
+        TestQuery.Data.Luke(
+          id = id!!,
+          name = name!!,
+          friendsConnection = friendsConnection!!
+        )
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
+      writer.writeString(RESPONSE_FIELDS[0], value.id)
+      writer.writeString(RESPONSE_FIELDS[1], value.name)
+      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+        FriendsConnection.toResponse(writer, value.friendsConnection)
+      }
+    }
+
+    object FriendsConnection : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("id", "id", null, false, null),
-        ResponseField.forString("name", "name", null, false, null),
-        ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+        ResponseField.forInt("totalCount", "totalCount", null, true, null),
+        ResponseField.forList("edges", "edges", null, true, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Luke {
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Luke.FriendsConnection {
         return reader.run {
-          var id: String? = null
-          var name: String? = null
-          var friendsConnection: TestQuery.Data.Luke.FriendsConnection? = null
+          var totalCount: Int? = null
+          var edges: List<TestQuery.Data.Luke.FriendsConnection.Edge?>? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> id = readString(RESPONSE_FIELDS[0])
-              1 -> name = readString(RESPONSE_FIELDS[1])
-              2 -> friendsConnection = readObject<TestQuery.Data.Luke.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                FriendsConnection.fromResponse(reader)
+              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+              1 -> edges = readList<TestQuery.Data.Luke.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                reader.readObject<TestQuery.Data.Luke.FriendsConnection.Edge> { reader ->
+                  Edge.fromResponse(reader)
+                }
               }
               else -> break
             }
           }
-          TestQuery.Data.Luke(
-            id = id!!,
-            name = name!!,
-            friendsConnection = friendsConnection!!
+          TestQuery.Data.Luke.FriendsConnection(
+            totalCount = totalCount,
+            edges = edges
           )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Luke) {
-        writer.writeString(RESPONSE_FIELDS[0], value.id)
-        writer.writeString(RESPONSE_FIELDS[1], value.name)
-        writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-          FriendsConnection.toResponse(writer, value.friendsConnection)
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Luke.FriendsConnection) {
+        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Edge.toResponse(writer, value)
+          }
         }
       }
 
-      object FriendsConnection : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection> {
+      object Edge : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection.Edge> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forInt("totalCount", "totalCount", null, true, null),
-          ResponseField.forList("edges", "edges", null, true, null)
+          ResponseField.forObject("node", "node", null, true, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Luke.FriendsConnection {
+            TestQuery.Data.Luke.FriendsConnection.Edge {
           return reader.run {
-            var totalCount: Int? = null
-            var edges: List<TestQuery.Data.Luke.FriendsConnection.Edge?>? = null
+            var node: TestQuery.Data.Luke.FriendsConnection.Edge.Node? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                1 -> edges = readList<TestQuery.Data.Luke.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                  reader.readObject<TestQuery.Data.Luke.FriendsConnection.Edge> { reader ->
-                    Edge.fromResponse(reader)
-                  }
+                0 -> node = readObject<TestQuery.Data.Luke.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                  Node.fromResponse(reader)
                 }
                 else -> break
               }
             }
-            TestQuery.Data.Luke.FriendsConnection(
-              totalCount = totalCount,
-              edges = edges
+            TestQuery.Data.Luke.FriendsConnection.Edge(
+              node = node
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Luke.FriendsConnection) {
-          writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-          writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Edge.toResponse(writer, value)
+            value: TestQuery.Data.Luke.FriendsConnection.Edge) {
+          if(value.node == null) {
+            writer.writeObject(RESPONSE_FIELDS[0], null)
+          } else {
+            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+              Node.toResponse(writer, value.node)
             }
           }
         }
 
-        object Edge : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection.Edge> {
+        object Node : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection.Edge.Node> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forObject("node", "node", null, true, null)
+            ResponseField.forString("name", "name", null, false, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Luke.FriendsConnection.Edge {
+              TestQuery.Data.Luke.FriendsConnection.Edge.Node {
             return reader.run {
-              var node: TestQuery.Data.Luke.FriendsConnection.Edge.Node? = null
+              var name: String? = null
               while(true) {
                 when (selectField(RESPONSE_FIELDS)) {
-                  0 -> node = readObject<TestQuery.Data.Luke.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                    Node.fromResponse(reader)
-                  }
+                  0 -> name = readString(RESPONSE_FIELDS[0])
                   else -> break
                 }
               }
-              TestQuery.Data.Luke.FriendsConnection.Edge(
-                node = node
+              TestQuery.Data.Luke.FriendsConnection.Edge.Node(
+                name = name!!
               )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Luke.FriendsConnection.Edge) {
-            if(value.node == null) {
-              writer.writeObject(RESPONSE_FIELDS[0], null)
-            } else {
-              writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                Node.toResponse(writer, value.node)
-              }
-            }
-          }
-
-          object Node : ResponseAdapter<TestQuery.Data.Luke.FriendsConnection.Edge.Node> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("name", "name", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Luke.FriendsConnection.Edge.Node {
-              return reader.run {
-                var name: String? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> name = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Luke.FriendsConnection.Edge.Node(
-                  name = name!!
-                )
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Luke.FriendsConnection.Edge.Node) {
-              writer.writeString(RESPONSE_FIELDS[0], value.name)
-            }
+              value: TestQuery.Data.Luke.FriendsConnection.Edge.Node) {
+            writer.writeString(RESPONSE_FIELDS[0], value.name)
           }
         }
       }

--- a/apollo-compiler/src/test/graphql/com/example/typename_always_first/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/typename_always_first/adapter/TestQuery_ResponseAdapter.kt
@@ -25,163 +25,148 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var hero: TestQuery.Data.Hero? = null
+      var __typename: String? = __typename
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
+            Hero.fromResponse(reader)
+          }
+          1 -> __typename = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        hero = hero,
+        __typename = __typename!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    if(value.hero == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        Hero.toResponse(writer, value.hero)
+      }
+    }
+    writer.writeString(RESPONSE_FIELDS[1], value.__typename)
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Hero : ResponseAdapter<TestQuery.Data.Hero> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("hero", "hero", null, true, null),
       ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var hero: TestQuery.Data.Hero? = null
-        var __typename: String? = __typename
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> hero = readObject<TestQuery.Data.Hero>(RESPONSE_FIELDS[0]) { reader ->
-              Hero.fromResponse(reader)
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHero.fromResponse(reader, typename)
+        "Droid" -> DroidHero.fromResponse(reader, typename)
+        else -> OtherHero.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
+      when(value) {
+        is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
+        is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
+      }
+    }
+
+    object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.HumanHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> height = readDouble(RESPONSE_FIELDS[1])
+              else -> break
             }
-            1 -> __typename = readString(RESPONSE_FIELDS[1])
-            else -> break
           }
+          TestQuery.Data.Hero.HumanHero(
+            __typename = __typename!!,
+            height = height
+          )
         }
-        TestQuery.Data(
-          hero = hero,
-          __typename = __typename!!
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeDouble(RESPONSE_FIELDS[1], value.height)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      if(value.hero == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          Hero.toResponse(writer, value.hero)
+    object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.DroidHero {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var primaryFunction: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+              else -> break
+            }
+          }
+          TestQuery.Data.Hero.DroidHero(
+            __typename = __typename!!,
+            name = name!!,
+            primaryFunction = primaryFunction
+          )
         }
       }
-      writer.writeString(RESPONSE_FIELDS[1], value.__typename)
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+      }
     }
 
-    object Hero : ResponseAdapter<TestQuery.Data.Hero> {
+    object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
-      override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Hero {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHero.fromResponse(reader, typename)
-          "Droid" -> DroidHero.fromResponse(reader, typename)
-          else -> OtherHero.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero) {
-        when(value) {
-          is TestQuery.Data.Hero.HumanHero -> HumanHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.DroidHero -> DroidHero.toResponse(writer, value)
-          is TestQuery.Data.Hero.OtherHero -> OtherHero.toResponse(writer, value)
-        }
-      }
-
-      object HumanHero : ResponseAdapter<TestQuery.Data.Hero.HumanHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forDouble("height", "height", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.HumanHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var height: Double? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> height = readDouble(RESPONSE_FIELDS[1])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Hero.OtherHero {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Hero.HumanHero(
-              __typename = __typename!!,
-              height = height
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.HumanHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeDouble(RESPONSE_FIELDS[1], value.height)
+          TestQuery.Data.Hero.OtherHero(
+            __typename = __typename!!
+          )
         }
       }
 
-      object DroidHero : ResponseAdapter<TestQuery.Data.Hero.DroidHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forString("primaryFunction", "primaryFunction", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.DroidHero {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var primaryFunction: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.DroidHero(
-              __typename = __typename!!,
-              name = name!!,
-              primaryFunction = primaryFunction
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.DroidHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-        }
-      }
-
-      object OtherHero : ResponseAdapter<TestQuery.Data.Hero.OtherHero> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Hero.OtherHero {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Hero.OtherHero(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Hero.OtherHero) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/adapter/TestQuery_ResponseAdapter.kt
@@ -25,128 +25,111 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var search: List<TestQuery.Data.Search?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
+            reader.readObject<TestQuery.Data.Search> { reader ->
+              Search.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        search = search
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Search.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Search : ResponseAdapter<TestQuery.Data.Search> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forList("search", "search", mapOf<String, Any?>(
-        "text" to "test"), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var search: List<TestQuery.Data.Search?>? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
-              reader.readObject<TestQuery.Data.Search> { reader ->
-                Search.fromResponse(reader)
-              }
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Search {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Starship" -> StarshipSearch.fromResponse(reader, typename)
+        else -> OtherSearch.fromResponse(reader, typename)
+      }
+    }
+
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
+      when(value) {
+        is TestQuery.Data.Search.StarshipSearch -> StarshipSearch.toResponse(writer, value)
+        is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
+      }
+    }
+
+    object StarshipSearch : ResponseAdapter<TestQuery.Data.Search.StarshipSearch> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Search.StarshipSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              else -> break
             }
-            else -> break
           }
+          TestQuery.Data.Search.StarshipSearch(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!
+          )
         }
-        TestQuery.Data(
-          search = search
-        )
+      }
+
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.StarshipSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Search.toResponse(writer, value)
-        }
-      }
-    }
-
-    object Search : ResponseAdapter<TestQuery.Data.Search> {
+    object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Search {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Starship" -> StarshipSearch.fromResponse(reader, typename)
-          else -> OtherSearch.fromResponse(reader, typename)
-        }
-      }
-
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
-        when(value) {
-          is TestQuery.Data.Search.StarshipSearch -> StarshipSearch.toResponse(writer, value)
-          is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
-        }
-      }
-
-      object StarshipSearch : ResponseAdapter<TestQuery.Data.Search.StarshipSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.StarshipSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                else -> break
-              }
+          TestQuery.Data.Search.OtherSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Search.StarshipSearch(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Search.StarshipSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
+          TestQuery.Data.Search.OtherSearch(
+            __typename = __typename!!
+          )
         }
       }
 
-      object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.OtherSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
-            }
-            TestQuery.Data.Search.OtherSearch(
-              __typename = __typename!!
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/adapter/StarshipImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_fragment/fragment/adapter/StarshipImpl_ResponseAdapter.kt
@@ -24,40 +24,25 @@ object StarshipImpl_ResponseAdapter : ResponseAdapter<StarshipImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): StarshipImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          else -> break
+        }
+      }
+      StarshipImpl.Data(
+        __typename = __typename!!,
+        name = name!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: StarshipImpl.Data) {
-    Data.toResponse(writer, value)
-  }
-
-  object Data : ResponseAdapter<StarshipImpl.Data> {
-    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null)
-    )
-
-    override fun fromResponse(reader: ResponseReader, __typename: String?): StarshipImpl.Data {
-      return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            else -> break
-          }
-        }
-        StarshipImpl.Data(
-          __typename = __typename!!,
-          name = name!!
-        )
-      }
-    }
-
-    override fun toResponse(writer: ResponseWriter, value: StarshipImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-    }
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/adapter/TestQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/adapter/TestQuery_ResponseAdapter.kt
@@ -26,449 +26,432 @@ object TestQuery_ResponseAdapter : ResponseAdapter<TestQuery.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var search: List<TestQuery.Data.Search?>? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
+            reader.readObject<TestQuery.Data.Search> { reader ->
+              Search.fromResponse(reader)
+            }
+          }
+          else -> break
+        }
+      }
+      TestQuery.Data(
+        search = search
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-    Data.toResponse(writer, value)
+    writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
+      listItemWriter.writeObject { writer ->
+        Search.toResponse(writer, value)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<TestQuery.Data> {
+  object Search : ResponseAdapter<TestQuery.Data.Search> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forList("search", "search", mapOf<String, Any?>(
-        "text" to "test"), true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data {
-      return reader.run {
-        var search: List<TestQuery.Data.Search?>? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> search = readList<TestQuery.Data.Search>(RESPONSE_FIELDS[0]) { reader ->
-              reader.readObject<TestQuery.Data.Search> { reader ->
-                Search.fromResponse(reader)
-              }
-            }
-            else -> break
-          }
-        }
-        TestQuery.Data(
-          search = search
-        )
+    override fun fromResponse(reader: ResponseReader, __typename: String?): TestQuery.Data.Search {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> CharacterSearch.fromResponse(reader, typename)
+        "Droid" -> CharacterSearch.fromResponse(reader, typename)
+        "Starship" -> StarshipSearch.fromResponse(reader, typename)
+        else -> OtherSearch.fromResponse(reader, typename)
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data) {
-      writer.writeList(RESPONSE_FIELDS[0], value.search) { value, listItemWriter ->
-        listItemWriter.writeObject { writer ->
-          Search.toResponse(writer, value)
-        }
+    override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
+      when(value) {
+        is TestQuery.Data.Search.CharacterSearch -> CharacterSearch.toResponse(writer, value)
+        is TestQuery.Data.Search.StarshipSearch -> StarshipSearch.toResponse(writer, value)
+        is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
       }
     }
 
-    object Search : ResponseAdapter<TestQuery.Data.Search> {
+    object CharacterSearch : ResponseAdapter<TestQuery.Data.Search.CharacterSearch> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forString("__typename", "__typename", null, false, null)
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("id", "id", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          TestQuery.Data.Search {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> CharacterSearch.fromResponse(reader, typename)
-          "Droid" -> CharacterSearch.fromResponse(reader, typename)
-          "Starship" -> StarshipSearch.fromResponse(reader, typename)
-          else -> OtherSearch.fromResponse(reader, typename)
+          TestQuery.Data.Search.CharacterSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          var id: String? = null
+          var name: String? = null
+          var friends: List<TestQuery.Data.Search.CharacterSearch.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> id = readString(RESPONSE_FIELDS[1])
+              2 -> name = readString(RESPONSE_FIELDS[2])
+              3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
+            }
+          }
+          TestQuery.Data.Search.CharacterSearch(
+            __typename = __typename!!,
+            id = id!!,
+            name = name!!,
+            friends = friends
+          )
         }
       }
 
-      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search) {
-        when(value) {
-          is TestQuery.Data.Search.CharacterSearch -> CharacterSearch.toResponse(writer, value)
-          is TestQuery.Data.Search.StarshipSearch -> StarshipSearch.toResponse(writer, value)
-          is TestQuery.Data.Search.OtherSearch -> OtherSearch.toResponse(writer, value)
+      override fun toResponse(writer: ResponseWriter,
+          value: TestQuery.Data.Search.CharacterSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.id)
+        writer.writeString(RESPONSE_FIELDS[2], value.name)
+        writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
         }
       }
 
-      object CharacterSearch : ResponseAdapter<TestQuery.Data.Search.CharacterSearch> {
+      object Friend : ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("id", "id", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null)
+          ResponseField.forString("__typename", "__typename", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.CharacterSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            var id: String? = null
-            var name: String? = null
-            var friends: List<TestQuery.Data.Search.CharacterSearch.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> id = readString(RESPONSE_FIELDS[1])
-                2 -> name = readString(RESPONSE_FIELDS[2])
-                3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                  reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            TestQuery.Data.Search.CharacterSearch(
-              __typename = __typename!!,
-              id = id!!,
-              name = name!!,
-              friends = friends
-            )
+            TestQuery.Data.Search.CharacterSearch.Friend {
+          val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+          return when(typename) {
+            "Droid" -> CharacterDroidFriend.fromResponse(reader, typename)
+            "Human" -> CharacterHumanFriend.fromResponse(reader, typename)
+            else -> OtherFriend.fromResponse(reader, typename)
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Search.CharacterSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.id)
-          writer.writeString(RESPONSE_FIELDS[2], value.name)
-          writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
+            value: TestQuery.Data.Search.CharacterSearch.Friend) {
+          when(value) {
+            is TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend -> CharacterDroidFriend.toResponse(writer, value)
+            is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend -> CharacterHumanFriend.toResponse(writer, value)
+            is TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
           }
         }
 
-        object Friend : ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend> {
+        object CharacterDroidFriend :
+            ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend> {
           private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("__typename", "__typename", null, false, null)
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
+            ResponseField.forList("friends", "friends", null, true, null)
           )
 
           override fun fromResponse(reader: ResponseReader, __typename: String?):
-              TestQuery.Data.Search.CharacterSearch.Friend {
-            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-            return when(typename) {
-              "Droid" -> CharacterDroidFriend.fromResponse(reader, typename)
-              "Human" -> CharacterHumanFriend.fromResponse(reader, typename)
-              else -> OtherFriend.fromResponse(reader, typename)
+              TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var primaryFunction: String? = null
+              var friends: List<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend?>? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
+                  3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                    reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend> { reader ->
+                      Friend.fromResponse(reader)
+                    }
+                  }
+                  else -> break
+                }
+              }
+              TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend(
+                __typename = __typename!!,
+                name = name!!,
+                primaryFunction = primaryFunction,
+                friends = friends
+              )
             }
           }
 
           override fun toResponse(writer: ResponseWriter,
-              value: TestQuery.Data.Search.CharacterSearch.Friend) {
-            when(value) {
-              is TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend -> CharacterDroidFriend.toResponse(writer, value)
-              is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend -> CharacterHumanFriend.toResponse(writer, value)
-              is TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+              value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
+            writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+              listItemWriter.writeObject { writer ->
+                Friend.toResponse(writer, value)
+              }
             }
           }
 
-          object CharacterDroidFriend :
-              ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend> {
+          object Friend :
+              ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend>
+              {
             private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forString("primaryFunction", "primaryFunction", null, true, null),
-              ResponseField.forList("friends", "friends", null, true, null)
+              ResponseField.forString("id", "id", null, false, null)
             )
 
             override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend {
+                TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend {
               return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var primaryFunction: String? = null
-                var friends: List<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend?>? = null
+                var id: String? = null
                 while(true) {
                   when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> primaryFunction = readString(RESPONSE_FIELDS[2])
-                    3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                      reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend> { reader ->
-                        Friend.fromResponse(reader)
-                      }
-                    }
+                    0 -> id = readString(RESPONSE_FIELDS[0])
                     else -> break
                   }
                 }
-                TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  primaryFunction = primaryFunction,
-                  friends = friends
+                TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend(
+                  id = id!!
                 )
               }
             }
 
             override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeString(RESPONSE_FIELDS[2], value.primaryFunction)
-              writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-                listItemWriter.writeObject { writer ->
-                  Friend.toResponse(writer, value)
+                value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend) {
+              writer.writeString(RESPONSE_FIELDS[0], value.id)
+            }
+          }
+        }
+
+        object CharacterHumanFriend :
+            ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null),
+            ResponseField.forString("name", "name", null, false, null),
+            ResponseField.forString("homePlanet", "homePlanet", null, true, null),
+            ResponseField.forList("friends", "friends", null, true, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              var name: String? = null
+              var homePlanet: String? = null
+              var friends: List<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend?>? = null
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  1 -> name = readString(RESPONSE_FIELDS[1])
+                  2 -> homePlanet = readString(RESPONSE_FIELDS[2])
+                  3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend>(RESPONSE_FIELDS[3]) { reader ->
+                    reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend> { reader ->
+                      Friend.fromResponse(reader)
+                    }
+                  }
+                  else -> break
                 }
+              }
+              TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend(
+                __typename = __typename!!,
+                name = name!!,
+                homePlanet = homePlanet,
+                friends = friends
+              )
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            writer.writeString(RESPONSE_FIELDS[1], value.name)
+            writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
+            writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
+              listItemWriter.writeObject { writer ->
+                Friend.toResponse(writer, value)
+              }
+            }
+          }
+
+          object Friend :
+              ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend>
+              {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("__typename", "__typename", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend {
+              val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+              return when(typename) {
+                "Droid" -> CharacterFriend.fromResponse(reader, typename)
+                "Human" -> CharacterFriend.fromResponse(reader, typename)
+                else -> OtherFriend.fromResponse(reader, typename)
               }
             }
 
-            object Friend :
-                ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend>
+            override fun toResponse(writer: ResponseWriter,
+                value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend) {
+              when(value) {
+                is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend -> CharacterFriend.toResponse(writer, value)
+                is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+              }
+            }
+
+            object CharacterFriend :
+                ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend>
                 {
               private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("id", "id", null, false, null)
+                ResponseField.forString("__typename", "__typename", null, false, null),
+                ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
               )
 
               override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend {
+                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend {
                 return reader.run {
-                  var id: String? = null
+                  var __typename: String? = __typename
+                  var firstAppearsIn: Episode? = null
                   while(true) {
                     when (selectField(RESPONSE_FIELDS)) {
-                      0 -> id = readString(RESPONSE_FIELDS[0])
+                      0 -> __typename = readString(RESPONSE_FIELDS[0])
+                      1 -> firstAppearsIn = readString(RESPONSE_FIELDS[1])?.let { Episode.safeValueOf(it) }
                       else -> break
                     }
                   }
-                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend(
-                    id = id!!
+                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend(
+                    __typename = __typename!!,
+                    firstAppearsIn = firstAppearsIn!!
                   )
                 }
               }
 
               override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterDroidFriend.Friend) {
-                writer.writeString(RESPONSE_FIELDS[0], value.id)
-              }
-            }
-          }
-
-          object CharacterHumanFriend :
-              ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null),
-              ResponseField.forString("name", "name", null, false, null),
-              ResponseField.forString("homePlanet", "homePlanet", null, true, null),
-              ResponseField.forList("friends", "friends", null, true, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                var name: String? = null
-                var homePlanet: String? = null
-                var friends: List<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend?>? = null
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    1 -> name = readString(RESPONSE_FIELDS[1])
-                    2 -> homePlanet = readString(RESPONSE_FIELDS[2])
-                    3 -> friends = readList<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend>(RESPONSE_FIELDS[3]) { reader ->
-                      reader.readObject<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend> { reader ->
-                        Friend.fromResponse(reader)
-                      }
-                    }
-                    else -> break
-                  }
-                }
-                TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend(
-                  __typename = __typename!!,
-                  name = name!!,
-                  homePlanet = homePlanet,
-                  friends = friends
-                )
+                  value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend) {
+                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+                writer.writeString(RESPONSE_FIELDS[1], value.firstAppearsIn.rawValue)
               }
             }
 
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              writer.writeString(RESPONSE_FIELDS[1], value.name)
-              writer.writeString(RESPONSE_FIELDS[2], value.homePlanet)
-              writer.writeList(RESPONSE_FIELDS[3], value.friends) { value, listItemWriter ->
-                listItemWriter.writeObject { writer ->
-                  Friend.toResponse(writer, value)
-                }
-              }
-            }
-
-            object Friend :
-                ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend>
+            object OtherFriend :
+                ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend>
                 {
               private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
                 ResponseField.forString("__typename", "__typename", null, false, null)
               )
 
               override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend {
-                val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-                return when(typename) {
-                  "Droid" -> CharacterFriend.fromResponse(reader, typename)
-                  "Human" -> CharacterFriend.fromResponse(reader, typename)
-                  else -> OtherFriend.fromResponse(reader, typename)
+                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend {
+                return reader.run {
+                  var __typename: String? = __typename
+                  while(true) {
+                    when (selectField(RESPONSE_FIELDS)) {
+                      0 -> __typename = readString(RESPONSE_FIELDS[0])
+                      else -> break
+                    }
+                  }
+                  TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend(
+                    __typename = __typename!!
+                  )
                 }
               }
 
               override fun toResponse(writer: ResponseWriter,
-                  value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend) {
-                when(value) {
-                  is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend -> CharacterFriend.toResponse(writer, value)
-                  is TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-                }
-              }
-
-              object CharacterFriend :
-                  ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend>
-                  {
-                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forString("__typename", "__typename", null, false, null),
-                  ResponseField.forEnum("firstAppearsIn", "firstAppearsIn", null, false, null)
-                )
-
-                override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend {
-                  return reader.run {
-                    var __typename: String? = __typename
-                    var firstAppearsIn: Episode? = null
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> __typename = readString(RESPONSE_FIELDS[0])
-                        1 -> firstAppearsIn = readString(RESPONSE_FIELDS[1])?.let { Episode.safeValueOf(it) }
-                        else -> break
-                      }
-                    }
-                    TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend(
-                      __typename = __typename!!,
-                      firstAppearsIn = firstAppearsIn!!
-                    )
-                  }
-                }
-
-                override fun toResponse(writer: ResponseWriter,
-                    value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.CharacterFriend) {
-                  writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                  writer.writeString(RESPONSE_FIELDS[1], value.firstAppearsIn.rawValue)
-                }
-              }
-
-              object OtherFriend :
-                  ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend>
-                  {
-                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forString("__typename", "__typename", null, false, null)
-                )
-
-                override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend {
-                  return reader.run {
-                    var __typename: String? = __typename
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> __typename = readString(RESPONSE_FIELDS[0])
-                        else -> break
-                      }
-                    }
-                    TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend(
-                      __typename = __typename!!
-                    )
-                  }
-                }
-
-                override fun toResponse(writer: ResponseWriter,
-                    value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend) {
-                  writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                }
+                  value: TestQuery.Data.Search.CharacterSearch.Friend.CharacterHumanFriend.Friend.OtherFriend) {
+                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
               }
             }
           }
+        }
 
-          object OtherFriend :
-              ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend> {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
+        object OtherFriend :
+            ResponseAdapter<TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend> {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null)
+          )
 
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend {
-              return reader.run {
-                var __typename: String? = __typename
-                while(true) {
-                  when (selectField(RESPONSE_FIELDS)) {
-                    0 -> __typename = readString(RESPONSE_FIELDS[0])
-                    else -> break
-                  }
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend {
+            return reader.run {
+              var __typename: String? = __typename
+              while(true) {
+                when (selectField(RESPONSE_FIELDS)) {
+                  0 -> __typename = readString(RESPONSE_FIELDS[0])
+                  else -> break
                 }
-                TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend(
-                  __typename = __typename!!
-                )
               }
+              TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend(
+                __typename = __typename!!
+              )
             }
+          }
 
-            override fun toResponse(writer: ResponseWriter,
-                value: TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend) {
-              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-            }
+          override fun toResponse(writer: ResponseWriter,
+              value: TestQuery.Data.Search.CharacterSearch.Friend.OtherFriend) {
+            writer.writeString(RESPONSE_FIELDS[0], value.__typename)
           }
         }
       }
+    }
 
-      object StarshipSearch : ResponseAdapter<TestQuery.Data.Search.StarshipSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null)
-        )
+    object StarshipSearch : ResponseAdapter<TestQuery.Data.Search.StarshipSearch> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null)
+      )
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.StarshipSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                else -> break
-              }
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Search.StarshipSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              else -> break
             }
-            TestQuery.Data.Search.StarshipSearch(
-              __typename = __typename!!,
-              name = name!!
-            )
           }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: TestQuery.Data.Search.StarshipSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
+          TestQuery.Data.Search.StarshipSearch(
+            __typename = __typename!!,
+            name = name!!
+          )
         }
       }
 
-      object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null)
-        )
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.StarshipSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+      }
+    }
 
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            TestQuery.Data.Search.OtherSearch {
-          return reader.run {
-            var __typename: String? = __typename
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                else -> break
-              }
+    object OtherSearch : ResponseAdapter<TestQuery.Data.Search.OtherSearch> {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          TestQuery.Data.Search.OtherSearch {
+        return reader.run {
+          var __typename: String? = __typename
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              else -> break
             }
-            TestQuery.Data.Search.OtherSearch(
-              __typename = __typename!!
-            )
           }
+          TestQuery.Data.Search.OtherSearch(
+            __typename = __typename!!
+          )
         }
+      }
 
-        override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-        }
+      override fun toResponse(writer: ResponseWriter, value: TestQuery.Data.Search.OtherSearch) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
       }
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/adapter/HeroDetailQuery_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/adapter/HeroDetailQuery_ResponseAdapter.kt
@@ -26,50 +26,371 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
     ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true, null)
   )
 
-  override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailQuery.Data {
-    return Data.fromResponse(reader, __typename)
+  override fun fromResponse(reader: ResponseReader, __typename: String?):
+      com.example.unique_type_name.HeroDetailQuery.Data {
+    return reader.run {
+      var heroDetailQuery: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> heroDetailQuery = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery>(RESPONSE_FIELDS[0]) { reader ->
+            HeroDetailQuery.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      com.example.unique_type_name.HeroDetailQuery.Data(
+        heroDetailQuery = heroDetailQuery
+      )
+    }
   }
 
-  override fun toResponse(writer: ResponseWriter, value: HeroDetailQuery.Data) {
-    Data.toResponse(writer, value)
+  override fun toResponse(writer: ResponseWriter,
+      value: com.example.unique_type_name.HeroDetailQuery.Data) {
+    if(value.heroDetailQuery == null) {
+      writer.writeObject(RESPONSE_FIELDS[0], null)
+    } else {
+      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+        HeroDetailQuery.toResponse(writer, value.heroDetailQuery)
+      }
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailQuery.Data> {
+  object HeroDetailQuery :
+      ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forObject("heroDetailQuery", "heroDetailQuery", null, true, null)
+      ResponseField.forString("__typename", "__typename", null, false, null),
+      ResponseField.forString("name", "name", null, false, null),
+      ResponseField.forList("friends", "friends", null, true, null)
     )
 
     override fun fromResponse(reader: ResponseReader, __typename: String?):
-        com.example.unique_type_name.HeroDetailQuery.Data {
-      return reader.run {
-        var heroDetailQuery: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery? = null
-        while(true) {
-          when (selectField(RESPONSE_FIELDS)) {
-            0 -> heroDetailQuery = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery>(RESPONSE_FIELDS[0]) { reader ->
-              HeroDetailQuery.fromResponse(reader)
-            }
-            else -> break
-          }
-        }
-        com.example.unique_type_name.HeroDetailQuery.Data(
-          heroDetailQuery = heroDetailQuery
-        )
+        com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery {
+      val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+      return when(typename) {
+        "Human" -> HumanHeroDetailQuery.fromResponse(reader, typename)
+        else -> OtherHeroDetailQuery.fromResponse(reader, typename)
       }
     }
 
     override fun toResponse(writer: ResponseWriter,
-        value: com.example.unique_type_name.HeroDetailQuery.Data) {
-      if(value.heroDetailQuery == null) {
-        writer.writeObject(RESPONSE_FIELDS[0], null)
-      } else {
-        writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-          HeroDetailQuery.toResponse(writer, value.heroDetailQuery)
+        value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery) {
+      when(value) {
+        is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery -> HumanHeroDetailQuery.toResponse(writer, value)
+        is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery -> OtherHeroDetailQuery.toResponse(writer, value)
+      }
+    }
+
+    object HumanHeroDetailQuery :
+        ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery>
+        {
+      private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+        ResponseField.forString("__typename", "__typename", null, false, null),
+        ResponseField.forString("name", "name", null, false, null),
+        ResponseField.forList("friends", "friends", null, true, null),
+        ResponseField.forDouble("height", "height", null, true, null)
+      )
+
+      override fun fromResponse(reader: ResponseReader, __typename: String?):
+          com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend?>? = null
+          var height: Double? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              3 -> height = readDouble(RESPONSE_FIELDS[3])
+              else -> break
+            }
+          }
+          com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends,
+            height = height
+          )
+        }
+      }
+
+      override fun toResponse(writer: ResponseWriter,
+          value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
+        }
+        writer.writeDouble(RESPONSE_FIELDS[3], value.height)
+      }
+
+      object Friend :
+          ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend>
+          {
+        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+          ResponseField.forString("name", "name", null, false, null),
+          ResponseField.forList("appearsIn", "appearsIn", null, false, null),
+          ResponseField.forList("friends", "friends", null, true, null)
+        )
+
+        override fun fromResponse(reader: ResponseReader, __typename: String?):
+            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend {
+          return reader.run {
+            var name: String? = null
+            var appearsIn: List<Episode?>? = null
+            var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend?>? = null
+            while(true) {
+              when (selectField(RESPONSE_FIELDS)) {
+                0 -> name = readString(RESPONSE_FIELDS[0])
+                1 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
+                  Episode.safeValueOf(reader.readString())
+                }
+                2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                  reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend> { reader ->
+                    Friend.fromResponse(reader)
+                  }
+                }
+                else -> break
+              }
+            }
+            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend(
+              name = name!!,
+              appearsIn = appearsIn!!,
+              friends = friends
+            )
+          }
+        }
+
+        override fun toResponse(writer: ResponseWriter,
+            value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
+          writer.writeList(RESPONSE_FIELDS[1], value.appearsIn) { value, listItemWriter ->
+            listItemWriter.writeString(value?.rawValue)}
+          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+            listItemWriter.writeObject { writer ->
+              Friend.toResponse(writer, value)
+            }
+          }
+        }
+
+        object Friend :
+            ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend>
+            {
+          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+            ResponseField.forString("__typename", "__typename", null, false, null)
+          )
+
+          override fun fromResponse(reader: ResponseReader, __typename: String?):
+              com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend {
+            val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
+            return when(typename) {
+              "Droid" -> CharacterFriend.fromResponse(reader, typename)
+              "Human" -> CharacterFriend.fromResponse(reader, typename)
+              else -> OtherFriend.fromResponse(reader, typename)
+            }
+          }
+
+          override fun toResponse(writer: ResponseWriter,
+              value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend) {
+            when(value) {
+              is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend -> CharacterFriend.toResponse(writer, value)
+              is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
+            }
+          }
+
+          object CharacterFriend :
+              ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend>
+              {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("__typename", "__typename", null, false, null),
+              ResponseField.forString("name", "name", null, false, null),
+              ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend {
+              return reader.run {
+                var __typename: String? = __typename
+                var name: String? = null
+                var friendsConnection: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection? = null
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> __typename = readString(RESPONSE_FIELDS[0])
+                    1 -> name = readString(RESPONSE_FIELDS[1])
+                    2 -> friendsConnection = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+                      FriendsConnection.fromResponse(reader)
+                    }
+                    else -> break
+                  }
+                }
+                com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend(
+                  __typename = __typename!!,
+                  name = name!!,
+                  friendsConnection = friendsConnection!!
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend) {
+              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+              writer.writeString(RESPONSE_FIELDS[1], value.name)
+              writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+                FriendsConnection.toResponse(writer, value.friendsConnection)
+              }
+            }
+
+            object FriendsConnection :
+                ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection>
+                {
+              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                ResponseField.forInt("totalCount", "totalCount", null, true, null),
+                ResponseField.forList("edges", "edges", null, true, null)
+              )
+
+              override fun fromResponse(reader: ResponseReader, __typename: String?):
+                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection {
+                return reader.run {
+                  var totalCount: Int? = null
+                  var edges: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge?>? = null
+                  while(true) {
+                    when (selectField(RESPONSE_FIELDS)) {
+                      0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+                      1 -> edges = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+                        reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge> { reader ->
+                          Edge.fromResponse(reader)
+                        }
+                      }
+                      else -> break
+                    }
+                  }
+                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection(
+                    totalCount = totalCount,
+                    edges = edges
+                  )
+                }
+              }
+
+              override fun toResponse(writer: ResponseWriter,
+                  value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection) {
+                writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+                writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+                  listItemWriter.writeObject { writer ->
+                    Edge.toResponse(writer, value)
+                  }
+                }
+              }
+
+              object Edge :
+                  ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge>
+                  {
+                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                  ResponseField.forObject("node", "node", null, true, null)
+                )
+
+                override fun fromResponse(reader: ResponseReader, __typename: String?):
+                    com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge {
+                  return reader.run {
+                    var node: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node? = null
+                    while(true) {
+                      when (selectField(RESPONSE_FIELDS)) {
+                        0 -> node = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                          Node.fromResponse(reader)
+                        }
+                        else -> break
+                      }
+                    }
+                    com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge(
+                      node = node
+                    )
+                  }
+                }
+
+                override fun toResponse(writer: ResponseWriter,
+                    value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge) {
+                  if(value.node == null) {
+                    writer.writeObject(RESPONSE_FIELDS[0], null)
+                  } else {
+                    writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+                      Node.toResponse(writer, value.node)
+                    }
+                  }
+                }
+
+                object Node :
+                    ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node>
+                    {
+                  private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+                    ResponseField.forString("name", "name", null, false, null)
+                  )
+
+                  override fun fromResponse(reader: ResponseReader, __typename: String?):
+                      com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node {
+                    return reader.run {
+                      var name: String? = null
+                      while(true) {
+                        when (selectField(RESPONSE_FIELDS)) {
+                          0 -> name = readString(RESPONSE_FIELDS[0])
+                          else -> break
+                        }
+                      }
+                      com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node(
+                        name = name!!
+                      )
+                    }
+                  }
+
+                  override fun toResponse(writer: ResponseWriter,
+                      value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node) {
+                    writer.writeString(RESPONSE_FIELDS[0], value.name)
+                  }
+                }
+              }
+            }
+          }
+
+          object OtherFriend :
+              ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend>
+              {
+            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
+              ResponseField.forString("__typename", "__typename", null, false, null)
+            )
+
+            override fun fromResponse(reader: ResponseReader, __typename: String?):
+                com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend {
+              return reader.run {
+                var __typename: String? = __typename
+                while(true) {
+                  when (selectField(RESPONSE_FIELDS)) {
+                    0 -> __typename = readString(RESPONSE_FIELDS[0])
+                    else -> break
+                  }
+                }
+                com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend(
+                  __typename = __typename!!
+                )
+              }
+            }
+
+            override fun toResponse(writer: ResponseWriter,
+                value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend) {
+              writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+            }
+          }
         }
       }
     }
 
-    object HeroDetailQuery :
-        ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery> {
+    object OtherHeroDetailQuery :
+        ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery>
+        {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
         ResponseField.forString("__typename", "__typename", null, false, null),
         ResponseField.forString("name", "name", null, false, null),
@@ -77,403 +398,68 @@ object HeroDetailQuery_ResponseAdapter : ResponseAdapter<HeroDetailQuery.Data> {
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery {
-        val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-        return when(typename) {
-          "Human" -> HumanHeroDetailQuery.fromResponse(reader, typename)
-          else -> OtherHeroDetailQuery.fromResponse(reader, typename)
+          com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery {
+        return reader.run {
+          var __typename: String? = __typename
+          var name: String? = null
+          var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend?>? = null
+          while(true) {
+            when (selectField(RESPONSE_FIELDS)) {
+              0 -> __typename = readString(RESPONSE_FIELDS[0])
+              1 -> name = readString(RESPONSE_FIELDS[1])
+              2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend>(RESPONSE_FIELDS[2]) { reader ->
+                reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend> { reader ->
+                  Friend.fromResponse(reader)
+                }
+              }
+              else -> break
+            }
+          }
+          com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery(
+            __typename = __typename!!,
+            name = name!!,
+            friends = friends
+          )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery) {
-        when(value) {
-          is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery -> HumanHeroDetailQuery.toResponse(writer, value)
-          is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery -> OtherHeroDetailQuery.toResponse(writer, value)
+          value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery) {
+        writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+        writer.writeString(RESPONSE_FIELDS[1], value.name)
+        writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
+          listItemWriter.writeObject { writer ->
+            Friend.toResponse(writer, value)
+          }
         }
       }
 
-      object HumanHeroDetailQuery :
-          ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery>
+      object Friend :
+          ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend>
           {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null),
-          ResponseField.forDouble("height", "height", null, true, null)
+          ResponseField.forString("name", "name", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery {
+            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend {
           return reader.run {
-            var __typename: String? = __typename
             var name: String? = null
-            var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend?>? = null
-            var height: Double? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                3 -> height = readDouble(RESPONSE_FIELDS[3])
+                0 -> name = readString(RESPONSE_FIELDS[0])
                 else -> break
               }
             }
-            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends,
-              height = height
+            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend(
+              name = name!!
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
-          }
-          writer.writeDouble(RESPONSE_FIELDS[3], value.height)
-        }
-
-        object Friend :
-            ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend>
-            {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null),
-            ResponseField.forList("appearsIn", "appearsIn", null, false, null),
-            ResponseField.forList("friends", "friends", null, true, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend {
-            return reader.run {
-              var name: String? = null
-              var appearsIn: List<Episode?>? = null
-              var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend?>? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  1 -> appearsIn = readList<Episode>(RESPONSE_FIELDS[1]) { reader ->
-                    Episode.safeValueOf(reader.readString())
-                  }
-                  2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                    reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend> { reader ->
-                      Friend.fromResponse(reader)
-                    }
-                  }
-                  else -> break
-                }
-              }
-              com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend(
-                name = name!!,
-                appearsIn = appearsIn!!,
-                friends = friends
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-            writer.writeList(RESPONSE_FIELDS[1], value.appearsIn) { value, listItemWriter ->
-              listItemWriter.writeString(value?.rawValue)}
-            writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-              listItemWriter.writeObject { writer ->
-                Friend.toResponse(writer, value)
-              }
-            }
-          }
-
-          object Friend :
-              ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend>
-              {
-            private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-              ResponseField.forString("__typename", "__typename", null, false, null)
-            )
-
-            override fun fromResponse(reader: ResponseReader, __typename: String?):
-                com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend {
-              val typename = __typename ?: reader.readString(RESPONSE_FIELDS[0])
-              return when(typename) {
-                "Droid" -> CharacterFriend.fromResponse(reader, typename)
-                "Human" -> CharacterFriend.fromResponse(reader, typename)
-                else -> OtherFriend.fromResponse(reader, typename)
-              }
-            }
-
-            override fun toResponse(writer: ResponseWriter,
-                value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend) {
-              when(value) {
-                is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend -> CharacterFriend.toResponse(writer, value)
-                is com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend -> OtherFriend.toResponse(writer, value)
-              }
-            }
-
-            object CharacterFriend :
-                ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("__typename", "__typename", null, false, null),
-                ResponseField.forString("name", "name", null, false, null),
-                ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend {
-                return reader.run {
-                  var __typename: String? = __typename
-                  var name: String? = null
-                  var friendsConnection: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection? = null
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> __typename = readString(RESPONSE_FIELDS[0])
-                      1 -> name = readString(RESPONSE_FIELDS[1])
-                      2 -> friendsConnection = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-                        FriendsConnection.fromResponse(reader)
-                      }
-                      else -> break
-                    }
-                  }
-                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend(
-                    __typename = __typename!!,
-                    name = name!!,
-                    friendsConnection = friendsConnection!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend) {
-                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-                writer.writeString(RESPONSE_FIELDS[1], value.name)
-                writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-                  FriendsConnection.toResponse(writer, value.friendsConnection)
-                }
-              }
-
-              object FriendsConnection :
-                  ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection>
-                  {
-                private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                  ResponseField.forInt("totalCount", "totalCount", null, true, null),
-                  ResponseField.forList("edges", "edges", null, true, null)
-                )
-
-                override fun fromResponse(reader: ResponseReader, __typename: String?):
-                    com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection {
-                  return reader.run {
-                    var totalCount: Int? = null
-                    var edges: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge?>? = null
-                    while(true) {
-                      when (selectField(RESPONSE_FIELDS)) {
-                        0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-                        1 -> edges = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                          reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge> { reader ->
-                            Edge.fromResponse(reader)
-                          }
-                        }
-                        else -> break
-                      }
-                    }
-                    com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection(
-                      totalCount = totalCount,
-                      edges = edges
-                    )
-                  }
-                }
-
-                override fun toResponse(writer: ResponseWriter,
-                    value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection) {
-                  writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-                  writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-                    listItemWriter.writeObject { writer ->
-                      Edge.toResponse(writer, value)
-                    }
-                  }
-                }
-
-                object Edge :
-                    ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge>
-                    {
-                  private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                    ResponseField.forObject("node", "node", null, true, null)
-                  )
-
-                  override fun fromResponse(reader: ResponseReader, __typename: String?):
-                      com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge {
-                    return reader.run {
-                      var node: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node? = null
-                      while(true) {
-                        when (selectField(RESPONSE_FIELDS)) {
-                          0 -> node = readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                            Node.fromResponse(reader)
-                          }
-                          else -> break
-                        }
-                      }
-                      com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge(
-                        node = node
-                      )
-                    }
-                  }
-
-                  override fun toResponse(writer: ResponseWriter,
-                      value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge) {
-                    if(value.node == null) {
-                      writer.writeObject(RESPONSE_FIELDS[0], null)
-                    } else {
-                      writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-                        Node.toResponse(writer, value.node)
-                      }
-                    }
-                  }
-
-                  object Node :
-                      ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node>
-                      {
-                    private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                      ResponseField.forString("name", "name", null, false, null)
-                    )
-
-                    override fun fromResponse(reader: ResponseReader, __typename: String?):
-                        com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node {
-                      return reader.run {
-                        var name: String? = null
-                        while(true) {
-                          when (selectField(RESPONSE_FIELDS)) {
-                            0 -> name = readString(RESPONSE_FIELDS[0])
-                            else -> break
-                          }
-                        }
-                        com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node(
-                          name = name!!
-                        )
-                      }
-                    }
-
-                    override fun toResponse(writer: ResponseWriter,
-                        value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.CharacterFriend.FriendsConnection.Edge.Node) {
-                      writer.writeString(RESPONSE_FIELDS[0], value.name)
-                    }
-                  }
-                }
-              }
-            }
-
-            object OtherFriend :
-                ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend>
-                {
-              private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-                ResponseField.forString("__typename", "__typename", null, false, null)
-              )
-
-              override fun fromResponse(reader: ResponseReader, __typename: String?):
-                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend {
-                return reader.run {
-                  var __typename: String? = __typename
-                  while(true) {
-                    when (selectField(RESPONSE_FIELDS)) {
-                      0 -> __typename = readString(RESPONSE_FIELDS[0])
-                      else -> break
-                    }
-                  }
-                  com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend(
-                    __typename = __typename!!
-                  )
-                }
-              }
-
-              override fun toResponse(writer: ResponseWriter,
-                  value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.HumanHeroDetailQuery.Friend.Friend.OtherFriend) {
-                writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-              }
-            }
-          }
-        }
-      }
-
-      object OtherHeroDetailQuery :
-          ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery>
-          {
-        private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forString("__typename", "__typename", null, false, null),
-          ResponseField.forString("name", "name", null, false, null),
-          ResponseField.forList("friends", "friends", null, true, null)
-        )
-
-        override fun fromResponse(reader: ResponseReader, __typename: String?):
-            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery {
-          return reader.run {
-            var __typename: String? = __typename
-            var name: String? = null
-            var friends: List<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend?>? = null
-            while(true) {
-              when (selectField(RESPONSE_FIELDS)) {
-                0 -> __typename = readString(RESPONSE_FIELDS[0])
-                1 -> name = readString(RESPONSE_FIELDS[1])
-                2 -> friends = readList<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend>(RESPONSE_FIELDS[2]) { reader ->
-                  reader.readObject<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend> { reader ->
-                    Friend.fromResponse(reader)
-                  }
-                }
-                else -> break
-              }
-            }
-            com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery(
-              __typename = __typename!!,
-              name = name!!,
-              friends = friends
-            )
-          }
-        }
-
-        override fun toResponse(writer: ResponseWriter,
-            value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery) {
-          writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-          writer.writeString(RESPONSE_FIELDS[1], value.name)
-          writer.writeList(RESPONSE_FIELDS[2], value.friends) { value, listItemWriter ->
-            listItemWriter.writeObject { writer ->
-              Friend.toResponse(writer, value)
-            }
-          }
-        }
-
-        object Friend :
-            ResponseAdapter<com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend>
-            {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend {
-            return reader.run {
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend(
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
+            value: com.example.unique_type_name.HeroDetailQuery.Data.HeroDetailQuery.OtherHeroDetailQuery.Friend) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
         }
       }
     }

--- a/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
+++ b/apollo-compiler/src/test/graphql/com/example/unique_type_name/fragment/adapter/HeroDetailsImpl_ResponseAdapter.kt
@@ -27,149 +27,132 @@ object HeroDetailsImpl_ResponseAdapter : ResponseAdapter<HeroDetailsImpl.Data> {
   )
 
   override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
-    return Data.fromResponse(reader, __typename)
+    return reader.run {
+      var __typename: String? = __typename
+      var name: String? = null
+      var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+      while(true) {
+        when (selectField(RESPONSE_FIELDS)) {
+          0 -> __typename = readString(RESPONSE_FIELDS[0])
+          1 -> name = readString(RESPONSE_FIELDS[1])
+          2 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
+            FriendsConnection.fromResponse(reader)
+          }
+          else -> break
+        }
+      }
+      HeroDetailsImpl.Data(
+        __typename = __typename!!,
+        name = name!!,
+        friendsConnection = friendsConnection!!
+      )
+    }
   }
 
   override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-    Data.toResponse(writer, value)
+    writer.writeString(RESPONSE_FIELDS[0], value.__typename)
+    writer.writeString(RESPONSE_FIELDS[1], value.name)
+    writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
+      FriendsConnection.toResponse(writer, value.friendsConnection)
+    }
   }
 
-  object Data : ResponseAdapter<HeroDetailsImpl.Data> {
+  object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
     private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-      ResponseField.forString("__typename", "__typename", null, false, null),
-      ResponseField.forString("name", "name", null, false, null),
-      ResponseField.forObject("friendsConnection", "friendsConnection", null, false, null)
+      ResponseField.forInt("totalCount", "totalCount", null, true, null),
+      ResponseField.forList("edges", "edges", null, true, null)
     )
 
-    override fun fromResponse(reader: ResponseReader, __typename: String?): HeroDetailsImpl.Data {
+    override fun fromResponse(reader: ResponseReader, __typename: String?):
+        HeroDetailsImpl.Data.FriendsConnection {
       return reader.run {
-        var __typename: String? = __typename
-        var name: String? = null
-        var friendsConnection: HeroDetailsImpl.Data.FriendsConnection? = null
+        var totalCount: Int? = null
+        var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
         while(true) {
           when (selectField(RESPONSE_FIELDS)) {
-            0 -> __typename = readString(RESPONSE_FIELDS[0])
-            1 -> name = readString(RESPONSE_FIELDS[1])
-            2 -> friendsConnection = readObject<HeroDetailsImpl.Data.FriendsConnection>(RESPONSE_FIELDS[2]) { reader ->
-              FriendsConnection.fromResponse(reader)
+            0 -> totalCount = readInt(RESPONSE_FIELDS[0])
+            1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
+              reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
+                Edge.fromResponse(reader)
+              }
             }
             else -> break
           }
         }
-        HeroDetailsImpl.Data(
-          __typename = __typename!!,
-          name = name!!,
-          friendsConnection = friendsConnection!!
+        HeroDetailsImpl.Data.FriendsConnection(
+          totalCount = totalCount,
+          edges = edges
         )
       }
     }
 
-    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data) {
-      writer.writeString(RESPONSE_FIELDS[0], value.__typename)
-      writer.writeString(RESPONSE_FIELDS[1], value.name)
-      writer.writeObject(RESPONSE_FIELDS[2]) { writer ->
-        FriendsConnection.toResponse(writer, value.friendsConnection)
+    override fun toResponse(writer: ResponseWriter, value: HeroDetailsImpl.Data.FriendsConnection) {
+      writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
+      writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
+        listItemWriter.writeObject { writer ->
+          Edge.toResponse(writer, value)
+        }
       }
     }
 
-    object FriendsConnection : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection> {
+    object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
       private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-        ResponseField.forInt("totalCount", "totalCount", null, true, null),
-        ResponseField.forList("edges", "edges", null, true, null)
+        ResponseField.forObject("node", "node", null, true, null)
       )
 
       override fun fromResponse(reader: ResponseReader, __typename: String?):
-          HeroDetailsImpl.Data.FriendsConnection {
+          HeroDetailsImpl.Data.FriendsConnection.Edge {
         return reader.run {
-          var totalCount: Int? = null
-          var edges: List<HeroDetailsImpl.Data.FriendsConnection.Edge?>? = null
+          var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
           while(true) {
             when (selectField(RESPONSE_FIELDS)) {
-              0 -> totalCount = readInt(RESPONSE_FIELDS[0])
-              1 -> edges = readList<HeroDetailsImpl.Data.FriendsConnection.Edge>(RESPONSE_FIELDS[1]) { reader ->
-                reader.readObject<HeroDetailsImpl.Data.FriendsConnection.Edge> { reader ->
-                  Edge.fromResponse(reader)
-                }
+              0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
+                Node.fromResponse(reader)
               }
               else -> break
             }
           }
-          HeroDetailsImpl.Data.FriendsConnection(
-            totalCount = totalCount,
-            edges = edges
+          HeroDetailsImpl.Data.FriendsConnection.Edge(
+            node = node
           )
         }
       }
 
       override fun toResponse(writer: ResponseWriter,
-          value: HeroDetailsImpl.Data.FriendsConnection) {
-        writer.writeInt(RESPONSE_FIELDS[0], value.totalCount)
-        writer.writeList(RESPONSE_FIELDS[1], value.edges) { value, listItemWriter ->
-          listItemWriter.writeObject { writer ->
-            Edge.toResponse(writer, value)
+          value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
+        if(value.node == null) {
+          writer.writeObject(RESPONSE_FIELDS[0], null)
+        } else {
+          writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
+            Node.toResponse(writer, value.node)
           }
         }
       }
 
-      object Edge : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge> {
+      object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
         private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-          ResponseField.forObject("node", "node", null, true, null)
+          ResponseField.forString("name", "name", null, false, null)
         )
 
         override fun fromResponse(reader: ResponseReader, __typename: String?):
-            HeroDetailsImpl.Data.FriendsConnection.Edge {
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
           return reader.run {
-            var node: HeroDetailsImpl.Data.FriendsConnection.Edge.Node? = null
+            var name: String? = null
             while(true) {
               when (selectField(RESPONSE_FIELDS)) {
-                0 -> node = readObject<HeroDetailsImpl.Data.FriendsConnection.Edge.Node>(RESPONSE_FIELDS[0]) { reader ->
-                  Node.fromResponse(reader)
-                }
+                0 -> name = readString(RESPONSE_FIELDS[0])
                 else -> break
               }
             }
-            HeroDetailsImpl.Data.FriendsConnection.Edge(
-              node = node
+            HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
+              name = name!!
             )
           }
         }
 
         override fun toResponse(writer: ResponseWriter,
-            value: HeroDetailsImpl.Data.FriendsConnection.Edge) {
-          if(value.node == null) {
-            writer.writeObject(RESPONSE_FIELDS[0], null)
-          } else {
-            writer.writeObject(RESPONSE_FIELDS[0]) { writer ->
-              Node.toResponse(writer, value.node)
-            }
-          }
-        }
-
-        object Node : ResponseAdapter<HeroDetailsImpl.Data.FriendsConnection.Edge.Node> {
-          private val RESPONSE_FIELDS: Array<ResponseField> = arrayOf(
-            ResponseField.forString("name", "name", null, false, null)
-          )
-
-          override fun fromResponse(reader: ResponseReader, __typename: String?):
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node {
-            return reader.run {
-              var name: String? = null
-              while(true) {
-                when (selectField(RESPONSE_FIELDS)) {
-                  0 -> name = readString(RESPONSE_FIELDS[0])
-                  else -> break
-                }
-              }
-              HeroDetailsImpl.Data.FriendsConnection.Edge.Node(
-                name = name!!
-              )
-            }
-          }
-
-          override fun toResponse(writer: ResponseWriter,
-              value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
-            writer.writeString(RESPONSE_FIELDS[0], value.name)
-          }
+            value: HeroDetailsImpl.Data.FriendsConnection.Edge.Node) {
+          writer.writeString(RESPONSE_FIELDS[0], value.name)
         }
       }
     }


### PR DESCRIPTION
For ResponseAdapters, we don't have an `Operation` wrapper class like we have for operations/fragments so we can save one level of nesting and a bunch of bytecode.

Instead of having 
```
TestQuery_ResponseAdapter
TestQuery_ResponseAdapter.Data
TestQuery_ResponseAdapter.Data.Hero
```
we now have
```
TestQuery_ResponseAdapter
TestQuery_ResponseAdapter.Hero
```