### PR TITLE
Migrate RealApolloStore to KN

### DIFF
--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/ApolloWatcherTest.kt
@@ -19,7 +19,7 @@ import com.apollographql.apollo.integration.normalizer.EpisodeHeroNameWithIdQuer
 import com.apollographql.apollo.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo.integration.normalizer.type.Episode
-import com.apollographql.apollo.internal.RealApolloStore
+import com.apollographql.apollo.cache.normalized.internal.RealApolloStore
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import junit.framework.Assert

--- a/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/ApolloStoreTest.kt
+++ b/apollo-integration/src/test/kotlin/com/apollographql/apollo/internal/ApolloStoreTest.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.internal.json.JsonReader
 import com.apollographql.apollo.cache.CacheHeaders
 import com.apollographql.apollo.cache.normalized.CacheKey
 import com.apollographql.apollo.cache.normalized.CacheKeyResolver
+import com.apollographql.apollo.cache.normalized.internal.RealApolloStore
 import com.apollographql.apollo.cache.normalized.NormalizedCache
 import com.apollographql.apollo.cache.normalized.Record
 import org.junit.Test

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
@@ -1,5 +1,11 @@
 package com.apollographql.apollo.cache.normalized.internal
 
-expect object Platform {
+internal expect object Platform {
   fun currentTimeMillis(): Long
 }
+
+expect class ReentrantReadWriteLock constructor()
+
+internal expect inline fun <T> ReentrantReadWriteLock.read(action: () -> T): T
+
+internal expect inline fun <T> ReentrantReadWriteLock.write(action: () -> T): T

--- a/apollo-normalized-cache/src/iosMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
+++ b/apollo-normalized-cache/src/iosMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
@@ -1,12 +1,27 @@
 package com.apollographql.apollo.cache.normalized.internal
 
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import kotlinx.cinterop.convert
 import platform.darwin.DISPATCH_TIME_NOW
 import platform.darwin.dispatch_time
 
-actual object Platform {
+internal actual object Platform {
   actual fun currentTimeMillis(): Long {
     val nanoseconds: Long = dispatch_time(DISPATCH_TIME_NOW, 0).convert()
     return nanoseconds * 1_000_000L
   }
 }
+
+actual class ReentrantReadWriteLock {
+  internal val lock = reentrantLock()
+}
+
+internal actual inline fun <T> ReentrantReadWriteLock.read(action: () -> T): T {
+  return lock.withLock(action)
+}
+
+internal actual inline fun <T> ReentrantReadWriteLock.write(action: () -> T): T {
+  return lock.withLock(action)
+}
+

--- a/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
+++ b/apollo-normalized-cache/src/jvmMain/kotlin/com/apollographql/apollo/cache/normalized/internal/Platform.kt
@@ -1,7 +1,21 @@
 package com.apollographql.apollo.cache.normalized.internal
 
-actual object Platform {
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+internal actual object Platform {
   actual fun currentTimeMillis(): Long {
     return System.currentTimeMillis()
   }
+}
+
+actual typealias ReentrantReadWriteLock = ReentrantReadWriteLock
+
+internal actual inline fun <T> ReentrantReadWriteLock.read(action: () -> T): T {
+  return this.read(action)
+}
+
+internal actual inline fun <T> ReentrantReadWriteLock.write(action: () -> T): T {
+  return this.write(action)
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.kt
@@ -27,7 +27,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptorFactory
 import com.apollographql.apollo.internal.ApolloCallTracker
 import com.apollographql.apollo.internal.RealApolloCall
 import com.apollographql.apollo.internal.RealApolloPrefetch
-import com.apollographql.apollo.internal.RealApolloStore
+import com.apollographql.apollo.cache.normalized.internal.RealApolloStore
 import com.apollographql.apollo.internal.RealApolloSubscriptionCall
 import com.apollographql.apollo.internal.subscription.NoOpSubscriptionManager
 import com.apollographql.apollo.internal.subscription.RealSubscriptionManager

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptor.kt
@@ -15,9 +15,7 @@ import com.apollographql.apollo.interceptor.ApolloInterceptor.FetchSourceType
 import com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorRequest
 import com.apollographql.apollo.interceptor.ApolloInterceptor.InterceptorResponse
 import com.apollographql.apollo.interceptor.ApolloInterceptorChain
-import com.apollographql.apollo.internal.RealApolloStore
 import java.lang.Runnable
-import java.util.HashSet
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicReference
 


### PR DESCRIPTION
For now it's just a 1-1 migration without any changes to actual implementation (except obviously stubbing JVM concurrency primitives).