### PR TITLE
Add redirect for tutorial

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -4,3 +4,5 @@
 
 /docs/android/essentials/caching/ /docs/android/essentials/normalized-cache
 /docs/android/advanced/android/ /docs/android/advanced/ui-tests/
+
+/docs/android/tutorial /docs/android/tutorial/00-introduction


### PR DESCRIPTION
Added a redirect so that when you go to [https://www.apollographql.com/docs/android/tutorial](https://www.apollographql.com/docs/android/tutorial/), the first page of the tutorial loads (rather than the 404 you get at the moment). This also helps us avoid giving out hard links to the first page of the tutorial so that if that URL ever changes in the future it can get redirected easily. 