### PR TITLE
Be more robust to publish errors

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloStore.java
@@ -113,8 +113,18 @@ public final class RealApolloStore implements ApolloStore, ReadableStore, Writea
       iterableSubscribers = new LinkedHashSet<>(subscribers);
     }
 
+    RuntimeException firstException = null;
     for (RecordChangeSubscriber subscriber : iterableSubscribers) {
-      subscriber.onCacheRecordsChanged(changedKeys);
+      try {
+        subscriber.onCacheRecordsChanged(changedKeys);
+      } catch (RuntimeException e) {
+        if (firstException == null) {
+          firstException = e;
+        }
+      }
+    }
+    if (firstException != null) {
+      throw firstException;
     }
   }
 


### PR DESCRIPTION
Fixes #2899 

The issue was that the first NETWORK_ONLY watcher was cancelled when trying to refetch and threw and exception before the other store listeners had a chance to do anything. 

This changes makes it so that the store always tries to notify all listeners. If one or more fail, the first exception will be rethrown.