### PR TITLE
Added toString methods to api.Error and api.Error.Location

### DIFF
--- a/apollo-api/api.txt
+++ b/apollo-api/api.txt
@@ -145,6 +145,7 @@ package com.apollographql.apollo.api {
     method public int hashCode();
     method @Deprecated public java.util.List<com.apollographql.apollo.api.Error.Location> locations();
     method @Deprecated public String? message();
+    method public String toString();
   }
 
   public static final class Error.Location {
@@ -155,6 +156,7 @@ package com.apollographql.apollo.api {
     method public long getLine();
     method public int hashCode();
     method @Deprecated public long line();
+    method public String toString();
   }
 
   @com.apollographql.apollo.api.ApolloExperimental public interface ExecutionContext {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
@@ -61,6 +61,10 @@ class Error(
     return result
   }
 
+  override fun toString(): String {
+    return "Error(message = $message, locations = $locations, customAttributes = $customAttributes)"
+  }
+
   /**
    * Represents the location of the error in the GraphQL operation sent to the server. This location is represented in
    * terms of the line and column number.
@@ -105,6 +109,10 @@ class Error(
       var result = line.hashCode()
       result = 31 * result + column.hashCode()
       return result
+    }
+
+    override fun toString(): String {
+      return "Location(line = $line, column = $column)"
     }
   }
 }


### PR DESCRIPTION
The aim of this PR is to see better error messages when printing `Error` classes to the log.