### PR TITLE
properly forward antlr syntax errors

### DIFF
--- a/apollo-compiler/src/test/validation/operation/SyntaxError.graphql
+++ b/apollo-compiler/src/test/validation/operation/SyntaxError.graphql
@@ -1,0 +1,4 @@
+# Invalid fragment (does not specify its type condition)
+fragment HumanFragment {
+  name
+}

--- a/apollo-compiler/src/test/validation/operation/SyntaxError.issues
+++ b/apollo-compiler/src/test/validation/operation/SyntaxError.issues
@@ -1,0 +1,2 @@
+ERROR: ParsingError (2:23)
+Unsupported token `{`


### PR DESCRIPTION
The current pipeline is antlr -> GQL -> FrontendIR -> ...

The GQL transformation assumes a syntactically correct document and will throw null pointer exceptions if not. Rather than throwing an obscure null pointer exception, stop the processing and output parsing issues.