### PR TITLE
Do not crash when writing indented SDL schemas

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/frontend/gqldocument.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/frontend/gqldocument.kt
@@ -87,6 +87,10 @@ private fun String.withIndents(): String {
   var indent = 0
   return lines().joinToString(separator = "\n") { line ->
     if (line.endsWith("}")) indent -= 2
+    if (indent < 0) {
+      // This happens if a description ends with '}'
+      indent = 0
+    }
     (" ".repeat(indent) + line).also {
       if (line.endsWith("{")) indent += 2
     }


### PR DESCRIPTION
That's more a workaround than a fix, the indentation produced by our SDL writing is a bit off at the moment but at least that'll produce a valid SDL schema.