### PR TITLE
Remove publishing to Jcenter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - name: Build with Gradle
         run: ./scripts/ci.sh
         env: # Or as an environment variable
-          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/Contributing.md
+++ b/Contributing.md
@@ -51,6 +51,6 @@ Please note that we will not accept pull requests for style changes.
 Releasing
 --------
 
-The CI contains credentials and will push artifacts to bintray/sonatype/gradlePortal when a tag is pushed. Every tag will trigger a new release.
+The CI contains credentials and will push artifacts to sonatype/gradlePortal when a tag is pushed. Every tag will trigger a new release.
 
 After a successful release, do not forget to add a changelog to the [releases page](https://github.com/apollographql/apollo-android/releases).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The latest version is [![Maven Central](https://img.shields.io/maven-central/v/c
 
 Check the [changelog](https://github.com/apollographql/apollo-android/releases) for the release history. 
 
-Releases are hosted on [Jcenter](https://jcenter.bintray.com/com/apollographql/apollo3/) and [Maven Central](https://repo1.maven.org/maven2/com/apollographql/apollo3/). The plugin is additionally hosted on the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.apollographql.apollo3) 
+Releases are hosted on [Maven Central](https://repo1.maven.org/maven2/com/apollographql/apollo3/). The plugin is additionally hosted on the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.apollographql.apollo3) 
 
 
 ```groovy:title=build.gradle.kts

--- a/docs/source/advanced/ui-tests.mdx
+++ b/docs/source/advanced/ui-tests.mdx
@@ -8,7 +8,7 @@ Apollo Android offers a built-in [IdlingResource](https://developer.android.com/
 
 Add the following `dependency`:
 
-[ ![apollo-idling-resource](https://img.shields.io/bintray/v/apollographql/android/apollo-idling-resource.svg?label=apollo-idling-resource) ](https://bintray.com/apollographql/android/apollo-idling-resource/_latestVersion)
+[ ![apollo-idling-resource](https://img.shields.io/maven-central/v/com.apollographql.apollo3/apollo-idling-resource?label=apollo-idling-resource)](https://repo1.maven.org/maven2/com/apollographql/apollo3/apollo-idling-resource)
 ```groovy
 implementation("com.apollographql.apollo3:apollo-idling-resource:x.y.z")
 ```

--- a/docs/source/essentials/get-started-java.mdx
+++ b/docs/source/essentials/get-started-java.mdx
@@ -55,7 +55,7 @@ apply(plugin = "com.apollographql.apollo3")
 
 </MultiCodeBlock>
 
-The plugin is hosted on the Gradle plugin portal, Jcenter and Maven Central.
+The plugin is hosted on the Gradle plugin portal and Maven Central.
 ## Add the runtime dependencies
 
 ```kotlin

--- a/docs/source/shared/add-plugin.mdx
+++ b/docs/source/shared/add-plugin.mdx
@@ -46,4 +46,4 @@ apply plugin: "com.apollographql.apollo3"
 
 </MultiCodeBlock>
 
-The plugin is hosted on the Gradle plugin portal, Jcenter and Maven Central.
+The plugin is hosted on the Gradle plugin portal and Maven Central.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,6 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=apollographql
 POM_DEVELOPER_NAME=Apollo
 
-BINTRAY_POM_REPO=android
-
 org.gradle.jvmargs=-Xmx2g
 android.useAndroidX=true
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -13,6 +13,5 @@ export PATH="$ANDROID_HOME"/tools/bin:$PATH
 
 ./gradlew publishSnapshotsIfNeeded  --parallel
 
-./gradlew publishToBintrayIfNeeded
 ./gradlew publishToOssStagingIfNeeded
 ./gradlew publishToGradlePortalIfNeeded -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,7 +1,3 @@
-# Jcenter
-./gradlew publishAllPublicationsToBintrayRepository
-./gradlew bintrayPublish
-
 # Gradle Plugin Portal
 ./gradlew :apollo-gradle-plugin:publishPlugins -Pgradle.publish.key="$GRADLE_PUBLISH_KEY" -Pgradle.publish.secret="$GRADLE_PUBLISH_SECRET"
 


### PR DESCRIPTION
Remove publishing to Jcenter. 
Jcenter is still in the repositories for dependencies because of trove4j. 