### PR TITLE
Use the operationId as a key for ResponseFieldMapperFactory

### DIFF
--- a/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
+++ b/apollo-coroutines-support/src/main/kotlin/com/apollographql/apollo/coroutines/CoroutinesExtensions.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.resume
  */
 @ExperimentalCoroutinesApi
 fun <T> ApolloCall<T>.toFlow(): Flow<Response<T>> = callbackFlow {
-  val clone = clone()
+  val clone = toBuilder().build()
   clone.enqueue(
       object : ApolloCall.Callback<T>() {
         override fun onResponse(response: Response<T>) {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/ApolloClient.java
@@ -27,7 +27,6 @@ import com.apollographql.apollo.internal.ApolloCallTracker;
 import com.apollographql.apollo.internal.RealApolloCall;
 import com.apollographql.apollo.internal.RealApolloPrefetch;
 import com.apollographql.apollo.internal.RealApolloSubscriptionCall;
-import com.apollographql.apollo.internal.ResponseFieldMapperFactory;
 import com.apollographql.apollo.internal.RealApolloStore;
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer;
 import com.apollographql.apollo.internal.subscription.NoOpSubscriptionManager;
@@ -85,7 +84,6 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   private final HttpCache httpCache;
   private final ApolloStore apolloStore;
   private final ScalarTypeAdapters scalarTypeAdapters;
-  private final ResponseFieldMapperFactory responseFieldMapperFactory = new ResponseFieldMapperFactory();
   private final Executor dispatcher;
   private final HttpCachePolicy.Policy defaultHttpCachePolicy;
   private final ResponseFetcher defaultResponseFetcher;
@@ -173,7 +171,7 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
   public <D extends Subscription.Data, T, V extends Subscription.Variables> ApolloSubscriptionCall<T> subscribe(
       @NotNull Subscription<D, T, V> subscription) {
     return new RealApolloSubscriptionCall<>(subscription, subscriptionManager, apolloStore, ApolloSubscriptionCall.CachePolicy.NO_CACHE,
-        dispatcher, responseFieldMapperFactory, logger);
+        dispatcher, logger);
   }
 
   /**
@@ -369,7 +367,6 @@ public final class ApolloClient implements ApolloQueryCall.Factory, ApolloMutati
         .httpCallFactory(httpCallFactory)
         .httpCache(httpCache)
         .httpCachePolicy(defaultHttpCachePolicy)
-        .responseFieldMapperFactory(responseFieldMapperFactory)
         .scalarTypeAdapters(scalarTypeAdapters)
         .apolloStore(apolloStore)
         .responseFetcher(defaultResponseFetcher)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/QueryReFetcher.java
@@ -45,7 +45,6 @@ final class QueryReFetcher {
           .operation(query)
           .serverUrl(builder.serverUrl)
           .httpCallFactory(builder.httpCallFactory)
-          .responseFieldMapperFactory(builder.responseFieldMapperFactory)
           .scalarTypeAdapters(builder.scalarTypeAdapters)
           .apolloStore(builder.apolloStore)
           .httpCachePolicy(HttpCachePolicy.NETWORK_ONLY)
@@ -120,7 +119,6 @@ final class QueryReFetcher {
     List<OperationName> queryWatchers = Collections.emptyList();
     HttpUrl serverUrl;
     Call.Factory httpCallFactory;
-    ResponseFieldMapperFactory responseFieldMapperFactory;
     ScalarTypeAdapters scalarTypeAdapters;
     ApolloStore apolloStore;
     Executor dispatcher;
@@ -150,8 +148,11 @@ final class QueryReFetcher {
       return this;
     }
 
-    Builder responseFieldMapperFactory(ResponseFieldMapperFactory responseFieldMapperFactory) {
-      this.responseFieldMapperFactory = responseFieldMapperFactory;
+    /**
+     * @deprecated The mapper factory is no longer used and will be removed in the future.
+     */
+    @Deprecated
+    Builder responseFieldMapperFactory(@SuppressWarnings("unused") ResponseFieldMapperFactory responseFieldMapperFactory) {
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -56,7 +56,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
   final Call.Factory httpCallFactory;
   final HttpCache httpCache;
   final HttpCachePolicy.Policy httpCachePolicy;
-  final ResponseFieldMapperFactory responseFieldMapperFactory;
   final ScalarTypeAdapters scalarTypeAdapters;
   final ApolloStore apolloStore;
   final CacheHeaders cacheHeaders;
@@ -90,7 +89,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     httpCallFactory = builder.httpCallFactory;
     httpCache = builder.httpCache;
     httpCachePolicy = builder.httpCachePolicy;
-    responseFieldMapperFactory = builder.responseFieldMapperFactory;
     scalarTypeAdapters = builder.scalarTypeAdapters;
     apolloStore = builder.apolloStore;
     responseFetcher = builder.responseFetcher;
@@ -113,7 +111,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
           .queryWatchers(refetchQueryNames)
           .serverUrl(builder.serverUrl)
           .httpCallFactory(builder.httpCallFactory)
-          .responseFieldMapperFactory(builder.responseFieldMapperFactory)
           .scalarTypeAdapters(builder.scalarTypeAdapters)
           .apolloStore(builder.apolloStore)
           .dispatcher(builder.dispatcher)
@@ -308,7 +305,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .httpCallFactory(httpCallFactory)
         .httpCache(httpCache)
         .httpCachePolicy(httpCachePolicy)
-        .responseFieldMapperFactory(responseFieldMapperFactory)
         .scalarTypeAdapters(scalarTypeAdapters)
         .apolloStore(apolloStore)
         .cacheHeaders(cacheHeaders)
@@ -385,7 +381,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
 
   private ApolloInterceptorChain prepareInterceptorChain(Operation operation) {
     HttpCachePolicy.Policy httpCachePolicy = operation instanceof Query ? this.httpCachePolicy : null;
-    ResponseFieldMapper responseFieldMapper = responseFieldMapperFactory.create(operation);
+    ResponseFieldMapper responseFieldMapper = operation.responseFieldMapper();
 
     List<ApolloInterceptor> interceptors = new ArrayList<>();
 
@@ -430,7 +426,6 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
     Call.Factory httpCallFactory;
     HttpCache httpCache;
     HttpCachePolicy.Policy httpCachePolicy;
-    ResponseFieldMapperFactory responseFieldMapperFactory;
     ScalarTypeAdapters scalarTypeAdapters;
     ApolloStore apolloStore;
     ResponseFetcher responseFetcher;
@@ -470,8 +465,11 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
       return this;
     }
 
-    public Builder<T> responseFieldMapperFactory(ResponseFieldMapperFactory responseFieldMapperFactory) {
-      this.responseFieldMapperFactory = responseFieldMapperFactory;
+    /**
+     * @deprecated The mapper factory is no longer used and will be removed in the future.
+     */
+    @Deprecated
+    public Builder<T> responseFieldMapperFactory(@SuppressWarnings("unused") ResponseFieldMapperFactory responseFieldMapperFactory) {
       return this;
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloSubscriptionCall.java
@@ -36,20 +36,17 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
   private final ApolloStore apolloStore;
   private final CachePolicy cachePolicy;
   private final Executor dispatcher;
-  private final ResponseFieldMapperFactory responseFieldMapperFactory;
   private final ApolloLogger logger;
   private final AtomicReference<CallState> state = new AtomicReference<>(IDLE);
   private SubscriptionManagerCallback<T> subscriptionCallback;
 
   public RealApolloSubscriptionCall(@NotNull Subscription<?, T, ?> subscription, @NotNull SubscriptionManager subscriptionManager,
-      @NotNull ApolloStore apolloStore, @NotNull CachePolicy cachePolicy, @NotNull Executor dispatcher,
-      @NotNull ResponseFieldMapperFactory responseFieldMapperFactory, @NotNull ApolloLogger logger) {
+      @NotNull ApolloStore apolloStore, @NotNull CachePolicy cachePolicy, @NotNull Executor dispatcher, @NotNull ApolloLogger logger) {
     this.subscription = subscription;
     this.subscriptionManager = subscriptionManager;
     this.apolloStore = apolloStore;
     this.cachePolicy = cachePolicy;
     this.dispatcher = dispatcher;
-    this.responseFieldMapperFactory = responseFieldMapperFactory;
     this.logger = logger;
   }
 
@@ -124,7 +121,7 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
   @Override
   public ApolloSubscriptionCall<T> clone() {
     return new RealApolloSubscriptionCall<>(subscription, subscriptionManager, apolloStore, cachePolicy, dispatcher,
-        responseFieldMapperFactory, logger);
+        logger);
   }
 
   @Override public boolean isCanceled() {
@@ -134,7 +131,7 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
   @NotNull @Override public ApolloSubscriptionCall<T> cachePolicy(@NotNull CachePolicy cachePolicy) {
     checkNotNull(cachePolicy, "cachePolicy is null");
     return new RealApolloSubscriptionCall<>(subscription, subscriptionManager, apolloStore, cachePolicy, dispatcher,
-        responseFieldMapperFactory, logger);
+        logger);
   }
 
   private void terminate() {
@@ -163,7 +160,7 @@ public class RealApolloSubscriptionCall<T> implements ApolloSubscriptionCall<T> 
   @SuppressWarnings("unchecked")
   private Response<T> resolveFromCache() {
     final ResponseNormalizer<Record> responseNormalizer = apolloStore.cacheResponseNormalizer();
-    final ResponseFieldMapper responseFieldMapper = responseFieldMapperFactory.create(subscription);
+    final ResponseFieldMapper responseFieldMapper = subscription.responseFieldMapper();
 
     final ApolloStoreOperation<Response> apolloStoreOperation = apolloStore.read(subscription, responseFieldMapper, responseNormalizer,
         CacheHeaders.NONE);

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/ResponseFieldMapperFactory.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/ResponseFieldMapperFactory.java
@@ -8,17 +8,21 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static com.apollographql.apollo.api.internal.Utils.checkNotNull;
 
+/**
+ * @deprecated The mapper is no longer used and will be removed in a future version
+ */
+@Deprecated
 public final class ResponseFieldMapperFactory {
-  private final ConcurrentHashMap<Class, ResponseFieldMapper> pool = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, ResponseFieldMapper> pool = new ConcurrentHashMap<>();
 
   @NotNull public ResponseFieldMapper create(@NotNull Operation operation) {
     checkNotNull(operation, "operation == null");
-    Class operationClass = operation.getClass();
-    ResponseFieldMapper mapper = pool.get(operationClass);
+    String operationId = operation.operationId();
+    ResponseFieldMapper mapper = pool.get(operationId);
     if (mapper != null) {
       return mapper;
     }
-    pool.putIfAbsent(operationClass, operation.responseFieldMapper());
-    return pool.get(operationClass);
+    pool.putIfAbsent(operationId, operation.responseFieldMapper());
+    return pool.get(operationId);
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/subscription/RealSubscriptionManager.java
@@ -7,7 +7,6 @@ import com.apollographql.apollo.api.Subscription;
 import com.apollographql.apollo.api.internal.ResponseFieldMapper;
 import com.apollographql.apollo.cache.normalized.Record;
 import com.apollographql.apollo.exception.ApolloNetworkException;
-import com.apollographql.apollo.internal.ResponseFieldMapperFactory;
 import com.apollographql.apollo.cache.normalized.internal.ResponseNormalizer;
 import com.apollographql.apollo.response.OperationResponseParser;
 import com.apollographql.apollo.subscription.OnSubscriptionManagerStateChangeListener;
@@ -53,7 +52,6 @@ public final class RealSubscriptionManager implements SubscriptionManager {
   private final Executor dispatcher;
   private final long connectionHeartbeatTimeoutMs;
   private final Function0<ResponseNormalizer<Map<String, Object>>> responseNormalizer;
-  private final ResponseFieldMapperFactory responseFieldMapperFactory = new ResponseFieldMapperFactory();
   private final Runnable connectionAcknowledgeTimeoutTimerTask = new Runnable() {
     @Override
     public void run() {
@@ -403,7 +401,7 @@ public final class RealSubscriptionManager implements SubscriptionManager {
 
     if (subscriptionRecord != null) {
       ResponseNormalizer<Map<String, Object>> normalizer = responseNormalizer.invoke();
-      ResponseFieldMapper responseFieldMapper = responseFieldMapperFactory.create(subscriptionRecord.subscription);
+      ResponseFieldMapper responseFieldMapper = subscriptionRecord.subscription.responseFieldMapper();
       OperationResponseParser parser = new OperationResponseParser(subscriptionRecord.subscription, responseFieldMapper,
           scalarTypeAdapters, normalizer);
 


### PR DESCRIPTION
This will prevent errors when wrapping subscriptions in a shared type.

This fixes #2944