### PR TITLE
[3.x] Use graphQl name when writing variables

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/ast/AstBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/ast/AstBuilder.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3.compiler.backend.ast
 
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.backend.codegen.kotlinNameForVariable
 import com.apollographql.apollo3.compiler.backend.ir.BackendIr
 import com.apollographql.apollo3.compiler.backend.ir.SelectionKey
 import com.apollographql.apollo3.compiler.introspection.IntrospectionSchema
@@ -332,7 +333,7 @@ internal class AstBuilder private constructor(
         typesPackageName = typesPackageName,
     )
     return CodeGenerationAst.InputField(
-        name = name.toLowerCamelCase(),
+        name = kotlinNameForVariable(name),
         schemaName = name,
         deprecationReason = null,
         type = fieldType,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/codegen/InputFields.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/codegen/InputFields.kt
@@ -101,11 +101,11 @@ internal fun List<CodeGenerationAst.InputField>.serializerTypeSpec(
         forEach {
           if (!it.isRequired) {
             beginControlFlow("if (value.%L is %T)", kotlinNameForVariable(it.name), Input.Present::class)
-            addStatement("writer.name(%S)", it.name)
+            addStatement("writer.name(%S)", it.schemaName)
             addStatement("%L.toResponse(writer, value.%L.value)", kotlinNameForAdapterField(it.type), kotlinNameForVariable(it.name))
             endControlFlow()
           } else {
-            addStatement("writer.name(%S)", it.name)
+            addStatement("writer.name(%S)", it.schemaName)
             addStatement("%L.toResponse(writer, value.%L)", kotlinNameForAdapterField(it.type), kotlinNameForVariable(it.name))
           }
         }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/codegen/KotlinNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/backend/codegen/KotlinNames.kt
@@ -21,7 +21,8 @@ internal fun kotlinNameForTypeCaseAdapterField(typeRef: CodeGenerationAst.TypeRe
 }
 internal fun kotlinNameForInputObjectType(name: String) = capitalizedIdentifier(name)
 internal fun kotlinNameForSerializer(operationName: String) = kotlinNameForOperation(operationName) + "_Adapter"
-internal fun kotlinNameForVariable(variableName: String) = decapitalizedIdentifier(variableName)
+// variables keep the same case as their declared name
+internal fun kotlinNameForVariable(variableName: String) = variableName.escapeKotlinReservedWord()
 
 private fun decapitalizedIdentifier(name: String) = name.decapitalize().escapeKotlinReservedWord()
 private fun capitalizedIdentifier(name: String) = name.capitalize().escapeKotlinReservedWord()

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/TestQuery.kt.expected
@@ -27,7 +27,7 @@ import kotlin.collections.List
     "RemoveRedundantQualifierName")
 data class TestQuery(
   val episode: Input<Episode?> = Input.Absent,
-  val includeName: Boolean,
+  val IncludeName: Boolean,
   val friendsCount: Int,
   val listOfListOfStringArgs: List<List<String?>>
 ) : Query<TestQuery.Data> {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/adapter/TestQuery_Adapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/adapter/TestQuery_Adapter.kt.expected
@@ -45,8 +45,8 @@ class TestQuery_Adapter(
       writer.name("episode")
       nullableEpisodeAdapter.toResponse(writer, value.episode.value)
     }
-    writer.name("includeName")
-    booleanAdapter.toResponse(writer, value.includeName)
+    writer.name("IncludeName")
+    booleanAdapter.toResponse(writer, value.IncludeName)
     writer.name("friendsCount")
     intAdapter.toResponse(writer, value.friendsCount)
     writer.name("listOfListOfStringArgs")

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetailsImpl.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/HeroDetailsImpl.kt.expected
@@ -20,7 +20,7 @@ import kotlin.collections.List
 
 data class HeroDetailsImpl(
   val friendsCount: Input<Int?> = Input.Absent,
-  val includeName: Boolean
+  val IncludeName: Boolean
 ) : Fragment<HeroDetailsImpl.Data> {
   override fun adapter(responseAdapterCache: ResponseAdapterCache): ResponseAdapter<Data> {
     val adapter = responseAdapterCache.getAdapterFor(this::class) {

--- a/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/adapter/HeroDetailsImpl_Adapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/arguments_simple/fragment/adapter/HeroDetailsImpl_Adapter.kt.expected
@@ -34,8 +34,8 @@ class HeroDetailsImpl_Adapter(
       writer.name("friendsCount")
       nullableIntAdapter.toResponse(writer, value.friendsCount.value)
     }
-    writer.name("includeName")
-    booleanAdapter.toResponse(writer, value.includeName)
+    writer.name("IncludeName")
+    booleanAdapter.toResponse(writer, value.IncludeName)
     writer.endObject()
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/type/adapter/ReviewInput_Adapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/type/adapter/ReviewInput_Adapter.kt.expected
@@ -161,11 +161,11 @@ class ReviewInput_Adapter(
       nullableListOfListOfColorInputAdapter.toResponse(writer, value.listOfListOfObject.value)
     }
     if (value.capitalizedField is Input.Present) {
-      writer.name("capitalizedField")
+      writer.name("CapitalizedField")
       nullableStringAdapter.toResponse(writer, value.capitalizedField.value)
     }
     if (value.capitalizedInt is Input.Present) {
-      writer.name("capitalizedInt")
+      writer.name("CapitalizedInt")
       nullableIntAdapter.toResponse(writer, value.capitalizedInt.value)
     }
     writer.endObject()

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/adapter/ReviewInput_Adapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/type/adapter/ReviewInput_Adapter.kt.expected
@@ -161,11 +161,11 @@ internal class ReviewInput_Adapter(
       nullableListOfListOfColorInputAdapter.toResponse(writer, value.listOfListOfObject.value)
     }
     if (value.capitalizedField is Input.Present) {
-      writer.name("capitalizedField")
+      writer.name("CapitalizedField")
       nullableStringAdapter.toResponse(writer, value.capitalizedField.value)
     }
     if (value.capitalizedInt is Input.Present) {
-      writer.name("capitalizedInt")
+      writer.name("CapitalizedInt")
       nullableIntAdapter.toResponse(writer, value.capitalizedInt.value)
     }
     writer.endObject()

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/adapter/ReviewInput_Adapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/type/adapter/ReviewInput_Adapter.kt.expected
@@ -161,11 +161,11 @@ class ReviewInput_Adapter(
       nullableListOfListOfColorInputAdapter.toResponse(writer, value.listOfListOfObject.value)
     }
     if (value.capitalizedField is Input.Present) {
-      writer.name("capitalizedField")
+      writer.name("CapitalizedField")
       nullableStringAdapter.toResponse(writer, value.capitalizedField.value)
     }
     if (value.capitalizedInt is Input.Present) {
-      writer.name("capitalizedInt")
+      writer.name("CapitalizedInt")
       nullableIntAdapter.toResponse(writer, value.capitalizedInt.value)
     }
     writer.endObject()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -173,7 +173,6 @@ class CodegenTest(private val folder: File) {
           .sortedBy {
             it.name
           }
-          .filter { it.name == "arguments_simple"}
           .filter { file ->
             /**
              * This allows to run a specific test from the command line by using something like:

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -173,6 +173,7 @@ class CodegenTest(private val folder: File) {
           .sortedBy {
             it.name
           }
+          .filter { it.name == "arguments_simple"}
           .filter { file ->
             /**
              * This allows to run a specific test from the command line by using something like:


### PR DESCRIPTION
Use the actual GraphQL name when writing variables. 

Also do not force the identifier to lower case so that something like this is possible:

```
data class GetUserQuery(val IS_ADMIN: Boolean) {
  ...
}
```

I don't see a good reason to force a lower case there. `iS_ADMIN` feels weird and `isAdmin` would feel nicer in kotlin but I don't think that's worth the surprise effect of not having the variable name match the GraphQL. Plus the GraphQL query can be changed if needed.