### PR TITLE
Nicer IntelliJ errors

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
@@ -56,7 +56,7 @@ class GraphQLCompiler(val logger: Logger = NoOpLogger) {
     val firstError = errors.firstOrNull()
     if (firstError != null) {
       throw SourceAwareException(
-          message = firstError.message,
+          error = firstError.message,
           sourceLocation = firstError.sourceLocation,
       )
     }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/GraphQLParser.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/GraphQLParser.kt
@@ -231,7 +231,7 @@ object GraphQLParser {
       val sameChannel = lastToken.channel == documentStopToken.channel
       if (!eof && lastToken.tokenIndex > documentStopToken.tokenIndex && sameChannel) {
         throw AntlrParseException(
-            message = "Unsupported token `${lastToken.text}`",
+            error = "Unsupported token `${lastToken.text}`",
             sourceLocation = SourceLocation(lastToken.line, lastToken.charPositionInLine, filePath)
         )
       }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/exception.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/exception.kt
@@ -4,43 +4,50 @@ import java.io.File
 import java.io.IOException
 
 open class SourceAwareException(
-    message: String,
-    sourceLocation: SourceLocation,
+    val error: String,
+    val sourceLocation: SourceLocation,
 ) : RuntimeException(preview(
-    message = message,
+    error = error,
     sourceLocation = sourceLocation
 )) {
 
   companion object {
-    private fun preview(message: String, sourceLocation: SourceLocation): String {
-      val filePath = sourceLocation.filePath
-      return when {
-        sourceLocation == SourceLocation.UNKNOWN -> "\nFailed to parse $filePath:\n$message"
-        filePath == null -> "\nFailed to parse GraphQL stream $sourceLocation:\n$message"
-        else -> {
-          val document = try {
-            File(filePath).readText()
-          } catch (e: IOException) {
-            throw RuntimeException("Failed to read GraphQL file `$this`", e)
-          }
-          val documentLines = document.lines()
-          return "\nFailed to parse $filePath ${sourceLocation}\n$message" +
-              "\n----------------------------------------------------\n" +
-              kotlin.run {
-                val prefix = if (sourceLocation.line - 2 >= 0) {
-                  "[${sourceLocation.line - 1}]:" + documentLines[sourceLocation.line - 2]
-                } else ""
-                val body = if (sourceLocation.line - 1 >= 0) {
-                  "\n[${sourceLocation.line}]:${documentLines[sourceLocation.line - 1]}\n"
-                } else ""
-                val postfix = if (sourceLocation.line < documentLines.size) {
-                  "[${sourceLocation.line + 1}]:" + documentLines[sourceLocation.line]
-                } else ""
-                "$prefix$body$postfix"
-              } +
-              "\n----------------------------------------------------"
-        }
+    fun formatForIdea(sourceLocation: SourceLocation, description: String): String {
+      // Idea understands a certain format and makes logs clickable
+      // It's not 100% clear where this is specified but it at least works with
+      // 2020.3
+      return sourceLocation.run {
+        "e: $filePath: ($line, ${position + 1}): $description"
       }
+    }
+
+    private fun preview(error: String, sourceLocation: SourceLocation): String {
+      val filePath = sourceLocation.filePath
+      val preview = if (filePath != null) {
+        val document = try {
+          File(filePath).readText()
+        } catch (e: IOException) {
+          throw RuntimeException("Failed to read GraphQL file `$this`", e)
+        }
+        val documentLines = document.lines()
+        "\n----------------------------------------------------\n" +
+            run {
+              val prefix = if (sourceLocation.line - 2 >= 0) {
+                "[${sourceLocation.line - 1}]:" + documentLines[sourceLocation.line - 2]
+              } else ""
+              val body = if (sourceLocation.line - 1 >= 0) {
+                "\n[${sourceLocation.line}]:${documentLines[sourceLocation.line - 1]}\n"
+              } else ""
+              val postfix = if (sourceLocation.line < documentLines.size) {
+                "[${sourceLocation.line + 1}]:" + documentLines[sourceLocation.line]
+              } else ""
+              "$prefix$body$postfix"
+            } +
+            "\n----------------------------------------------------"
+      } else {
+        ""
+      }
+      return formatForIdea(sourceLocation, "$error$preview")
     }
   }
 }
@@ -48,25 +55,25 @@ open class SourceAwareException(
 /**
  * Antlr found an error
  */
-class AntlrParseException(message: String, val sourceLocation: SourceLocation) : SourceAwareException(message, sourceLocation)
+class AntlrParseException(error: String, sourceLocation: SourceLocation) : SourceAwareException(error, sourceLocation)
 
 /**
  * Something went wrong while building the GraphQL AST, analyzing the schema, ...
  *
  * This most likely means an Antlr rule was added to the grammar but the Kotlin code does not handle it
  */
-class UnrecognizedAntlrRule(message: String, val sourceLocation: SourceLocation) : SourceAwareException(message, sourceLocation)
+class UnrecognizedAntlrRule(error: String, sourceLocation: SourceLocation) : SourceAwareException(error, sourceLocation)
 
 /**
  * An exception while converting to/from introspection
  *
  * This most likely means the json/sdl was inconsistent or corrupted
  */
-class ConversionException(message: String, val sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(message, sourceLocation)
+class ConversionException(error: String, sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(error, sourceLocation)
 
 /**
  * The schema is invalid
  *
  * TODO: transform this into issues
  */
-class SchemaValidationException(message: String, val sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(message, sourceLocation)
+class SchemaValidationException(error: String, sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(error, sourceLocation)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/gqldocument.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/frontend/gqldocument.kt
@@ -23,7 +23,7 @@ internal fun GQLDocument.rootOperationTypeDefinition(operationType: String): GQL
         definitions.filterIsInstance<GQLObjectTypeDefinition>()
             .firstOrNull { it.name == namedType }
             ?: throw SchemaValidationException(
-                message = "Schema defines `$namedType` as root for `$operationType` but `$namedType` is not defined",
+                error = "Schema defines `$namedType` as root for `$operationType` but `$namedType` is not defined",
                 sourceLocation = sourceLocation
             )
       }


### PR DESCRIPTION
Display errors as `e: $filePath: ($line, ${position + 1}): $description` so that IntelliJ can open the file directly at the correct position