### PR TITLE
Make sure all publications get uploaded to the same staging repo

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -30,7 +30,7 @@ abstract class GeneratePluginVersion : DefaultTask() {
 
   @org.gradle.api.tasks.TaskAction
   fun taskAction() {
-    val versionFile = File(outputDir.asFile.get(), "Version.kt")
+    val versionFile = File(outputDir.asFile.get(), "com/apollographql/apollo3/compiler/Version.kt")
     versionFile.parentFile.mkdirs()
     versionFile.writeText("""// Generated file. Do not edit!
 package com.apollographql.apollo3.compiler
@@ -40,7 +40,7 @@ val VERSION = "${project.version}"
 }
 
 val pluginVersionTaskProvider = tasks.register("pluginVersion", GeneratePluginVersion::class.java) {
-  outputDir.set(project.layout.buildDirectory.dir("generated/kotlin/com/apollographql/apollo3/compiler/"))
+  outputDir.set(project.layout.buildDirectory.dir("generated/kotlin/"))
   version.set(project.version.toString())
 }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,11 +23,12 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.gradleMetalavaPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
   implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.plugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.gradlePublishPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.benManesVersions"))
   // this plugin is added to the classpath but never applied, it is only used for the closeAndRelease code
-  implementation(groovy.util.Eval.x(project, "x.dep.vanniktechPlugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.vespene"))
 
   implementation(groovy.util.Eval.x(project, "x.dep.kotlin.atomicGradle"))
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.plugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.gradlePublishPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.benManesVersions"))
-  // this plugin is added to the classpath but never applied, it is only used for the closeAndRelease code
   implementation(groovy.util.Eval.x(project, "x.dep.vespene"))
 
   implementation(groovy.util.Eval.x(project, "x.dep.kotlin.atomicGradle"))

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 apply(from = "../gradle/dependencies.gradle")
 
 repositories {
-  gradlePluginPortal()
-  google()
   mavenCentral()
+  google()
+  gradlePluginPortal()
 }
 
 group = "com.apollographql.apollo"

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -4,8 +4,8 @@ apply(from = "../gradle/dependencies.gradle")
 
 pluginManagement {
   repositories {
-    gradlePluginPortal()
     mavenCentral()
+    gradlePluginPortal()
   }
   pluginManagement {
     resolutionStrategy {

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -1,0 +1,229 @@
+import com.android.build.gradle.BaseExtension
+import net.mbonnin.vespene.lib.NexusStagingClient
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.plugins.signing.Sign
+import org.gradle.plugins.signing.SigningExtension
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.plugins.ExtraPropertiesExtension
+
+fun Project.configurePublishing() {
+  apply {
+    it.plugin("signing")
+  }
+  apply {
+    it.plugin("maven-publish")
+  }
+
+  // Not sure if we still need that afterEvaluate
+  afterEvaluate {
+    configurePublishingDelayed()
+  }
+}
+
+fun Project.getOssStagingUrl(): String {
+  val url = try {
+    this.extensions.extraProperties["ossStagingUrl"] as String?
+  } catch (e: ExtraPropertiesExtension.UnknownPropertyException) {
+    null
+  }
+  if (url != null) {
+    return url
+  }
+  val client = NexusStagingClient(
+      username = System.getenv("SONATYPE_NEXUS_USERNAME"),
+      password = System.getenv("SONATYPE_NEXUS_PASSWORD"),
+  )
+  val repositoryId = runBlocking {
+    client.createRepository(
+        profileId = System.getenv("COM_APOLLOGRAPHQL_PROFILE_ID"),
+        description = "com.apollo.apollo3 $version"
+    )
+  }
+  println("publishing to '$repositoryId")
+  return "https://oss.sonatype.org/service/local/staging/deployByRepositoryId/${repositoryId}/".also {
+    this.extensions.extraProperties["ossStagingUrl"] = it
+  }
+}
+
+private fun Project.configurePublishingDelayed() {
+  /**
+   * Javadoc
+   */
+  val emptyJavadocJarTaskProvider = tasks.register("emptyJavadocJar", org.gradle.jvm.tasks.Jar::class.java) {
+    it.archiveClassifier.set("javadoc")
+  }
+
+  tasks.withType(Jar::class.java) {
+    it.manifest {
+      it.attributes["Built-By"] = findProperty("POM_DEVELOPER_ID") as String?
+      it.attributes["Build-Jdk"] = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")} ${System.getProperty("java.vm.version")})"
+      it.attributes["Created-By"] = "Gradle ${gradle.gradleVersion}"
+      it.attributes["Implementation-Title"] = findProperty("POM_NAME") as String?
+      it.attributes["Implementation-Version"] = findProperty("VERSION_NAME") as String?
+    }
+  }
+
+  extensions.configure(PublishingExtension::class.java) { publishingExtension ->
+    publishingExtension.publications { publicationContainer ->
+      when {
+        plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") -> {
+          /**
+           * Kotlin MPP creates a nice publication.
+           * It only misses the javadoc for which we add an empty one
+           */
+          publicationContainer.withType(MavenPublication::class.java).configureEach {
+             it.artifact(emptyJavadocJarTaskProvider.get())
+          }
+        }
+        plugins.hasPlugin("java-gradle-plugin") -> {
+          /**
+           * java-gradle-plugin creates 2 publications (one marker and one regular) but without source/javadoc.
+           */
+          publicationContainer.withType(MavenPublication::class.java) { mavenPublication ->
+            mavenPublication.artifact(emptyJavadocJarTaskProvider.get())
+            // Only add sources for the main publication
+            // XXX: is there a nicer way to do this?
+            if (!mavenPublication.name.toLowerCase().contains("marker")) {
+              mavenPublication.artifact(createJavaSourcesTask())
+            }
+          }
+        }
+        extensions.findByName("android") != null -> {
+          /**
+           * Android projects do not create publications (yet?). Do it ourselves.
+           */
+          publicationContainer.create("default", MavenPublication::class.java) { mavenPublication ->
+            afterEvaluate {
+              // afterEvaluate is required for Android
+              mavenPublication.from(components.findByName("release"))
+            }
+
+            mavenPublication.artifact(emptyJavadocJarTaskProvider.get())
+            mavenPublication.artifact(createAndroidSourcesTask().get())
+
+            mavenPublication.artifactId = findProperty("POM_ARTIFACT_ID") as String?
+          }
+        }
+        else -> {
+          /**
+           * Kotlin JVM do not create publications (yet?). Do it ourselves.
+           */
+          publicationContainer.create("default", MavenPublication::class.java) { mavenPublication ->
+
+            mavenPublication.from(components.findByName("java"))
+            mavenPublication.artifact(emptyJavadocJarTaskProvider.get())
+            mavenPublication.artifact(createJavaSourcesTask().get())
+
+            mavenPublication.artifactId = findProperty("POM_ARTIFACT_ID") as String?
+          }
+        }
+      }
+
+      /**
+       * In all cases, configure the pom
+       */
+      publicationContainer.withType(MavenPublication::class.java).configureEach { mavenPublication ->
+        setDefaultPomFields(mavenPublication)
+      }
+    }
+
+    publishingExtension.repositories { repositoryHandler ->
+      repositoryHandler.maven { repository ->
+        repository.name = "pluginTest"
+        repository.url = uri("file://${rootProject.buildDir}/localMaven")
+      }
+
+      repositoryHandler.maven { repository ->
+        repository.name = "ossSnapshots"
+        repository.url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+        repository.credentials { credentials ->
+          credentials.username = System.getenv("SONATYPE_NEXUS_USERNAME")
+          credentials.password = System.getenv("SONATYPE_NEXUS_PASSWORD")
+        }
+      }
+
+      repositoryHandler.maven { repository ->
+        repository.name = "ossStaging"
+        repository.setUrl {
+          uri(rootProject.getOssStagingUrl())
+        }
+        repository.credentials { credentials ->
+          credentials.username = System.getenv("SONATYPE_NEXUS_USERNAME")
+          credentials.password = System.getenv("SONATYPE_NEXUS_PASSWORD")
+        }
+      }
+    }
+  }
+
+  extensions.configure(SigningExtension::class.java) { signingExtension ->
+    // GPG_PRIVATE_KEY should contain the armoured private key that starts with -----BEGIN PGP PRIVATE KEY BLOCK-----
+    // It can be obtained with gpg --armour --export-secret-keys KEY_ID
+    signingExtension.useInMemoryPgpKeys(System.getenv("GPG_PRIVATE_KEY"), System.getenv("GPG_PRIVATE_KEY_PASSWORD"))
+    val publicationsContainer = (extensions.getByName("publishing") as PublishingExtension).publications
+    signingExtension.sign(publicationsContainer)
+  }
+  tasks.withType(Sign::class.java).configureEach {
+    it.isEnabled = !System.getenv("GPG_PRIVATE_KEY").isNullOrBlank()
+  }
+}
+
+
+/**
+ * Set fields which are common to all project, either KMP or non-KMP
+ */
+private fun Project.setDefaultPomFields(mavenPublication: MavenPublication) {
+  mavenPublication.groupId = findProperty("GROUP") as String?
+  mavenPublication.version = findProperty("VERSION_NAME") as String?
+
+  mavenPublication.pom { mavenPom ->
+    mavenPom.name.set(findProperty("POM_NAME") as String?)
+    (findProperty("POM_PACKAGING") as String?)?.let {
+      // Do not overwrite packaging if already set by the multiplatform plugin
+      mavenPom.packaging = it
+    }
+
+    mavenPom.description.set(findProperty("POM_DESCRIPTION") as String?)
+    mavenPom.url.set(findProperty("POM_URL") as String?)
+
+    mavenPom.scm { scm ->
+      scm.url.set(findProperty("POM_SCM_URL") as String?)
+      scm.connection.set(findProperty("POM_SCM_CONNECTION") as String?)
+      scm.developerConnection.set(findProperty("POM_SCM_DEV_CONNECTION") as String?)
+    }
+
+    mavenPom.licenses { licenseSpec ->
+      licenseSpec.license { license ->
+        license.name.set(findProperty("POM_LICENCE_NAME") as String?)
+        license.url.set(findProperty("POM_LICENCE_URL") as String?)
+      }
+    }
+
+    mavenPom.developers { developerSpec ->
+      developerSpec.developer { developer ->
+        developer.id.set(findProperty("POM_DEVELOPER_ID") as String?)
+        developer.name.set(findProperty("POM_DEVELOPER_NAME") as String?)
+      }
+    }
+  }
+}
+
+private fun Project.createJavaSourcesTask(): TaskProvider<Jar> {
+  return tasks.register("javaSourcesJar", Jar::class.java) { jar ->
+    jar.archiveClassifier.set("sources")
+    val sourceSets = project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets
+    jar.from(sourceSets.getByName("main").allSource)
+  }
+}
+
+private fun Project.createAndroidSourcesTask(): TaskProvider<Jar> {
+  return tasks.register("javaSourcesJar", Jar::class.java) { jar ->
+    val android = extensions.findByName("android") as BaseExtension
+    jar.archiveClassifier.set("sources")
+    jar.from(android.sourceSets.getByName("main").java.sourceFiles)
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   repositories {
-    gradlePluginPortal()
     mavenCentral()
     google()
+    gradlePluginPortal()
   }
   project.apply {
     from(rootProject.file("gradle/dependencies.gradle"))

--- a/composite/build.gradle.kts
+++ b/composite/build.gradle.kts
@@ -4,9 +4,9 @@ buildscript {
   }
 
   repositories {
-    gradlePluginPortal()
-    google()
     mavenCentral()
+    google()
+    gradlePluginPortal()
   }
 
   dependencies {

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -52,7 +52,7 @@ ext.dep = [
     gradleJapiCmpPlugin   : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
     gradleMetalavaPlugin  : "me.tylerbwong.gradle:metalava-gradle:0.1.5",
     oneEightPlugin        : "gradle.plugin.net.mbonnin:one-eight:0.1",
-    vanniktechPlugin      : "com.vanniktech:gradle-maven-publish-plugin:0.11.1",
+    vespene               : "net.mbonnin.vespene:vespene-lib:0.5",
     gradlePublishPlugin   : "com.gradle.publish:plugin-publish-plugin:0.12.0",
     guavaJre              : "com.google.guava:guava:$versions.guava",
     jetbrainsAnnotations  : "org.jetbrains:annotations:$versions.jetbrainsAnnotations",


### PR DESCRIPTION
OSSRH has a tendency of creating multiple staging repos. This happened twice today will trying to upload the 1000+ files of `3.0.0-dev5`. Closing individual staging repos is not an option in that case because the artifacts seem randomly dispatch which means that the signature will not always be in the same repo as the jar for an example. Which makes the verifications fail.

Instead, create a new staging repo explicitely and upload all artifacts to it.

Also move all the publishing logic to `build-logic` and fix the sources artifacts that were somewhat lost in `dev-3.x`