### PR TITLE
Read form feed sequence as well

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/BufferedSourceJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/BufferedSourceJsonReader.kt
@@ -891,6 +891,7 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
       'b' -> '\b'
       'n' -> '\n'
       'r' -> '\r'
+      'f' -> '\f'
       '\n', '\'', '"', '\\', '/' -> escaped
       else -> {
         if (!lenient) throw syntaxError("Invalid escape sequence: \\$escaped")

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/BufferedSourceJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/json/BufferedSourceJsonReader.kt
@@ -891,7 +891,7 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
       'b' -> '\b'
       'n' -> '\n'
       'r' -> '\r'
-      'f' -> '\f'
+      'f' -> '\u000C'
       '\n', '\'', '"', '\\', '/' -> escaped
       else -> {
         if (!lenient) throw syntaxError("Invalid escape sequence: \\$escaped")


### PR DESCRIPTION
According to Google's Gson JsonReader class https://github.com/google/gson/blob/master/gson/src/main/java/com/google/gson/stream/JsonReader.java#L1538 you have to read escaped '\f' character as well (used for page break). And also please can you suggest some workaround for this problem for now?