### PR TITLE
Strip the priorResponse before returning it to the upstream interceptor

### DIFF
--- a/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/Utils.java
+++ b/apollo-http-cache/src/main/java/com/apollographql/apollo/cache/http/Utils.java
@@ -37,7 +37,7 @@ final class Utils {
 
   static Response strip(Response response) {
     return response != null && response.body() != null
-        ? response.newBuilder().body(null).networkResponse(null).cacheResponse(null).build()
+        ? response.newBuilder().body(null).networkResponse(null).cacheResponse(null).priorResponse(null).build()
         : response;
   }
 

--- a/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTestKotlin.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/HttpCacheTestKotlin.kt
@@ -1,0 +1,52 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.Utils.mockResponse
+import com.apollographql.apollo.api.cache.http.HttpCachePolicy
+import com.apollographql.apollo.cache.http.ApolloHttpCache
+import com.apollographql.apollo.cache.http.DiskLruHttpCacheStore
+import com.apollographql.apollo.coroutines.await
+import com.apollographql.apollo.integration.httpcache.AllPlanetsQuery
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Test
+import java.io.File
+
+class HttpCacheTestKotlin {
+  private val response408 = MockResponse().setResponseCode(408).setBody("error")
+  private val response200 = mockResponse("HttpCacheTestAllPlanets.json")
+
+  @Test
+  fun test408() {
+    val cacheDir = File("build/integrationTestCache")
+    cacheDir.deleteRecursively()
+    val mockServer = MockWebServer()
+
+    val apolloClient = ApolloClient
+      .builder()
+      .serverUrl(mockServer.url("/"))
+      .httpCache(
+        ApolloHttpCache(
+          DiskLruHttpCacheStore(
+            cacheDir,
+            Long.MAX_VALUE
+          )
+        )
+      )
+      .defaultHttpCachePolicy(HttpCachePolicy.NETWORK_FIRST)
+      .useHttpGetMethodForQueries(true)
+      .useHttpGetMethodForPersistedQueries(true)
+      .enableAutoPersistedQueries(true)
+      .defaultHttpCachePolicy(HttpCachePolicy.NETWORK_FIRST)
+      .build()
+
+    runBlocking {
+      mockServer.enqueue(response200)
+      apolloClient.query(AllPlanetsQuery()).await()
+      mockServer.enqueue(response408)
+      mockServer.enqueue(response408)
+      apolloClient.query(AllPlanetsQuery()).await()
+    }
+  }
+}


### PR DESCRIPTION
fixes #2998

`priorResponse` is used internally by OkHttp to retry requests, for an example in the 208 case but I don't think we are using it anywhere in the Apollo code. Remove it so that the Response builders do not crash.