### PR TITLE
Package the Gradle plugin as a fat jar to avoid any classpath issues

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -41,7 +41,6 @@ val shadowJarTask = tasks.named("shadowJar", com.github.jengelman.gradle.plugins
 val shadowPrefix = "com.apollographql.relocated"
 
 shadowJarTask.configure {
-  minimize()
   configurations = listOf(shadowImplementation)
   relocate("org.antlr", "com.apollographql.relocated.org.antlr")
   relocate("okio", "com.apollographql.relocated.okio")

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -56,7 +56,8 @@ configurations {
       val removed = artifacts.removeIf { it.classifier.isNullOrEmpty() }
       if (removed) {
         artifact(tasks.shadowJar) {
-          classifier = "all"
+          // Pom and maven consumers do not like the `-all` default classifier
+          classifier = ""
         }
       }
     }

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   kotlin("jvm")
   id("java-gradle-plugin")
   id("com.gradle.plugin-publish")
+  id("com.github.johnrengelman.shadow")
 }
 
 
@@ -9,22 +10,62 @@ metalava {
   hiddenPackages += setOf("com.apollographql.apollo3.gradle.internal")
 }
 
+/**
+ * Special configuration to be included in resulting shadowed jar, but not added to the generated pom and gradle
+ * metadata files.
+ * Largely inspired by Ktlint https://github.com/JLLeitschuh/ktlint-gradle/blob/530aa9829abea01e4c91e8798fb7341c438aac3b/plugin/build.gradle.kts
+ */
+val shadowImplementation by configurations.creating
+configurations["compileOnly"].extendsFrom(shadowImplementation)
+configurations["testImplementation"].extendsFrom(shadowImplementation)
+
 dependencies {
+  compileOnly(gradleApi())
   compileOnly(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
   compileOnly(groovy.util.Eval.x(project, "x.dep.android.minPlugin"))
   // kotlin-reflect is transitively pulled by the android plugin, make it explicit so that it uses the same version as the rest of kotlin libs
   compileOnly(groovy.util.Eval.x(project, "x.dep.kotlin.reflect"))
 
-  api(project(":apollo-compiler"))
-  implementation(project(":apollo-api")) // for QueryDocumentMinifier
-  implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4"))
+  shadowImplementation(project(":apollo-compiler"))
+  shadowImplementation(project(":apollo-api"))
+  shadowImplementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4").toString())
   // Needed for manual Json construction in `SchemaDownloader`
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
+  shadowImplementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi").toString())
 
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.truth"))
-
   testImplementation(groovy.util.Eval.x(project, "x.dep.okHttp.mockWebServer4"))
+}
+
+val shadowJarTask = tasks.named("shadowJar", com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar::class.java)
+val shadowPrefix = "com.apollographql.relocated"
+
+shadowJarTask.configure {
+  minimize()
+  configurations = listOf(shadowImplementation)
+  relocate("org.antlr", "com.apollographql.relocated.org.antlr")
+  relocate("okio", "com.apollographql.relocated.okio")
+  relocate("okhttp3", "com.apollographql.relocated.okhttp3")
+}
+
+tasks.getByName("jar").enabled = false
+tasks.getByName("jar").dependsOn(shadowJarTask)
+
+configurations {
+  configureEach {
+    outgoing {
+      val removed = artifacts.removeIf { it.classifier.isNullOrEmpty() }
+      if (removed) {
+        artifact(tasks.shadowJar) {
+          classifier = "all"
+        }
+      }
+    }
+  }
+  // used by plugin-publish plugin
+  archives {
+    extendsFrom(signatures.get())
+  }
 }
 
 tasks.withType<Test> {
@@ -60,6 +101,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
     apiVersion = "1.3"
   }
 }
+
 
 /**
  * This is so that the plugin marker pom contains a <scm> tag

--- a/apollo-gradle-plugin/gradle.properties
+++ b/apollo-gradle-plugin/gradle.properties
@@ -1,3 +1,5 @@
 POM_ARTIFACT_ID=apollo-gradle-plugin
 POM_NAME=Apollo Gradle Plugin
 POM_DESCRIPTION=Gradle plugin for generating java/kotlin classes for graphql files
+
+kotlin.stdlib.default.dependency=false

--- a/apollo-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.apollographql.apollo.properties
+++ b/apollo-gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.apollographql.apollo.properties
@@ -1,1 +1,0 @@
-implementation-class=com.apollographql.apollo3.gradle.internal.ApolloPlugin

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.gradlePublishPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.benManesVersions"))
   implementation(groovy.util.Eval.x(project, "x.dep.vespene"))
+  implementation(groovy.util.Eval.x(project, "x.dep.shadow"))
 
   implementation(groovy.util.Eval.x(project, "x.dep.kotlin.atomicGradle"))
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -97,6 +97,7 @@ ext.dep = [
     truth                 : "com.google.truth:truth:$versions.truth",
     uuid                  : "com.benasher44:uuid:0.2.2",
     benManesVersions      : "com.github.ben-manes:gradle-versions-plugin:0.33.0",
+    shadow                : "com.github.jengelman.gradle.plugins:shadow:6.1.0",
 ]
 ext.androidConfig = [
     compileSdkVersion: 30,


### PR DESCRIPTION
Relocate okio, okhttp and antlr in `apollo-gradle-plugin` and ship everything as a fatjar.

Fixes #3011 and other issues where gradle loads older versions of these dependencies on the classpath