### PR TITLE
Gradle plugin: Shadow everything

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 // Only expose the antlr runtime dependency
 // See https://github.com/gradle/gradle/issues/820#issuecomment-288838412
 configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
-  apiConfiguration.setExtendsFrom(apiConfiguration.extendsFrom.filter { it.name != "antlr" }.toSet())
+  apiConfiguration.setExtendsFrom(apiConfiguration.extendsFrom.filter { it.name != "antlr" })
 }
 
 abstract class GeneratePluginVersion : DefaultTask() {

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 dependencies {
   antlr(groovy.util.Eval.x(project, "x.dep.antlr.antlr"))
-  api(groovy.util.Eval.x(project, "x.dep.antlr.runtime"))
+  implementation(groovy.util.Eval.x(project, "x.dep.antlr.runtime"))
   implementation(groovy.util.Eval.x(project, "x.dep.moshi.adapters"))
   implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
   implementation(groovy.util.Eval.x(project, "x.dep.poet.kotlin"))

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
   antlr(groovy.util.Eval.x(project, "x.dep.antlr.antlr"))
+  api(groovy.util.Eval.x(project, "x.dep.antlr.runtime"))
   implementation(groovy.util.Eval.x(project, "x.dep.moshi.adapters"))
   implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
   implementation(groovy.util.Eval.x(project, "x.dep.poet.kotlin"))
@@ -19,6 +20,12 @@ dependencies {
   testImplementation(groovy.util.Eval.x(project, "x.dep.kotlinCompileTesting"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.truth"))
+}
+
+// Only expose the antlr runtime dependency
+// See https://github.com/gradle/gradle/issues/820#issuecomment-288838412
+configurations[JavaPlugin.API_CONFIGURATION_NAME].let { apiConfiguration ->
+  apiConfiguration.setExtendsFrom(apiConfiguration.extendsFrom.filter { it.name != "antlr" }.toSet())
 }
 
 abstract class GeneratePluginVersion : DefaultTask() {

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -80,20 +80,15 @@ shadowJarTask.configure {
    * this will clash with any other version in the classpath
    * - When there are multiple subpackages, we usually include a shared prefx package to avoid this list being huge... But we don't
    * want these packages to be too short either as it increases the risk of a string being renamed
-   * - It would be nice to remove antlr4 and just have antlr4-runtime in the classpath ultimately. Not sure how that would work though.
    */
   listOf(
       "com.benasher44.uuid",
-      "com.ibm.icu",
       "com.squareup.kotlinpoet",
       "com.squareup.moshi",
       "javax.json",
       "okhttp3",
       "okio",
-      "org.abego.treelayout",
       "org.antlr",
-      "org.glassfish.json",
-      "org.stringtemplate.v4",
   ).forEach { packageName ->
     relocate(packageName, "com.apollographql.relocated.$packageName")
   }

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -42,14 +42,14 @@ fun addShadowImplementation(dependency: Dependency) {
 dependencies {
   compileOnly(gradleApi())
   compileOnly(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  compileOnly(groovy.util.Eval.x(project, "x.dep.android.minPlugin").toString())
+  compileOnly(groovy.util.Eval.x(project, "x.dep.android.minPlugin"))
 
   addShadowImplementation(project(":apollo-compiler"))
   addShadowImplementation(project(":apollo-api"))
 
   addShadowImplementation(create(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4")))
   // Needed for manual Json construction in `SchemaDownloader`
-  addShadowImplementation(create(groovy.util.Eval.x(project, "x.dep.moshi.moshi").toString()))
+  addShadowImplementation(create(groovy.util.Eval.x(project, "x.dep.moshi.moshi")))
 
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.truth"))
@@ -80,6 +80,7 @@ shadowJarTask.configure {
    * this will clash with any other version in the classpath
    * - When there are multiple subpackages, we usually include a shared prefx package to avoid this list being huge... But we don't
    * want these packages to be too short either as it increases the risk of a string being renamed
+   * - It would be nice to remove antlr4 and just have antlr4-runtime in the classpath ultimately. Not sure how that would work though.
    */
   listOf(
       "com.benasher44.uuid",

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -28,7 +28,7 @@ fun addShadowImplementation(dependency: Dependency) {
    * 1. it's less bytes to download and load as the stdlib should be on the classpath already
    * 2. there's a weird bug where trying to relocate the stdlib will also rename the "kotlin"
    * strings inside the plugin so something like `extensions.findByName("kotlin")` becomes
-   * `extensions.findByName("com.apollographql.relocated")
+   * `extensions.findByName("com.apollographql.relocated.kotlin")
    * See https://github.com/johnrengelman/shadow/issues/232 for more details
    */
   dependency.exclude(group  = "org.jetbrains.kotlin", module = "kotlin-stdlib")

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -85,7 +85,6 @@ shadowJarTask.configure {
       "com.benasher44.uuid",
       "com.squareup.kotlinpoet",
       "com.squareup.moshi",
-      "javax.json",
       "okhttp3",
       "okio",
       "org.antlr",

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -40,6 +40,7 @@ ext.dep = [
     ],
     antlr                 : [
         antlr  : "org.antlr:antlr4:$versions.antlr4",
+        runtime: "org.antlr:antlr4-runtime:$versions.antlr4",
     ],
     apollo                : [
         plugin : "com.apollographql.apollo3:apollo-gradle-plugin:$versions.apollo",


### PR DESCRIPTION
This avoids conflicts with other dependencies like moshi that wouldn't have
conflicted otherwise but depend on relocated libraries for some of their
API

'com.squareup.moshi.JsonReader com.squareup.moshi.JsonReader.of(com.apollographql.relocated.okio.BufferedSource)'