### PR TITLE
Fix fragments nested inside inline fragments

### DIFF
--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -217,7 +217,6 @@ class CodegenTest(private val folder: File, private val fragmentsCodegenMode: Fr
           dumpIR = false,
           generateFragmentImplementations = generateFragmentImplementations,
           generateFragmentsAsInterfaces = fragmentAsInterfaces,
-          useUnifiedIr = false
       )
     }
 


### PR DESCRIPTION
For something like this:

```kotlin
{
   ... on Character {
      ...NodeFragment
   }
}
```

we were previously not adding `NodeFragment` to the list of super interfaces for the `Character` typeset. 

Traverse inline fragments to make sure we catch those