### PR TITLE
Use KSP and Moshix to generate Json adapters

### DIFF
--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -57,8 +57,12 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension> {
 }
 
 tasks.withType(KotlinCompile::class.java) {
-  // Fixes Task ':apollo-android:apollo-compiler:kaptGenerateStubsKotlin' uses the output of task ':apollo-android:apollo-compiler:pluginVersion', without declaring an explicit dependency
+  // Fixes the warning below:
+  // "Task ':apollo-android:apollo-compiler:kaptGenerateStubsKotlin' uses the output of task ':apollo-android:apollo-compiler:pluginVersion', without declaring an explicit dependency"
   dependsOn(pluginVersionTaskProvider)
+  // This used to work and fails now. Strangely enough, it fails on both `dev-3.x` and `main` as of writing while both these branches have
+  // compiled successfully before...
+  dependsOn("generateGrammarSource")
 }
 
 tasks.withType(KotlinCompile::class.java) {

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
   antlr
   kotlin("jvm")
-  kotlin("kapt")
+  id("com.google.devtools.ksp")
 }
 
 dependencies {
@@ -14,7 +14,7 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.poet.kotlin"))
   implementation(project(":apollo-api"))
 
-  kapt(groovy.util.Eval.x(project, "x.dep.moshi.kotlinCodegen"))
+  ksp(groovy.util.Eval.x(project, "x.dep.moshi.kotlinCodegen"))
 
   testImplementation(groovy.util.Eval.x(project, "x.dep.compiletesting"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.kotlinCompileTesting"))

--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -1,6 +1,4 @@
-if (System.getProperty("idea.sync.active") == null) {
-  apply(plugin = "com.android.library")
-}
+apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.multiplatform")
 apply(plugin = "com.squareup.sqldelight")
 
@@ -15,10 +13,8 @@ configure<com.squareup.sqldelight.gradle.SqlDelightExtension> {
 configureMppDefaults(withJs = false)
 
 configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
-  if (System.getProperty("idea.sync.active") == null) {
-    android {
-      publishAllLibraryVariants()
-    }
+  android {
+    publishAllLibraryVariants()
   }
 
   sourceSets {
@@ -49,35 +45,31 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
       }
     }
 
-    if (System.getProperty("idea.sync.active") == null) {
-      val androidMain by getting {
-        dependsOn(commonMain)
-        dependencies {
-          api(groovy.util.Eval.x(project, "x.dep.androidx.sqlite"))
-          implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.android"))
-          implementation(groovy.util.Eval.x(project, "x.dep.androidx.sqliteFramework"))
-        }
+    val androidMain by getting {
+      dependsOn(commonMain)
+      dependencies {
+        api(groovy.util.Eval.x(project, "x.dep.androidx.sqlite"))
+        implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.android"))
+        implementation(groovy.util.Eval.x(project, "x.dep.androidx.sqliteFramework"))
       }
-      val androidTest by getting {
-        // this allows the android unit test to use the JVM driver
-        // TODO: makes this better with HMPP?
-        dependsOn(jvmTest)
-        dependencies {
-          implementation(kotlin("test-junit"))
-        }
+    }
+    val androidTest by getting {
+      // this allows the android unit test to use the JVM driver
+      // TODO: makes this better with HMPP?
+      dependsOn(jvmTest)
+      dependencies {
+        implementation(kotlin("test-junit"))
       }
     }
   }
 }
 
-if (System.getProperty("idea.sync.active") == null) {
-  configure<com.android.build.gradle.LibraryExtension> {
-    compileSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.compileSdkVersion").toString().toInt())
+configure<com.android.build.gradle.LibraryExtension> {
+  compileSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.compileSdkVersion").toString().toInt())
 
-    defaultConfig {
-      minSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.minSdkVersion").toString())
-      targetSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.targetSdkVersion").toString())
-    }
+  defaultConfig {
+    minSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.minSdkVersion").toString())
+    targetSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.targetSdkVersion").toString())
   }
 }
 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -13,6 +13,8 @@ buildscript {
   dependencies {
     classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.kspGradlePlugin"))
+
     classpath("com.apollographql.apollo3:apollo-gradle-plugin:${properties.get("apolloVersion")}")
     classpath("androidx.benchmark:benchmark-gradle-plugin:1.0.0")
   }
@@ -22,7 +24,7 @@ apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.android")
 apply(plugin = "com.apollographql.apollo3")
 apply(plugin = "androidx.benchmark")
-apply(plugin = "org.jetbrains.kotlin.kapt")
+apply(plugin = "com.google.devtools.ksp")
 
 repositories {
   google()
@@ -40,7 +42,7 @@ dependencies {
   add("implementation", "com.apollographql.apollo3:apollo-normalized-cache-sqlite:${properties.get("apolloVersion")}")
 
   add("implementation", groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
-  add("kapt", groovy.util.Eval.x(project, "x.dep.moshi.kotlinCodegen"))
+  add("ksp", groovy.util.Eval.x(project, "x.dep.moshi.kotlinCodegen"))
 
   add("androidTestImplementation", "androidx.benchmark:benchmark-junit4:1.0.0")
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.benManesVersions"))
   implementation(groovy.util.Eval.x(project, "x.dep.vespene"))
   implementation(groovy.util.Eval.x(project, "x.dep.shadow"))
+  implementation(groovy.util.Eval.x(project, "x.dep.kspGradlePlugin"))
 
   implementation(groovy.util.Eval.x(project, "x.dep.kotlin.atomicGradle"))
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
   implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp4"))
   implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
 
+  compileOnly(groovy.util.Eval.x(project, "x.dep.kotlin.reflect").toString()) {
+    because("AGP pulls kotlin-reflect 1.3.72 and that triggers a warning in the Kotlin compiler.")
+  }
+
   // We add all the plugins to the classpath here so that they are loaded with proper conflict resolution
   // See https://github.com/gradle/gradle/issues/4741
   implementation(groovy.util.Eval.x(project, "x.dep.android.plugin"))

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -233,6 +233,6 @@ private fun Project.createAndroidSourcesTask(): TaskProvider<Jar> {
   return tasks.register("javaSourcesJar", Jar::class.java) { jar ->
     val android = extensions.findByName("android") as BaseExtension
     jar.archiveClassifier.set("sources")
-    jar.from(android.sourceSets.getByName("main").java.sourceFiles)
+    jar.from(android.sourceSets.getByName("main").java.getSourceFiles())
   }
 }

--- a/composite/settings.gradle.kts
+++ b/composite/settings.gradle.kts
@@ -9,14 +9,13 @@ include(":multiplatform")
 project(":multiplatform").projectDir = file("samples/multiplatform")
 include(":multiplatform:kmp-lib-sample")
 project(":multiplatform:kmp-lib-sample").projectDir = file("samples/multiplatform/kmp-lib-sample")
-if (System.getProperty("idea.sync.active") == null) {
-    include(":java-sample")
-    project(":java-sample").projectDir = file("samples/java-sample")
-    include(":kotlin-sample")
-    project(":kotlin-sample").projectDir = file("samples/kotlin-sample")
-    include(":multiplatform:kmp-android-app")
-    project(":multiplatform:kmp-android-app").projectDir = file("samples/multiplatform/kmp-android-app")
-}
+include(":java-sample")
+project(":java-sample").projectDir = file("samples/java-sample")
+include(":kotlin-sample")
+project(":kotlin-sample").projectDir = file("samples/kotlin-sample")
+include(":multiplatform:kmp-android-app")
+project(":multiplatform:kmp-android-app").projectDir = file("samples/multiplatform/kmp-android-app")
+
 includeBuild("../build-logic")
 includeBuild("../")
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -11,7 +11,7 @@ def versions = [
     javaPoet              : '1.9.0',
     jetbrainsAnnotations  : '13.0',
     junit                 : '4.13.1',
-    kotlin                : '1.4.31',
+    kotlin                : '1.4.32',
     kotlinAtomic          : '0.15.1',
     kotlinCoroutines      : '1.4.2',
     kotlinPoet            : '1.6.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ def versions = [
     androidPlugin         : '4.1.3',
     androidxSqlite        : '2.1.0',
     apollo                : '3.0.0-dev7-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
-    antlr4                : '4.8-1',
+    antlr4                : '4.9.2',
     cache                 : '2.0.2',
     compiletesting        : '0.18',
     espressoIdlingResource: '3.2.0',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 def versions = [
     minAndroidPlugin      : '3.4.2',
-    androidPlugin         : '4.0.1',
+    androidPlugin         : '4.1.3',
     androidxSqlite        : '2.1.0',
     apollo                : '3.0.0-dev7-SNAPSHOT', // This should only be used by apollo-gradle-plugin-incubating:test to get the artifacts locally
     antlr4                : '4.8-1',

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -68,7 +68,7 @@ ext.dep = [
     ],
     moshi                 : [
         adapters     : "com.squareup.moshi:moshi-adapters:$versions.moshi",
-        kotlinCodegen: "com.squareup.moshi:moshi-kotlin-codegen:$versions.moshi",
+        kotlinCodegen: "dev.zacsweers.moshix:moshi-ksp:0.10.0",
         moshi        : "com.squareup.moshi:moshi:$versions.moshi",
     ],
     okHttp                : [
@@ -99,6 +99,7 @@ ext.dep = [
     uuid                  : "com.benasher44:uuid:0.2.2",
     benManesVersions      : "com.github.ben-manes:gradle-versions-plugin:0.33.0",
     shadow                : "com.github.jengelman.gradle.plugins:shadow:6.1.0",
+    kspGradlePlugin: "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.4.32-1.0.0-alpha07"
 ]
 ext.androidConfig = [
     compileSdkVersion: 30,

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-milestone-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,10 +7,6 @@ rootProject.projectDir
     .filter { it.isDirectory }
     .filter { it.name.startsWith("apollo-") }
     .forEach {
-      if (System.getProperty("idea.sync.active") != null
-          && it.name in listOf("apollo-android-support", "apollo-idling-resource")) {
-        return@forEach
-      }
       include(it.name)
     }
 


### PR DESCRIPTION
While iterating on the compiler I had wayyyyy to many stale kapt files
issue. That should fix it.
KSP itself is still experimental but I think it's ok to use since it's
run mostly on the dev machine and the generated adapter do not do
anything crazy. On the contrary, it's a way to move the ecosystem
forward by providing feedback if needed.