### PR TITLE
Update SQLDelight to 1.5.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -21,7 +21,7 @@ def versions = [
     rxjava                : '2.2.20',
     rxjava3               : '3.0.7',
     rxandroid             : '2.0.1',
-    sqldelight            : '1.4.4',
+    sqldelight            : '1.5.0',
     truth                 : '0.30',
 ]
 


### PR DESCRIPTION
That should fix the `generateSqlDelightInterface` task sometime not being executed