### PR TITLE
[dev3.x] #3071 Asynchronous caching per request

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
@@ -109,6 +109,7 @@ class ApolloClient internal constructor(
   val subscriptionManager: SubscriptionManager
   private val useHttpGetMethodForQueries: Boolean
   private val useHttpGetMethodForPersistedQueries: Boolean
+
   override fun <D : Mutation.Data> mutate(
       mutation: Mutation<D>): ApolloMutationCall<D> {
     return newCall(mutation).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
@@ -96,8 +96,7 @@ class ApolloClient internal constructor(
     enableAutoPersistedQueries: Boolean,
     subscriptionManager: SubscriptionManager,
     useHttpGetMethodForQueries: Boolean,
-    useHttpGetMethodForPersistedQueries: Boolean,
-    writeToNormalizedCacheAsynchronously: Boolean) : ApolloQueryCall.Factory, ApolloMutationCall.Factory, ApolloPrefetch.Factory, ApolloSubscriptionCall.Factory {
+    useHttpGetMethodForPersistedQueries: Boolean) : ApolloQueryCall.Factory, ApolloMutationCall.Factory, ApolloPrefetch.Factory, ApolloSubscriptionCall.Factory {
   private val tracker = ApolloCallTracker()
   private val applicationInterceptors: List<ApolloInterceptor>
   private val applicationInterceptorFactories: List<ApolloInterceptorFactory>
@@ -110,7 +109,6 @@ class ApolloClient internal constructor(
   val subscriptionManager: SubscriptionManager
   private val useHttpGetMethodForQueries: Boolean
   private val useHttpGetMethodForPersistedQueries: Boolean
-  private val writeToNormalizedCacheAsynchronously: Boolean
   override fun <D : Mutation.Data> mutate(
       mutation: Mutation<D>): ApolloMutationCall<D> {
     return newCall(mutation).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
@@ -256,7 +254,6 @@ class ApolloClient internal constructor(
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
         .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
-        .writeToNormalizedCacheAsynchronously(writeToNormalizedCacheAsynchronously)
         .build()
   }
 
@@ -285,7 +282,6 @@ class ApolloClient internal constructor(
     var subscriptionHeartbeatTimeout: Long = -1
     var useHttpGetMethodForQueries = false
     var useHttpGetMethodForPersistedQueries = false
-    var writeToNormalizedCacheAsynchronously = false
 
     internal constructor()
     constructor(apolloClient: ApolloClient) {
@@ -306,7 +302,6 @@ class ApolloClient internal constructor(
       subscriptionManager = apolloClient.subscriptionManager
       useHttpGetMethodForQueries = apolloClient.useHttpGetMethodForQueries
       useHttpGetMethodForPersistedQueries = apolloClient.useHttpGetMethodForPersistedQueries
-      writeToNormalizedCacheAsynchronously = apolloClient.writeToNormalizedCacheAsynchronously
     }
 
     /**
@@ -369,9 +364,6 @@ class ApolloClient internal constructor(
      *
      * @param normalizedCacheFactory the [NormalizedCacheFactory] used to construct a [NormalizedCache].
      * @param keyResolver the [CacheKeyResolver] to use to normalize records
-     * @param writeToCacheAsynchronously If true returning response data will not wait on the normalized cache write. This can
-     * improve request performance, but means that subsequent requests are not guaranteed to hit the cache for data contained
-     * in previously received requests.
      * @return The [Builder] object to be used for chaining method calls
      */
     /**
@@ -389,10 +381,9 @@ class ApolloClient internal constructor(
      */
     @JvmOverloads
     fun normalizedCache(normalizedCacheFactory: NormalizedCacheFactory,
-                        keyResolver: CacheKeyResolver = CacheKeyResolver.DEFAULT, writeToCacheAsynchronously: Boolean = false): Builder {
+                        keyResolver: CacheKeyResolver = CacheKeyResolver.DEFAULT): Builder {
       cacheFactory = fromNullable(normalizedCacheFactory)
       cacheKeyResolver = fromNullable((keyResolver))
-      writeToNormalizedCacheAsynchronously = writeToCacheAsynchronously
       return this
     }
 
@@ -662,8 +653,7 @@ class ApolloClient internal constructor(
           enableAutoPersistedQueries,
           subscriptionManager,
           useHttpGetMethodForQueries,
-          useHttpGetMethodForPersistedQueries,
-          writeToNormalizedCacheAsynchronously)
+          useHttpGetMethodForPersistedQueries)
     }
 
     private fun defaultDispatcher(): Executor {
@@ -707,6 +697,5 @@ class ApolloClient internal constructor(
     this.subscriptionManager = subscriptionManager
     this.useHttpGetMethodForQueries = useHttpGetMethodForQueries
     this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries
-    this.writeToNormalizedCacheAsynchronously = writeToNormalizedCacheAsynchronously
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloQueryCall.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloQueryCall.kt
@@ -107,6 +107,15 @@ interface ApolloQueryCall<D : Operation.Data> : ApolloCall<D> {
      * @return The Builder
      */
     fun requestHeaders(requestHeaders: RequestHeaders): Builder<D>
+
+    /**
+     * Sets the [writeToCacheAsynchronously] boolean to use for this call. If true returning response data will not wait on the normalized
+     * cache write. This can improve request performance, but means that subsequent requests are not guaranteed to hit the cache for data
+     * contained in previously received requests.
+     *
+     * @param writeToCacheAsynchronously The [Boolean] value to use for this call.
+     */
+    fun writeToCacheAsynchronously(writeToCacheAsynchronously: Boolean): Builder<D>
   }
 
   /**

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/interceptor/ApolloInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/interceptor/ApolloInterceptor.kt
@@ -133,6 +133,7 @@ interface ApolloInterceptor {
       private var useHttpGetMethodForQueries = false
       private var autoPersistQueries = false
       private var writeToCacheAsynchronously = false
+
       fun cacheHeaders(cacheHeaders: CacheHeaders): Builder {
         this.cacheHeaders = cacheHeaders
         return this

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/interceptor/ApolloInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/interceptor/ApolloInterceptor.kt
@@ -108,6 +108,7 @@ interface ApolloInterceptor {
                                                 val sendQueryDocument: Boolean,
                                                 val useHttpGetMethodForQueries: Boolean,
                                                 val autoPersistQueries: Boolean,
+                                                val writeToCacheAsynchronously: Boolean
                                                 ) {
     val uniqueId = UUID.randomUUID()
     fun toBuilder(): Builder {
@@ -119,6 +120,7 @@ interface ApolloInterceptor {
           .sendQueryDocument(sendQueryDocument)
           .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
           .autoPersistQueries(autoPersistQueries)
+          .writeToCacheAsynchronously(writeToCacheAsynchronously)
     }
 
     class Builder internal constructor(operation: Operation<*>) {
@@ -130,6 +132,7 @@ interface ApolloInterceptor {
       private var sendQueryDocument = true
       private var useHttpGetMethodForQueries = false
       private var autoPersistQueries = false
+      private var writeToCacheAsynchronously = false
       fun cacheHeaders(cacheHeaders: CacheHeaders): Builder {
         this.cacheHeaders = cacheHeaders
         return this
@@ -170,6 +173,11 @@ interface ApolloInterceptor {
         return this
       }
 
+      fun writeToCacheAsynchronously(writeToCacheAsynchronously: Boolean): Builder {
+        this.writeToCacheAsynchronously = writeToCacheAsynchronously
+        return this
+      }
+
       fun build(): InterceptorRequest {
         return InterceptorRequest(
             operation,
@@ -180,6 +188,7 @@ interface ApolloInterceptor {
             sendQueryDocument,
             useHttpGetMethodForQueries,
             autoPersistQueries,
+            writeToCacheAsynchronously
         )
       }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloCall.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloCall.kt
@@ -69,7 +69,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
   val optimisticUpdates: Optional<Operation.Data>
   val useHttpGetMethodForQueries: Boolean
   val useHttpGetMethodForPersistedQueries: Boolean
-  val writeToNormalizedCacheAsynchronously: Boolean
+  val writeToCacheAsynchronously: Boolean
   override fun enqueue(responseCallback: ApolloCall.Callback<D>?) {
     try {
       activate(Optional.fromNullable(responseCallback))
@@ -86,6 +86,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
         .requestHeaders(requestHeaders)
         .fetchFromCache(false)
         .optimisticUpdates(optimisticUpdates)
+        .writeToCacheAsynchronously(writeToCacheAsynchronously)
         .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
         .build()
     interceptorChain.proceedAsync(request, dispatcher!!, interceptorCallbackProxy())
@@ -247,7 +248,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
         .useHttpGetMethodForQueries(useHttpGetMethodForQueries)
         .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
         .optimisticUpdates(optimisticUpdates)
-        .writeToNormalizedCacheAsynchronously(writeToNormalizedCacheAsynchronously)
+        .writeToCacheAsynchronously(writeToCacheAsynchronously)
   }
 
   @Synchronized
@@ -310,7 +311,6 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
         dispatcher!!,
         logger!!,
         originalCallback,
-        writeToNormalizedCacheAsynchronously,
         responseAdapterCache
     ))
     if (autoPersistedOperationsInterceptorFactory != null) {
@@ -357,7 +357,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
     var optimisticUpdates = Optional.absent<Operation.Data>()
     var useHttpGetMethodForQueries = false
     var useHttpGetMethodForPersistedQueries = false
-    var writeToNormalizedCacheAsynchronously = false
+    var writeToCacheAsynchronously = false
     fun operation(operation: Operation<*>?): Builder<D> {
       this.operation = operation
       return this
@@ -468,8 +468,8 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
       return this
     }
 
-    fun writeToNormalizedCacheAsynchronously(writeToNormalizedCacheAsynchronously: Boolean): Builder<D> {
-      this.writeToNormalizedCacheAsynchronously = writeToNormalizedCacheAsynchronously
+    fun writeToCacheAsynchronously(writeToCacheAsynchronously: Boolean): Builder<D> {
+      this.writeToCacheAsynchronously = writeToCacheAsynchronously
       return this
     }
 
@@ -526,7 +526,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
     enableAutoPersistedQueries = builder.enableAutoPersistedQueries
     useHttpGetMethodForPersistedQueries = builder.useHttpGetMethodForPersistedQueries
     optimisticUpdates = builder.optimisticUpdates
-    writeToNormalizedCacheAsynchronously = builder.writeToNormalizedCacheAsynchronously
+    writeToCacheAsynchronously = builder.writeToCacheAsynchronously
     interceptorChain = prepareInterceptorChain(operation)
   }
 }

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloCall.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloCall.kt
@@ -70,6 +70,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
   val useHttpGetMethodForQueries: Boolean
   val useHttpGetMethodForPersistedQueries: Boolean
   val writeToCacheAsynchronously: Boolean
+
   override fun enqueue(responseCallback: ApolloCall.Callback<D>?) {
     try {
       activate(Optional.fromNullable(responseCallback))
@@ -358,6 +359,7 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
     var useHttpGetMethodForQueries = false
     var useHttpGetMethodForPersistedQueries = false
     var writeToCacheAsynchronously = false
+
     fun operation(operation: Operation<*>?): Builder<D> {
       this.operation = operation
       return this
@@ -418,6 +420,11 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
       return this
     }
 
+    override fun writeToCacheAsynchronously(writeToCacheAsynchronously: Boolean): Builder<D> {
+      this.writeToCacheAsynchronously = writeToCacheAsynchronously
+      return this
+    }
+
     fun dispatcher(dispatcher: Executor?): Builder<D> {
       this.dispatcher = dispatcher
       return this
@@ -465,11 +472,6 @@ class RealApolloCall<D : Operation.Data> internal constructor(builder: Builder<D
 
     fun useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries: Boolean): Builder<D> {
       this.useHttpGetMethodForPersistedQueries = useHttpGetMethodForPersistedQueries
-      return this
-    }
-
-    fun writeToCacheAsynchronously(writeToCacheAsynchronously: Boolean): Builder<D> {
-      this.writeToCacheAsynchronously = writeToCacheAsynchronously
       return this
     }
 

--- a/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/interceptor/ApolloCacheInterceptor.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo3/internal/interceptor/ApolloCacheInterceptor.kt
@@ -33,7 +33,6 @@ class ApolloCacheInterceptor<D : Operation.Data>(
     private val dispatcher: Executor,
     val logger: ApolloLogger,
     private val responseCallback: AtomicReference<ApolloCall.Callback<D>?>,
-    private val writeToCacheAsynchronously: Boolean,
     private val responseAdapterCache: ResponseAdapterCache
 ) : ApolloInterceptor {
 
@@ -58,7 +57,7 @@ class ApolloCacheInterceptor<D : Operation.Data>(
         chain.proceedAsync(request, dispatcher, object : CallBack {
           override fun onResponse(response: InterceptorResponse) {
             if (disposed) return
-            cacheResponseAndPublish(request, response, writeToCacheAsynchronously)
+            cacheResponseAndPublish(request, response)
             callBack.onResponse(response)
             callBack.onCompleted()
           }
@@ -137,8 +136,8 @@ class ApolloCacheInterceptor<D : Operation.Data>(
     }
   }
 
-  fun cacheResponseAndPublish(request: InterceptorRequest, networkResponse: InterceptorResponse, async: Boolean) {
-    if (async) {
+  fun cacheResponseAndPublish(request: InterceptorRequest, networkResponse: InterceptorResponse) {
+    if (request.writeToCacheAsynchronously) {
       dispatcher.execute { cacheResponseAndPublishSynchronously(request, networkResponse) }
     } else {
       cacheResponseAndPublishSynchronously(request, networkResponse)


### PR DESCRIPTION
Fix #3071 

The idea was to make an asynchronous caching flag available on per-request basis, as we would configure the request depending on our needs. This is basically moving the writeToCacheAsynchronously boolean from ApolloClient (and interceptors) to the ApolloCall/InterceptorRequest classes.