### PR TITLE
Normalized Cache: Make `variables` available to the `fromFieldRecordSet` method in `CacheKeyResolver`

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -12,6 +12,7 @@ import kotlin.jvm.JvmSuppressWildcards
 abstract class CacheKeyResolver {
   abstract fun fromFieldRecordSet(
       field: ResponseField,
+      variables: Operation.Variables,
       recordSet: Map<String, @JvmSuppressWildcards Any?>
   ): CacheKey
 
@@ -25,7 +26,7 @@ abstract class CacheKeyResolver {
 
     @JvmField
     val DEFAULT: CacheKeyResolver = object : CacheKeyResolver() {
-      override fun fromFieldRecordSet(field: ResponseField, recordSet: Map<String, Any?>) = CacheKey.NO_KEY
+      override fun fromFieldRecordSet(field: ResponseField, variables: Operation.Variables, recordSet: Map<String, Any?>) = CacheKey.NO_KEY
 
       override fun fromFieldArguments(field: ResponseField, variables: Operation.Variables) = CacheKey.NO_KEY
     }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
@@ -12,7 +12,6 @@ import com.apollographql.apollo3.api.variables
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheKeyResolver
-import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.ReadOnlyNormalizedCache
 
 fun <D : Operation.Data> Operation<D>.normalize(
@@ -54,7 +53,7 @@ private fun <D> normalizeInternal(
   val writer = MapJsonWriter()
   adapter.toResponse(writer, responseAdapterCache, data)
   return Normalizer(variables) { responseField, fields ->
-    cacheKeyResolver.fromFieldRecordSet(responseField, fields).let { if (it == CacheKey.NO_KEY) null else it.key }
+    cacheKeyResolver.fromFieldRecordSet(responseField, variables, fields).let { if (it == CacheKey.NO_KEY) null else it.key }
   }.normalize(writer.root() as Map<String, Any?>, null, rootKey, fieldSets)
 }
 

--- a/composite/integration-tests-kotlin/src/commonTest/kotlin/com/apollographql/apollo3/integration/Utils.kt
+++ b/composite/integration-tests-kotlin/src/commonTest/kotlin/com/apollographql/apollo3/integration/Utils.kt
@@ -36,7 +36,7 @@ fun readTestFixture(name: String) = readFile("../integration-tests/testFixtures/
 fun readResource(name: String) = readFile("../integration-tests/testFixtures/resources/$name")
 
 object IdFieldCacheKeyResolver : CacheKeyResolver() {
-  override fun fromFieldRecordSet(field: ResponseField, recordSet: Map<String, Any?>): CacheKey {
+  override fun fromFieldRecordSet(field: ResponseField, variables: Operation.Variables, recordSet: Map<String, Any?>): CacheKey {
     val id = recordSet["id"]
     return if (id != null) {
       formatCacheKey(id.toString())

--- a/composite/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/IdFieldCacheKeyResolver.kt
+++ b/composite/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/IdFieldCacheKeyResolver.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheKeyResolver
 
 class IdFieldCacheKeyResolver : CacheKeyResolver() {
-  override fun fromFieldRecordSet(field: ResponseField, recordSet: Map<String, Any?>): CacheKey {
+  override fun fromFieldRecordSet(field: ResponseField, variables: Operation.Variables, recordSet: Map<String, Any?>): CacheKey {
     val id = recordSet["id"]
     return if (id != null) {
       formatCacheKey(id.toString())


### PR DESCRIPTION
Per slack discussion, this is a quick change to make `variables` available in `CacheKeyResolver.fromFieldRecordSet`. 

The idea is that we are now able to uniformly normalize a field in both `fromFieldArguments` and `fromFieldRecordSet`, without having the need to reflect back one of the input variables if not present in the response `recordSet`. 

Separately, one potential problem which this allows us to fix: if we are normalizing by `id`, we can now verify that the `id` we passed in `variables` is actually equal to the `id` we get back in `recordSet`. In some APIs, a new `id` returned in `recordSet` can be used as a signal by the client to treat it as a cache miss.  

Note that this is a preliminary approach to the original problem we discussed: we might decide to find other solutions, in which case this API is subject to change. 