### PR TITLE
Pretty print schema, minor typo fix

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
@@ -8,7 +8,6 @@ import com.apollographql.apollo3.graphql.ast.Issue
 import com.apollographql.apollo3.graphql.ast.Schema
 import com.apollographql.apollo3.graphql.ast.SourceAwareException
 import com.apollographql.apollo3.compiler.operationoutput.OperationDescriptor
-import com.apollographql.apollo3.compiler.operationoutput.toJson
 import com.apollographql.apollo3.compiler.unified.ir.IrBuilder
 import com.apollographql.apollo3.compiler.codegen.KotlinCodeGenerator
 import com.apollographql.apollo3.compiler.introspection.IntrospectionSchema

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/moshi.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/moshi.kt
@@ -70,17 +70,7 @@ inline fun <reified T> T.toJson(indent: String = ""): String {
   return getJsonAdapter<T>().indent(indent).toJson(this)
 }
 
-inline fun <reified T> T.toJson(writer: JsonWriter) {
-  getJsonAdapter<T>().toJson(writer, this)
-}
-
-inline fun <reified T> T.toJson(file: File) {
-  file.outputStream().sink().buffer().use {
-    return getJsonAdapter<T>().toJson(it, this)
-  }
-}
-
-inline fun <reified T> T.toJson(file: File, indent: String) {
+inline fun <reified T> T.toJson(file: File, indent: String = "") {
   file.outputStream().sink().buffer().use {
     return getJsonAdapter<T>().indent(indent).toJson(it, this)
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/moshi.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/moshi.kt
@@ -66,8 +66,8 @@ inline fun <reified T> File.fromJsonList(): List<T> {
   return inputStream().fromJsonList<T>()
 }
 
-inline fun <reified T> T.toJson(): String {
-  return getJsonAdapter<T>().toJson(this)
+inline fun <reified T> T.toJson(indent: String = ""): String {
+  return getJsonAdapter<T>().indent(indent).toJson(this)
 }
 
 inline fun <reified T> T.toJson(writer: JsonWriter) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/operationoutput/OperationOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/operationoutput/OperationOutput.kt
@@ -25,15 +25,13 @@ class OperationDescriptor(
     val source: String
 )
 
-private fun operationOutputAdapter(indent: String? = null): JsonAdapter<OperationOutput> {
+private fun operationOutputAdapter(indent: String = ""): JsonAdapter<OperationOutput> {
   val moshi = Moshi.Builder().build()
   val type = Types.newParameterizedType(Map::class.java, String::class.java, OperationDescriptor::class.java)
-  return moshi.adapter<OperationOutput>(type).applyIf(indent != null) {
-    this.indent(indent!!)
-  }
+  return moshi.adapter<OperationOutput>(type).indent(indent)
 }
 
-fun OperationOutput.toJson(indent: String? = null): String {
+fun OperationOutput.toJson(indent: String = ""): String {
   return operationOutputAdapter(indent).toJson(this)
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/operationoutput/OperationOutput.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/operationoutput/OperationOutput.kt
@@ -25,26 +25,6 @@ class OperationDescriptor(
     val source: String
 )
 
-private fun operationOutputAdapter(indent: String = ""): JsonAdapter<OperationOutput> {
-  val moshi = Moshi.Builder().build()
-  val type = Types.newParameterizedType(Map::class.java, String::class.java, OperationDescriptor::class.java)
-  return moshi.adapter<OperationOutput>(type).indent(indent)
-}
-
-fun OperationOutput.toJson(indent: String = ""): String {
-  return operationOutputAdapter(indent).toJson(this)
-}
-
-fun OperationOutput(file: File): OperationOutput {
-  return try {
-    file.source().buffer().use {
-      operationOutputAdapter().fromJson(it)!!
-    }
-  } catch (e: Exception) {
-    throw IllegalArgumentException("cannot parse operation output $file")
-  }
-}
-
 fun OperationOutput.findOperationId(name: String): String {
   val id = entries.find { it.value.name == name }?.key
   check(id != null) {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -116,7 +116,7 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
 
     if (schema.extension.toLowerCase() == "json") {
       if (introspectionSchema == null) {
-        introspectionSchema = GraphQLParser.parseSchema(sdlSchema!!).toIntrospectionSchema().wrap().toJson()
+        introspectionSchema = GraphQLParser.parseSchema(sdlSchema!!).toIntrospectionSchema().wrap().toJson(indent = "  ")
       }
       schema.writeText(introspectionSchema)
     } else {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
@@ -7,7 +7,7 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 
 object BuildDirLayout {
-  internal fun operationOuput(project: Project, service: Service): Provider<RegularFile> {
+  internal fun operationOutput(project: Project, service: Service): Provider<RegularFile> {
     return project.layout.buildDirectory.file(
         "generated/operationOutput/apollo/${service.name}/operationOutput.json"
     )

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -345,7 +345,7 @@ abstract class DefaultApolloExtension(
       }
       if (service.operationOutputAction != null) {
         task.operationOutputFile.apply {
-          set(BuildDirLayout.operationOuput(project, service))
+          set(BuildDirLayout.operationOutput(project, service))
           disallowChanges()
         }
       }


### PR DESCRIPTION
Passing an `indent` should allow the schema from introspection to be pretty-printed. I also fixed a minor typo that I found in the gradle plugin.

I've not tested this change yet because I couldn't find an existing test in `ServiceTests`, but I will add one as a follow-up. 