### PR TITLE
Pass 'operationName' in the introspection query

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaDownloader.kt
@@ -8,7 +8,11 @@ object SchemaDownloader {
       headers: Map<String, String>
   ): String {
 
-    val response = SchemaHelper.executeQuery(introspectionQuery, emptyMap(), endpoint, headers)
+    val body = mapOf(
+        "query" to introspectionQuery,
+        "operationName" to "IntrospectionQuery"
+    )
+    val response = SchemaHelper.executeQuery(body, endpoint, headers)
 
     return response.body.use { responseBody ->
       responseBody!!.string()

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaHelper.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/SchemaHelper.kt
@@ -31,12 +31,8 @@ internal object SchemaHelper {
         .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
         .build()
   }
-
-  /**
-   * @param variables a map representing the variable as Json values
-   */
-  internal fun executeQuery(query: String, variables: Map<String, Any>, url: String, headers: Map<String, String>): Response {
-    val body = mapOf("query" to query, "variables" to variables).toJson().toByteArray().toRequestBody("application/json".toMediaTypeOrNull())
+  internal fun executeQuery(map: Map<String, Any?>, url: String, headers: Map<String, String>): Response {
+    val body = map.toJson().toByteArray().toRequestBody("application/json".toMediaTypeOrNull())
     val request = Request.Builder()
         .post(body)
         .apply {
@@ -56,5 +52,11 @@ internal object SchemaHelper {
     }
 
     return response
+  }
+  /**
+   * @param variables a map representing the variable as Json values
+   */
+  internal fun executeQuery(query: String, variables: Map<String, Any>, url: String, headers: Map<String, String>): Response {
+    return executeQuery(mapOf("query" to query, "variables" to variables), url, headers)
   }
 }


### PR DESCRIPTION
Some servers require that and it shouldn't harm to include it by default.