### PR TITLE
Bump junit to 4.13.2

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ def versions = [
     guava                 : '28.0-jre',
     javaPoet              : '1.9.0',
     jetbrainsAnnotations  : '13.0',
-    junit                 : '4.13.1',
+    junit                 : '4.13.2',
     kotlin                : '1.5.0',
     kotlinCoroutines      : '1.5.0',
     kotlinPoet            : '1.6.0',


### PR DESCRIPTION
Because of https://nvd.nist.gov/vuln/detail/CVE-2020-15250

From my understanding, there are no big consequences of this besides maybe exposing some tests computations to other users on CI systems which seems ok considering everything is open source anyways. 

This was caught by Sonatype: https://sbom.lift.sonatype.com/report/T1-0ff0976f7f21c391f20f-41bb48f2497679-1622027531-a7791f99da8c40d0b96f605132ae2272