### PR TITLE
Fix overriding `canBeBatched` value when cloning `QueryCall` with `toBuilder()`

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -329,7 +329,8 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         .useHttpGetMethodForPersistedQueries(useHttpGetMethodForPersistedQueries)
         .optimisticUpdates(optimisticUpdates)
         .writeToNormalizedCacheAsynchronously(writeToNormalizedCacheAsynchronously)
-        .batchPoller(batchPoller);
+        .batchPoller(batchPoller)
+        .canBeBatched(canBeBatched);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")


### PR DESCRIPTION
Missed passing the `canBeBatched` value from a `RealApolloCall` object back to its builder when cloning with `toBuilder()`. Found this while integrating the new version in our app, where we do clone queries in that way in some cases.

Added a unit test for it as well.