### PR TITLE
Update get-started-multiplatform.mdx to use the new 'strictly' api

### DIFF
--- a/docs/source/essentials/get-started-multiplatform.mdx
+++ b/docs/source/essentials/get-started-multiplatform.mdx
@@ -40,8 +40,10 @@ kotlin {
 If using the x.y.z-native-mt branch of coroutines, gradle will replace the -native-mt version with the non-mt version as outlined [here](https://kotlinlang.org/docs/mobile/concurrency-and-coroutines.html#multithreaded-coroutines). To prevent this happening use the following:
 
 ```
-implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:x.y.z-native-mt"){
-    isForce = true
+implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core"){
+    version {
+      strictly("x.y.z-native-mt")
+    }
 }
 ```
 


### PR DESCRIPTION
Update dependency version override as per gradle new api at 

https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:enforcing_dependency_version