### PR TITLE
Gradle Plugin: Keep sourceFolder

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -40,9 +40,14 @@ interface Service {
   val exclude: ListProperty<String>
 
   /**
+   * A shorthand property that will be used if [srcDir] is notCalled
+   */
+  val sourceFolder: Property<String>
+
+  /**
    * Adds the given directory as a GraphQL source root
    *
-   * By default, the plugin will use "src/main/graphql/" for Android/JVM projects and "src/commonMain/graphql" for multiplatform projects.
+   * By default, the plugin will use "src/main/graphql/$sourceFolder" for Android/JVM projects and "src/commonMain/graphql/$sourceFolder" for multiplatform projects.
    *
    * Use [srcDir] if your files are outside of "src/main/graphql" or to have them in multiple folders.
    *

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -337,7 +337,8 @@ abstract class DefaultApolloExtension(
 
 
       if (service.graphqlSourceDirectorySet.isReallyEmpty) {
-        val dir = File(project.projectDir, "src/${mainSourceSet(project)}/graphql")
+        val sourceFolder = service.sourceFolder.getOrElse("")
+        val dir = File(project.projectDir, "src/${mainSourceSet(project)}/graphql/$sourceFolder")
 
         service.graphqlSourceDirectorySet.srcDir(dir)
       }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -41,6 +41,8 @@ abstract class DefaultService @Inject constructor(val objects: ObjectFactory, ov
 
   abstract override val include: ListProperty<String>
 
+  abstract override val sourceFolder: Property<String>
+
   abstract override val schemaFiles: ConfigurableFileCollection
 
   abstract override val debugDir: DirectoryProperty

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,12 @@ subprojects {
     }
   }
 
+  // Ensure "org.gradle.jvm.version" is set to "8" in Gradle metadata.
+  tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+  }
+  
   tasks.withType<Test> {
     systemProperty("updateTestFixtures", System.getProperty("updateTestFixtures"))
     systemProperty("testFilter", System.getProperty("testFilter"))


### PR DESCRIPTION
To ease the 3.x transition, keep sourceFolder for now.

Also set the JDK target level to 1.8