### PR TITLE
Hide CompiledField from `cacheKeyForObject`

### DIFF
--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
@@ -53,9 +53,9 @@ private fun <D> normalizeInternal(
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter.toJson(writer, customScalarAdapters, data)
-  return Normalizer(variables) { compiledField, fields ->
-    cacheResolver.cacheKeyForObject(compiledField, variables, fields)?.key
-  }.normalize(writer.root() as Map<String, Any?>, null, rootKey, selections)
+  return Normalizer(variables, rootKey) { type, fields ->
+    cacheResolver.cacheKeyForObject(type, variables, fields)?.key
+  }.normalize(writer.root() as Map<String, Any?>, selections)
 }
 
 fun <D : Operation.Data> Operation<D>.readDataFromCache(

--- a/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
+++ b/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.ApolloAndroidLogger
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Executable
-import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.cache.http.HttpCachePolicy
 import com.apollographql.apollo3.cache.http.ApolloHttpCache
 import com.apollographql.apollo3.cache.http.DiskLruHttpCacheStore
@@ -46,7 +46,7 @@ class KotlinSampleApp : Application() {
 
     val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(this, "github_cache")
     val cacheResolver = object : CacheResolver() {
-      override fun cacheKeyForObject(field: CompiledField, variables: Executable.Variables, map: Map<String, Any?>): CacheKey? {
+      override fun cacheKeyForObject(type: CompiledNamedType, variables: Executable.Variables, map: Map<String, Any?>): CacheKey? {
         return if (map["__typename"] == "Repository") {
           CacheKey(map["id"] as String)
         } else {

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -24,8 +24,8 @@ import com.apollographql.apollo3.integration.normalizer.type.Episode
 import readResource
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import assertEquals2 as assertEquals
 
 /**
  * Tests for the normalization without an instance of [ApolloClient]

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
@@ -3,6 +3,7 @@ package test.declarativecache
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Executable
+import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheResolver
@@ -74,7 +75,7 @@ class DeclarativeCacheTest {
         if (field.name == "books") {
           val isbns = field.resolveArgument("isbns", variables) as? List<String>
           if (isbns != null) {
-            return isbns.map { buildCacheKey(field, listOf(it))}
+            return isbns.map { buildCacheKey(field.type.leafType().name, listOf(it))}
           }
         }
 

--- a/composite/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
+++ b/composite/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
@@ -1,6 +1,7 @@
 import com.apollographql.apollo.sample.server.DefaultApplication
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
@@ -49,11 +50,6 @@ class CachedSubscriptionTest {
   fun subscriptionsCanUpdateTheCache() {
     val store = ApolloStore(
         MemoryCacheFactory(Int.MAX_VALUE),
-        object : CacheResolver() {
-          override fun cacheKeyForObject(field: CompiledField, variables: Executable.Variables, map: Map<String, Any?>): CacheKey {
-            return CacheKey(field.responseName)
-          }
-        }
     )
 
     val apolloClient = ApolloClient(

--- a/docs/source/essentials/normalized-cache.mdx
+++ b/docs/source/essentials/normalized-cache.mdx
@@ -208,7 +208,7 @@ To do this, specify a `CacheKeyResolver` when configuring your `NormalizedCacheF
 
 ```kotlin:title=Kotlin
 val resolver: CacheKeyResolver = object : CacheResolver() {
-  override fun cacheKeyForObject(field: CompiledField, map: Map<String, Any>): CacheKey {
+  override fun cacheKeyForObject(type: CompiledNamedType, map: Map<String, Any>): CacheKey {
     // Retrieve the id from the object itself
     return CacheKey(recordSet["id"] as String)
   }
@@ -231,7 +231,7 @@ val apolloClient = ApolloClient.builder()
 ```java:title=Java
 CacheKeyResolver resolver = new CacheResolver() {
    @NotNull @Override
-   public CacheKey cacheKeyForObject(@NotNull ResponseField field, @NotNull Map<String, Object> recordSet) {
+   public CacheKey cacheKeyForObject(@NotNull CompiledNamedType type, @NotNull Map<String, Object> recordSet) {
      // Retrieve the id from the object itself
      return CacheKey(((String) recordSet.get("id"));
    }


### PR DESCRIPTION
`cacheKeyForObject` is at the object level. 

`resolveField` is at the field level. 

This change should make the API more consistent and slightly more self-explanatory