### PR TITLE
Add CacheKeyResolver to use CacheResolver with keys only

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.isComposite
 
 /**
- * A [CacheResolver] that only works with [CacheKey]s. This is intended to simplify the usage of [CacheResolver].
+ * A [CacheResolver] that only works with [CacheKey]s. This is intended to simplify the usage of [CacheResolver] when no special handling is needed for scalar fields.
  *
  * Override [cacheKeyForField] to compute a cache key for an object field.
  * Override [listOfCacheKeysForField] to compute a list of cache keys for a field that contains a list of objects.
@@ -20,14 +20,14 @@ abstract class CacheKeyResolver : CacheResolver() {
   /**
    * Return the computed the cache key for an object field.
    *
-   * Return `null` if this field does not need a special cache key.
+   * If the returned [CacheKey] is null, the resolver will use the default handling and use any previously cached value.
    */
   abstract fun cacheKeyForField(field: CompiledField, variables: Executable.Variables): CacheKey?
 
   /**
-   * For a field that has a list of objects, this function should return the cache key computed for each object.
-   *
-   * Return `null` if this field does not need a special cache key.
+   * For a field that contains a list of objects, [listOfCacheKeysForField ] returns a list of [CacheKey]s where each [CacheKey] identifies an object. 
+   * If an individual [CacheKey] is null, the resulting object will be null in the response.
+   * If the returned list of [CacheKey]s is null, the resolver will use the default handling and use any previously cached value.
    */
   abstract fun listOfCacheKeysForField(field: CompiledField, variables: Executable.Variables): List<CacheKey?>?
 

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -1,0 +1,61 @@
+package com.apollographql.apollo3.cache.normalized
+
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.CompiledListType
+import com.apollographql.apollo3.api.CompiledNamedType
+import com.apollographql.apollo3.api.CompiledNotNullType
+import com.apollographql.apollo3.api.Executable
+import com.apollographql.apollo3.api.isComposite
+
+/**
+ * A [CacheResolver] that only works with [CacheKey]s. This is intended to simplify the usage of [CacheResolver].
+ *
+ * Override [cacheKeyForField] to compute a cache key for an object field.
+ * Override [listOfCacheKeysForField] to compute a list of cache keys for a field that contains a list of objects.
+ *
+ * For simplicity, this only handles one level of list. Subclass [CacheResolver] if you need arbitrary nested lists of objects.
+ */
+abstract class CacheKeyResolver : CacheResolver() {
+
+  /**
+   * Return the computed the cache key for an object field.
+   *
+   * Return `null` if this field does not need a special cache key.
+   */
+  abstract fun cacheKeyForField(field: CompiledField, variables: Executable.Variables): CacheKey?
+
+  /**
+   * For a field that has a list of objects, this function should return the cache key computed for each object.
+   *
+   * Return `null` if this field does not need a special cache key.
+   */
+  abstract fun listOfCacheKeysForField(field: CompiledField, variables: Executable.Variables): List<CacheKey?>?
+
+  final override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentKey: String): Any? {
+    var type = field.type
+    if (type is CompiledNotNullType) {
+      type = type.ofType
+    }
+    if (type is CompiledNamedType && type.isComposite()) {
+      val result = cacheKeyForField(field, variables)
+      if (result != null) {
+        return result
+      }
+    }
+
+    if (type is CompiledListType) {
+      type = type.ofType
+      if (type is CompiledNotNullType) {
+        type = type.ofType
+      }
+      if (type is CompiledNamedType && type.isComposite()) {
+        val result = listOfCacheKeysForField(field, variables)
+        if (result != null) {
+          return result
+        }
+      }
+    }
+
+    return super.resolveField(field, variables, parent, parentKey)
+  }
+}

--- a/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolverTest.kt
+++ b/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolverTest.kt
@@ -32,7 +32,7 @@ class CacheKeyResolverTest {
   }
 
   @Test
-  fun `cacheKeyForField called for named composite field`() {
+  fun verify_cacheKeyForField_called_for_named_composite_field() {
     val expectedKey = CacheKey("test")
     val fields = mutableListOf<CompiledField>()
 
@@ -48,7 +48,7 @@ class CacheKeyResolverTest {
   }
 
   @Test
-  fun `listOfCacheKeysForField called for list field`() {
+  fun listOfCacheKeysForField_called_for_list_field() {
     val expectedKeys = listOf(CacheKey("test"))
     val fields = mutableListOf<CompiledField>()
 
@@ -64,7 +64,7 @@ class CacheKeyResolverTest {
   }
 
   @Test
-  fun `super called for null return values`() {
+  fun super_called_for_null_return_values() {
     onCacheKeyForField = { _, _ -> null }
     onListOfCacheKeysForField = { _, _ -> null }
 

--- a/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolverTest.kt
+++ b/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolverTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 
 
 class CacheKeyResolverTest {
@@ -23,10 +24,10 @@ class CacheKeyResolverTest {
   fun setup() {
     subject = FakeCacheKeyResolver()
     onCacheKeyForField = { _, _ ->
-      TODO("Unexpected call to cacheKeyForField")
+      fail("Unexpected call to cacheKeyForField")
     }
     onListOfCacheKeysForField = { _, _, ->
-      TODO("Unexpected call to listOfCacheKeysForField")
+      fail("Unexpected call to listOfCacheKeysForField")
     }
   }
 


### PR DESCRIPTION
With the new `CacheResolver`, we have more powerful APIs that can include a lot of custom transformation. However, the intended usage might not always be straightforward to understand. Also, if you want to continue using the previous API that worked with keys only, `CacheKeyResolver` is a good starting point. 

Additionally,  this resolver supports resolving a list field into cache keys represented by their constituent objects. 

TODO: Add tests for declarative caching

Thank you @martinbonnin ! 