### PR TITLE
Introduce ObjectIdGenerator

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -54,6 +54,24 @@ class CompiledField(
       throw RuntimeException(e)
     }
   }
+
+  fun copy(
+      name: String= this.name,
+      alias: String? = this.alias,
+      type: CompiledType = this.type,
+      condition: List<CompiledCondition> = this.condition,
+      arguments: List<CompiledArgument> = this.arguments,
+      selections: List<CompiledSelection> = this.selections,
+      ): CompiledField {
+    return CompiledField(
+        name,
+        alias,
+        type,
+        condition,
+        arguments,
+        selections
+    )
+  }
 }
 
 /**

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKey.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKey.kt
@@ -44,5 +44,20 @@ class CacheKey(val key: String) {
     fun rootKey(): CacheKey {
       return ROOT_CACHE_KEY
     }
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    fun from(typename: String, values: List<String>): CacheKey {
+      return CacheKey(
+          buildString {
+            append(typename)
+            append(":")
+            values.forEach {
+              append(it)
+            }
+          }
+      )
+    }
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -15,7 +15,7 @@ import com.apollographql.apollo3.api.isComposite
  *
  * For simplicity, this only handles one level of list. Subclass [CacheResolver] if you need arbitrary nested lists of objects.
  */
-abstract class CacheKeyResolver : CacheResolver() {
+abstract class CacheKeyResolver : CacheResolver {
 
   /**
    * Return the computed the cache key for an object field.
@@ -56,6 +56,6 @@ abstract class CacheKeyResolver : CacheResolver() {
       }
     }
 
-    return super.resolveField(field, variables, parent, parentId)
+    return MapCacheResolver.resolveField(field, variables, parent, parentId)
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
@@ -2,13 +2,15 @@ package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.api.CompiledArgument
 import com.apollographql.apollo3.api.CompiledField
-import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.exception.CacheMissException
 import kotlin.jvm.JvmSuppressWildcards
 
-open class CacheResolver {
+/**
+ * An interface for [CacheResolver] used to read the cache
+ */
+interface CacheResolver {
   /**
    * Resolves a field from the cache. Called when reading from the cache, usually before a network request.
    * This API is similar to a backend side resolver in that it allows resolving fields to arbitrary values.
@@ -63,7 +65,39 @@ open class CacheResolver {
    * @return a value that can go in a [Record]. No type checking is done. It is the responsibility of implementations to return the correct
    * type
    */
-  open fun resolveField(
+  fun resolveField(
+      field: CompiledField,
+      variables: Executable.Variables,
+      parent: Map<String, @JvmSuppressWildcards Any?>,
+      parentId: String,
+  ): Any?
+}
+
+/**
+ * A cache resolver that uses the parent to resolve fields. [parent] is a [Map] that
+ * can contain the same values as [Record]
+ */
+object MapCacheResolver: CacheResolver {
+  override fun resolveField(
+      field: CompiledField,
+      variables: Executable.Variables,
+      parent: Map<String, @JvmSuppressWildcards Any?>,
+      parentId: String,
+  ): Any? {
+    val name = field.nameWithArguments(variables)
+    if (!parent.containsKey(name)) {
+      throw CacheMissException(parentId, name)
+    }
+
+    return parent[name]
+  }
+}
+
+/**
+ * A [CacheResolver] that uses @fieldPolicy annotations to resolve fields and delegates to [MapCacheResolver] else
+ */
+object FieldPolicyCacheResolver: CacheResolver {
+  override fun resolveField(
       field: CompiledField,
       variables: Executable.Variables,
       parent: Map<String, @JvmSuppressWildcards Any?>,
@@ -77,22 +111,20 @@ open class CacheResolver {
       return CacheKey.from(field.type.leafType().name, keyArgsValues)
     }
 
-    val name = field.nameWithArguments(variables)
-    if (!parent.containsKey(name)) {
-      throw CacheMissException(parentId, name)
-    }
-
-    return parent[name]
+    return MapCacheResolver.resolveField(field, variables, parent, parentId)
   }
 }
 
-class IdCacheResolver: CacheResolver() {
+/**
+ * A [CacheResolver] that looks for an "id" argument to resolve fields and delegates to [FieldPolicyCacheResolver] else
+ */
+object IdCacheResolver: CacheResolver {
   override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
     val id = field.resolveArgument("id", variables)?.toString()
     if (id != null) {
        return CacheKey(id)
     }
 
-    return super.resolveField(field, variables, parent, parentId)
+    return FieldPolicyCacheResolver.resolveField(field, variables, parent, parentId)
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/Record.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/Record.kt
@@ -16,7 +16,7 @@ class Record (
      * - Boolean
      * - String
      * - Double
-     * - CacheKey
+     * - CacheKey (for composite types)
      * - List
      * - Map (for custom scalars)
      * - null

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -6,10 +6,10 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore.RecordChangeSubscriber
-import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObject
-import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObjectAndField
 import com.apollographql.apollo3.cache.normalized.internal.NoOpApolloStore
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
+import com.apollographql.apollo3.cache.normalized.internal.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.reflect.KClass
@@ -190,17 +190,6 @@ interface ApolloStore {
 
 fun ApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
-    cacheKeyForObject: CacheKeyForObject = { _, _ -> null },
-    cacheResolver: CacheResolver = CacheResolver(),
-): ApolloStore {
-  val cacheKeyForObjectAndField: CacheKeyForObjectAndField = { field, _, obj ->
-    cacheKeyForObject(field.type.leafType(), obj)
-  }
-  return DefaultApolloStore(normalizedCacheFactory, cacheKeyForObjectAndField, cacheResolver)
-}
-
-fun ApolloStore(
-    normalizedCacheFactory: NormalizedCacheFactory,
-    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
-    cacheResolver: CacheResolver = CacheResolver(),
-): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyForObjectAndField, cacheResolver)
+    objectIdGenerator: ObjectIdGenerator = TypePolicyObjectIdGenerator,
+    cacheResolver: CacheResolver = FieldPolicyCacheResolver,
+): ApolloStore = DefaultApolloStore(normalizedCacheFactory, objectIdGenerator, cacheResolver)

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -3,8 +3,11 @@ package com.apollographql.apollo3.cache.normalized
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore.RecordChangeSubscriber
+import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObjectAndField
 import com.apollographql.apollo3.cache.normalized.internal.NoOpApolloStore
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
 import com.benasher44.uuid.Uuid
@@ -187,5 +190,17 @@ interface ApolloStore {
 
 fun ApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
+    cacheKeyForObject: CacheKeyForObject = { _, _ -> null },
     cacheResolver: CacheResolver = CacheResolver(),
-): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheResolver)
+): ApolloStore {
+  val cacheKeyForObjectAndField: CacheKeyForObjectAndField = { field, _, obj ->
+    cacheKeyForObject(field.type.leafType(), obj)
+  }
+  return DefaultApolloStore(normalizedCacheFactory, cacheKeyForObjectAndField, cacheResolver)
+}
+
+fun ApolloStore(
+    normalizedCacheFactory: NormalizedCacheFactory,
+    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
+    cacheResolver: CacheResolver = CacheResolver(),
+): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyForObjectAndField, cacheResolver)

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -3,13 +3,10 @@ package com.apollographql.apollo3.cache.normalized
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore.RecordChangeSubscriber
 import com.apollographql.apollo3.cache.normalized.internal.NoOpApolloStore
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
-import com.apollographql.apollo3.cache.normalized.internal.ObjectIdGenerator
-import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.reflect.KClass

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
@@ -1,10 +1,9 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.keyFields
-import com.apollographql.apollo3.cache.normalized.CacheKey
 
 /**
  * An [ObjectIdGenerator] is responsible for finding an id for a given object
@@ -20,10 +19,10 @@ interface ObjectIdGenerator {
    * @param type the concrete type of the object. Use this with [CacheKey.from] to namespace the ids
    * @param obj a [Map] representing the object. The values in the map can have the same types as the ones
    * in [Record]
-   * @param context the context in which the object is. In most use cases, the id should not depend on the context.
-   * Only use for advanced use cases.
+   * @param context the context in which the object is normalized. In most use cases, the id should not depend on the normalization
+   * context. Only use for advanced use cases.
    */
-  fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey?
+  fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey?
 }
 
 /**
@@ -34,8 +33,8 @@ interface ObjectIdGenerator {
  * @param variables the variables used in the operation where the object is normalized.
  */
 class ObjectIdGeneratorContext(
-    field: CompiledField,
-    variables: Executable.Variables,
+    val field: CompiledField,
+    val variables: Executable.Variables,
 )
 
 /**
@@ -44,8 +43,8 @@ class ObjectIdGeneratorContext(
  * It will coerce Int, Floats and other types to String using [toString]
  */
 object IdObjectIdGenerator : ObjectIdGenerator {
-  override fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
-    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.generateIdFor(type, obj, context)
+  override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(type, obj, context)
   }
 }
 
@@ -53,7 +52,7 @@ object IdObjectIdGenerator : ObjectIdGenerator {
  * A [ObjectIdGenerator] that uses annotations to compute the id
  */
 object TypePolicyObjectIdGenerator : ObjectIdGenerator {
-  override fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+  override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
     val keyFields = type.keyFields()
 
     return if (keyFields.isNotEmpty()) {

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/OperationCacheExtensions.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Executable
@@ -8,10 +8,8 @@ import com.apollographql.apollo3.api.internal.json.MapJsonReader
 import com.apollographql.apollo3.api.internal.json.MapJsonWriter
 import com.apollographql.apollo3.api.variables
 import com.apollographql.apollo3.cache.CacheHeaders
-import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.CacheResolver
-import com.apollographql.apollo3.cache.normalized.ReadOnlyNormalizedCache
-import com.apollographql.apollo3.cache.normalized.Record
+import com.apollographql.apollo3.cache.normalized.internal.CacheBatchReader
+import com.apollographql.apollo3.cache.normalized.internal.Normalizer
 
 
 fun <D : Operation.Data> Operation<D>.normalize(

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -9,7 +9,10 @@ import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheResolver
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.Record
+import com.apollographql.apollo3.cache.normalized.normalize
+import com.apollographql.apollo3.cache.normalized.readDataFromCache
 import com.apollographql.apollo3.mpp.Guard
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.GlobalScope

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -23,7 +23,7 @@ import kotlin.reflect.KClass
 
 class DefaultApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
-    private val cacheKeyForObjectAndField: CacheKeyForObjectAndField,
+    private val objectIdGenerator: ObjectIdGenerator,
     private val cacheResolver: CacheResolver,
 ) : ApolloStore {
   private val changedKeysEvents = MutableSharedFlow<Set<String>>(
@@ -120,7 +120,7 @@ class DefaultApolloStore(
     return operation.normalize(
         data,
         customScalarAdapters,
-        cacheKeyForObjectAndField
+        objectIdGenerator
     )
   }
 
@@ -130,14 +130,14 @@ class DefaultApolloStore(
       cacheHeaders: CacheHeaders,
   ): D {
     // Capture a local reference so as not to freeze "this"
-    val cacheKeyResolver = cacheResolver
+    val cacheResolver = cacheResolver
 
 
     return cacheHolder.access { cache ->
       operation.readDataFromCache(
           customScalarAdapters = customScalarAdapters,
           cache = cache,
-          cacheResolver = cacheKeyResolver,
+          cacheResolver = cacheResolver,
           cacheHeaders = cacheHeaders,
       )
     }
@@ -150,13 +150,13 @@ class DefaultApolloStore(
       cacheHeaders: CacheHeaders,
   ): D {
     // Capture a local reference so as not to freeze "this"
-    val cacheKeyResolver = cacheResolver
+    val cacheResolver = cacheResolver
 
     return cacheHolder.access { cache ->
       fragment.readDataFromCache(
           customScalarAdapters = customScalarAdapters,
           cache = cache,
-          cacheResolver = cacheKeyResolver,
+          cacheResolver = cacheResolver,
           cacheHeaders = cacheHeaders,
           cacheKey = cacheKey
       )
@@ -192,13 +192,13 @@ class DefaultApolloStore(
       publish: Boolean,
   ): Set<String> {
     // Capture a local reference so as not to freeze "this"
-    val cacheKeyResolver = cacheResolver
+    val objectIdGenerator = objectIdGenerator
 
     val changedKeys =  cacheHolder.access { cache ->
       val records = fragment.normalize(
           data = fragmentData,
           customScalarAdapters = customScalarAdapters,
-          cacheKeyForObjectAndField = cacheKeyForObjectAndField,
+          objectIdGenerator = objectIdGenerator,
           rootKey = cacheKey.key
       ).values
 
@@ -221,13 +221,13 @@ class DefaultApolloStore(
   ): Pair<Set<Record>, Set<String>> {
 
     // Capture a local reference so as not to freeze "this"
-    val cacheKeyResolver = cacheResolver
+    val objectIdGenerator = objectIdGenerator
 
     val (records, changedKeys) = cacheHolder.access { cache ->
       val records = operation.normalize(
           data = operationData,
           customScalarAdapters = customScalarAdapters,
-          cacheKeyForObjectAndField = cacheKeyForObjectAndField
+          objectIdGenerator = objectIdGenerator
       )
 
       records to cache.merge(records.values.toList(), cacheHeaders)
@@ -248,13 +248,13 @@ class DefaultApolloStore(
   ): Set<String> {
 
     // Capture a local reference so as not to freeze "this"
-    val cacheKeyResolver = cacheResolver
+    val objectIdGenerator = objectIdGenerator
 
     val changedKeys = cacheHolder.access { cache ->
       val records = operation.normalize(
           data = operationData,
           customScalarAdapters = customScalarAdapters,
-          cacheKeyForObjectAndField = cacheKeyForObjectAndField
+          objectIdGenerator = objectIdGenerator
       ).values.map { record ->
         Record(
             key = record.key,

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -23,6 +23,7 @@ import kotlin.reflect.KClass
 
 class DefaultApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
+    private val cacheKeyForObjectAndField: CacheKeyForObjectAndField,
     private val cacheResolver: CacheResolver,
 ) : ApolloStore {
   private val changedKeysEvents = MutableSharedFlow<Set<String>>(
@@ -119,7 +120,7 @@ class DefaultApolloStore(
     return operation.normalize(
         data,
         customScalarAdapters,
-        cacheResolver
+        cacheKeyForObjectAndField
     )
   }
 
@@ -197,7 +198,7 @@ class DefaultApolloStore(
       val records = fragment.normalize(
           data = fragmentData,
           customScalarAdapters = customScalarAdapters,
-          cacheResolver = cacheKeyResolver,
+          cacheKeyForObjectAndField = cacheKeyForObjectAndField,
           rootKey = cacheKey.key
       ).values
 
@@ -226,7 +227,7 @@ class DefaultApolloStore(
       val records = operation.normalize(
           data = operationData,
           customScalarAdapters = customScalarAdapters,
-          cacheResolver = cacheKeyResolver
+          cacheKeyForObjectAndField = cacheKeyForObjectAndField
       )
 
       records to cache.merge(records.values.toList(), cacheHeaders)
@@ -253,7 +254,7 @@ class DefaultApolloStore(
       val records = operation.normalize(
           data = operationData,
           customScalarAdapters = customScalarAdapters,
-          cacheResolver = cacheKeyResolver
+          cacheKeyForObjectAndField = cacheKeyForObjectAndField
       ).values.map { record ->
         Record(
             key = record.key,

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/Normalizer.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/Normalizer.kt
@@ -10,6 +10,8 @@ import com.apollographql.apollo3.api.CompiledType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.isComposite
 import com.apollographql.apollo3.cache.normalized.CacheKey
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
 import com.apollographql.apollo3.cache.normalized.Record
 
 /**
@@ -125,7 +127,7 @@ class Normalizer(
       type is CompiledNamedType && type.isComposite() -> {
         check(value is Map<*, *>)
         @Suppress("UNCHECKED_CAST")
-        val key = objectIdGenerator.generateIdFor(
+        val key = objectIdGenerator.cacheKeyForObject(
             type,
             value as Map<String, Any?>,
             ObjectIdGeneratorContext(field, variables),

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ObjectIdGenerator.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ObjectIdGenerator.kt
@@ -1,0 +1,65 @@
+package com.apollographql.apollo3.cache.normalized.internal
+
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.CompiledNamedType
+import com.apollographql.apollo3.api.Executable
+import com.apollographql.apollo3.api.keyFields
+import com.apollographql.apollo3.cache.normalized.CacheKey
+
+/**
+ * An [ObjectIdGenerator] is responsible for finding an id for a given object
+ * Called during normalization after a network reponse has been received to build
+ * the [Record] that will be stored in cache
+ *
+ * See also `@typePolicy`
+ */
+interface ObjectIdGenerator {
+  /**
+   * Returns a [CacheKey] for the given object or null if the object doesn't have an id
+   *
+   * @param type the concrete type of the object. Use this with [CacheKey.from] to namespace the ids
+   * @param obj a [Map] representing the object. The values in the map can have the same types as the ones
+   * in [Record]
+   * @param context the context in which the object is. In most use cases, the id should not depend on the context.
+   * Only use for advanced use cases.
+   */
+  fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey?
+}
+
+/**
+ * The context in which an object is normalized.
+ *
+ * @param field the field representing the object or for lists, the field representing the list. [field.type] is not
+ * always the type of the object. Especially, it can be any combination of [CompiledNotNullType] and [CompiledListType]
+ * @param variables the variables used in the operation where the object is normalized.
+ */
+class ObjectIdGeneratorContext(
+    field: CompiledField,
+    variables: Executable.Variables,
+)
+
+/**
+ * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
+ *
+ * It will coerce Int, Floats and other types to String using [toString]
+ */
+object IdObjectIdGenerator : ObjectIdGenerator {
+  override fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.generateIdFor(type, obj, context)
+  }
+}
+
+/**
+ * A [ObjectIdGenerator] that uses annotations to compute the id
+ */
+object TypePolicyObjectIdGenerator : ObjectIdGenerator {
+  override fun generateIdFor(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    val keyFields = type.keyFields()
+
+    return if (keyFields.isNotEmpty()) {
+      CacheKey.from(type.name, keyFields.map { obj[it].toString() })
+    } else {
+      null
+    }
+  }
+}

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
@@ -17,22 +17,21 @@ import com.apollographql.apollo3.cache.normalized.Record
 fun <D : Operation.Data> Operation<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
-    cacheResolver: CacheResolver,
-) = normalize(data, customScalarAdapters, cacheResolver, CacheKey.rootKey().key)
+    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
+) = normalize(data, customScalarAdapters, cacheKeyForObjectAndField, CacheKey.rootKey().key)
 
 @Suppress("UNCHECKED_CAST")
 fun <D : Executable.Data> Executable<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
-    cacheResolver: CacheResolver,
+    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
     rootKey: String,
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
-  return Normalizer(variables, rootKey) { type, fields ->
-    cacheResolver.cacheKeyForObject(type, variables, fields)?.key
-  }.normalize(writer.root() as Map<String, Any?>, selections())
+  return Normalizer(variables, rootKey, cacheKeyForObjectAndField)
+      .normalize(writer.root() as Map<String, Any?>, selections())
 }
 
 fun <D : Executable.Data> Executable<D>.readDataFromCache(

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/OperationCacheExtensions.kt
@@ -17,20 +17,20 @@ import com.apollographql.apollo3.cache.normalized.Record
 fun <D : Operation.Data> Operation<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
-    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
-) = normalize(data, customScalarAdapters, cacheKeyForObjectAndField, CacheKey.rootKey().key)
+    objectIdGenerator: ObjectIdGenerator,
+) = normalize(data, customScalarAdapters, objectIdGenerator, CacheKey.rootKey().key)
 
 @Suppress("UNCHECKED_CAST")
 fun <D : Executable.Data> Executable<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
-    cacheKeyForObjectAndField: CacheKeyForObjectAndField,
+    objectIdGenerator: ObjectIdGenerator,
     rootKey: String,
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
-  return Normalizer(variables, rootKey, cacheKeyForObjectAndField)
+  return Normalizer(variables, rootKey, objectIdGenerator)
       .normalize(writer.root() as Map<String, Any?>, selections())
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheInterceptor
 import com.apollographql.apollo3.cache.normalized.internal.CacheInput
+import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.internal.CacheOutput
 import com.apollographql.apollo3.cache.normalized.internal.DefaultCacheInput
 import com.apollographql.apollo3.cache.normalized.internal.StoreExecutionContext
@@ -59,10 +60,11 @@ const val CACHE_FLAG_STORE_PARTIAL_RESPONSE = 2
  */
 fun ApolloClient.withNormalizedCache(
     normalizedCacheFactory: NormalizedCacheFactory,
+    cacheKeyForObject: CacheKeyForObject,
     cacheResolver: CacheResolver = CacheResolver(),
     writeToCacheAsynchronously: Boolean = false
 ): ApolloClient {
-  return withStore(ApolloStore(normalizedCacheFactory, cacheResolver), writeToCacheAsynchronously)
+  return withStore(ApolloStore(normalizedCacheFactory, cacheKeyForObject, cacheResolver), writeToCacheAsynchronously)
 }
 
 fun ApolloClient.withStore(store: ApolloStore, writeToCacheAsynchronously: Boolean = false): ApolloClient {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -3,19 +3,17 @@ package com.apollographql.apollo3.cache.normalized
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
-import com.apollographql.apollo3.api.ClientContext
-import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.Mutation
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheInterceptor
 import com.apollographql.apollo3.cache.normalized.internal.CacheInput
-import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.internal.CacheOutput
 import com.apollographql.apollo3.cache.normalized.internal.DefaultCacheInput
-import com.apollographql.apollo3.cache.normalized.internal.StoreExecutionContext
+import com.apollographql.apollo3.cache.normalized.internal.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
+import com.apollographql.apollo3.exception.ApolloCompositeException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -60,11 +58,11 @@ const val CACHE_FLAG_STORE_PARTIAL_RESPONSE = 2
  */
 fun ApolloClient.withNormalizedCache(
     normalizedCacheFactory: NormalizedCacheFactory,
-    cacheKeyForObject: CacheKeyForObject,
-    cacheResolver: CacheResolver = CacheResolver(),
+    objectIdGenerator: ObjectIdGenerator = TypePolicyObjectIdGenerator,
+    cacheResolver: CacheResolver = FieldPolicyCacheResolver,
     writeToCacheAsynchronously: Boolean = false
 ): ApolloClient {
-  return withStore(ApolloStore(normalizedCacheFactory, cacheKeyForObject, cacheResolver), writeToCacheAsynchronously)
+  return withStore(ApolloStore(normalizedCacheFactory, objectIdGenerator, cacheResolver), writeToCacheAsynchronously)
 }
 
 fun ApolloClient.withStore(store: ApolloStore, writeToCacheAsynchronously: Boolean = false): ApolloClient {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -11,8 +11,6 @@ import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheIntercepto
 import com.apollographql.apollo3.cache.normalized.internal.CacheInput
 import com.apollographql.apollo3.cache.normalized.internal.CacheOutput
 import com.apollographql.apollo3.cache.normalized.internal.DefaultCacheInput
-import com.apollographql.apollo3.cache.normalized.internal.ObjectIdGenerator
-import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.exception.ApolloCompositeException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -14,6 +14,7 @@ import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.cache.normalized.CACHE_FLAG_DO_NOT_STORE
 import com.apollographql.apollo3.cache.normalized.CACHE_FLAG_STORE_PARTIAL_RESPONSE
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.dependentKeys
 import com.apollographql.apollo3.cache.normalized.isFromCache
 import com.apollographql.apollo3.mpp.ensureNeverFrozen
 import kotlinx.coroutines.flow.Flow

--- a/benchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/Benchmark.kt
+++ b/benchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/Benchmark.kt
@@ -53,7 +53,7 @@ class Benchmark {
     }
 
     val data = operation.fromResponse(bufferedSource, customScalarAdapters).data!!
-    val records = operation.normalize(data, ResponseAdapterCache.DEFAULT, CacheResolver())
+    val records = operation.normalize(data, ResponseAdapterCache.DEFAULT)
   }
 
   @Test
@@ -96,7 +96,7 @@ class Benchmark {
         sqlStore.writeOperation(operation, data)
       }
 
-      memoryStore = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), CacheKeyResolver.DEFAULT)
+      memoryStore = ApolloStore(MemoryCacheFactory(), CacheKeyResolver.DEFAULT)
       runBlocking {
         memoryStore.writeOperation(operation, data)
       }

--- a/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
+++ b/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
@@ -12,6 +12,8 @@ import com.apollographql.apollo3.cache.http.ApolloHttpCache
 import com.apollographql.apollo3.cache.http.DiskLruHttpCacheStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheResolver
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.kotlinsample.data.ApolloCallbackService
 import com.apollographql.apollo3.kotlinsample.data.ApolloCoroutinesService
@@ -45,11 +47,13 @@ class KotlinSampleApp : Application() {
         .build()
 
     val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(this, "github_cache")
-    val cacheKeyForObject = { _, obj ->
-      if (obj["__typename"] == "Repository") {
-        obj["id"] as String
-      } else {
-        null
+    val objectIdGenerator = object : ObjectIdGenerator {
+      override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+        return if (obj["__typename"] == "Repository") {
+          CacheKey(obj["id"] as String)
+        } else {
+          null
+        }
       }
     }
 
@@ -59,7 +63,7 @@ class KotlinSampleApp : Application() {
 
     ApolloClient.builder()
         .serverUrl(baseUrl)
-        .normalizedCache(sqlNormalizedCacheFactory, cacheKeyForObject)
+        .normalizedCache(sqlNormalizedCacheFactory, objectIdGenerator)
         .httpCache(ApolloHttpCache(cacheStore, logger))
         .defaultHttpCachePolicy(HttpCachePolicy.CACHE_FIRST)
         .okHttpClient(okHttpClient)

--- a/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
+++ b/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
@@ -45,13 +45,11 @@ class KotlinSampleApp : Application() {
         .build()
 
     val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(this, "github_cache")
-    val cacheResolver = object : CacheResolver() {
-      override fun cacheKeyForObject(type: CompiledNamedType, variables: Executable.Variables, obj: Map<String, Any?>): CacheKey? {
-        return if (obj["__typename"] == "Repository") {
-          CacheKey(obj["id"] as String)
-        } else {
-          null
-        }
+    val cacheKeyForObject = { _, obj ->
+      if (obj["__typename"] == "Repository") {
+        obj["id"] as String
+      } else {
+        null
       }
     }
 
@@ -61,7 +59,7 @@ class KotlinSampleApp : Application() {
 
     ApolloClient.builder()
         .serverUrl(baseUrl)
-        .normalizedCache(sqlNormalizedCacheFactory, cacheResolver)
+        .normalizedCache(sqlNormalizedCacheFactory, cacheKeyForObject)
         .httpCache(ApolloHttpCache(cacheStore, logger))
         .defaultHttpCachePolicy(HttpCachePolicy.CACHE_FIRST)
         .okHttpClient(okHttpClient)

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
@@ -17,6 +17,7 @@ import com.apollographql.apollo3.integration.normalizer.SameHeroTwiceQuery
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -43,7 +44,10 @@ class BasicTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
@@ -17,7 +17,7 @@ import com.apollographql.apollo3.integration.normalizer.SameHeroTwiceQuery
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -46,7 +46,7 @@ class BasicTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
@@ -5,7 +5,6 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
@@ -17,7 +16,7 @@ import com.apollographql.apollo3.integration.normalizer.SameHeroTwiceQuery
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
@@ -23,7 +23,12 @@ class CacheResolverTest {
         }
       }
     }
-    val apolloClient = ApolloClient(serverUrl = "").withStore(ApolloStore(MemoryCacheFactory(), resolver))
+    val apolloClient = ApolloClient(serverUrl = "").withStore(
+        ApolloStore(
+            normalizedCacheFactory = MemoryCacheFactory(),
+            cacheResolver = resolver
+        )
+    )
 
     runWithMainLoop {
       val response = apolloClient.query(HeroNameQuery())

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheResolver
+import com.apollographql.apollo3.cache.normalized.MapCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.cache.normalized.withStore
@@ -15,11 +16,11 @@ import kotlin.test.assertEquals
 class CacheResolverTest {
   @Test
   fun cacheResolverCanResolveQuery() {
-    val resolver = object : CacheResolver() {
+    val resolver = object : CacheResolver {
       override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
         return when (field.name) {
           "hero" -> mapOf("name" to "Luke")
-          else -> super.resolveField(field, variables, parent, parentId)
+          else -> MapCacheResolver.resolveField(field, variables, parent, parentId)
         }
       }
     }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/JsonScalarTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/JsonScalarTest.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.GetJsonScalarQuery
 import com.apollographql.apollo3.integration.normalizer.type.Types
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -27,7 +28,7 @@ class JsonScalarTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory())
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url())
         .withStore(store)

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/JsonScalarTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/JsonScalarTest.kt
@@ -4,12 +4,10 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.GetJsonScalarQuery
 import com.apollographql.apollo3.integration.normalizer.type.Types
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.Record
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.internal.normalize
 import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
@@ -37,7 +38,7 @@ class NormalizerTest {
 
   @BeforeTest
   fun setUp() {
-    normalizedCache = MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE).create()
+    normalizedCache = MemoryCacheFactory().create()
   }
 
   @Test
@@ -245,7 +246,7 @@ class NormalizerTest {
   companion object {
     internal fun <D : Operation.Data> records(operation: Operation<D>, name: String): Map<String, Record> {
       val response = operation.parseJsonResponse(readResource(name))
-      return operation.normalize(data = response.data!!, CustomScalarAdapters.Empty, IdCacheResolver())
+      return operation.normalize(data = response.data!!, CustomScalarAdapters.Empty, objectIdGenerator = IdObjectIdGenerator)
     }
 
     private const val TEST_FIELD_KEY_JEDI = "hero({\"episode\":\"JEDI\"})"

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -5,12 +5,11 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.Record
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
-import com.apollographql.apollo3.cache.normalized.internal.normalize
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.normalize
 import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
@@ -15,7 +14,7 @@ import com.apollographql.apollo3.integration.normalizer.type.ColorInput
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.integration.normalizer.type.ReviewInput
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withOptimisticUpdates

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo3.integration.normalizer.type.ColorInput
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.integration.normalizer.type.ReviewInput
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withOptimisticUpdates
@@ -40,7 +41,7 @@ class OptimisticCacheTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator)
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsDirectives
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -14,6 +14,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsDirectives
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -37,7 +38,7 @@ class OtherCacheTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator, cacheResolver = IdCacheResolver)
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.isFromCache
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.isFromCache
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
@@ -36,7 +37,7 @@ class StoreTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator, cacheResolver = IdCacheResolver)
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
@@ -5,7 +5,6 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameWithIdQuery
@@ -13,7 +12,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithI
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withRefetchPolicy

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithI
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withRefetchPolicy
@@ -39,7 +40,7 @@ class WatcherTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator)
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
@@ -8,10 +8,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.CacheResolver
 import com.apollographql.apollo3.cache.normalized.FieldPolicyCacheResolver
-import com.apollographql.apollo3.cache.normalized.MapCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
-import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.testing.runWithMainLoop
 import declarativecache.GetBookQuery
 import declarativecache.GetBooksQuery

--- a/composite/tests/integration-tests-kotlin/src/jvmTest/kotlin/test/WriteToCacheAsynchronouslyTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/jvmTest/kotlin/test/WriteToCacheAsynchronouslyTest.kt
@@ -34,7 +34,7 @@ class WriteToCacheAsynchronouslyTest {
   @BeforeTest
   fun setUp() {
     dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(MemoryCacheFactory())
     mockServer = MockServer()
     apolloClient = ApolloClient(
         serverUrl = mockServer.url(),

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
@@ -14,6 +14,7 @@ import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.variablesJson
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.coroutines.await
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers
 import com.apollographql.apollo3.http.OkHttpExecutionContext
@@ -58,7 +59,11 @@ class IntegrationTest {
         .serverUrl(server.url("/"))
         .okHttpClient(OkHttpClient.Builder().dispatcher(Dispatcher(immediateExecutorService())).build())
         .addCustomScalarAdapter(Types.Date, dateCustomScalarAdapter)
-        .normalizedCache(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+        .normalizedCache(
+            MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE),
+            { _, _, obj -> obj["id"] as? String},
+            IdCacheResolver()
+        )
         .defaultResponseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .dispatcher(immediateExecutor())
         .build()

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.coroutines.await
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3
 
-import com.apollographql.apollo3.Utils.checkTestFixture
 import com.apollographql.apollo3.Utils.immediateExecutor
 import com.apollographql.apollo3.Utils.immediateExecutorService
 import com.apollographql.apollo3.Utils.readFileToString
@@ -8,22 +7,16 @@ import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.api.variablesJson
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.coroutines.await
+import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers
-import com.apollographql.apollo3.http.OkHttpExecutionContext
-import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
-import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
-import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.integration.normalizer.type.Types
-import com.google.common.base.Charsets
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import okhttp3.Dispatcher
@@ -60,9 +53,9 @@ class IntegrationTest {
         .okHttpClient(OkHttpClient.Builder().dispatcher(Dispatcher(immediateExecutorService())).build())
         .addCustomScalarAdapter(Types.Date, dateCustomScalarAdapter)
         .normalizedCache(
-            MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE),
-            { _, _, obj -> obj["id"] as? String},
-            IdCacheResolver()
+            MemoryCacheFactory(),
+            IdObjectIdGenerator,
+            IdCacheResolver
         )
         .defaultResponseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .dispatcher(immediateExecutor())

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.integration.subscription.NewRepoCommentSubscription
 import com.apollographql.apollo3.isFromCache
 import com.apollographql.apollo3.subscription.OperationClientMessage

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.integration.subscription.NewRepoCommentSubscription
 import com.apollographql.apollo3.isFromCache
 import com.apollographql.apollo3.subscription.OperationClientMessage
@@ -33,7 +34,7 @@ class SubscriptionNormalizedCacheTest {
         .serverUrl("http://google.com")
         .dispatcher(TrampolineExecutor())
         .subscriptionTransportFactory(subscriptionTransportFactory)
-        .normalizedCache(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+        .normalizedCache(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator, cacheResolver = IdCacheResolver)
         .build()
     subscriptionCall = apolloClient.subscribe(NewRepoCommentSubscription("repo"))
     networkOperationData = mapOf(

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -30,7 +31,10 @@ class BasicTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
@@ -8,10 +8,9 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
-import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -33,7 +32,7 @@ class BasicTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -29,7 +29,7 @@ class StoreTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
@@ -9,8 +9,8 @@ import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -27,7 +27,10 @@ class StoreTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -30,7 +31,10 @@ class BasicTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -8,10 +8,9 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -33,7 +32,7 @@ class BasicTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -9,9 +9,8 @@ import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -30,7 +29,7 @@ class StoreTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -27,7 +28,10 @@ class StoreTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -12,10 +12,9 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -37,7 +36,7 @@ class BasicTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
@@ -34,7 +35,10 @@ class BasicTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -28,7 +29,10 @@ class StoreTest {
 
   @BeforeTest
   fun setUp() {
-    store = ApolloStore(MemoryCacheFactory(maxSizeBytes = Int.MAX_VALUE), IdCacheResolver())
+    store = ApolloStore(
+        normalizedCacheFactory = MemoryCacheFactory(),
+        cacheKeyForObject = IdCacheKeyForObject
+    )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)
   }

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,9 +10,8 @@ import codegen.models.fragment.HumanWithIdFragmentImpl
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.internal.IdCacheKeyForObject
+import com.apollographql.apollo3.cache.normalized.internal.IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -31,7 +30,7 @@ class StoreTest {
   fun setUp() {
     store = ApolloStore(
         normalizedCacheFactory = MemoryCacheFactory(),
-        cacheKeyForObject = IdCacheKeyForObject
+        objectIdGenerator = IdObjectIdGenerator
     )
     mockServer = MockServer()
     apolloClient = ApolloClient(mockServer.url()).withStore(store)

--- a/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
+++ b/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
@@ -20,6 +20,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheResolver
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.internal.CacheKeyForObjectAndField
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers
 import com.apollographql.apollo3.fetcher.ResponseFetcher
@@ -96,7 +97,8 @@ class ApolloClient internal constructor(
     enableAutoPersistedQueries: Boolean,
     subscriptionManager: SubscriptionManager,
     useHttpGetMethodForQueries: Boolean,
-    useHttpGetMethodForPersistedQueries: Boolean) : ApolloQueryCall.Factory, ApolloMutationCall.Factory, ApolloPrefetch.Factory, ApolloSubscriptionCall.Factory {
+    useHttpGetMethodForPersistedQueries: Boolean,
+) : ApolloQueryCall.Factory, ApolloMutationCall.Factory, ApolloPrefetch.Factory, ApolloSubscriptionCall.Factory {
   private val tracker = ApolloCallTracker()
   private val applicationInterceptors: List<ApolloInterceptor>
   private val applicationInterceptorFactories: List<ApolloInterceptorFactory>
@@ -111,12 +113,14 @@ class ApolloClient internal constructor(
   private val useHttpGetMethodForPersistedQueries: Boolean
 
   override fun <D : Mutation.Data> mutate(
-      mutation: Mutation<D>): ApolloMutationCall<D> {
+      mutation: Mutation<D>,
+  ): ApolloMutationCall<D> {
     return newCall(mutation).responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
   }
 
   override fun <D : Mutation.Data> mutate(
-      mutation: Mutation<D>, withOptimisticUpdates: D): ApolloMutationCall<D> {
+      mutation: Mutation<D>, withOptimisticUpdates: D,
+  ): ApolloMutationCall<D> {
     return newCall(mutation).toBuilder().responseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .optimisticUpdates(fromNullable(withOptimisticUpdates)).build()
   }
@@ -126,13 +130,15 @@ class ApolloClient internal constructor(
   }
 
   override fun <D : Operation.Data> prefetch(
-      operation: Operation<D>): ApolloPrefetch {
+      operation: Operation<D>,
+  ): ApolloPrefetch {
     return RealApolloPrefetch(operation, serverUrl!!, httpCallFactory!!, customScalarAdapters, dispatcher!!, logger,
         tracker)
   }
 
   override fun <D : Subscription.Data> subscribe(
-      subscription: Subscription<D>): ApolloSubscriptionCall<D> {
+      subscription: Subscription<D>,
+  ): ApolloSubscriptionCall<D> {
     return RealApolloSubscriptionCall(
         subscription,
         subscriptionManager,
@@ -233,7 +239,8 @@ class ApolloClient internal constructor(
   }
 
   private fun <D : Operation.Data> newCall(
-      operation: Operation<D>): RealApolloCall<D> {
+      operation: Operation<D>,
+  ): RealApolloCall<D> {
     return RealApolloCall.builder<D>()
         .operation(operation)
         .serverUrl(serverUrl)
@@ -265,6 +272,7 @@ class ApolloClient internal constructor(
     var apolloStore: ApolloStore = ApolloStore.emptyApolloStore
     var cacheFactory = absent<NormalizedCacheFactory>()
     var cacheKeyResolver = absent<CacheResolver>()
+    var cacheKeyForObjectAndField: CacheKeyForObjectAndField = { _, _, _ -> null }
     var defaultHttpCachePolicy = HttpCachePolicy.NETWORK_ONLY
     var defaultResponseFetcher = ApolloResponseFetchers.CACHE_FIRST
     var defaultCacheHeaders = CacheHeaders.NONE
@@ -381,11 +389,14 @@ class ApolloClient internal constructor(
      * @return The [Builder] object to be used for chaining method calls
      */
     @JvmOverloads
-    fun normalizedCache(normalizedCacheFactory: NormalizedCacheFactory,
-                        cacheResolver: CacheResolver = CacheResolver()
+    fun normalizedCache(
+        normalizedCacheFactory: NormalizedCacheFactory,
+        cacheKeyForObjectAndField: CacheKeyForObjectAndField,
+        cacheResolver: CacheResolver = CacheResolver(),
     ): Builder {
       cacheFactory = fromNullable(normalizedCacheFactory)
       cacheKeyResolver = fromNullable((cacheResolver))
+      this.cacheKeyForObjectAndField = cacheKeyForObjectAndField
       return this
     }
 
@@ -397,8 +408,10 @@ class ApolloClient internal constructor(
      * @param <T> the value type
      * @return The [Builder] object to be used for chaining method calls
     </T> */
-    fun <T> addCustomScalarAdapter(customScalar: CustomScalarType,
-                                   customScalarAdapter: Adapter<T>): Builder {
+    fun <T> addCustomScalarAdapter(
+        customScalar: CustomScalarType,
+        customScalarAdapter: Adapter<T>,
+    ): Builder {
       customScalarAdapters[customScalar.name] = customScalarAdapter
       return this
     }
@@ -625,7 +638,7 @@ class ApolloClient internal constructor(
       val cacheFactory = cacheFactory
       val cacheKeyResolver = cacheKeyResolver
       if (cacheFactory.isPresent && cacheKeyResolver.isPresent) {
-        apolloStore = DefaultApolloStore(cacheFactory.get(), cacheKeyResolver.get())
+        apolloStore = DefaultApolloStore(cacheFactory.get(), cacheKeyForObjectAndField, cacheKeyResolver.get())
       }
       var subscriptionManager = subscriptionManager
       val subscriptionTransportFactory = subscriptionTransportFactory
@@ -664,8 +677,10 @@ class ApolloClient internal constructor(
     }
 
     companion object {
-      private fun addHttpCacheInterceptorIfNeeded(callFactory: Call.Factory,
-                                                  httpCacheInterceptor: Interceptor): Call.Factory {
+      private fun addHttpCacheInterceptorIfNeeded(
+          callFactory: Call.Factory,
+          httpCacheInterceptor: Interceptor,
+      ): Call.Factory {
         if (callFactory is OkHttpClient) {
           val client = callFactory
           for (interceptor in client.interceptors()) {

--- a/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
+++ b/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/ApolloClient.kt
@@ -22,8 +22,8 @@ import com.apollographql.apollo3.cache.normalized.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
-import com.apollographql.apollo3.cache.normalized.internal.ObjectIdGenerator
-import com.apollographql.apollo3.cache.normalized.internal.TypePolicyObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers
 import com.apollographql.apollo3.fetcher.ResponseFetcher
 import com.apollographql.apollo3.interceptor.ApolloInterceptor

--- a/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloQueryWatcher.kt
+++ b/deprecated-apollo-runtime/src/main/java/com/apollographql/apollo3/internal/RealApolloQueryWatcher.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.internal.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.ApolloStore.RecordChangeSubscriber
 import com.apollographql.apollo3.cache.normalized.Record
-import com.apollographql.apollo3.cache.normalized.internal.dependentKeys
+import com.apollographql.apollo3.cache.normalized.dependentKeys
 import com.apollographql.apollo3.exception.ApolloCanceledException
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException

--- a/deprecated-apollo-runtime/src/test/java/com/apollographql/apollo3/internal/subscription/SubscriptionAutoPersistTest.kt
+++ b/deprecated-apollo-runtime/src/test/java/com/apollographql/apollo3/internal/subscription/SubscriptionAutoPersistTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.cache.normalized.CacheResolver
+import com.apollographql.apollo3.cache.normalized.FieldPolicyCacheResolver
 import com.apollographql.apollo3.subscription.ApolloOperationMessageSerializer
 import com.apollographql.apollo3.subscription.OperationClientMessage
 import com.apollographql.apollo3.subscription.OperationServerMessage
@@ -35,7 +36,7 @@ class SubscriptionAutoPersistTest {
         SubscriptionConnectionParamsProvider.Const(SubscriptionConnectionParams()),
         MockExecutor(),
         -1,
-        CacheResolver(),
+        FieldPolicyCacheResolver,
         true)
     Truth.assertThat(subscriptionTransportFactory!!.subscriptionTransport).isNotNull()
     Truth.assertThat(subscriptionManager!!.state).isEqualTo(SubscriptionManagerState.DISCONNECTED)

--- a/deprecated-apollo-runtime/src/test/java/com/apollographql/apollo3/internal/subscription/SubscriptionManagerTest.kt
+++ b/deprecated-apollo-runtime/src/test/java/com/apollographql/apollo3/internal/subscription/SubscriptionManagerTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.cache.normalized.CacheResolver
+import com.apollographql.apollo3.cache.normalized.FieldPolicyCacheResolver
 import com.apollographql.apollo3.subscription.OperationClientMessage
 import com.apollographql.apollo3.subscription.OperationServerMessage
 import com.apollographql.apollo3.subscription.SubscriptionConnectionParams
@@ -34,7 +35,7 @@ class SubscriptionManagerTest {
         SubscriptionConnectionParamsProvider.Const(SubscriptionConnectionParams()),
         MockExecutor(),
         connectionHeartbeatTimeoutMs,
-        CacheResolver(),
+        FieldPolicyCacheResolver,
         false)
     subscriptionManager.addOnStateChangeListener(onStateChangeListener)
   }


### PR DESCRIPTION
Split the normalization and resolution paths:

* Normalization takes data in and outputs a flat list of records. It can be made declarative with `@typePolicy` and is happens while writing to the cache.
* Resolution take a record in and outputs data. It can be made declarative with `@fieldPolicy` and happens while reading the cache.