### PR TITLE
Hide type from ObjectIdGenerator

### DIFF
--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
@@ -1,9 +1,9 @@
 package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.api.CompiledField
-import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.keyFields
+import com.apollographql.apollo3.api.leafType
 
 /**
  * An [ObjectIdGenerator] is responsible for finding an id for a given object
@@ -16,20 +16,21 @@ interface ObjectIdGenerator {
   /**
    * Returns a [CacheKey] for the given object or null if the object doesn't have an id
    *
-   * @param type the concrete type of the object. Use this with [CacheKey.from] to namespace the ids
    * @param obj a [Map] representing the object. The values in the map can have the same types as the ones
    * in [Record]
    * @param context the context in which the object is normalized. In most use cases, the id should not depend on the normalization
    * context. Only use for advanced use cases.
    */
-  fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey?
+  fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey?
 }
 
 /**
  * The context in which an object is normalized.
  *
  * @param field the field representing the object or for lists, the field representing the list. [field.type] is not
- * always the type of the object. Especially, it can be any combination of [CompiledNotNullType] and [CompiledListType]
+ * always the type of the object. Especially, it can be any combination of [CompiledNotNullType] and [CompiledListType].
+ * Use `field.type.leafType()` to access the type of the object. For interface fields, it will be the interface type,
+ * not concrete types.
  * @param variables the variables used in the operation where the object is normalized.
  */
 class ObjectIdGeneratorContext(
@@ -43,8 +44,8 @@ class ObjectIdGeneratorContext(
  * It will coerce Int, Floats and other types to String using [toString]
  */
 object IdObjectIdGenerator : ObjectIdGenerator {
-  override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
-    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(type, obj, context)
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
   }
 }
 
@@ -52,11 +53,11 @@ object IdObjectIdGenerator : ObjectIdGenerator {
  * A [ObjectIdGenerator] that uses annotations to compute the id
  */
 object TypePolicyObjectIdGenerator : ObjectIdGenerator {
-  override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
-    val keyFields = type.keyFields()
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    val keyFields = context.field.type.leafType().keyFields()
 
     return if (keyFields.isNotEmpty()) {
-      CacheKey.from(type.name, keyFields.map { obj[it].toString() })
+      CacheKey.from(obj["__typename"].toString(), keyFields.map { obj[it].toString() })
     } else {
       null
     }

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/Normalizer.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/Normalizer.kt
@@ -128,7 +128,6 @@ class Normalizer(
         check(value is Map<*, *>)
         @Suppress("UNCHECKED_CAST")
         val key = objectIdGenerator.cacheKeyForObject(
-            type,
             value as Map<String, Any?>,
             ObjectIdGeneratorContext(field, variables),
         )?.key ?: path

--- a/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
+++ b/composite/samples/kotlin-sample/src/main/java/com/apollographql/apollo3/kotlinsample/KotlinSampleApp.kt
@@ -48,7 +48,7 @@ class KotlinSampleApp : Application() {
 
     val sqlNormalizedCacheFactory = SqlNormalizedCacheFactory(this, "github_cache")
     val objectIdGenerator = object : ObjectIdGenerator {
-      override fun cacheKeyForObject(type: CompiledNamedType, obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+      override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
         return if (obj["__typename"] == "Repository") {
           CacheKey(obj["id"] as String)
         } else {


### PR DESCRIPTION
`type` shouldn't be needed in most cases. If needed it can be get from `context.field.type.leafType()`