### PR TITLE
Cache resolver tweaks

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKey.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKey.kt
@@ -59,5 +59,10 @@ class CacheKey(val key: String) {
           }
       )
     }
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    fun from(typename: String, vararg values: String) = from(typename, values.toList())
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -56,6 +56,6 @@ abstract class CacheKeyResolver : CacheResolver {
       }
     }
 
-    return MapCacheResolver.resolveField(field, variables, parent, parentId)
+    return DefaultCacheResolver.resolveField(field, variables, parent, parentId)
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheKeyResolver.kt
@@ -8,24 +8,33 @@ import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.isComposite
 
 /**
- * A [CacheResolver] that only works with [CacheKey]s. This is intended to simplify the usage of [CacheResolver] when no special handling is needed for scalar fields.
+ * A [CacheResolver] that resolves objects and list of objects and fallbacks to the default resolver for scalar fields.
+ * It is intended to simplify the usage of [CacheResolver] when no special handling is needed for scalar fields.
  *
- * Override [cacheKeyForField] to compute a cache key for an object field.
- * Override [listOfCacheKeysForField] to compute a list of cache keys for a field that contains a list of objects.
+ * Override [cacheKeyForField] to compute a cache key for a field of composite type.
+ * Override [listOfCacheKeysForField] to compute a list of cache keys for a field of 'list-of-composite' type.
  *
- * For simplicity, this only handles one level of list. Subclass [CacheResolver] if you need arbitrary nested lists of objects.
+ * For simplicity, this only handles one level of list. Implement [CacheResolver] if you need arbitrary nested lists of objects.
  */
 abstract class CacheKeyResolver : CacheResolver {
-
   /**
-   * Return the computed the cache key for an object field.
+   * Return the computed the cache key for a composite field.
+   *
+   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
+   * in the whole schema as it cannot be namespaced by the typename anymore.
    *
    * If the returned [CacheKey] is null, the resolver will use the default handling and use any previously cached value.
    */
   abstract fun cacheKeyForField(field: CompiledField, variables: Executable.Variables): CacheKey?
 
   /**
-   * For a field that contains a list of objects, [listOfCacheKeysForField ] returns a list of [CacheKey]s where each [CacheKey] identifies an object. 
+   * For a field that contains a list of objects, [listOfCacheKeysForField ] returns a list of [CacheKey]s where each [CacheKey] identifies an object.
+   *
+   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
+   * in the whole schema as it cannot be namespaced by the typename anymore.
+   *
    * If an individual [CacheKey] is null, the resulting object will be null in the response.
    * If the returned list of [CacheKey]s is null, the resolver will use the default handling and use any previously cached value.
    */

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
@@ -13,7 +13,11 @@ import kotlin.jvm.JvmSuppressWildcards
 interface CacheResolver {
   /**
    * Resolves a field from the cache. Called when reading from the cache, usually before a network request.
-   * This API is similar to a backend side resolver in that it allows resolving fields to arbitrary values.
+   * - takes a GraphQL field and operation variables as input and generates data for this field
+   * - this data can be a CacheKey for objects but it can also be any other data if needed. In that respect,
+   * it's closer to a resolver as might be found in apollo-server
+   * - is used before a network request
+   * - is used when reading the cache
    *
    * It can be used to map field arguments to [CacheKey]:
    *
@@ -55,6 +59,7 @@ interface CacheResolver {
    * ```
    *
    * See also @fieldPolicy
+   * See also [ObjectIdGenerator]
    *
    * @param field the field to resolve
    * @param variables the variables of the current operation

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
@@ -115,16 +115,4 @@ object FieldPolicyCacheResolver: CacheResolver {
   }
 }
 
-/**
- * A [CacheResolver] that looks for an "id" argument to resolve fields and delegates to [FieldPolicyCacheResolver] else
- */
-object IdCacheResolver: CacheResolver {
-  override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
-    val id = field.resolveArgument("id", variables)?.toString()
-    if (id != null) {
-       return CacheKey(id)
-    }
 
-    return FieldPolicyCacheResolver.resolveField(field, variables, parent, parentId)
-  }
-}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheResolver.kt
@@ -77,7 +77,7 @@ interface CacheResolver {
  * A cache resolver that uses the parent to resolve fields. [parent] is a [Map] that
  * can contain the same values as [Record]
  */
-object MapCacheResolver: CacheResolver {
+object DefaultCacheResolver: CacheResolver {
   override fun resolveField(
       field: CompiledField,
       variables: Executable.Variables,
@@ -94,7 +94,7 @@ object MapCacheResolver: CacheResolver {
 }
 
 /**
- * A [CacheResolver] that uses @fieldPolicy annotations to resolve fields and delegates to [MapCacheResolver] else
+ * A [CacheResolver] that uses @fieldPolicy annotations to resolve fields and delegates to [DefaultCacheResolver] else
  */
 object FieldPolicyCacheResolver: CacheResolver {
   override fun resolveField(
@@ -111,7 +111,7 @@ object FieldPolicyCacheResolver: CacheResolver {
       return CacheKey.from(field.type.leafType().name, keyArgsValues)
     }
 
-    return MapCacheResolver.resolveField(field, variables, parent, parentId)
+    return DefaultCacheResolver.resolveField(field, variables, parent, parentId)
   }
 }
 

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
@@ -39,17 +39,6 @@ class ObjectIdGeneratorContext(
 )
 
 /**
- * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
- *
- * It will coerce Int, Floats and other types to String using [toString]
- */
-object IdObjectIdGenerator : ObjectIdGenerator {
-  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
-    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
-  }
-}
-
-/**
  * A [ObjectIdGenerator] that uses annotations to compute the id
  */
 object TypePolicyObjectIdGenerator : ObjectIdGenerator {

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ObjectIdGenerator.kt
@@ -7,10 +7,12 @@ import com.apollographql.apollo3.api.leafType
 
 /**
  * An [ObjectIdGenerator] is responsible for finding an id for a given object
- * Called during normalization after a network reponse has been received to build
- * the [Record] that will be stored in cache
+ * - takes Json data as input and returns a unique id for an object
+ * - is used after a network request
+ * - is used during normalization when writing to the cache
  *
  * See also `@typePolicy`
+ * See also [CacheResolver]
  */
 interface ObjectIdGenerator {
   /**

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/Utils.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/Utils.kt
@@ -1,3 +1,11 @@
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.Executable
+import com.apollographql.apollo3.cache.normalized.CacheKey
+import com.apollographql.apollo3.cache.normalized.CacheResolver
+import com.apollographql.apollo3.cache.normalized.FieldPolicyCacheResolver
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
+import com.apollographql.apollo3.cache.normalized.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.testing.checkFile
 import com.apollographql.apollo3.testing.readFile
 import kotlin.test.assertEquals
@@ -12,3 +20,29 @@ fun readResource(name: String) = readFile("../integration-tests/testFixtures/res
  * A helper function to reverse the order of the argument so that we can easily column edit the tests
  */
 fun assertEquals2(actual: Any?, expected: Any?) = assertEquals(expected, actual)
+
+
+/**
+ * A [CacheResolver] that looks for an "id" argument to resolve fields and delegates to [FieldPolicyCacheResolver] else
+ */
+object IdCacheResolver: CacheResolver {
+  override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
+    val id = field.resolveArgument("id", variables)?.toString()
+    if (id != null) {
+      return CacheKey(id)
+    }
+
+    return FieldPolicyCacheResolver.resolveField(field, variables, parent, parentId)
+  }
+}
+
+/**
+ * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
+ *
+ * It will coerce Int, Floats and other types to String using [toString]
+ */
+object IdObjectIdGenerator : ObjectIdGenerator {
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
+  }
+}

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/BasicTest.kt
@@ -16,7 +16,7 @@ import com.apollographql.apollo3.integration.normalizer.SameHeroTwiceQuery
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/CacheResolverTest.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheResolver
-import com.apollographql.apollo3.cache.normalized.MapCacheResolver
+import com.apollographql.apollo3.cache.normalized.DefaultCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.cache.normalized.withStore
@@ -20,7 +20,7 @@ class CacheResolverTest {
       override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
         return when (field.name) {
           "hero" -> mapOf("name" to "Luke")
-          else -> MapCacheResolver.resolveField(field, variables, parent, parentId)
+          else -> DefaultCacheResolver.resolveField(field, variables, parent, parentId)
         }
       }
     }

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.Record
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.normalize
 import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.integration.normalizer.type.ColorInput
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.integration.normalizer.type.ReviewInput
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withOptimisticUpdates

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
+import IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.CharacterDetailsQuery
 import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsDirectives
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/StoreTest.kt
@@ -6,13 +6,13 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
+import IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.isFromCache
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore

--- a/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/commonTest/kotlin/test/WatcherTest.kt
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithI
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withRefetchPolicy

--- a/composite/tests/integration-tests-kotlin/src/jvmTest/kotlin/test/WriteToCacheAsynchronouslyTest.kt
+++ b/composite/tests/integration-tests-kotlin/src/jvmTest/kotlin/test/WriteToCacheAsynchronouslyTest.kt
@@ -1,11 +1,9 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.ClientScope
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.cache.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.cache.normalized.withWriteToCacheAsynchronously
@@ -16,10 +14,9 @@ import com.apollographql.apollo3.mockserver.enqueue
 import com.apollographql.apollo3.testing.runBlocking
 import com.apollographql.apollo3.testing.runWithMainLoop
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
-import java.util.concurrent.Executors
 import readResource
+import java.util.concurrent.Executors
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertNotNull

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/StatusEventsTest.kt
@@ -9,9 +9,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.coroutines.await
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.fetcher.ApolloResponseFetchers
@@ -54,8 +52,8 @@ class IntegrationTest {
         .addCustomScalarAdapter(Types.Date, dateCustomScalarAdapter)
         .normalizedCache(
             MemoryCacheFactory(),
-            IdObjectIdGenerator,
-            IdCacheResolver
+            Utils.IdObjectIdGenerator,
+            Utils.IdCacheResolver
         )
         .defaultResponseFetcher(ApolloResponseFetchers.NETWORK_ONLY)
         .dispatcher(immediateExecutor())

--- a/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
+++ b/composite/tests/integration-tests/src/testShared/kotlin/com/apollographql/apollo3/SubscriptionNormalizedCacheTest.kt
@@ -1,16 +1,12 @@
-package com.apollographql.apollo3.internal.subscription
+package com.apollographql.apollo3
 
-import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.ApolloSubscriptionCall
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.exception.ApolloException
-import com.apollographql.apollo3.cache.normalized.IdCacheResolver
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.NormalizedCache
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
 import com.apollographql.apollo3.integration.subscription.NewRepoCommentSubscription
-import com.apollographql.apollo3.isFromCache
+import com.apollographql.apollo3.internal.subscription.RealSubscriptionManager
 import com.apollographql.apollo3.subscription.OperationClientMessage
 import com.apollographql.apollo3.subscription.OperationServerMessage
 import com.apollographql.apollo3.subscription.SubscriptionTransport
@@ -34,7 +30,7 @@ class SubscriptionNormalizedCacheTest {
         .serverUrl("http://google.com")
         .dispatcher(TrampolineExecutor())
         .subscriptionTransportFactory(subscriptionTransportFactory)
-        .normalizedCache(MemoryCacheFactory(), objectIdGenerator = IdObjectIdGenerator, cacheResolver = IdCacheResolver)
+        .normalizedCache(MemoryCacheFactory(), objectIdGenerator = Utils.IdObjectIdGenerator, cacheResolver = Utils.IdCacheResolver)
         .build()
     subscriptionCall = apolloClient.subscribe(NewRepoCommentSubscription("repo"))
     networkOperationData = mapOf(

--- a/composite/tests/models-compat/src/commonTest/kotlin/Utils.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,18 @@
+import com.apollographql.apollo3.cache.normalized.CacheKey
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
+import com.apollographql.apollo3.cache.normalized.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.testing.readFile
 
 fun readJson(name: String) = readFile("../models-fixtures/json/$name")
 
+/**
+ * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
+ *
+ * It will coerce Int, Floats and other types to String using [toString]
+ */
+object IdObjectIdGenerator : ObjectIdGenerator {
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
+  }
+}

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/BasicTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-compat/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,18 @@
+import com.apollographql.apollo3.cache.normalized.CacheKey
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
+import com.apollographql.apollo3.cache.normalized.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.testing.readFile
 
 fun readJson(name: String) = readFile("../models-fixtures/json/$name")
 
+/**
+ * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
+ *
+ * It will coerce Int, Floats and other types to String using [toString]
+ */
+object IdObjectIdGenerator : ObjectIdGenerator {
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
+  }
+}

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-operation-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/composite/tests/models-response-based/src/commonTest/kotlin/Utils.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/Utils.kt
@@ -1,4 +1,18 @@
+import com.apollographql.apollo3.cache.normalized.CacheKey
+import com.apollographql.apollo3.cache.normalized.ObjectIdGenerator
+import com.apollographql.apollo3.cache.normalized.ObjectIdGeneratorContext
+import com.apollographql.apollo3.cache.normalized.TypePolicyObjectIdGenerator
 import com.apollographql.apollo3.testing.readFile
 
 fun readJson(name: String) = readFile("../models-fixtures/json/$name")
 
+/**
+ * A [ObjectIdGenerator] that always uses the "id" field if it exists and delegates to [TypePolicyObjectIdGenerator] else
+ *
+ * It will coerce Int, Floats and other types to String using [toString]
+ */
+object IdObjectIdGenerator : ObjectIdGenerator {
+  override fun cacheKeyForObject(obj: Map<String, Any?>, context: ObjectIdGeneratorContext): CacheKey? {
+    return obj["id"]?.toString()?.let { CacheKey(it) } ?: TypePolicyObjectIdGenerator.cacheKeyForObject(obj, context)
+  }
+}

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/BasicTest.kt
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withFetchPolicy
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer

--- a/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
+++ b/composite/tests/models-response-based/src/commonTest/kotlin/test/StoreTest.kt
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheKey
 import com.apollographql.apollo3.cache.normalized.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.IdObjectIdGenerator
+import IdObjectIdGenerator
 import com.apollographql.apollo3.cache.normalized.withStore
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue


### PR DESCRIPTION
A few improvements to the `CacheResolver` API that I found while writing the release notes:

* move IdObjectIdGenerator and IdCacheResolver to tests as they don't take typename into account
* added a version of CacheKey.from that takes variadic arguments
* mapCacheResolver -> DefaultCacheResolver
* more Kdoc