### PR TITLE
Dev 3.x: Websocket closed error missing from graphql-ws subscription (#3230)

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -6,9 +6,17 @@ package com.apollographql.apollo3.exception
 open class ApolloException(message: String? = null, cause: Throwable? = null) : RuntimeException(message, cause)
 
 /**
- * A network happened: socket closed, DNS issue, TLS problem, etc...
+ * A network error happened: socket closed, DNS issue, TLS problem, etc...
  */
 class ApolloNetworkException(message: String? = null, cause: Throwable? = null) : ApolloException(message = message, cause = cause)
+
+/**
+ * A WebSocket connection could not be established: e.g., expired token
+ */
+class ApolloWebSocketException(
+    val code: Int,
+    message: String? = null,
+    cause: Throwable? = null) : ApolloException(message = message, cause = cause)
 
 /**
  * The response was received but the response code was not 200

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -13,7 +13,7 @@ class ApolloNetworkException(message: String? = null, cause: Throwable? = null) 
 /**
  * A WebSocket connection could not be established: e.g., expired token
  */
-class ApolloWebSocketException(
+class ApolloWebSocketClosedException(
     val code: Int,
     message: String? = null,
     cause: Throwable? = null) : ApolloException(message = message, cause = cause)

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.network.ws
 
+import com.apollographql.apollo3.exception.ApolloWebSocketException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -63,6 +64,13 @@ actual class DefaultWebSocketEngine(
         messageChannel.close(t)
       }
 
+      override fun onClosing(webSocket: WebSocket?, code: Int, reason: String?) {
+        webSocketOpenResult.complete(Unit)
+
+        val t = ApolloWebSocketException(code, reason)
+        messageChannel.close(t)
+      }
+      
       override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
         messageChannel.close()
       }

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.network.ws
 
-import com.apollographql.apollo3.exception.ApolloWebSocketException
+import com.apollographql.apollo3.exception.ApolloWebSocketClosedException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -67,7 +67,7 @@ actual class DefaultWebSocketEngine(
       override fun onClosing(webSocket: WebSocket?, code: Int, reason: String?) {
         webSocketOpenResult.complete(Unit)
 
-        val t = ApolloWebSocketException(code, reason)
+        val t = ApolloWebSocketClosedException(code, reason)
         messageChannel.close(t)
       }
       

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -15,7 +15,7 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
     if (withJs) {
       js {
         useCommonJs()
-        browser()
+//        browser()
         nodejs()
       }
     }

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -15,7 +15,7 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
     if (withJs) {
       js {
         useCommonJs()
-//        browser()
+        browser()
         nodejs()
       }
     }


### PR DESCRIPTION
This is a minor update to communicate if the WebSocket has been closed by the server for some reason e.g., expired or invalid token.