### PR TITLE
Update documentation about constructors for the v3 migration guide

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -174,12 +174,16 @@ To customize the `OkHttpClient`:
 ```kotlin
 // Replace
 val apolloClient = ApolloClient.builder()
+    .serverUrl(serverUrl)
     .okHttpClient(okHttpClient)
     .build()
 
 // With
 val apolloClient = ApolloClient(
-  networkTransport = DefaultHttpNetworkTransport(callFactory = okHttpClient)
+  networkTransport = HttpNetworkTransport(
+    httpRequestComposer = DefaultHttpRequestComposer(serverUrl),
+    engine = DefaultHttpEngine(okHttpClient = okHttpClient)
+  )
 )
 ```
 


### PR DESCRIPTION
I am using version 3.0.0-alpha02 in a Kotlin project.

I found that the class mentioned in the documentation, `DefaultHttpNetworkTransport`, did not exist, but after some fiddling around I pieced something together that seems to work. Please correct me if this is not what you intended.

Other than this, the migration to v3 was pretty smooth. Many thanks for the Kotlin support!

_Offtopic for this PR:_
One other minor confusion was about the `@optional` directive, I first thought that you wanted to replace nullability by the Optional class just as some other programming languages do, so I replaced all nullable variables in my query by Optional parameters.
But then I found that it didn't work because graphql will still attempt to pass null values for some reason (not in my code, I got it back as an error in the query result so no stacktrace. Maybe on the side of the GitHub api?).
So I keep [my query](https://github.com/PHPirates/TeXiFy-stats/blob/master/src/main/graphql/nl/deltadak/texifystats/TotalIssues.graphql) as `query MyQuery($nonNullable: String!, $nullable: String)`. I think the documentation just meant to speak about a situation where you really have optional parameters that are there or are not there (not sure when that would arise).
 If I misunderstood the intention, I would appreciate if you let me know.
But I know that my story is pretty vague, so if you can't make sense of it please ignore me :) 