### PR TITLE
Add error.path

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
@@ -17,9 +17,16 @@ class Error(
     val locations: List<Location> = emptyList(),
 
     /**
+     * If this error comes from a field, the path of the field where the error happened.
+     * Values in the list can be either Strings or Int
+     * Can be null if the error doesn't come from a field, like validation errors.
+     */
+    val path: List<Any>? = null,
+
+    /**
      * Custom attributes associated with this error
      */
-    val customAttributes: Map<String, Any?> = emptyMap()
+    val customAttributes: Map<String, Any?> = emptyMap(),
 ) {
 
   /**
@@ -49,6 +56,7 @@ class Error(
 
     if (message != other.message) return false
     if (locations != other.locations) return false
+    if (path != other.path) return false
     if (customAttributes != other.customAttributes) return false
 
     return true
@@ -57,12 +65,13 @@ class Error(
   override fun hashCode(): Int {
     var result = message.hashCode()
     result = 31 * result + locations.hashCode()
+    result = 31 * result + path.hashCode()
     result = 31 * result + customAttributes.hashCode()
     return result
   }
 
   override fun toString(): String {
-    return "Error(message = $message, locations = $locations, customAttributes = $customAttributes)"
+    return "Error(message = $message, locations = $locations, path = $path, customAttributes = $customAttributes)"
   }
 
   /**

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/internal/SimpleOperationResponseParser.kt
@@ -56,6 +56,7 @@ object SimpleOperationResponseParser {
   private fun Map<String, Any?>.readError(): Error {
     var message = ""
     var locations = emptyList<Error.Location>()
+    var path: List<Any>? = null
     val customAttributes = mutableMapOf<String, Any?>()
     for ((key, value) in this) {
       when (key) {
@@ -64,10 +65,13 @@ object SimpleOperationResponseParser {
           val locationItems = value as? List<Map<String, Any?>>
           locations = locationItems?.map { it.readErrorLocation() } ?: emptyList()
         }
+        "path" -> {
+          path = (value as? List<Any>)?.map { if (it is Number) it.toInt() else it }
+        }
         else -> customAttributes[key] = value
       }
     }
-    return Error(message, locations, customAttributes)
+    return Error(message, locations, path, customAttributes)
   }
 
   private fun Map<String, Any?>?.readErrorLocation(): Error.Location {

--- a/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/IntegrationTest.java
@@ -136,7 +136,33 @@ public class IntegrationTest {
             //noinspection ConstantConditions
             assertThat(response.errors()).containsExactly(new Error(
                 "Cannot query field \"names\" on type \"Species\".",
-                Collections.singletonList(new Error.Location(3, 5)), Collections.<String, Object>emptyMap()));
+                Collections.singletonList(new Error.Location(3, 5)),
+                null,
+                Collections.<String, Object>emptyMap())
+            );
+            return true;
+          }
+        }
+    );
+  }
+
+  @Test public void error_response_with_path() throws Exception {
+    server.enqueue(mockResponse("ResponseErrorWithPath.json"));
+    assertResponse(
+        apolloClient.query(new HeroNameQuery()),
+        new Predicate<Response<HeroNameQuery.Data>>() {
+          @Override public boolean test(Response<HeroNameQuery.Data> response) throws Exception {
+            assertThat(response.hasErrors()).isTrue();
+            //noinspection ConstantConditions
+            assertThat(response.hasErrors()).isTrue();
+            assertThat(response.errors()).hasSize(1);
+            assertThat(response.errors().get(0).message()).isEqualTo("Name for character with ID 1002 could not be fetched.");
+            assertThat(response.errors().get(0).locations()).hasSize(1);
+            assertThat(response.errors().get(0).getPath()).hasSize(4);
+            assertThat(response.errors().get(0).getPath().get(0)).isEqualTo("hero");
+            assertThat(response.errors().get(0).getPath().get(1)).isEqualTo("heroFriends");
+            assertThat(response.errors().get(0).getPath().get(2)).isEqualTo(1);
+            assertThat(response.errors().get(0).getPath().get(3)).isEqualTo("name");
             return true;
           }
         }
@@ -190,7 +216,9 @@ public class IntegrationTest {
             assertThat(response.data().hero().name()).isEqualTo("R2-D2");
             assertThat(response.errors()).containsExactly(new Error(
                 "Cannot query field \"names\" on type \"Species\".",
-                Collections.singletonList(new Error.Location(3, 5)), Collections.<String, Object>emptyMap()));
+                Collections.singletonList(new Error.Location(3, 5)),
+                null,
+                Collections.<String, Object>emptyMap()));
             return true;
           }
         }
@@ -306,6 +334,7 @@ public class IntegrationTest {
         new Error(
             "Cannot query field \"names\" on type \"Species\".",
             Collections.singletonList(new Error.Location(3, 5)),
+            null,
             Collections.<String, Object>emptyMap()
         )
     );

--- a/apollo-integration/src/test/resources/ResponseErrorWithPath.json
+++ b/apollo-integration/src/test/resources/ResponseErrorWithPath.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "message": "Name for character with ID 1002 could not be fetched.",
+      "locations": [{ "line": 6, "column": 7 }],
+      "path": ["hero", "heroFriends", 1, "name"]
+    }
+  ]
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/response/OperationResponseParser.java
@@ -140,6 +140,7 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
     String message = "";
     final List<Error.Location> locations = new ArrayList<>();
     final Map<String, Object> customAttributes = new HashMap<>();
+    List<Object> path = null;
     for (Map.Entry<String, Object> entry : payload.entrySet()) {
       if ("message".equals(entry.getKey())) {
         Object value = entry.getValue();
@@ -151,13 +152,22 @@ public final class OperationResponseParser<D extends Operation.Data, W> {
             locations.add(parseErrorLocation(item));
           }
         }
+      } else if ("path".equals(entry.getKey())) {
+        path = new ArrayList<Object>();
+        for (Object item : (List<Object>) entry.getValue()) {
+          if (item instanceof Number) {
+            path.add(((Number) item).intValue());
+          } else {
+            path.add(item);
+          }
+        }
       } else {
         if (entry.getValue() != null) {
           customAttributes.put(entry.getKey(), entry.getValue());
         }
       }
     }
-    return new Error(message, locations, customAttributes);
+    return new Error(message, locations, path, customAttributes);
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloAutoPersistedOperationInterceptorTest.java
@@ -97,7 +97,7 @@ public class ApolloAutoPersistedOperationInterceptorTest {
                   com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
                       .errors(
                           Collections.singletonList(
-                              new Error("PersistedQueryNotFound", Collections.emptyList(), Collections.emptyMap())
+                              new Error("PersistedQueryNotFound", Collections.emptyList(), null, Collections.emptyMap())
                           )
                       )
                       .build(),
@@ -150,7 +150,7 @@ public class ApolloAutoPersistedOperationInterceptorTest {
                   com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
                       .errors(
                           Collections.singletonList(
-                              new Error("PersistedQueryNotSupported", Collections.emptyList(), Collections.emptyMap())
+                              new Error("PersistedQueryNotSupported", Collections.emptyList(), null, Collections.emptyMap())
                           )
                       )
                       .build(),
@@ -198,7 +198,7 @@ public class ApolloAutoPersistedOperationInterceptorTest {
                 com.apollographql.apollo.api.Response.<MockOperation.Data>builder(new MockOperation())
                     .errors(
                         Collections.singletonList(
-                            new Error("SomeOtherError", Collections.<Error.Location>emptyList(), Collections.<String, Object>emptyMap())
+                            new Error("SomeOtherError", Collections.<Error.Location>emptyList(), null, Collections.<String, Object>emptyMap())
                         )
                     )
                     .build(),

--- a/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
+++ b/apollo-runtime/src/test/java/com/apollographql/apollo/internal/interceptor/ApolloCacheInterceptorTest.java
@@ -63,7 +63,7 @@ public class ApolloCacheInterceptorTest {
   @Test
   public void testDoesNotCacheErrorResponse() {
     Operation<?, ?, ?> operation = mock(Operation.class);
-    Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
+    Error error = new Error("Error", Collections.emptyList(), null, Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
         com.apollographql.apollo.api.Response.builder(operation).errors(Collections.singletonList(error)).build(),
@@ -80,7 +80,7 @@ public class ApolloCacheInterceptorTest {
   @Test
   public void testCachesErrorResponseWhenStorePartialResponsesCacheHeaderPresent() {
     Operation<?, ?, ?> operation = mock(Operation.class);
-    Error error = new Error("Error", Collections.emptyList(), Collections.emptyMap());
+    Error error = new Error("Error", Collections.emptyList(), null, Collections.emptyMap());
     ApolloInterceptor.InterceptorResponse networkResponse = new ApolloInterceptor.InterceptorResponse(
         okHttpResponse,
         com.apollographql.apollo.api.Response.builder(operation).errors(Collections.singletonList(error)).build(),


### PR DESCRIPTION
Follow up from https://community.apollographql.com/t/path-in-error-type/931

Add `path` to GraphQL errors