### PR TITLE
Gradle Plugin: Simplify the Android setup

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -349,29 +349,18 @@ interface Service {
     fun connectToJavaSourceSet(name: String)
 
     /**
-     * Connects the generated sources to all the Android application variants.
-     * Throws if the Android Application plugin is not applied
-     */
-    fun connectToAllAndroidApplicationVariants()
-
-    /**
-     * Connects the generated sources to all the Android application variants.
-     * Throws if the Android Library plugin is not applied
-     */
-    fun connectToAllAndroidLibraryVariants()
-
-    /**
-     * Connects the generated sources to all the Android instrumented test variants.
+     * Connects the generated sources to the given Android source set.
      * Throws if the Android plugin is not applied
+     *
+     * @param name: the name of the source set. For an example, "main", "test" or "androidTest"
+     * You can also use more qualified source sets like "demo", "debug" or "demoDebug"
      */
-    fun connectToAllAndroidInstrumentedTestVariants()
+    fun connectToAndroidSourceSet(name: String)
 
     /**
-     * Connects the generated sources to all the Android unit test variants.
-     * Throws if the Android plugin is not applied
+     * Connects the generated sources to the given Android variant. This will
+     * look up the most specific source set used by this variant. For an example, "demoDebug"
      */
-    fun connectToAllAndroidUnitTestVariants()
-
     fun connectToAndroidVariant(variant: BaseVariant)
 
     /**

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -303,12 +303,7 @@ abstract class DefaultApolloExtension(
         connection.connectToKotlinSourceSet(KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME)
       }
       project.androidExtension != null -> {
-        /**
-         * Call both application and library
-         * Only one will be active at a time
-         */
-        connection.connectToAllAndroidApplicationVariants()
-        connection.connectToAllAndroidLibraryVariants()
+        connection.connectToAndroidSourceSet("main")
       }
       project.kotlinProjectExtension != null -> {
         connection.connectToKotlinSourceSet("main")

--- a/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
@@ -60,7 +60,7 @@ configure<ApolloExtension> {
     srcDir("src/test/graphql")
     packageName.set("com.example")
     outputDirConnection {
-      connectToAllAndroidUnitTestVariants()
+      connectToAndroidSourceSet("test")
     }
   }
 }


### PR DESCRIPTION
Turns out `registerJavaGeneratingTask` isn't required to wire generated sources to android Variants. Adding a `DirectoryProperty` carrying its task dependencies is enough and more flexible as any task using the sourceSet will now depend on the appropriate `generateApolloSources`

Closes https://github.com/apollographql/apollo-android/issues/1454