### PR TITLE
Mandate package name

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -186,7 +186,7 @@ interface Service {
    *
    * ```
    * srcDir("src/main/graphql")
-   * filePathAwarePackageNameGenerator("com.example")
+   * packageNamesFromFilePaths("com.example")
    * ```
    *
    * an operation defined in `src/main/graphql/query/feature1` will use `com.example.query.feature1`
@@ -194,7 +194,7 @@ interface Service {
    * an input object defined in `src/main/graphql/schema/schema.graphqls` will use `com.example.schema.type`
    * as package name
    */
-  fun filePathAwarePackageNameGenerator(rootPackageName: String? = null)
+  fun packageNamesFromFilePaths(rootPackageName: String? = null)
 
   /**
    * Whether to generate Kotlin models with `internal` visibility modifier.

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -407,9 +407,14 @@ abstract class DefaultApolloExtension(
       check(!(service.packageName.isPresent && service.packageNameGenerator.isPresent)) {
         println("ApolloGraphQL: it is an error to specify both 'packageName' and 'packageNameGenerator'")
       }
-      val packageNameGenerator = service.packageNameGenerator.getOrElse(
-          PackageNameGenerator.Flat(service.packageName.getOrElse(""))
-      )
+      var packageNameGenerator = service.packageNameGenerator.orNull
+      if (packageNameGenerator == null) {
+        packageNameGenerator = PackageNameGenerator.Flat(service.packageName.orNull ?: error("""ApolloGraphQL: specify 'packageName':
+            |apollo {
+            |  packageName.set("com.example")
+            |}
+          """.trimMargin()))
+      }
       task.packageNameGenerator = packageNameGenerator
       task.generateAsInternal.set(service.generateAsInternal)
       task.generateFilterNotNull.set(project.isKotlinMultiplatform)

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -141,7 +141,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
     this.outputDirAction = action
   }
 
-  override fun filePathAwarePackageNameGenerator(rootPackageName: String?) {
+  override fun packageNamesFromFilePaths(rootPackageName: String?) {
     packageNameGenerator.set(
       project.provider {
         PackageNameGenerator.FilePathAware(

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/AndroidProjectTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/AndroidProjectTests.kt
@@ -18,7 +18,7 @@ class AndroidProjectTests {
   fun `android library compiles`() {
     withProject(apolloConfiguration = """
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent(),
         usesKotlinDsl = false,
@@ -39,7 +39,7 @@ class AndroidProjectTests {
   fun `android application compiles and produces an apk`() {
     withProject(apolloConfiguration = """
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent(),
         usesKotlinDsl = false,

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/AndroidProjectTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/AndroidProjectTests.kt
@@ -16,7 +16,11 @@ class AndroidProjectTests {
 
   @Test
   fun `android library compiles`() {
-    withProject(apolloConfiguration = "",
+    withProject(apolloConfiguration = """
+      apollo {
+        filePathAwarePackageNameGenerator()
+      }
+    """.trimIndent(),
         usesKotlinDsl = false,
         plugins = listOf(TestUtils.androidLibraryPlugin, TestUtils.apolloPlugin, TestUtils.kotlinAndroidPlugin)) { dir ->
       val result = TestUtils.executeTask("build", dir)
@@ -24,16 +28,20 @@ class AndroidProjectTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("service/DroidDetailsQuery.kt").isFile)
-      assertTrue(dir.generatedChild("service/FilmsQuery.kt").isFile)
-      assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/FilmsQuery.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
     }
   }
 
 
   @Test
   fun `android application compiles and produces an apk`() {
-    withProject(apolloConfiguration = "",
+    withProject(apolloConfiguration = """
+      apollo {
+        filePathAwarePackageNameGenerator()
+      }
+    """.trimIndent(),
         usesKotlinDsl = false,
         plugins = listOf(TestUtils.androidApplicationPlugin, TestUtils.apolloPlugin, TestUtils.kotlinAndroidPlugin)) { dir ->
       val result = TestUtils.executeTask("build", dir)
@@ -41,9 +49,9 @@ class AndroidProjectTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":build")!!.outcome)
 
       // Java classes generated successfully
-      assertTrue(dir.generatedChild("service/DroidDetailsQuery.kt").isFile)
-      assertTrue(dir.generatedChild("service/FilmsQuery.kt").isFile)
-      assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/FilmsQuery.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
       assertTrue(File(dir, "build/outputs/apk/debug/testProject-debug.apk").isFile)
     }
   }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/KotlinJVMProjectTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/KotlinJVMProjectTests.kt
@@ -26,7 +26,7 @@ class KotlinJVMProjectTests {
   fun `non-android-kotlin builds a jar`() {
     val apolloConfiguration = """
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent()
     TestUtils.withProject(usesKotlinDsl = false,

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/LazyTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/LazyTests.kt
@@ -12,6 +12,7 @@ class LazyTests {
 
     val apolloConfiguration = """
 configure<ApolloExtension> {
+  filePathAwarePackageNameGenerator()
   useSemanticNaming.set(project.provider {
       throw IllegalArgumentException("this should not be called during configuration")
   })
@@ -44,7 +45,7 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
   outputDir.set(project.file("build/toto"))
 }
 configure<ApolloExtension> {
-  println("adding default toto")
+  filePathAwarePackageNameGenerator()
   srcDir(installTask.flatMap { it.outputDir })
 }
 """.trimIndent()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/LazyTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/LazyTests.kt
@@ -12,7 +12,7 @@ class LazyTests {
 
     val apolloConfiguration = """
 configure<ApolloExtension> {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   useSemanticNaming.set(project.provider {
       throw IllegalArgumentException("this should not be called during configuration")
   })
@@ -45,7 +45,7 @@ val installTask = tasks.register("installTask", InstallGraphQLFilesTask::class.j
   outputDir.set(project.file("build/toto"))
 }
 configure<ApolloExtension> {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   srcDir(installTask.flatMap { it.outputDir })
 }
 """.trimIndent()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
@@ -31,7 +31,12 @@ class MultiServicesTests {
 
   @Test
   fun `multiple schema files in different folders throw an error`() {
-    withMultipleServicesProject("") { dir ->
+    val apolloConfiguration = """
+      apollo {
+        filePathAwarePackageNameGenerator()
+      }
+    """.trimIndent()
+    withMultipleServicesProject(apolloConfiguration) { dir ->
       try {
         TestUtils.executeTask("generateApolloSources", dir)
         fail("expected to fail")

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
@@ -33,7 +33,7 @@ class MultiServicesTests {
   fun `multiple schema files in different folders throw an error`() {
     val apolloConfiguration = """
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent()
     withMultipleServicesProject(apolloConfiguration) { dir ->

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
@@ -24,6 +24,7 @@ class OperationIdGeneratorTests {
       
       apollo {
         operationIdGenerator = new MyIdGenerator()
+        filePathAwarePackageNameGenerator()
       }
     """.trimIndent()
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
@@ -24,7 +24,7 @@ class OperationIdGeneratorTests {
       
       apollo {
         operationIdGenerator = new MyIdGenerator()
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent()
 
@@ -56,7 +56,7 @@ class OperationIdGeneratorTests {
       }
       
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         operationIdGenerator = new MyIdGenerator()
       }
     """.trimIndent()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/SchemaResolutionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/SchemaResolutionTests.kt
@@ -21,6 +21,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
+          filePathAwarePackageNameGenerator()
         }
       }
     """.trimIndent()
@@ -50,6 +51,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
+          filePathAwarePackageNameGenerator()
           schemaFile.set(file("src/main/graphql/schema.sdl"))
         }
       }
@@ -78,6 +80,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
+          filePathAwarePackageNameGenerator()
         }
       }
     """.trimIndent()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/SchemaResolutionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/SchemaResolutionTests.kt
@@ -21,7 +21,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
         }
       }
     """.trimIndent()
@@ -51,7 +51,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
           schemaFile.set(file("src/main/graphql/schema.sdl"))
         }
       }
@@ -80,7 +80,7 @@ class SchemaResolutionTests {
     val apolloConfiguration = """
       apollo {
         service("api") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
         }
       }
     """.trimIndent()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
@@ -25,7 +25,7 @@ class ServiceTests {
   fun `customScalarsMapping is working`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         customScalarsMapping = ["DateTime": "java.util.Date"]
       }
     """.trimIndent()) { dir ->
@@ -38,7 +38,7 @@ class ServiceTests {
   fun `registering an unknown custom scalar fails`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         customScalarsMapping = ["UnknownScalar": "java.util.Date"]
       }
     """.trimIndent()) { dir ->
@@ -56,7 +56,7 @@ class ServiceTests {
   fun canConfigureOutputDir() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         outputDir.set(file("build/apollo"))
       }
     """.trimIndent()) { dir ->
@@ -69,7 +69,7 @@ class ServiceTests {
   fun `customScalarsMapping put is working`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         customScalarsMapping.put("DateTime", "java.util.Date")
       }
     """.trimIndent()) { dir ->
@@ -83,10 +83,10 @@ class ServiceTests {
     withSimpleProject("""
       apollo {
         service("other") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
         }
         service("api") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
           customScalarsMapping = ["DateTime": "java.util.Date"]
         }
       }
@@ -100,7 +100,7 @@ class ServiceTests {
   fun `useSemanticNaming defaults to true`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
@@ -112,7 +112,7 @@ class ServiceTests {
   fun `useSemanticNaming can be turned off correctly`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         useSemanticNaming = false
       }
     """.trimIndent()) { dir ->
@@ -174,7 +174,7 @@ class ServiceTests {
     withSimpleProject("""
       apollo {
         service("starwars") {
-          filePathAwarePackageNameGenerator()
+          packageNamesFromFilePaths()
           exclude = ["**/*.gql"]
         }
       }
@@ -244,7 +244,7 @@ class ServiceTests {
   fun `operationOutput generates queries with __typename`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         generateOperationOutput.set(true)
       }
     """.trimIndent()) { dir ->
@@ -264,7 +264,7 @@ class ServiceTests {
   fun `operationOutput uses same id as the query`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         generateOperationOutput.set(true)
       }
     """.trimIndent()) { dir ->
@@ -285,7 +285,7 @@ class ServiceTests {
     withSimpleProject("""
       apollo { 
         generateOperationOutput.set(true)
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         operationOutputConnection {
           tasks.register("customTaskService") {
             inputs.file(operationOutputFile)
@@ -347,7 +347,7 @@ class ServiceTests {
   fun `when generateAsInternal set to true - generated models are internal`() {
     val apolloConfiguration = """
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         generateAsInternal = true
       }
     """.trimIndent()
@@ -386,7 +386,7 @@ class ServiceTests {
   fun `when generateFragmentImplementations set to true, it generates default fragment implementation`() {
     withSimpleProject("""
       apollo {
-        filePathAwarePackageNameGenerator()
+        packageNamesFromFilePaths()
         generateFragmentImplementations = true
       }
     """.trimIndent()) { dir ->

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
@@ -56,11 +56,12 @@ class ServiceTests {
   fun canConfigureOutputDir() {
     withSimpleProject("""
       apollo {
+        filePathAwarePackageNameGenerator()
         outputDir.set(file("build/apollo"))
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      assertTrue(File(dir, "build/apollo/type/Types.kt").exists())
+      assertTrue(File(dir, "build/apollo/com/example/type/Types.kt").exists())
     }
   }
 
@@ -243,6 +244,7 @@ class ServiceTests {
   fun `operationOutput generates queries with __typename`() {
     withSimpleProject("""
       apollo {
+        filePathAwarePackageNameGenerator()
         generateOperationOutput.set(true)
       }
     """.trimIndent()) { dir ->
@@ -283,6 +285,7 @@ class ServiceTests {
     withSimpleProject("""
       apollo { 
         generateOperationOutput.set(true)
+        filePathAwarePackageNameGenerator()
         operationOutputConnection {
           tasks.register("customTaskService") {
             inputs.file(operationOutputFile)
@@ -297,28 +300,27 @@ class ServiceTests {
   }
 
   @Test
-  fun `symlinks are not followed for the schema`() {
+  fun `symlinks are followed for the schema`() {
     withSimpleProject { dir ->
       File(dir, "src/main/graphql/com/example/schema.json").copyTo(File(dir, "schema.json"))
       File(dir, "src/main/graphql/com/example/schema.json").delete()
 
-
-      Files.createSymbolicLink(File(dir, "src/main/graphql/com/example/schema.json").toPath(),
+      Files.createSymbolicLink(
+          File(dir, "src/main/graphql/com/example/schema.json").toPath(),
           File(dir, "schema.json").toPath()
       )
 
       TestUtils.executeTask("generateApolloSources", dir)
 
-      assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
     }
   }
 
   @Test
-  fun `symlinks are not followed for sources`() {
+  fun `symlinks are followed for GraphQL sources`() {
     withSimpleProject { dir ->
       File(dir, "src/main/graphql/com/example").copyRecursively(File(dir, "tmp"))
       File(dir, "src/main/graphql/com/").deleteRecursively()
-
 
       Files.createSymbolicLink(
           File(dir, "src/main/graphql/example").toPath(),
@@ -327,7 +329,7 @@ class ServiceTests {
 
       TestUtils.executeTask("generateApolloSources", dir)
 
-      assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+      assertTrue(dir.generatedChild("service/example/fragment/SpeciesInformation.kt").isFile)
     }
   }
 
@@ -336,7 +338,7 @@ class ServiceTests {
     withTestProject("testSourceSet") { dir ->
       TestUtils.executeTask("build", dir)
 
-      assertTrue(dir.generatedChild("service/GreetingQuery.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/GreetingQuery.kt").isFile)
       assertTrue(File(dir, "build/libs/testProject.jar").isFile)
     }
   }
@@ -384,11 +386,12 @@ class ServiceTests {
   fun `when generateFragmentImplementations set to true, it generates default fragment implementation`() {
     withSimpleProject("""
       apollo {
+        filePathAwarePackageNameGenerator()
         generateFragmentImplementations = true
       }
     """.trimIndent()) { dir ->
       TestUtils.executeTask("generateApolloSources", dir)
-      assertTrue(dir.generatedChild("service/fragment/SpeciesInformationImpl.kt").isFile)
+      assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformationImpl.kt").isFile)
     }
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/UpToDateTests.kt
@@ -30,12 +30,12 @@ class UpToDateTests {
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("service/DroidDetailsQuery.kt").isFile)
-    assertTrue(dir.generatedChild("service/FilmsQuery.kt").isFile)
-    assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/FilmsQuery.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
 
     // verify that the custom type generated was Any because no customScalarsMapping was specified
-    TestUtils.assertFileContains(dir, "service/type/Types.kt", "\"kotlin.Any\"")
+    TestUtils.assertFileContains(dir, "service/com/example/type/Types.kt", "\"kotlin.Any\"")
   }
 
   fun `nothing changed, task up to date`(dir: File) {
@@ -44,9 +44,9 @@ class UpToDateTests {
     assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateApolloSources")!!.outcome)
 
     // Java classes generated successfully
-    assertTrue(dir.generatedChild("service/DroidDetailsQuery.kt").isFile)
-    assertTrue(dir.generatedChild("service/FilmsQuery.kt").isFile)
-    assertTrue(dir.generatedChild("service/fragment/SpeciesInformation.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/FilmsQuery.kt").isFile)
+    assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
   }
 
   fun `adding a custom scalar to the build script re-generates the CustomScalars`(dir: File) {
@@ -65,7 +65,7 @@ class UpToDateTests {
     // and the task should run again
     assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
 
-    TestUtils.assertFileContains(dir, "service/type/Types.kt", "\"java.util.Date\"")
+    TestUtils.assertFileContains(dir, "service/com/example/type/Types.kt", "\"java.util.Date\"")
 
     val text = File(dir, "build.gradle").readText()
     File(dir, "build.gradle").writeText(text.replace(apolloBlock, ""))
@@ -77,14 +77,14 @@ class UpToDateTests {
       var result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("service/DroidDetailsQuery.kt").readText(), containsString("classification"))
+      assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText(), containsString("classification"))
 
       File(dir, "src/main/graphql/com/example/DroidDetails.graphql").replaceInText("classification", "")
 
       result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("service/DroidDetailsQuery.kt").readText(), not(containsString("classification")))
+      assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText(), not(containsString("classification")))
     }
   }
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -49,7 +49,6 @@ object TestUtils {
     File(source, "gradle/settings.gradle").copyTo(target = File(dest, "settings.gradle"))
 
     val isAndroid = plugins.firstOrNull { it.id.startsWith("com.android") } != null
-    val hasKotlin = plugins.firstOrNull { it.id.startsWith("org.jetbrains.kotlin") } != null
 
     if (usesKotlinDsl) {
       val applyLines = plugins.map { "apply(plugin = \"${it.id}\")" }.joinToString("\n")
@@ -144,7 +143,11 @@ object TestUtils {
   /**
    * creates a simple java non-android non-kotlin-gradle project
    */
-  fun withSimpleProject(apolloConfiguration: String = "", block: (File) -> Unit) = withProject(
+  fun withSimpleProject(apolloConfiguration: String = """
+    apollo {
+      filePathAwarePackageNameGenerator()
+    }
+  """.trimIndent(), block: (File) -> Unit) = withProject(
       usesKotlinDsl = false,
       plugins = listOf(kotlinJvmPlugin, apolloPlugin),
       apolloConfiguration = apolloConfiguration

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -145,7 +145,7 @@ object TestUtils {
    */
   fun withSimpleProject(apolloConfiguration: String = """
     apollo {
-      filePathAwarePackageNameGenerator()
+      packageNamesFromFilePaths()
     }
   """.trimIndent(), block: (File) -> Unit) = withProject(
       usesKotlinDsl = false,

--- a/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
@@ -2,34 +2,12 @@ import com.apollographql.apollo3.gradle.api.ApolloExtension
 import com.android.build.gradle.BaseExtension
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
 
 apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.android")
 apply(plugin = "com.apollographql.apollo3")
-
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  google()
-  mavenCentral()
-}
 
 dependencies {
   add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))

--- a/apollo-gradle-plugin/testProjects/androidVariants/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/androidVariants/build.gradle.kts
@@ -2,34 +2,12 @@ import com.apollographql.apollo3.gradle.api.ApolloExtension
 import com.android.build.gradle.BaseExtension
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
 
 apply(plugin = "com.android.library")
 apply(plugin = "org.jetbrains.kotlin.android")
 apply(plugin = "com.apollographql.apollo3")
-
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  google()
-  mavenCentral()
-}
 
 dependencies {
   add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))

--- a/apollo-gradle-plugin/testProjects/buildCache/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildCache/build.gradle.kts
@@ -1,4 +1,8 @@
 buildscript {
+    /**
+     * This doesn't use buildscript.gradle.kts as it's copied with different
+     * directory layouts to ensure the build cache works as expected
+     */
     apply(from = "../../../../gradle/dependencies.gradle")
 
     repositories {
@@ -12,4 +16,3 @@ buildscript {
         classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
     }
 }
-

--- a/apollo-gradle-plugin/testProjects/buildCache/module/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildCache/module/build.gradle.kts
@@ -2,3 +2,7 @@ plugins {
   kotlin("jvm")
   id("com.apollographql.apollo3")
 }
+
+apollo {
+  packageName.set("com.example")
+}

--- a/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
@@ -1,0 +1,26 @@
+apply(from = "../../../gradle/dependencies.gradle")
+
+project.buildscript.repositories {
+  maven {
+    url = uri("../../../build/localMaven")
+  }
+  mavenCentral()
+  google()
+}
+
+project.buildscript.dependencies.apply {
+  add("classpath", groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
+  add("classpath", groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
+  add("classpath", groovy.util.Eval.x(project, "x.dep.android.plugin"))
+}
+
+allprojects {
+  repositories {
+    maven {
+      // Some projects are in submoodules, use the
+      url = uri(File(project.rootDir, "../../../build/localMaven").absolutePath)
+    }
+    google()
+    mavenCentral()
+  }
+}

--- a/apollo-gradle-plugin/testProjects/convertSchema/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/convertSchema/build.gradle.kts
@@ -1,25 +1,7 @@
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  mavenCentral()
-}

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
@@ -25,4 +25,8 @@ repositories {
   }
 }
 
+configure<ApolloExtension> {
+  packageName.set("com.example")
+}
+
 

--- a/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/deprecationWarnings/build.gradle.kts
@@ -1,32 +1,12 @@
 import com.apollographql.apollo3.gradle.api.ApolloExtension
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    mavenCentral()
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
-repositories {
-  mavenCentral()
-  maven {
-    url = uri("../../../../build/localMaven")
-  }
-}
-
 configure<ApolloExtension> {
   packageName.set("com.example")
 }
-
-

--- a/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
@@ -7,7 +7,6 @@ buildscript {
     maven {
       url = uri("../../../build/localMaven")
     }
-    google()
     mavenCentral()
   }
   dependencies {
@@ -17,7 +16,6 @@ buildscript {
   }
 }
 
-
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
@@ -25,7 +23,6 @@ repositories {
   maven {
     url = uri("../../../build/localMaven")
   }
-  google()
   mavenCentral()
 }
 

--- a/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
@@ -33,3 +33,7 @@ dependencies {
   add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
 }
 
+configure<ApolloExtension> {
+  packageName.set("com.example")
+}
+

--- a/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
@@ -1,32 +1,11 @@
 import com.apollographql.apollo3.gradle.api.ApolloExtension
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
 
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
-
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  google()
-  mavenCentral()
-}
 
 dependencies {
   add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))

--- a/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
 configure<ApolloExtension> {
   createAllKotlinSourceSetServices(".", "example") {
-    filePathAwarePackageNameGenerator()
+    packageNamesFromFilePaths()
     schemaFile.set(file("src/main/graphql/com/example/schema.sdl"))
   }
 }

--- a/apollo-gradle-plugin/testProjects/mismatchedVersions/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/mismatchedVersions/build.gradle.kts
@@ -1,21 +1,3 @@
-
 buildscript {
-    apply(from = "../../../gradle/dependencies.gradle")
-
-    repositories {
-        mavenCentral()
-        maven {
-            url = uri("../../../build/localMaven")
-        }
-    }
-    dependencies {
-        classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-        classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    }
-}
-
-subprojects {
-    repositories {
-        mavenCentral()
-    }
+    apply(from = "../../testProjects/buildscript.gradle.kts")
 }

--- a/apollo-gradle-plugin/testProjects/mismatchedVersions/module/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/mismatchedVersions/module/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
 }
 
 configure<ApolloExtension> {
-    filePathAwarePackageNameGenerator()
+    packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/mismatchedVersions/module/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/mismatchedVersions/module/build.gradle.kts
@@ -1,6 +1,12 @@
+import com.apollographql.apollo3.gradle.api.ApolloExtension
+
 apply(plugin = "kotlin")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
     add("implementation","com.apollographql.apollo3:apollo-runtime:1.4.5")
+}
+
+configure<ApolloExtension> {
+    filePathAwarePackageNameGenerator()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/build.gradle.kts
@@ -1,26 +1,3 @@
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
-
-subprojects {
-  repositories {
-    mavenCentral()
-    maven {
-      url = uri("../../../../build/localMaven")
-    }
-  }
-}
-
-

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/leaf/build.gradle.kts
@@ -21,5 +21,5 @@ application {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/node1/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/node1/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/node2/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/node2/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/root/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
   customScalarsMapping.set(mapOf("Date" to "java.util.Date"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/build.gradle.kts
@@ -1,26 +1,5 @@
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
-}
-
-
-subprojects {
-  repositories {
-    mavenCentral()
-    maven {
-      url = uri("../../../../build/localMaven")
-    }
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
   customScalarsMapping.set(mapOf("Date" to "java.util.Date"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/build.gradle.kts
@@ -1,25 +1,4 @@
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
-subprojects {
-  repositories {
-    mavenCentral()
-    maven {
-      url = uri("../../../../build/localMaven")
-    }
-  }
-}
-
 

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
@@ -19,5 +19,5 @@ application {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
@@ -11,6 +11,6 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
   customScalarsMapping.set(mapOf("Date" to "java.util.Date"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/build.gradle.kts
@@ -1,25 +1,3 @@
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
-
-subprojects {
-  repositories {
-    mavenCentral()
-    maven {
-      url = uri("../../../../build/localMaven")
-    }
-  }
-}
-
-

--- a/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
@@ -18,5 +18,5 @@ application {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 apollo {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   generateApolloMetadata.set(true)
   customScalarsMapping.set(mapOf("Date" to "java.util.Date"))
 }

--- a/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
@@ -33,5 +33,5 @@ configure<KotlinMultiplatformExtension> {
 }
 
 configure<ApolloExtension> {
-    filePathAwarePackageNameGenerator()
+    packageNamesFromFilePaths()
 }

--- a/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.apollographql.apollo3.gradle.api.ApolloExtension
 
 buildscript {
     apply(from = "../../../gradle/dependencies.gradle")
@@ -40,4 +41,8 @@ configure<KotlinMultiplatformExtension> {
             }
         }
     }
+}
+
+configure<ApolloExtension> {
+    filePathAwarePackageNameGenerator()
 }

--- a/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
@@ -3,18 +3,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.apollographql.apollo3.gradle.api.ApolloExtension
 
 buildscript {
-    apply(from = "../../../gradle/dependencies.gradle")
-
-    repositories {
-        maven {
-            url = uri("../../../build/localMaven")
-        }
-        mavenCentral()
-    }
-    dependencies {
-        classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-        classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-    }
+    apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 apply(plugin = "org.jetbrains.kotlin.multiplatform")

--- a/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
@@ -21,6 +21,6 @@ configure<ApolloExtension> {
     override val version = "OperationOutputGenerator-v1"
   }
 
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   operationOutputGenerator.set(customOperationOutputGenerator)
 }

--- a/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/operationIds/build.gradle.kts
@@ -4,29 +4,11 @@ import com.apollographql.apollo3.compiler.operationoutput.OperationDescriptor
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
-
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  mavenCentral()
-}
 
 configure<ApolloExtension> {
   val customOperationOutputGenerator = object: OperationOutputGenerator {

--- a/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
 }
 
 configure<ApolloExtension> {
+  filePathAwarePackageNameGenerator()
   outputDirConnection {
     connectToKotlinSourceSet("test")
   }

--- a/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
@@ -1,32 +1,11 @@
 import com.apollographql.apollo3.gradle.api.ApolloExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
-  apply(from = "../../../gradle/dependencies.gradle")
-
-  repositories {
-    maven {
-      url = uri("../../../build/localMaven")
-    }
-    google()
-    mavenCentral()
-  }
-  dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.kotlin.plugin"))
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-  }
+  apply(from = "../../testProjects/buildscript.gradle.kts")
 }
 
 apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
-
-repositories {
-  maven {
-    url = uri("../../../build/localMaven")
-  }
-  mavenCentral()
-}
 
 dependencies {
   add("testImplementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))

--- a/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 }
 
 configure<ApolloExtension> {
-  filePathAwarePackageNameGenerator()
+  packageNamesFromFilePaths()
   outputDirConnection {
     connectToKotlinSourceSet("test")
   }

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -140,7 +140,7 @@ If you need different package names for different operation folders, you can fal
 
 ```kotlin
 apollo {
-  filePathAwarePackageNameGenerator("$rootPackageName")
+  packageNamesFromFilePaths("$rootPackageName")
 }
 ```
 

--- a/tests/idling-resource/build.gradle.kts
+++ b/tests/idling-resource/build.gradle.kts
@@ -20,3 +20,7 @@ android {
     targetSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.targetSdkVersion").toString().toInt())
   }
 }
+
+apollo {
+  packageName.set("idling.resource")
+}

--- a/tests/idling-resource/src/test/java/IdlingResourceTest.kt
+++ b/tests/idling-resource/src/test/java/IdlingResourceTest.kt
@@ -3,6 +3,7 @@ import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.android.ApolloIdlingResource
 import com.apollographql.apollo3.android.withIdlingResource
+import idling.resource.IdlingResourceQuery
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher


### PR DESCRIPTION
See https://github.com/apollographql/apollo-android/issues/3292

kapt (and most likely other tools too) doesn't like classes in the root package name. Make `packageName` mandatory