### PR TITLE
Remove root redirect and build deploy previews at /

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -1,5 +1,3 @@
-/ /docs/android
-
 /docs/android/advanced/file-upload/ /docs/android/essentials/mutations/#uploading-files
 
 /docs/android/essentials/caching/ /docs/android/essentials/normalized-cache

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,5 @@
   command = "./generate-docs.sh"
 [build.environment]
   NPM_VERSION = "6"
+[context.deploy-preview]
+  command = "gatsby build"


### PR DESCRIPTION
This branch removes the root-level redirect in the docs and forces deploy previews to be deployed at the root to account for this change.