### PR TITLE
Deploy the prod site at the root

### DIFF
--- a/docs/generate-docs.sh
+++ b/docs/generate-docs.sh
@@ -5,8 +5,4 @@ set -e
 
 echo -e "---\ntitle: Introduction\ndescription: A strongly-typed, caching GraphQL client for the JVM, Android and Kotlin multiplatform\n---\n\n$(cat ../README.md | grep -v 'the official docs')" > source/index.md
 
-gatsby build --prefix-paths
-mkdir -p docs/android
-mv public/* docs/android
-mv docs public/
-mv public/docs/android/_redirects public
+gatsby build

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,10 @@
 [build]
-  base    = "docs/"
-  publish = "docs/public/"
+  base    = "docs"
+  publish = "docs/public"
   command = "./generate-docs.sh"
 [build.environment]
   NPM_VERSION = "6"
-[context.deploy-preview]
-  command = "gatsby build"
+[context.production.environment]
+  PREFIX_PATHS = "true"
+[context.branch-deploy.environment]
+  PREFIX_PATHS = "true"


### PR DESCRIPTION
This branch changes our prod deploy to no longer put its built files in a nested directory structure. This was inspired by https://github.com/apollographql/federation/pull/964#pullrequestreview-732605899 and follows the same patterns already tested and deployed in the Community docs (more info here: https://github.com/apollographql/federation/pull/964#issuecomment-901306430) as well as the docs homepage and Studio docs.

After merging, we'll need to update the website router to reflect this change of location of the built files, but this change will uncomplicate our prod build command considerably.