### PR TITLE
Expose NSError

### DIFF
--- a/apollo-api/src/appleMain/kotlin/com.apollographql.apollo3.exception/NSError.kt
+++ b/apollo-api/src/appleMain/kotlin/com.apollographql.apollo3.exception/NSError.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.exception
+
+import platform.Foundation.NSError
+
+val ApolloNetworkException.nsError
+  get() = platformCause as? NSError

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -1,4 +1,4 @@
-// This is in the exception package for historical reasons
+// This is in the `exception` package and not `api.exception` to keep some compatibility with 2.x
 package com.apollographql.apollo3.exception
 
 import com.apollographql.apollo3.api.http.HttpHeader
@@ -10,8 +10,17 @@ open class ApolloException(message: String? = null, cause: Throwable? = null) : 
 
 /**
  * A network error happened: socket closed, DNS issue, TLS problem, etc...
+ *
+ * @param message a message indicating what the error was.
+ * @param platformCause the underlying cause. Might be null. When not null, it can be cast to:
+ * - a [Throwable] on JVM platforms.
+ * - a [NSError] on Darwin platforms.
+ * to get more details about what went wrong.
  */
-class ApolloNetworkException(message: String? = null, cause: Throwable? = null) : ApolloException(message = message, cause = cause)
+class ApolloNetworkException(
+    message: String? = null,
+    val platformCause: Any? = null
+) : ApolloException(message = message, cause = platformCause as? Throwable)
 
 /**
  * A WebSocket connection could not be established: e.g., expired token

--- a/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHTTPEngine.kt
+++ b/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHTTPEngine.kt
@@ -126,7 +126,7 @@ private fun buildHttpResponse(
     return Result.failure(
         ApolloNetworkException(
             message = "Failed to execute GraphQL http network request",
-            cause = IOException(error.localizedDescription)
+            platformCause = error.freeze()
         )
     )
   }

--- a/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
+++ b/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
@@ -194,7 +194,7 @@ private fun NSError.dispatch(webSocketConnectionPtr: COpaquePointer) {
   webSocketConnection.messageChannel.close(
       ApolloNetworkException(
           message = "Web socket communication error",
-          cause = IOException(localizedDescription)
+          platformCause = this
       )
   )
   webSocketConnection.webSocket.cancel()

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.network.http
 
-import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.api.http.HttpMethod
@@ -79,7 +78,7 @@ actual class DefaultHttpEngine(
       continuation.resumeWithException(
           ApolloNetworkException(
               message = "Failed to execute GraphQL http network request",
-              cause = networkResult.exceptionOrNull()!!
+              platformCause = networkResult.exceptionOrNull()!!
           )
       )
       return@suspendCancellableCoroutine

--- a/tests/integration-tests/src/appleTest/kotlin/test/HttpEngineTest.kt
+++ b/tests/integration-tests/src/appleTest/kotlin/test/HttpEngineTest.kt
@@ -1,0 +1,36 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.testing.runWithMainLoop
+import platform.Foundation.NSError
+import platform.Foundation.NSURLErrorCannotFindHost
+import platform.Foundation.NSURLErrorDomain
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class HttpEngineTest {
+  @Test
+  fun canReadNSError() = runWithMainLoop {
+    val apolloClient = ApolloClient("https://inexistent.host/graphql")
+
+    val result = kotlin.runCatching {
+      apolloClient.query(HeroNameQuery())
+    }
+
+    val apolloNetworkException = result.exceptionOrNull()
+    assertNotNull(apolloNetworkException)
+    assertIs<ApolloNetworkException>(apolloNetworkException)
+
+    val cause = apolloNetworkException.platformCause
+    // assertIs doesn't work with Obj-C classes so we rely on `check` instead
+    // assertIs<NSError>(cause)
+    check(cause is NSError)
+
+    assertEquals(NSURLErrorCannotFindHost, cause.code)
+    assertEquals(NSURLErrorDomain, cause.domain)
+  }
+}

--- a/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
@@ -1,6 +1,7 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery

--- a/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -90,6 +90,7 @@ class ParseResponseBodyTest {
     assertEquals(response.errors!![0].extensions?.get("code"), 500)
     assertEquals(response.errors!![0].extensions?.get("status"), "Internal Error")
     assertEquals(response.errors!![0].extensions?.get("fatal"), true)
+    @Suppress("UNCHECKED_CAST")
     val listOfValues = response.errors!![0].extensions?.get("listOfValues") as List<Any>
     assertEquals(listOfValues[0], 0)
     assertEquals(listOfValues[1], "a")


### PR DESCRIPTION
Expose the platform error in `ApolloNetworkError`:

```kotlin
    try {
      apolloClient.query(HeroNameQuery())
    } catch (e: ApolloNetworkException) {
      when((e.platformCause as? NSError)?.code) {
        NSURLErrorCannotFindHost -> handleCannotFindHost()
        NSURLErrorNetworkUnavailableReason -> handleNetworkUnavailable()
        else -> // fallback
      }
    }
```

Closes #3307 