### PR TITLE
Remove most of runCatching

### DIFF
--- a/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
+++ b/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
@@ -9,6 +9,7 @@ import kotlinx.cinterop.convert
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.nativeHeap
+import okio.IOException
 import okio.buffer
 import platform.Foundation.NSMutableArray
 import platform.posix.POLLIN
@@ -70,6 +71,7 @@ class Socket(private val socketFd: Int) {
         }
 
         handleConnection(connectionFd)
+        close(connectionFd)
       }
     }
     close(socketFd)
@@ -98,7 +100,12 @@ class Socket(private val socketFd: Int) {
 
         debug("'$connectionFd': Read request")
 
-        val request = readRequest(source)
+        val request = try {
+          readRequest(source)
+        } catch (e: IOException) {
+          debug("'$connectionFd': Connection error")
+          return
+        }
         if (request == null) {
           debug("'$connectionFd': Connection closed")
           return

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -27,6 +27,7 @@ import com.apollographql.apollo3.cache.normalized.withCacheInfo
 import com.apollographql.apollo3.cache.normalized.withDoNotStore
 import com.apollographql.apollo3.cache.normalized.writeToCacheAsynchronously
 import com.apollographql.apollo3.exception.ApolloCompositeException
+import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
@@ -158,18 +159,18 @@ internal class ApolloCacheInterceptor(
     val refetchPolicy = request.refetchPolicy
     val customScalarAdapters = request.customScalarAdapters
     return flow {
-      var result = kotlin.runCatching {
-        fetchOneMightThrow(request, chain, fetchPolicy, customScalarAdapters)
-      }
-      val response = result.getOrNull()
-
-      if (response != null) {
+      var exception: ApolloException? = null
+      var response: ApolloResponse<D>? = null
+      try {
+        response = fetchOneMightThrow(request, chain, fetchPolicy, customScalarAdapters)
         emit(response)
+      } catch (e: ApolloException) {
+        exception = e
       }
 
       if (!request.watch) {
-        if (result.isFailure) {
-          throw result.exceptionOrNull()!!
+        if (exception != null) {
+          throw exception
         }
         return@flow
       }
@@ -182,22 +183,20 @@ internal class ApolloCacheInterceptor(
 
       store.changedKeys.collect { changedKeys ->
         if (watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()) {
-          result = kotlin.runCatching {
-            fetchOneMightThrow(
+          try {
+            val newResponse = fetchOneMightThrow(
                 request,
                 chain,
                 refetchPolicy,
                 customScalarAdapters
             )
-          }
-
-          val newResponse = result.getOrNull()
-          if (newResponse != null) {
             emit(newResponse)
 
             if (!newResponse.hasErrors() && newResponse.data != null) {
               watchedKeys = store.normalize(request.operation, newResponse.data!!, customScalarAdapters).values.dependentKeys()
             }
+          } catch (e: ApolloException) {
+
           }
         }
       }
@@ -218,28 +217,25 @@ internal class ApolloCacheInterceptor(
           return cacheResult.response.withCacheInfo(cacheResult.cacheInfo)
         }
 
-        val networkResult = kotlin.runCatching {
-          readOneFromNetwork(request, chain, customScalarAdapters)
-        }
-
-        val networkResponse = networkResult.getOrNull()
-        if (networkResponse != null) {
-          return networkResponse.withCacheInfo(cacheResult.cacheInfo)
+        var networkException: ApolloException? = null
+        try {
+          return readOneFromNetwork(request, chain, customScalarAdapters)
+              .withCacheInfo(cacheResult.cacheInfo)
+        } catch (e: ApolloException) {
+          networkException = e
         }
 
         throw ApolloCompositeException(
             cacheResult.error,
-            networkResult.exceptionOrNull()
+            networkException
         )
       }
       FetchPolicy.NetworkFirst -> {
-        val networkResult = kotlin.runCatching {
-          readOneFromNetwork(request, chain, customScalarAdapters)
-        }
-
-        val networkResponse = networkResult.getOrNull()
-        if (networkResponse != null) {
-          return networkResponse
+        var networkException: ApolloException? = null
+        try {
+          return readOneFromNetwork(request, chain, customScalarAdapters)
+        } catch (e: ApolloException) {
+          networkException = e
         }
 
         val cacheResult = readFromCache(request, customScalarAdapters)
@@ -248,7 +244,7 @@ internal class ApolloCacheInterceptor(
         }
 
         throw ApolloCompositeException(
-            networkResult.exceptionOrNull(),
+            networkException,
             cacheResult.error,
         )
       }
@@ -278,26 +274,30 @@ internal class ApolloCacheInterceptor(
     val operation = request.operation
     val millisStart = currentTimeMillis()
 
-    val result = kotlin.runCatching {
+    var exception: ApolloException? = null
+    val data = try {
       store.readOperation(
           operation = operation,
           customScalarAdapters = customScalarAdapters,
           cacheHeaders = request.cacheHeaders
       )
+    } catch (e: ApolloException) {
+      exception = e
+      null
     }
 
-    val response = if (result.isSuccess) {
+    val response = if (data != null) {
       ApolloResponse(
           requestUuid = request.requestUuid,
           operation = operation,
-          data = result.getOrThrow(),
+          data = data,
           executionContext = request.executionContext
       )
     } else {
       null
     }
 
-    val cacheMissException = result.exceptionOrNull() as? CacheMissException
+    val cacheMissException = exception as? CacheMissException
 
     return CacheResult(
         response = response,
@@ -308,7 +308,7 @@ internal class ApolloCacheInterceptor(
             missedKey = cacheMissException?.key,
             missedField = cacheMissException?.fieldName
         ),
-        error = result.exceptionOrNull()
+        error = exception
     )
   }
 

--- a/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHTTPEngine.kt
+++ b/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHTTPEngine.kt
@@ -1,22 +1,19 @@
 package com.apollographql.apollo3.network.http
 
-import com.apollographql.apollo3.exception.ApolloHttpException
-import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
-import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpResponse
+import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.mpp.assertMainThreadOnNative
 import com.apollographql.apollo3.mpp.suspendAndResumeOnMain
 import com.apollographql.apollo3.network.toNSData
 import okio.Buffer
-import okio.IOException
 import okio.toByteString
 import platform.Foundation.NSData
 import platform.Foundation.NSError
 import platform.Foundation.NSHTTPURLResponse
 import platform.Foundation.NSMutableURLRequest
-import platform.Foundation.NSThread
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLRequest
 import platform.Foundation.NSURLRequestReloadIgnoringCacheData

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -145,7 +145,8 @@ class BatchingHttpEngine(
     )
     freeze(request)
 
-    val result = kotlin.runCatching {
+    var exception: ApolloException? = null
+    val result = try {
       val response = delegate.execute(request)
       if (response.statusCode !in 200..299) {
         throw ApolloHttpException(response.statusCode, response.headers, "HTTP error ${response.statusCode} while executing batched query: '${response.body?.readUtf8()}'")
@@ -168,26 +169,28 @@ class BatchingHttpEngine(
           AnyAdapter.toJson(this, it)
         }
       }
+    } catch (e: ApolloException) {
+      exception = e
+      null
     }
 
-    val failure = result.exceptionOrNull()
-    if (failure != null) {
+    if (exception != null) {
       pending.forEach {
-        it.deferred.completeExceptionally(failure)
+        it.deferred.completeExceptionally(exception)
       }
       return
-    }
-
-    result.getOrThrow().forEachIndexed { index, byteString ->
-      // This works because the server must return the responses in order
-      pending[index].deferred.complete(
-          HttpResponse(
-              statusCode = 200,
-              headers = emptyList(),
-              bodyString = byteString,
-              bodySource = null
-          )
-      )
+    } else {
+      result!!.forEachIndexed { index, byteString ->
+        // This works because the server must return the responses in order
+        pending[index].deferred.complete(
+            HttpResponse(
+                statusCode = 200,
+                headers = emptyList(),
+                bodyString = byteString,
+                bodySource = null
+            )
+        )
+      }
     }
   }
 
@@ -201,6 +204,6 @@ class BatchingHttpEngine(
   }
 }
 
-fun <T> ExecutionParameters<T>.withCanBeBatched(canBeBatched: Boolean) where T: ExecutionParameters<T> = withHttpHeader(
+fun <T> ExecutionParameters<T>.withCanBeBatched(canBeBatched: Boolean) where T : ExecutionParameters<T> = withHttpHeader(
     CAN_BE_BATCHED, canBeBatched.toString()
 )

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
@@ -2,8 +2,7 @@ package com.apollographql.apollo3.network.http
 
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.exception.ApolloException
-import com.apollographql.apollo3.exception.ApolloParseException
+import com.apollographql.apollo3.exception.ApolloNetworkException
 
 /**
  * A wrapper around platform specific engines
@@ -11,7 +10,7 @@ import com.apollographql.apollo3.exception.ApolloParseException
 interface HttpEngine {
 
   /**
-   * Executes the given HttpRequest, might throw
+   * Executes the given HttpRequest, might throw [ApolloNetworkException]
    */
   suspend fun execute(request: HttpRequest): HttpResponse
 

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
+import com.apollographql.apollo3.exception.ApolloException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Headers
@@ -13,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okio.BufferedSink
+import okio.IOException
 import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -70,35 +72,37 @@ actual class DefaultHttpEngine(
       call.cancel()
     }
 
-    val networkResult = kotlin.runCatching {
+    var exception: IOException? = null
+    val response = try {
       call.execute()
+    } catch (e: IOException) {
+      exception = e
+      null
     }
 
-    if (networkResult.isFailure) {
+    if (exception != null) {
       continuation.resumeWithException(
           ApolloNetworkException(
               message = "Failed to execute GraphQL http network request",
-              platformCause = networkResult.exceptionOrNull()!!
+              platformCause = exception
           )
       )
       return@suspendCancellableCoroutine
+    } else {
+      val result = Result.success(
+          HttpResponse(
+              statusCode = response!!.code(),
+              headers = response.headers().let { headers ->
+                0.until(headers.size()).map { index ->
+                  HttpHeader(headers.name(index), headers.value(index))
+                }
+              },
+              bodySource = response.body()!!.source(),
+              bodyString = null
+          )
+      )
+      continuation.resume(result.getOrThrow())
     }
-
-    val response = networkResult.getOrThrow()
-
-    val result = Result.success(
-        HttpResponse(
-            statusCode = response.code(),
-            headers = response.headers().let { headers ->
-              0.until(headers.size()).map { index ->
-                HttpHeader(headers.name(index), headers.value(index))
-              }
-            },
-            bodySource = response.body()!!.source(),
-            bodyString = null
-        )
-    )
-    continuation.resume(result.getOrThrow())
   }
 
   override fun dispose() {


### PR DESCRIPTION
`runCatching {}` silently caught the `CancellationExceptions` that are required by structured concurrency. See https://github.com/Kotlin/kotlinx.coroutines/issues/1814