### PR TITLE
Add Long support to JsonReader and JsonWriter

### DIFF
--- a/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/LongAdapter.kt
+++ b/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/LongAdapter.kt
@@ -5,18 +5,3 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 
-/**
- * An [Adapter] that converts a Json number to/from a Java [Long]
- *
- * If the Json number does not fit in a [Long], an exception will be thrown
- *
- */
-object LongAdapter: Adapter<Long>  {
-  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): Long {
-    return reader.nextString()!!.toLong()
-  }
-
-  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: Long) {
-    writer.value(value.toString())
-  }
-}

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/DefaultAdapters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/DefaultAdapters.kt
@@ -108,6 +108,21 @@ object DoubleAdapter : Adapter<Double> {
   }
 }
 
+/**
+ * An [Adapter] that converts to/from a [Long]
+ *
+ * If the Json number does not fit in a [Long], an exception will be thrown
+ */
+object LongAdapter: Adapter<Long>  {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): Long {
+    return reader.nextLong()
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: Long) {
+    writer.value(value)
+  }
+}
+
 object BooleanAdapter : Adapter<Boolean> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): Boolean {
     return reader.nextBoolean()
@@ -175,7 +190,7 @@ class ObjectAdapter<T>(
       /**
        * And write to the original writer
        */
-      AnyAdapter.toJson(writer, mapWriter.root()!!)
+      Utils.writeToJson(mapWriter.root()!!, writer)
     } else {
       writer.beginObject()
       wrappedAdapter.toJson(writer, customScalarAdapters, value)
@@ -207,3 +222,4 @@ val NullableBooleanAdapter = BooleanAdapter.nullable()
 @SharedImmutable
 @JvmField
 val NullableAnyAdapter = AnyAdapter.nullable()
+

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executable.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executable.kt
@@ -42,13 +42,13 @@ interface Executable<D: Executable.Data> {
 }
 
 @Suppress("UNCHECKED_CAST")
-fun <D : Executable.Data> Executable<D>.variables(customScalarAdapters: CustomScalarAdapters): Executable.Variables {
+fun <D : Executable.Data> Executable<D>.variables(customScalarAdapters: CustomScalarAdapters): Variables {
   val valueMap = MapJsonWriter().apply {
     beginObject()
     serializeVariables(this, customScalarAdapters)
     endObject()
   }.root() as Map<String, Any?>
-  return Executable.Variables(valueMap)
+  return Variables(valueMap)
 }
 
 fun <D : Executable.Data> Executable<D>.variablesJson(customScalarAdapters: CustomScalarAdapters): String {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Upload
 import com.apollographql.apollo3.api.internal.json.FileUploadAwareJsonWriter
+import com.apollographql.apollo3.api.internal.json.Utils
 import com.apollographql.apollo3.api.internal.json.buildJsonByteString
 import com.apollographql.apollo3.api.internal.json.buildJsonMap
 import com.apollographql.apollo3.api.internal.json.buildJsonString
@@ -257,9 +258,9 @@ class DefaultHttpRequestComposer(
     }
 
     private fun buildUploadMap(uploads: Map<String, Upload>) = buildJsonByteString {
-      AnyAdapter.toJson(this, CustomScalarAdapters.Empty, uploads.entries.mapIndexed { index, entry ->
+      Utils.writeToJson(uploads.entries.mapIndexed { index, entry ->
         index.toString() to listOf(entry.key)
-      }.toMap())
+      }.toMap(), this)
     }
 
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/BufferedSinkJsonWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/BufferedSinkJsonWriter.kt
@@ -18,6 +18,7 @@ package com.apollographql.apollo3.api.internal.json
 import com.apollographql.apollo3.api.Throws
 import com.apollographql.apollo3.api.Upload
 import com.apollographql.apollo3.api.internal.json.BufferedSourceJsonReader.Companion.MAX_STACK_SIZE
+import com.apollographql.apollo3.api.json.JsonNumber
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.exception.JsonDataException
 import okio.BufferedSink
@@ -152,47 +153,25 @@ class BufferedSinkJsonWriter(private val sink: BufferedSink) : JsonWriter {
   }
 
   @Throws(IOException::class)
-  override fun nullValue(): JsonWriter {
-    if (deferredName != null) {
-      writeDeferredName()
-    }
-    beforeValue()
-    sink.writeUtf8("null")
-    pathIndices[stackSize - 1]++
-    return this
-  }
+  override fun nullValue() = jsonValue("null")
 
   @Throws(IOException::class)
-  override fun value(value: Boolean): JsonWriter {
-    return run {
-      writeDeferredName()
-      beforeValue()
-      sink.writeUtf8(if (value) "true" else "false")
-      pathIndices[stackSize - 1]++
-      this
-    }
-  }
+  override fun value(value: Boolean) = jsonValue(if (value) "true" else "false")
 
   @Throws(IOException::class)
   override fun value(value: Double): JsonWriter {
     require(!(!isLenient && (value.isNaN() || value.isInfinite()))) {
       "Numeric values must be finite, but was $value"
     }
-    writeDeferredName()
-    beforeValue()
-    sink.writeUtf8(value.toString())
-    pathIndices[stackSize - 1]++
-    return this
+    return jsonValue(value.toString())
   }
 
   @Throws(IOException::class)
-  override fun value(value: Int): JsonWriter {
-    writeDeferredName()
-    beforeValue()
-    sink.writeUtf8(value.toString())
-    pathIndices[stackSize - 1]++
-    return this
-  }
+  override fun value(value: Int) = jsonValue(value.toString())
+
+  override fun value(value: Long) = jsonValue(value.toString())
+
+  override fun value(value: JsonNumber) = jsonValue(value.toString())
 
   override fun value(value: Upload) = apply {
     nullValue()

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/BufferedSourceJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/BufferedSourceJsonReader.kt
@@ -16,7 +16,9 @@
 package com.apollographql.apollo3.api.internal.json
 
 import com.apollographql.apollo3.api.Throws
+import com.apollographql.apollo3.api.json.JsonNumber
 import com.apollographql.apollo3.api.json.JsonReader
+import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.exception.JsonDataException
 import com.apollographql.apollo3.exception.JsonEncodingException
 import okio.Buffer
@@ -67,8 +69,6 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
   private val pathIndices = IntArray(MAX_STACK_SIZE)
 
   private var lenient = false
-
-  private var failOnUnknown = false
 
   private val indexStack = IntArray(MAX_STACK_SIZE).apply {
     this[0] = 0
@@ -509,7 +509,7 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
   }
 
   @Throws(IOException::class)
-  override fun <T> nextNull(): T? {
+  override fun nextNull(): Nothing? {
     return when (peeked.takeUnless { it == PEEKED_NONE } ?: doPeek()) {
       PEEKED_NULL -> {
         peeked = PEEKED_NONE
@@ -561,6 +561,54 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
     peeked = PEEKED_NONE
     pathIndices[stackSize - 1]++
     return result
+  }
+
+  @Throws(IOException::class)
+  override fun nextLong(): Long {
+    val p = peeked.takeUnless { it == PEEKED_NONE } ?: doPeek()
+    when {
+      p == PEEKED_LONG -> {
+        peeked = PEEKED_NONE
+        pathIndices[stackSize - 1]++
+        return peekedLong
+      }
+      p == PEEKED_NUMBER -> {
+        peekedString = buffer.readUtf8(peekedNumberLength.toLong())
+      }
+      p == PEEKED_DOUBLE_QUOTED || p == PEEKED_SINGLE_QUOTED -> {
+        peekedString = if (p == PEEKED_DOUBLE_QUOTED) nextQuotedValue(DOUBLE_QUOTE_OR_SLASH) else nextQuotedValue(SINGLE_QUOTE_OR_SLASH)
+        try {
+          val result = peekedString!!.toLong()
+          peeked = PEEKED_NONE
+          pathIndices[stackSize - 1]++
+          return result
+        } catch (ignored: NumberFormatException) { // Fall back to parse as a double below.
+        }
+      }
+      p != PEEKED_BUFFERED -> throw JsonDataException("Expected a long but was ${peek()} at path ${getPath()}")
+    }
+
+    peeked = PEEKED_BUFFERED
+
+    val asDouble: Double = try {
+      peekedString!!.toDouble()
+    } catch (e: NumberFormatException) {
+      throw JsonDataException("Expected a long but was $peekedString at path ${getPath()}")
+    }
+
+    val result = asDouble.toLong()
+    if (result.toDouble() != asDouble) { // Make sure no precision was lost casting to 'long'.
+      throw JsonDataException("Expected a long but was $peekedString at path ${getPath()}")
+    }
+    peekedString = null
+    peeked = PEEKED_NONE
+    pathIndices[stackSize - 1]++
+    return result
+  }
+
+  @Throws(IOException::class)
+  override fun nextNumber(): JsonNumber {
+    return JsonNumber(nextString()!!)
   }
 
   /**
@@ -687,8 +735,6 @@ class BufferedSourceJsonReader(private val source: BufferedSource) : JsonReader 
 
   @Throws(IOException::class)
   override fun skipValue() {
-    if (failOnUnknown) throw JsonDataException("Cannot skip unexpected ${peek()} at ${getPath()}")
-
     var count = 0
     do {
       when (peeked.takeUnless { it == PEEKED_NONE } ?: doPeek()) {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/FileUploadAwareJsonWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/FileUploadAwareJsonWriter.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.api.internal.json
 
 import com.apollographql.apollo3.api.Upload
+import com.apollographql.apollo3.api.json.JsonNumber
 import com.apollographql.apollo3.api.json.JsonWriter
 
 /**
@@ -45,6 +46,14 @@ class FileUploadAwareJsonWriter(private val wrappedWriter: JsonWriter): JsonWrit
   }
 
   override fun value(value: Int) = apply {
+    wrappedWriter.value(value)
+  }
+
+  override fun value(value: Long) = apply {
+    wrappedWriter.value(value)
+  }
+
+  override fun value(value: JsonNumber) = apply {
     wrappedWriter.value(value)
   }
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/MapJsonWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/json/MapJsonWriter.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.api.internal.json
 
 import com.apollographql.apollo3.api.Upload
+import com.apollographql.apollo3.api.json.JsonNumber
 import com.apollographql.apollo3.api.json.JsonWriter
 
 /**
@@ -8,16 +9,15 @@ import com.apollographql.apollo3.api.json.JsonWriter
  *
  * Call [beginObject], [name], [value], etc... like for regular Json writing. Once you're done, get the result in [root]
  *
- * The returned [Map] will contain:
+ * The returned [Map] will contain values of the following types:
  * - String
  * - Int
  * - Double
+ * - Long
+ * - JsonNumber
  * - null
  * - Map<String, Any?> where values are any of these values recursively
  * - List<Any?> where values are any of these values recursively
- *
- * The base implementation was taken from Moshi and ported to Kotlin multiplatform with some tweaks to make it better suited for GraphQL
- * (see [JsonWriter]).
  *
  * To write to a [okio.BufferedSink], see also [BufferedSinkJsonWriter]
  */
@@ -120,6 +120,10 @@ class MapJsonWriter : JsonWriter {
   override fun value(value: Double) = valueInternal(value)
 
   override fun value(value: Int) = valueInternal(value)
+
+  override fun value(value: Long) = valueInternal(value)
+
+  override fun value(value: JsonNumber) = valueInternal(value)
 
   override fun value(value: Upload) = valueInternal(null)
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonNumber.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonNumber.kt
@@ -1,0 +1,3 @@
+package com.apollographql.apollo3.api.json
+
+class JsonNumber(val value: String)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonWriter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonWriter.kt
@@ -96,6 +96,16 @@ interface JsonWriter : Closeable {
   fun value(value: Int): JsonWriter
 
   /**
+   * Encodes long `value`.
+   */
+  fun value(value: Long): JsonWriter
+
+  /**
+   * Encodes number `value`.
+   */
+  fun value(value: JsonNumber): JsonWriter
+
+  /**
    * Encodes a [Upload].
    */
   fun value(value: Upload): JsonWriter

--- a/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
+++ b/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
@@ -1,0 +1,31 @@
+package test
+
+import com.apollographql.apollo3.api.AnyAdapter
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.LongAdapter
+import com.apollographql.apollo3.api.ObjectAdapter
+import com.apollographql.apollo3.api.internal.json.MapJsonWriter
+import com.apollographql.apollo3.api.internal.json.buildJsonString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JsonTest {
+  @Test
+  fun longAdapterWritesNumbers() {
+    val json = buildJsonString {
+      LongAdapter.toJson(this, CustomScalarAdapters.Empty, Long.MAX_VALUE)
+    }
+    assertEquals("9223372036854775807", json)
+  }
+
+  @Test
+  fun longAdapterInBufferedObjectWritesNumbers() {
+    val mapWriter = MapJsonWriter()
+    mapWriter.value(Long.MAX_VALUE)
+
+    val json = buildJsonString {
+      AnyAdapter.toJson(this, mapWriter.root()!!)
+    }
+    assertEquals("9223372036854775807", json)
+  }
+}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/Record.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/Record.kt
@@ -12,10 +12,9 @@ class Record (
     /**
      * a list of fields. Values can be
      * - Int
-     * - Long
-     * - Boolean
-     * - String
      * - Double
+     * - Boolean
+     * - String (
      * - CacheKey (for composite types)
      * - List
      * - Map (for custom scalars)

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/RecordWeigher.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/RecordWeigher.kt
@@ -8,6 +8,7 @@ import kotlin.jvm.JvmStatic
 object RecordWeigher {
   private const val SIZE_OF_BOOLEAN = 16
   private const val SIZE_OF_INT = 4
+  private const val SIZE_OF_LONG = 8
   private const val SIZE_OF_DOUBLE = 8
   private const val SIZE_OF_ARRAY_OVERHEAD = 16
   private const val SIZE_OF_MAP_OVERHEAD = 16
@@ -35,6 +36,7 @@ object RecordWeigher {
       is String -> field.commonAsUtf8ToByteArray().size
       is Boolean -> SIZE_OF_BOOLEAN
       is Int -> SIZE_OF_INT
+      is Long -> SIZE_OF_LONG // Might happen with LongAdapter
       is Double -> SIZE_OF_DOUBLE
       is List<*> -> {
         SIZE_OF_ARRAY_OVERHEAD + field.sumOf { weighField(it) }

--- a/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/RecordWeigherTest.kt
+++ b/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/RecordWeigherTest.kt
@@ -27,7 +27,7 @@ class RecordWeigherTest {
         )
     )
 
-    assertTrue(record.sizeInBytes <= 222)
-    assertTrue(record.sizeInBytes >= 218) // JS takes less space, maybe for strings?
+    assertTrue(record.sizeInBytes <= 230)
+    assertTrue(record.sizeInBytes >= 226) // JS takes less space, maybe for strings?
   }
 }

--- a/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/RecordWeigherTest.kt
+++ b/apollo-normalized-cache-api/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/RecordWeigherTest.kt
@@ -8,6 +8,7 @@ class RecordWeigherTest {
   @Test
   fun testRecordWeigher() {
     val expectedDouble = 1.23
+    val expectedLongValue = Long.MAX_VALUE
     val expectedStringValue = "StringValue"
     val expectedBooleanValue = true
     val expectedCacheKey = CacheKey("foo")
@@ -19,12 +20,14 @@ class RecordWeigherTest {
             "double" to expectedDouble,
             "string" to expectedStringValue,
             "boolean" to expectedBooleanValue,
+            "long" to expectedLongValue,
             "cacheReference" to expectedCacheKey,
             "scalarList" to expectedScalarList,
             "referenceList" to expectedCacheKeyList,
         )
     )
-    assertTrue(record.sizeInBytes <= 218)
-    assertTrue(record.sizeInBytes >= 214) // JS takes less space, maybe for strings?
+
+    assertTrue(record.sizeInBytes <= 222)
+    assertTrue(record.sizeInBytes >= 218) // JS takes less space, maybe for strings?
   }
 }

--- a/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/apollo-normalized-cache-common/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -15,13 +15,9 @@ import com.apollographql.apollo3.cache.normalized.normalize
 import com.apollographql.apollo3.cache.normalized.readDataFromCache
 import com.apollographql.apollo3.mpp.Guard
 import com.benasher44.uuid.Uuid
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 class DefaultApolloStore(


### PR DESCRIPTION
`BufferedSourceJsonParser` can parse Longs on the fly so we can use this feature to save one String -> Int/Long conversion. Use `nextLong` and `value(Long)` for LongAdapter

Also move LongAdapter to apollo-api.

Closes #3365
