### PR TITLE
docs: Replace 'data graph' with 'graph'

### DIFF
--- a/docs/source/advanced/client-awareness.mdx
+++ b/docs/source/advanced/client-awareness.mdx
@@ -2,7 +2,7 @@
 title: Client Awareness
 ---
 
-Apollo Studio users can opt-in [Client Awareness](https://www.apollographql.com/docs/studio/client-awareness/). Client Awareness allows you to view operation metrics split per client, helping you understand how each one interacts with your data graph.
+Apollo Studio users can opt-in [Client Awareness](https://www.apollographql.com/docs/studio/client-awareness/). Client Awareness allows you to view operation metrics split per client, helping you understand how each one interacts with your graph.
 
 Client Awareness uses `apollographql-client-name` and `apollographql-client-version` custom HTTP headers to report client usage.
 


### PR DESCRIPTION
This branch replaces instances of 'data graph' in our docs with 'graph' to be more in line with the language that we use in our marketing these days.

cc @jchesterman