### PR TITLE
do not crash when trying to indent the GraphQL document

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentSourceBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/parser/graphql/GraphQLDocumentSourceBuilder.kt
@@ -89,7 +89,13 @@ object GraphQLDocumentSourceBuilder {
     get() {
       var indent = 0
       return lines().joinToString(separator = "\n") { line ->
-        if (line.endsWith("}")) indent -= 2
+        if (line.endsWith("}")) {
+          indent -= 2
+          if (indent < 0) {
+            // Workaround for https://github.com/apollographql/apollo-android/issues/3393
+            indent = 0
+          }
+        }
         (" ".repeat(indent) + line).also {
           if (line.endsWith("{")) indent += 2
         }


### PR DESCRIPTION
closes https://github.com/apollographql/apollo-android/issues/3393﻿
