### PR TITLE
Add matrix of supported features per platform on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Apollo Android is a [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplat
 
 Here's the current matrix of supported features per platform:
 
-|  | `jvm` | `iosX64`, `iosArm64` | `macosX64` | `macosArm64` | `js` |
-| --- | --- | --- | --- | --- | --- |
-| `apollo-api` (models)|✅|✅|✅|🚫|✅|
-| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅|🚫|🚫|
-| `apollo-normalized-cache` |✅|✅|✅|🚫|🚫|
-| `apollo-normalized-cache-sqlite` |✅|✅|✅|🚫|🚫|
-| `apollo-http-cache` |✅|🚫|🚫|🚫|🚫|
-| `apollo-adapters` |✅|✅|✅|🚫|✅|
+|  | `jvm` | `iosX64`, `iosArm64` | `macosX64` | `js` |
+| --- | :---: | :---: | :---: | :---: |
+| `apollo-api` (models)|✅|✅|✅|✅|
+| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅|🚫|
+| `apollo-normalized-cache` |✅|✅|✅|🚫|
+| `apollo-normalized-cache-sqlite` |✅|✅|✅|🚫|
+| `apollo-adapters` |✅|✅|✅|✅|
+| `apollo-http-cache` |✅|🚫|🚫|🚫|
 
 
 ## Requirements


### PR DESCRIPTION
Matrix taken from #3244 and tweaked a bit 😄

I've put `iosX64` and `iosArm64` on the same column to simplify (and `macosX64` and `macosArm64` can also be merged later when `macosArm64` is supported).

Also added a row for `apollo-adapters` but not 100% sure it's needed.