### PR TITLE
Add generateOptionalOperationVariables gradle param

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/GraphQLCompiler.kt
@@ -121,6 +121,7 @@ object GraphQLCompiler {
         alwaysGenerateTypesMatching = alwaysGenerateTypesMatching,
         customScalarsMapping = options.customScalarsMapping,
         codegenModels = options.codegenModels,
+        generateOptionalOperationVariables = options.generateOptionalOperationVariables
     ).build()
 
     if (debugDir != null) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -133,6 +133,16 @@ class Options(
     @Deprecated("Kotlin sealed classes are more flexible than Kotlin enums to represent GraphQL enums because they can expose the" +
         "rawValue of the unknown enums.")
     val sealedClassesForEnumsMatching: List<String> = defaultSealedClassesForEnumsMatching,
+
+    /**
+     * Whether to generate operation variables as [com.apollographql.apollo3.api.Optional]
+     *
+     * Using [com.apollographql.apollo3.api.Optional] allows to omit the variables if needed but makes the
+     * callsite more verbose in most cases.
+     *
+     * Default: false
+     */
+    val generateOptionalOperationVariables: Boolean = defaultGenerateOptionalOperationVariables
 ) {
 
   /**
@@ -184,17 +194,19 @@ class Options(
       targetLanguage: String = this.targetLanguage,
       generateTestBuilders: Boolean = this.generateTestBuilders,
       sealedClassesForEnumsMatching: List<String> = this.sealedClassesForEnumsMatching,
+      generateOptionalOperationVariables: Boolean = this.generateOptionalOperationVariables
   ) = Options(
+      executableFiles = executableFiles,
       schema = schema,
       outputDir = outputDir,
       debugDir = debugDir,
-      executableFiles = executableFiles,
       operationOutputFile = operationOutputFile,
       schemaPackageName = schemaPackageName,
       packageNameGenerator = packageNameGenerator,
       alwaysGenerateTypesMatching = alwaysGenerateTypesMatching,
       operationOutputGenerator = operationOutputGenerator,
       incomingCompilerMetadata = incomingCompilerMetadata,
+      targetLanguage = targetLanguage,
       customScalarsMapping = customScalarsMapping,
       codegenModels = codegenModels,
       flattenModels = flattenModels,
@@ -209,10 +221,10 @@ class Options(
       generateQueryDocument = generateQueryDocument,
       generateSchema = generateSchema,
       moduleName = moduleName,
-      targetLanguage = targetLanguage,
       generateTestBuilders = generateTestBuilders,
       testDir = testDir,
-      sealedClassesForEnumsMatching =  sealedClassesForEnumsMatching
+      sealedClassesForEnumsMatching =  sealedClassesForEnumsMatching,
+      generateOptionalOperationVariables = generateOptionalOperationVariables,
   )
 
   companion object {
@@ -236,6 +248,7 @@ class Options(
     const val defaultGenerateSchema = false
     const val defaultGenerateTestBuilders = false
     val defaultSealedClassesForEnumsMatching = listOf(".*")
+    const val defaultGenerateOptionalOperationVariables = false
   }
 }
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -62,13 +62,13 @@ class MetadataTest {
             testDir = outputDir,
             schema = schema,
             schemaPackageName = "",
-            codegenModels = codegenModels,
-            customScalarsMapping = defaultCustomScalarsMapping,
             packageNameGenerator = PackageNameGenerator.Flat(""),
             alwaysGenerateTypesMatching = alwaysGenerateTypesMatching,
-            flattenModels = true,
             incomingCompilerMetadata =incomingCompilerMetadata,
-            moduleName = "test"
+            customScalarsMapping = defaultCustomScalarsMapping,
+            codegenModels = codegenModels,
+            flattenModels = true,
+            moduleName = "test",
         )
     )
     ApolloMetadata(

--- a/apollo-gradle-plugin/api/apollo-gradle-plugin.api
+++ b/apollo-gradle-plugin/api/apollo-gradle-plugin.api
@@ -60,6 +60,7 @@ public abstract interface class com/apollographql/apollo3/gradle/api/Service {
 	public abstract fun getGenerateFragmentImplementations ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateKotlinModels ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateOperationOutput ()Lorg/gradle/api/provider/Property;
+	public abstract fun getGenerateOptionalOperationVariables ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateQueryDocument ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateSchema ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateTestBuilders ()Lorg/gradle/api/provider/Property;
@@ -85,10 +86,12 @@ public abstract interface class com/apollographql/apollo3/gradle/api/Service {
 	public abstract fun registry (Lorg/gradle/api/Action;)V
 	public abstract fun srcDir (Ljava/lang/Object;)V
 	public abstract fun testDirConnection (Lorg/gradle/api/Action;)V
+	public abstract fun useVersion2Compat (Ljava/lang/String;)V
 }
 
 public final class com/apollographql/apollo3/gradle/api/Service$DefaultImpls {
 	public static synthetic fun packageNamesFromFilePaths$default (Lcom/apollographql/apollo3/gradle/api/Service;Ljava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun useVersion2Compat$default (Lcom/apollographql/apollo3/gradle/api/Service;Ljava/lang/String;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/apollographql/apollo3/gradle/api/Service$DirectoryConnection {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -254,6 +254,16 @@ interface Service {
   val generateSchema: Property<Boolean>
 
   /**
+   * Whether to generate operation variables as [com.apollographql.apollo3.api.Optional]
+   *
+   * Using [com.apollographql.apollo3.api.Optional] allows to omit the variables if needed but makes the
+   * callsite more verbose in most cases.
+   *
+   * Default: false
+   */
+  val generateOptionalOperationVariables: Property<Boolean>
+
+  /**
    * Whether to generate the type safe Data builders. These are mainly used for tests but can also be used for other use
    * cases too.
    *
@@ -317,6 +327,27 @@ interface Service {
   @Deprecated("Kotlin sealed classes are more flexible than Kotlin enums to represent GraphQL enums because they can expose the" +
       "rawValue of the unknown enums.")
   val sealedClassesForEnumsMatching: ListProperty<String>
+
+  /**
+   * A shorthand method that configures defaults that match Apollo Android 2.x codegen
+   *
+   * In practice, it does the following:
+   *
+   * ```
+   * packageNamesFromFilePaths(rootPackageName)
+   * codegenModels.set(MODELS_COMPAT)
+   * sealedClassesForEnumsMatching.set(emptyList())
+   * generateOptionalOperationVariables.set(true)
+   * ```
+   *
+   * See the individual options for a more complete description.
+   *
+   * This method is deprecated and provided for migration purposes only. It will be removed
+   * in a future version
+   */
+  @Deprecated("useVersion2Compat() is a helper function to help migrating to 3.x " +
+      "and will be removed in a future version")
+  fun useVersion2Compat(rootPackageName: String? = null)
 
   /**
    * Configures [Introspection] to download an introspection Json schema

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -6,16 +6,17 @@ import com.apollographql.apollo3.compiler.CommonMetadata
 import com.apollographql.apollo3.compiler.GraphQLCompiler
 import com.apollographql.apollo3.compiler.IncomingOptions
 import com.apollographql.apollo3.compiler.IncomingOptions.Companion.resolveSchema
-import com.apollographql.apollo3.compiler.MODELS_COMPAT
 import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED
 import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
 import com.apollographql.apollo3.compiler.Options
 import com.apollographql.apollo3.compiler.Options.Companion.defaultAlwaysGenerateTypesMatching
+import com.apollographql.apollo3.compiler.Options.Companion.defaultCodegenModels
 import com.apollographql.apollo3.compiler.Options.Companion.defaultFailOnWarnings
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateAsInternal
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFilterNotNull
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFragmentImplementations
+import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateOptionalOperationVariables
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateQueryDocument
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateResponseFields
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateSchema
@@ -158,6 +159,10 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
 
   @get:Input
   @get:Optional
+  abstract val generateOptionalOperationVariables: Property<Boolean>
+
+  @get:Input
+  @get:Optional
   abstract val generateTestBuilders: Property<Boolean>
 
   @get:Inject
@@ -194,14 +199,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
       }
       IncomingOptions.fromMetadata(commonMetadata, packageNameGenerator)
     } else {
-      val codegenModels = codegenModels.getOrElse(
-          when (targetLanguage) {
-            TARGET_JAVA -> MODELS_OPERATION_BASED
-            TARGET_KOTLIN -> MODELS_COMPAT
-            else -> error("")
-          }
-      )
-
+      val codegenModels = codegenModels.getOrElse(defaultCodegenModels)
       val (schema, mainSchemaFilePath) = resolveSchema(schemaFiles.files, rootFolders.get())
 
       outputCommonMetadata = CommonMetadata(
@@ -272,7 +270,8 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         customScalarsMapping = customScalarsMapping.getOrElse(emptyMap()),
         targetLanguage = targetLanguage,
         generateTestBuilders = generateTestBuilders.getOrElse(defaultGenerateTestBuilders),
-        sealedClassesForEnumsMatching = sealedClassesForEnumsMatching.getOrElse(defaultSealedClassesForEnumsMatching)
+        sealedClassesForEnumsMatching = sealedClassesForEnumsMatching.getOrElse(defaultSealedClassesForEnumsMatching),
+        generateOptionalOperationVariables = generateOptionalOperationVariables.getOrElse(defaultGenerateOptionalOperationVariables)
     )
 
     val outputCompilerMetadata = GraphQLCompiler.write(options)

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -269,10 +269,6 @@ abstract class DefaultApolloExtension(
     if (service.outputDirAction == null) {
       service.outputDirAction = defaultOutputDirAction
     }
-    if (service.testDirAction == null) {
-      service.testDirAction = defaultTestDirAction
-    }
-
     service.outputDirAction!!.execute(
         DefaultDirectoryConnection(
             project = project,
@@ -280,6 +276,10 @@ abstract class DefaultApolloExtension(
             outputDir = codegenProvider.flatMap { it.outputDir }
         )
     )
+
+    if (service.testDirAction == null) {
+      service.testDirAction = defaultTestDirAction
+    }
     service.testDirAction!!.execute(
         DefaultDirectoryConnection(
             project = project,
@@ -454,8 +454,9 @@ abstract class DefaultApolloExtension(
       task.generateSchema.set(service.generateSchema)
       task.codegenModels.set(service.codegenModels)
       task.flattenModels.set(service.flattenModels)
-      task.sealedClassesForEnumsMatching.set(service.sealedClassesForEnumsMatching)
       task.generateTestBuilders.set(service.generateTestBuilders)
+      task.sealedClassesForEnumsMatching.set(service.sealedClassesForEnumsMatching)
+      task.generateOptionalOperationVariables.set(service.generateOptionalOperationVariables)
     }
   }
 

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.gradle.internal
 
-import com.apollographql.apollo3.compiler.OperationIdGenerator
-import com.apollographql.apollo3.compiler.OperationOutputGenerator
+import com.apollographql.apollo3.compiler.MODELS_COMPAT
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.Roots
 import com.apollographql.apollo3.gradle.api.Introspection
@@ -9,13 +8,6 @@ import com.apollographql.apollo3.gradle.api.Registry
 import com.apollographql.apollo3.gradle.api.Service
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.SetProperty
 import org.gradle.util.GradleVersion
 import javax.inject.Inject
 
@@ -41,53 +33,6 @@ abstract class DefaultService @Inject constructor(val project: Project, override
       sealedClassesForEnumsMatching.set(null as List<String>?)
     }
   }
-
-  abstract override val exclude: ListProperty<String>
-
-  abstract override val include: ListProperty<String>
-
-  abstract override val sourceFolder: Property<String>
-
-  abstract override val schemaFile: RegularFileProperty
-  abstract override val schemaFiles: ConfigurableFileCollection
-
-  abstract override val debugDir: DirectoryProperty
-  abstract override val outputDir: DirectoryProperty
-  abstract override val testDir: DirectoryProperty
-
-  abstract override val generateOperationOutput: Property<Boolean>
-  abstract override val operationOutputFile: RegularFileProperty
-
-  abstract override val warnOnDeprecatedUsages: Property<Boolean>
-
-  abstract override val failOnWarnings: Property<Boolean>
-
-  abstract override val customScalarsMapping: MapProperty<String, String>
-
-  abstract override val operationIdGenerator: Property<OperationIdGenerator>
-
-  abstract override val operationOutputGenerator: Property<OperationOutputGenerator>
-
-  abstract override val packageName: Property<String>
-  abstract override val packageNameGenerator: Property<PackageNameGenerator>
-
-  abstract override val useSemanticNaming: Property<Boolean>
-
-  abstract override val generateAsInternal: Property<Boolean>
-
-  abstract override val generateKotlinModels: Property<Boolean>
-
-  abstract override val generateApolloMetadata: Property<Boolean>
-
-  abstract override val alwaysGenerateTypesMatching: SetProperty<String>
-
-  abstract override val generateFragmentImplementations: Property<Boolean>
-
-  abstract override val codegenModels: Property<String>
-
-  abstract override val flattenModels: Property<Boolean>
-
-  abstract override val sealedClassesForEnumsMatching: ListProperty<String>
 
   val graphqlSourceDirectorySet = objects.sourceDirectorySet("graphql", "graphql")
 
@@ -145,6 +90,13 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
   override fun outputDirConnection(action: Action<in Service.DirectoryConnection>) {
     this.outputDirAction = action
+  }
+
+  override fun useVersion2Compat(rootPackageName: String?) {
+    packageNamesFromFilePaths(rootPackageName)
+    codegenModels.set(MODELS_COMPAT)
+    sealedClassesForEnumsMatching.set(emptyList())
+    generateOptionalOperationVariables.set(true)
   }
 
   override fun testDirConnection(action: Action<in Service.DirectoryConnection>) {

--- a/tests/models-compat/build.gradle.kts
+++ b/tests/models-compat/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.apollographql.apollo3.compiler.MODELS_COMPAT
+
 plugins {
   id("com.apollographql.apollo3")
   id("org.jetbrains.kotlin.multiplatform")
@@ -37,6 +39,7 @@ apollo {
         service(it.name) {
           srcDir(it)
           packageName.set(it.name)
+          codegenModels.set(MODELS_COMPAT)
         }
       }
 }

--- a/tests/optional-variables/build.gradle.kts
+++ b/tests/optional-variables/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.apollographql.apollo3")
+}
+
+dependencies {
+  implementation("com.apollographql.apollo3:apollo-runtime")
+  testImplementation(groovy.util.Eval.x(project, "x.dep.kotlinJunit"))
+  testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
+}
+
+apollo {
+  packageName.set("optional.variables")
+  generateOptionalOperationVariables.set(true)
+}

--- a/tests/optional-variables/src/main/graphql/operation.graphql
+++ b/tests/optional-variables/src/main/graphql/operation.graphql
@@ -1,0 +1,11 @@
+query NullableParams($param1: Int, $param2: Float) {
+  field(param1: $param1, param2: $param2)
+}
+
+query NonNullableParams($param1: Int!, $param2: Float!) {
+  field(param1: $param1, param2: $param2)
+}
+
+query DefaultValueParams($param1: Int = 0, $param2: Float! = 0.0) {
+  field(param1: $param1, param2: $param2)
+}

--- a/tests/optional-variables/src/main/graphql/schema.graphqls
+++ b/tests/optional-variables/src/main/graphql/schema.graphqls
@@ -1,0 +1,4 @@
+type Query {
+  field(param1: Int, param2: Float): Int
+}
+

--- a/tests/optional-variables/src/test/kotlin/test/VariablesTest.kt
+++ b/tests/optional-variables/src/test/kotlin/test/VariablesTest.kt
@@ -1,0 +1,39 @@
+package test
+
+import com.apollographql.apollo3.api.Optional
+import optional.variables.DefaultValueParamsQuery
+import optional.variables.NonNullableParamsQuery
+import optional.variables.NullableParamsQuery
+import org.junit.Test
+
+class VariablesTest {
+  @Test
+  fun nullableVariablesAreOptional() {
+    // By default, everything is absent. It is ok to omit everything
+    NullableParamsQuery()
+    // But we can pass arguments
+    NullableParamsQuery(param1 = Optional.Present(0), param2 = Optional.Present(3.0))
+    // Including null
+    NullableParamsQuery(param1 = Optional.Present(null), param2 = Optional.Present(null))
+  }
+
+  @Test
+  fun nonNullableVariablesAreNonOptional() {
+    // This doesn't compile, we need to set params
+    // NonNullableParamsQuery()
+    // But we can pass arguments
+    NonNullableParamsQuery(param1 = 0, param2 = 0.0)
+    // But not null
+    // NonNullableParamsQuery(param1 = null, param2 = null)
+  }
+
+  @Test
+  fun variablesWithDefaultValuesAreOptional() {
+    // By default, everything is absent. It is ok to omit everything
+    DefaultValueParamsQuery()
+    // But we can pass arguments
+    DefaultValueParamsQuery(param1 = Optional.Present(0), param2 = Optional.Present(3.0))
+    // Including null
+    DefaultValueParamsQuery(param1 = Optional.Present(null), param2 = Optional.Present(3.0))
+  }
+}


### PR DESCRIPTION
## generateOptionalOperationVariables

This PR adds `generateOptionalOperationVariables` to always wrap nullable GraphQL variables in `Optional<>`

```kotlin
apollo {
  generateOptionalOperationVariables.set(true)
}
```

By default it is false because it makes callsites easier for most cases but it can be set to true if omitting variables is desired. An example is bidirectional pagination:

```graphql
query GetItems(before: String, after: String)
```

In such a case, we want to be able to send either `before` or `after` but not always both at the same time. `generateOptionalOperationVariables` can be set to true and the params will be wrapped in `Optional<>`:

```kotlin
class GetItemsQuery(val before: Optional<String?>, val after: Optional<String?>)
```

generateOptionalOperationVariables can also be set to true to match the 2.x behaviour.

## use2xCompat

This PR also introduces `use2xCompat` as a shorthand for:

```
    packageNamesFromFilePaths(rootPackageName)
    codegenModels.set(MODELS_COMPAT)
    sealedClassesForEnumsMatching.set(emptyList())
    generateOptionalOperationVariables.set(true)
```

