### PR TITLE
Make safelistingHash closer to its apollo-tooling counterpart

### DIFF
--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/RegisterOperations.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/RegisterOperations.kt
@@ -116,6 +116,10 @@ private fun printDocument(document: Document): String {
         val out = args[0] as StringBuilder
         val node = args[1] as Field
 
+        /**
+         * This code is a copy/paste from graphql-java. It could be simplified but keeping it
+         * closer to graphql-java will make it easier to follow changes if any
+         */
         val compactMode = false
         val argSep = if (compactMode) "," else ", "
         val aliasSuffix = if (compactMode) ":" else ": "


### PR DESCRIPTION
This changes the algorithm so that:

* Inline Fragments are not sorted but kept in their original order as in https://github.com/apollographql/apollo-tooling/blob/6d69f226c2e2c54b4fc0de6394d813bddfb54694/packages/apollo-graphql/src/transforms.ts#L102
* Field arguments use a whitespace instead of a `','` if the line would otherwise be larger than 80 chars as in https://github.com/graphql/graphql-js/blob/6453612a6c40a1f8ad06845f1516c5f0dafa666c/src/language/printer.ts#L62