### PR TITLE
Add parsing of non-standard Error fields

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -365,11 +365,12 @@ public final class com/apollographql/apollo3/api/EnumType : com/apollographql/ap
 }
 
 public final class com/apollographql/apollo3/api/Error {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExtensions ()Ljava/util/Map;
 	public final fun getLocations ()Ljava/util/List;
 	public final fun getMessage ()Ljava/lang/String;
+	public final fun getNonStandardFields ()Ljava/util/Map;
 	public final fun getPath ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
@@ -27,10 +27,15 @@ class Error(
      * Extensions if any.
      */
     val extensions: Map<String, Any?>? = null,
+
+    /**
+     * Other non-standard fields (discouraged but allowed in the spec), if any.
+     */
+    val nonStandardFields: Map<String, Any?>? = null,
 ) {
 
   override fun toString(): String {
-    return "Error(message = $message, locations = $locations, path=$path, extensions = $extensions)"
+    return "Error(message = $message, locations = $locations, path=$path, extensions = $extensions, nonStandardFields = $nonStandardFields)"
   }
 
   /**

--- a/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -101,6 +101,30 @@ class ParseResponseBodyTest {
 
   @Test
   @Throws(Exception::class)
+  fun errorWithNonStandardFields() {
+    val response = AllPlanetsQuery().parseJsonResponse(readResource("ResponseErrorWithNonStandardFields.json"))
+    assertTrue(response.hasErrors())
+    val nonStandardFields = response.errors!![0].nonStandardFields!!
+    assertEquals(3, nonStandardFields.size)
+    assertEquals("INTERNAL_ERROR", nonStandardFields["type"])
+    assertNull(nonStandardFields["retry"])
+
+    @Suppress("UNCHECKED_CAST")
+    val moreInfo = nonStandardFields["moreInfo"] as Map<String, Any?>
+    assertEquals(500, moreInfo["code"])
+    assertEquals("Internal Error", moreInfo["status"])
+    assertEquals(true, moreInfo["fatal"])
+
+    @Suppress("UNCHECKED_CAST")
+    val listOfValues = moreInfo["listOfValues"] as List<Any>
+    assertEquals(0, listOfValues[0])
+    assertEquals("a", listOfValues[1])
+    assertEquals(true, listOfValues[2])
+    assertEquals(2.4, listOfValues[3])
+  }
+
+  @Test
+  @Throws(Exception::class)
   fun errorResponse_with_data() {
     val response = EpisodeHeroNameQuery(Episode.JEDI).parseJsonResponse(readResource("ResponseErrorWithData.json"))
     val data = response.data

--- a/tests/integration-tests/testFixtures/resources/ResponseErrorWithNonStandardFields.json
+++ b/tests/integration-tests/testFixtures/resources/ResponseErrorWithNonStandardFields.json
@@ -1,0 +1,29 @@
+{
+  "errors": [
+    {
+      "type": "INTERNAL_ERROR",
+      "message": "Cannot query field \"names\" on type \"Species\".",
+      "locations": [
+        {
+          "line": 3,
+          "column": 5
+        }
+      ],
+      "path": [
+        "query"
+      ],
+      "moreInfo": {
+        "code": 500,
+        "status": "Internal Error",
+        "fatal": true,
+        "listOfValues": [
+          0,
+          "a",
+          true,
+          2.4
+        ]
+      },
+      "retry": null
+    }
+  ]
+}


### PR DESCRIPTION
I noticed GitHub's API returns Errors that have a non standard `type` field.

Looking at the spec, these are discouraged but still allowed - so I thought it could be useful to surface them.

In v2 these would come up in the `extensions` field - but I opted to add a specific field instead, to avoid potential clashes in the (improbable) event where fields with the same name appear at the top level *and* in `extensions`.
