### PR TITLE
Add a few targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,16 +93,29 @@ Apollo Android is a [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplat
 
 Here's the current matrix of supported features per platform:
 
-|  | `jvm` | `iosX64`, `iosArm64` | `macosX64` | `js` |
-| --- | :---: | :---: | :---: | :---: |
-| `apollo-api` (models)|✅|✅|✅|✅|
-| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅|✅¹|
-| `apollo-normalized-cache` |✅|✅|✅|✅|
-| `apollo-normalized-cache-sqlite` |✅|✅|✅|🚫|
-| `apollo-adapters` |✅|✅|✅|✅|
-| `apollo-http-cache` |✅|🚫|🚫|🚫|
+|  | `jvm` | Apple¹ | `js` |
+| --- | :---: | :---: | :---: |
+| `apollo-api` (models)|✅|✅|✅|
+| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅²|
+| `apollo-normalized-cache` |✅|✅|✅|
+| `apollo-normalized-cache-sqlite` |✅|✅|🚫|
+| `apollo-adapters` |✅|✅|✅|
+| `apollo-http-cache` |✅|🚫|🚫|
 
-¹: WebSockets are currently not supported on `js`
+¹: Apple currently includes:
+
+- `macosX64`
+- `macosArm64`
+- `iosArm64`
+- `iosX64`
+- `iosSimulatorArm64`
+- `watchosArm64`
+- `watchosSimulatorArm64`
+- `tvosArm64`
+- `tvosX64`
+- `tvosSimulatorArm64`
+
+²: WebSockets are currently not supported on `js`
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Apollo Android is a [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplat
 
 Here's the current matrix of supported features per platform:
 
-|  | `jvm` | Apple¹ | `js` |
-| --- | :---: | :---: | :---: |
-| `apollo-api` (models)|✅|✅|✅|
-| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅²|
-| `apollo-normalized-cache` |✅|✅|✅|
-| `apollo-normalized-cache-sqlite` |✅|✅|🚫|
-| `apollo-adapters` |✅|✅|✅|
-| `apollo-http-cache` |✅|🚫|🚫|
+|  | `jvm` | Apple¹ | `js` | `linuxX64`
+| --- | :---: | :---: | :---: | :---: |
+| `apollo-api` (models)|✅|✅|✅|✅|
+| `apollo-runtime` (network, query batching, apq, ...) |✅|✅|✅²|🚫|
+| `apollo-normalized-cache` |✅|✅|✅|🚫|
+| `apollo-normalized-cache-sqlite` |✅|✅|🚫|🚫|
+| `apollo-adapters` |✅|✅|✅|🚫|
+| `apollo-http-cache` |✅|🚫|🚫|🚫|
 
 ¹: Apple currently includes:
 

--- a/apollo-adapters/build.gradle.kts
+++ b/apollo-adapters/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults()
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-adapters/src/appleMain/kotlin/com/apollographql/apollo3/adapter/BigDecimal.kt
+++ b/apollo-adapters/src/appleMain/kotlin/com/apollographql/apollo3/adapter/BigDecimal.kt
@@ -8,9 +8,9 @@ actual class BigDecimal internal constructor(private val raw: NSDecimalNumber) :
 
   actual constructor(doubleVal: Double) : this(NSDecimalNumber(doubleVal))
 
-  actual constructor(intVal: Int) : this(NSDecimalNumber(intVal))
+  actual constructor(intVal: Int) : this(NSDecimalNumber(int = intVal))
 
-  actual constructor(longVal: Long) : this(NSDecimalNumber(long = longVal))
+  actual constructor(longVal: Long) : this(NSDecimalNumber(longLong = longVal))
 
   actual fun add(augend: BigDecimal): BigDecimal = BigDecimal(raw.decimalNumberByAdding(augend.raw))
 
@@ -20,10 +20,10 @@ actual class BigDecimal internal constructor(private val raw: NSDecimalNumber) :
 
   actual fun divide(divisor: BigDecimal): BigDecimal = BigDecimal(raw.decimalNumberByDividingBy(divisor.raw))
 
-  actual fun negate(): BigDecimal = BigDecimal(NSDecimalNumber(0).decimalNumberBySubtracting(raw))
+  actual fun negate(): BigDecimal = BigDecimal(NSDecimalNumber(int = 0).decimalNumberBySubtracting(raw))
 
   actual fun signum(): Int {
-    val result = raw.compare(NSDecimalNumber(0)).toInt()
+    val result = raw.compare(NSDecimalNumber(int = 0)).toInt()
     return when {
       result < 0 -> -1
       result > 0 -> 1
@@ -36,7 +36,7 @@ actual class BigDecimal internal constructor(private val raw: NSDecimalNumber) :
   }
 
   override fun toLong(): Long {
-    return raw.longValue
+    return raw.longLongValue
   }
 
   override fun toShort(): Short {

--- a/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/Throws.kt
+++ b/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/Throws.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.api
+
+import kotlin.reflect.KClass
+
+actual annotation class Throws actual constructor(actual vararg val exceptionClasses: KClass<out Throwable>)

--- a/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/json/Closeable.kt
+++ b/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/json/Closeable.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.api.json
+
+actual interface Closeable {
+  actual fun close()
+}

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults(withJs = true)
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/FileDescriptorSource.kt
+++ b/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/FileDescriptorSource.kt
@@ -18,7 +18,7 @@ class FileDescriptorSource(val fd: Int) : Source {
 
   override fun read(
       sink: Buffer,
-      byteCount: Long
+      byteCount: Long,
   ): Long {
     require(byteCount >= 0L) { "byteCount < 0: $byteCount" }
     check(!closed) { "closed" }
@@ -33,7 +33,7 @@ class FileDescriptorSource(val fd: Int) : Source {
       var read = 0L
       while (read < byteCount) {
         val toRead = minOf(bufSize.toLong(), byteCount - read)
-        val len = platform.posix.read(fd, buf, toRead.convert())
+        val len: Long = platform.posix.read(fd, buf, toRead.convert()).convert()
         if (len < 0) {
           throw IOException("Cannot read $fd (errno = $errno)")
         }

--- a/apollo-mpp-utils/build.gradle.kts
+++ b/apollo-mpp-utils/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults()
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-normalized-cache-common/build.gradle.kts
+++ b/apollo-normalized-cache-common/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults()
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -12,7 +12,7 @@ configure<com.squareup.sqldelight.gradle.SqlDelightExtension> {
 }
 
 // https://github.com/cashapp/sqldelight/pull/1486
-configureMppDefaults(withJs = false)
+configureMppDefaults(withJs = false, withLinux = false)
 
 configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
   if (System.getProperty("idea.sync.active") == null) {

--- a/apollo-normalized-cache/build.gradle.kts
+++ b/apollo-normalized-cache/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults()
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-runtime/build.gradle.kts
+++ b/apollo-runtime/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults()
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
+++ b/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
@@ -6,14 +6,12 @@ import com.apollographql.apollo3.network.toNSData
 import kotlinx.cinterop.COpaquePointer
 import kotlinx.cinterop.StableRef
 import kotlinx.cinterop.asStableRef
+import kotlinx.cinterop.convert
 import kotlinx.cinterop.staticCFunction
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import okio.ByteString
-import okio.ByteString.Companion.toByteString
-import okio.IOException
-import okio.internal.commonAsUtf8ToByteArray
 import okio.toByteString
 import platform.Foundation.NSData
 import platform.Foundation.NSError
@@ -35,7 +33,6 @@ import platform.Foundation.setValue
 import platform.darwin.NSObject
 import platform.darwin.dispatch_async_f
 import platform.darwin.dispatch_get_main_queue
-import kotlin.native.concurrent.ensureNeverFrozen
 import kotlin.native.concurrent.freeze
 
 interface WebSocketConnectionListener {
@@ -113,7 +110,7 @@ private class WebSocketConnectionImpl(
   init {
     messageChannel.invokeOnClose {
       webSocket.cancelWithCloseCode(
-          closeCode = CLOSE_NORMAL.toLong(),
+          closeCode = CLOSE_NORMAL.convert(),
           reason = null
       )
     }

--- a/apollo-testing-support/build.gradle.kts
+++ b/apollo-testing-support/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   kotlin("multiplatform")
 }
 
-configureMppDefaults(withJs = true)
+configureMppDefaults(withLinux = false)
 
 kotlin {
   sourceSets {

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -1,7 +1,7 @@
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
-fun Project.configureMppDefaults(withJs: Boolean = true) {
+fun Project.configureMppDefaults(withJs: Boolean = true, withLinux: Boolean = true) {
   // See https://kotlinlang.org/docs/mpp-dsl-reference.html#targets
 
   val kotlinExtension = extensions.findByName("kotlin") as? KotlinMultiplatformExtension
@@ -73,6 +73,10 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
       macosX64("apple")
     }
 
+    if (withLinux) {
+      linuxX64("linux")
+    }
+
     addTestDependencies(withJs)
 
     if (System.getProperty("idea.sync.active") == null) {
@@ -91,7 +95,7 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
 }
 
 /**
- * Same as [configureMppDefaults] but without iOS targets.
+ * Same as [configureMppDefaults] but without iOS or Linux targets.
  * Tests only run on the JVM, JS and MacOS
  */
 fun Project.configureMppTestsDefaults(withJs: Boolean = true) {

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -2,6 +2,8 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 fun Project.configureMppDefaults(withJs: Boolean = true) {
+  // See https://kotlinlang.org/docs/mpp-dsl-reference.html#targets
+
   val kotlinExtension = extensions.findByName("kotlin") as? KotlinMultiplatformExtension
   check(kotlinExtension != null) {
     "No multiplatform extension found"
@@ -21,7 +23,17 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
     if (System.getProperty("idea.sync.active") == null) {
       val appleMain = sourceSets.create("appleMain")
       val appleTest = sourceSets.create("appleTest")
+
       macosX64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+      macosArm64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+
+      iosArm64().apply {
         compilations.getByName("main").source(appleMain)
         compilations.getByName("test").source(appleTest)
       }
@@ -29,11 +41,29 @@ fun Project.configureMppDefaults(withJs: Boolean = true) {
         compilations.getByName("main").source(appleMain)
         compilations.getByName("test").source(appleTest)
       }
-      iosArm64().apply {
+      iosSimulatorArm64().apply {
         compilations.getByName("main").source(appleMain)
         compilations.getByName("test").source(appleTest)
       }
-      iosSimulatorArm64().apply {
+
+      watchosArm64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+      watchosSimulatorArm64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+
+      tvosArm64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+      tvosX64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+      tvosSimulatorArm64().apply {
         compilations.getByName("main").source(appleMain)
         compilations.getByName("test").source(appleTest)
       }


### PR DESCRIPTION
Add `macosArm64`, `iosArm64`, `watchosArm64`, `watchosSimulatorArm64`, `tvosArm64`, `tvosX64` and `tvosSimulatorArm64` target.

Note: `watchosX64` can't be added yet since it's not in Okio yet (see https://github.com/square/okio/pull/1065)

Also, add `linuxX64` only for `apollo-api` for now