### PR TITLE
Add documentation for watch

### DIFF
--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -19,19 +19,9 @@ import kotlinx.coroutines.flow.flow
 
 enum class FetchPolicy {
   /**
-   * Try cache first, then network
+   * Try network first, then cache
    *
    * This is the default behaviour
-   */
-  CacheFirst,
-
-  /**
-   * Only try cache
-   */
-  CacheOnly,
-
-  /**
-   * Try network first, then cache
    */
   NetworkFirst,
 
@@ -39,6 +29,16 @@ enum class FetchPolicy {
    * Only try network
    */
   NetworkOnly,
+
+  /**
+   * Try cache first, then network
+   */
+  CacheFirst,
+
+  /**
+   * Only try cache
+   */
+  CacheOnly,
 }
 
 /**
@@ -66,11 +66,13 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
   return addInterceptor(ApolloCacheInterceptor(store)).writeToCacheAsynchronously(writeToCacheAsynchronously)
 }
 
-
+/***
+ * Gets the result from the network, then observes the cache for any changes.
+ * Overriding the [FetchPolicy] will change how the result is first queried.
+ */
 fun <D : Query.Data> ApolloQueryCall<D>.watch(): Flow<ApolloResponse<D>> {
   return copy().addExecutionContext(WatchContext(true)).executeAsFlow()
 }
-
 
 /**
  * Gets the result from the cache first and always fetch from the network. Use this to get an early

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -19,19 +19,9 @@ import kotlinx.coroutines.flow.flow
 
 enum class FetchPolicy {
   /**
-   * Try network first, then cache
+   * Try cache first, then network
    *
    * This is the default behaviour
-   */
-  NetworkFirst,
-
-  /**
-   * Only try network
-   */
-  NetworkOnly,
-
-  /**
-   * Try cache first, then network
    */
   CacheFirst,
 
@@ -39,6 +29,16 @@ enum class FetchPolicy {
    * Only try cache
    */
   CacheOnly,
+
+  /**
+   * Try network first, then cache
+   */
+  NetworkFirst,
+
+  /**
+   * Only try network
+   */
+  NetworkOnly,
 }
 
 /**


### PR DESCRIPTION
- I moved `NetworkFirst` to the top since that is the default `FetchPolicy` and fixed the documentation to state that this is the default.
- I also added documentation to clarify what `watch` does. 

``` Overriding the [FetchPolicy] will change how the result is first queried. ```
might make more sense to be
``` Setting the [FetchPolicy] will change how the result is first queried. ```

Feel free to adjust as needed. 