### PR TITLE
Fix concurrent accesses to the SQLite database

### DIFF
--- a/apollo-mpp-utils/api/apollo-mpp-utils.api
+++ b/apollo-mpp-utils/api/apollo-mpp-utils.api
@@ -1,8 +1,8 @@
 public final class com/apollographql/apollo3/mpp/Guard {
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public final fun access (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun blockingAccess (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public final fun dispose ()V
+	public final fun readAccess (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun writeAccess (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun writeAndForget (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/apollo-mpp-utils/src/appleMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
+++ b/apollo-mpp-utils/src/appleMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
@@ -1,7 +1,5 @@
 package com.apollographql.apollo3.mpp
 
-import kotlinx.coroutines.runBlocking
-
 actual class Guard<R: Any> actual constructor(name: String, private val producer: () -> R) {
   private val worker = SingleThreadWorker(producer = producer)
 
@@ -9,13 +7,9 @@ actual class Guard<R: Any> actual constructor(name: String, private val producer
     worker.dispose()
   }
 
-  actual suspend fun <T> access(block: (R) -> T) = worker.execute(block)
+  actual suspend fun <T> readAccess(block: (R) -> T) = worker.execute(block)
+
+  actual suspend fun <T> writeAccess(block: (R) -> T) = worker.execute(block)
 
   actual fun writeAndForget(block: (R) -> Unit) = worker.executeAndForget(block)
-
-  actual fun <T> blockingAccess(block: (R) -> T): T {
-    return runBlocking {
-      access(block)
-    }
-  }
 }

--- a/apollo-mpp-utils/src/commonMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
+++ b/apollo-mpp-utils/src/commonMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
@@ -1,10 +1,21 @@
 package com.apollographql.apollo3.mpp
 
 expect class Guard<R: Any>(name: String, producer: () -> R) {
-  suspend fun <T> access(block: (R) -> T): T
+  /**
+   * Accesses the underlying resource with 'read' semantics. Several threads can read the resource simultaneously.
+   */
+  suspend fun <T> readAccess(block: (R) -> T): T
 
-  fun <T> blockingAccess(block: (R) -> T): T
+  /**
+   * Accesses the underlying resource with 'write' semantics. Only one thread can write to a resource at a time. During that time,
+   * no readers can access the resource.
+   */
+  suspend fun <T> writeAccess(block: (R) -> T): T
 
+  /**
+   * Accesses the underlying resouce with 'write' semantics and does not wait for the response. The work might not be finished
+   * when this function returns
+   */
   fun writeAndForget(block: (R) -> Unit)
 
   fun dispose()

--- a/apollo-mpp-utils/src/jsMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
+++ b/apollo-mpp-utils/src/jsMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
@@ -3,7 +3,11 @@ package com.apollographql.apollo3.mpp
 actual class Guard<R: Any> actual constructor(name: String, producer: () -> R) {
   private val resource = producer()
 
-  actual suspend fun <T> access(block: (R) -> T): T {
+  actual suspend fun <T> readAccess(block: (R) -> T): T {
+    return block(resource)
+  }
+
+  actual suspend fun <T> writeAccess(block: (R) -> T): T {
     return block(resource)
   }
 
@@ -12,9 +16,5 @@ actual class Guard<R: Any> actual constructor(name: String, producer: () -> R) {
   }
 
   actual fun dispose() {
-  }
-
-  actual fun <T> blockingAccess(block: (R) -> T): T {
-    return block(resource)
   }
 }

--- a/apollo-mpp-utils/src/jvmMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
+++ b/apollo-mpp-utils/src/jvmMain/kotlin/com/apollographql/apollo3/mpp/Guard.kt
@@ -8,8 +8,16 @@ actual class Guard<R: Any> actual constructor(name: String, producer: () -> R) {
   private val lock = ReentrantReadWriteLock()
   private val resource = producer()
 
-  actual suspend fun <T> access(block: (R) -> T): T {
-    return blockingAccess(block)
+  actual suspend fun <T> readAccess(block: (R) -> T): T {
+    return lock.read {
+      block(resource)
+    }
+  }
+
+  actual suspend fun <T> writeAccess(block: (R) -> T): T {
+    return lock.write {
+      block(resource)
+    }
   }
 
   actual fun writeAndForget(block: (R) -> Unit) {
@@ -19,11 +27,5 @@ actual class Guard<R: Any> actual constructor(name: String, producer: () -> R) {
   }
 
   actual fun dispose() {
-  }
-
-  actual fun <T> blockingAccess(block: (R) -> T): T {
-    return lock.read {
-      block(resource)
-    }
   }
 }


### PR DESCRIPTION
Introduce `readAccess {}` and `writeAccess {}` for separate 'read' and 'write' database accesses. Previously, everything was using the 'read' lock which could trigger `SQLiteDatabaseLockedException: database is locked (code 5)` exceptions.