### PR TITLE
Mark Test Builders are experimental

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloExperimental.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloExperimental.kt
@@ -5,6 +5,6 @@ package com.apollographql.apollo3.api
     message = "This API is experimental and can be changed in a backwards-incompatible manner."
 )
 @Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 @MustBeDocumented
 annotation class ApolloExperimental

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/ClassNames.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen
 
-import com.apollographql.apollo3.api.test.StubbedProperty
+import com.squareup.kotlinpoet.ClassName
 
 /**
  * A list of constant [ResolverClassName] that don't use `class.name` and therefore survive proguard/R8
@@ -52,4 +52,6 @@ internal object ClassNames {
   val MapBuilder = ResolverClassName(apolloApiTestPackageName, "MapBuilder")
   val StubbedProperty = ResolverClassName(apolloApiTestPackageName, "StubbedProperty")
   val MandatoryTypenameProperty = ResolverClassName(apolloApiTestPackageName, "MandatoryTypenameProperty")
+
+  val ApolloExperimental = ClassName(apolloApiPackageName, "ApolloExperimental")
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
@@ -8,12 +8,10 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.block
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
 import com.apollographql.apollo3.compiler.codegen.Identifier.fromJson
 import com.apollographql.apollo3.compiler.codegen.Identifier.testResolver
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
-import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.CgOutputFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgTestFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinClassNames
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinMemberNames
 import com.apollographql.apollo3.compiler.codegen.kotlin.test.TBuilderBuilder
 import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
@@ -25,6 +23,7 @@ import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrProperty
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.PossibleTypes
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -64,6 +63,8 @@ class TestBuildersBuilder(
 
   private fun typeSpec(): TypeSpec {
     return TypeSpec.objectBuilder(simpleName)
+        // Note: the compiler forbids referencing ApolloExperimental::class directly, except in an @OptIn context
+        .addAnnotation(ClassName("com.apollographql.apollo3.api", "ApolloExperimental"))
         .addTypes(
             testBuildersBuilder.map { it.build() }
         )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
 import com.apollographql.apollo3.ast.GQLType
+import com.apollographql.apollo3.compiler.codegen.ClassNames
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.Data
@@ -23,7 +24,6 @@ import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrProperty
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.PossibleTypes
-import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.LambdaTypeName
@@ -63,8 +63,7 @@ class TestBuildersBuilder(
 
   private fun typeSpec(): TypeSpec {
     return TypeSpec.objectBuilder(simpleName)
-        // Note: the compiler forbids referencing ApolloExperimental::class directly, except in an @OptIn context
-        .addAnnotation(ClassName("com.apollographql.apollo3.api", "ApolloExperimental"))
+        .addAnnotation(ClassNames.ApolloExperimental)
         .addTypes(
             testBuildersBuilder.map { it.build() }
         )

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.gradle.api
 
 import com.android.build.gradle.api.BaseVariant
+import com.apollographql.apollo3.api.ApolloExperimental
 import com.apollographql.apollo3.compiler.OperationIdGenerator
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
 import com.apollographql.apollo3.compiler.PackageNameGenerator
@@ -294,6 +295,7 @@ interface Service {
    *
    * Only valid when [generateKotlinModels] is true
    */
+  @ApolloExperimental
   val generateTestBuilders: Property<Boolean>
 
   /**

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.gradle.internal
 
+import com.apollographql.apollo3.api.ApolloExperimental
 import com.apollographql.apollo3.compiler.OperationIdGenerator
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
 import com.apollographql.apollo3.compiler.PackageNameGenerator
@@ -473,6 +474,7 @@ abstract class DefaultApolloExtension(
       task.generateSchema.set(service.generateSchema)
       task.codegenModels.set(service.codegenModels)
       task.flattenModels.set(service.flattenModels)
+      @OptIn(ApolloExperimental::class)
       task.generateTestBuilders.set(service.generateTestBuilders)
       task.sealedClassesForEnumsMatching.set(service.sealedClassesForEnumsMatching)
       task.generateOptionalOperationVariables.set(service.generateOptionalOperationVariables)

--- a/tests/models-operation-based/src/jvmTest/kotlin/test/TestBuildersTest.kt
+++ b/tests/models-operation-based/src/jvmTest/kotlin/test/TestBuildersTest.kt
@@ -6,11 +6,13 @@ import codegen.models.MergedFieldWithSameShapeQuery
 import codegen.models.test.AllPlanetsQuery_TestBuilder.Data
 import codegen.models.test.HeroAndFriendsWithTypenameQuery_TestBuilder.Data
 import codegen.models.test.MergedFieldWithSameShapeQuery_TestBuilder.Data
+import com.apollographql.apollo3.api.ApolloExperimental
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.fail
 
+@OptIn(ApolloExperimental::class)
 class TestBuildersTest {
   @Test
   fun allPlanets() {

--- a/tests/models-response-based/src/commonTest/kotlin/test/TestBuildersTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/TestBuildersTest.kt
@@ -13,6 +13,7 @@ import codegen.models.test.MergedFieldWithSameShapeQuery_TestBuilder.Data
 import codegen.models.type.Date
 import codegen.models.type.Episode
 import com.apollographql.apollo3.api.Adapter
+import com.apollographql.apollo3.api.ApolloExperimental
 import com.apollographql.apollo3.api.CompiledListType
 import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.CompiledNotNullType
@@ -28,6 +29,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.fail
 
+@OptIn(ApolloExperimental::class)
 class TestBuildersTest {
   @Test
   fun allPlanets() {


### PR DESCRIPTION
Resolves #3444.

Add `@ApolloExperimental` to the generated code, which raises a warning when using it:

<img width="866" alt="Screen Shot 2021-11-08 at 17 36 15" src="https://user-images.githubusercontent.com/372852/140784276-9174e212-c55a-4ffd-a4a7-2915137bb21a.png">

Also mark the Gradle plugin setting as experimental but unfortunately this doesn't raise the warning at the call site in `build.gradle.kts`:

<img width="449" alt="Screen Shot 2021-11-08 at 17 48 58" src="https://user-images.githubusercontent.com/372852/140784547-e6af7b08-ba8d-4e15-954f-6028747e1ba1.png">

