### PR TITLE
Tweak the errors doc and add ApolloResponse.dataAssertNoErrors

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -83,6 +83,7 @@ public final class com/apollographql/apollo3/api/ApolloResponse {
 	public synthetic fun <init> (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Ljava/lang/Object;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse;
 	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/ApolloResponse;Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Ljava/lang/Object;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public final fun dataAssertNoErrors ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun dataOrThrow ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun hasErrors ()Z
 	public final fun withExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse;

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -47,7 +47,7 @@ class ApolloResponse<out D : Operation.Data>(
 ) {
 
   /**
-   * A shorthand property to get a non-nullable if handling partial data is not important
+   * A shorthand property to get a non-nullable `data` if handling partial data is not important
    */
   @Deprecated("Please use dataAssertNoErrors methods instead. This will be removed in v3.0.0.",
   ReplaceWith("dataAssertNoErrors"))
@@ -62,7 +62,7 @@ class ApolloResponse<out D : Operation.Data>(
     }
 
   /**
-   * A shorthand property to get a non-nullable if handling partial data is **not** important
+   * A shorthand property to get a non-nullable `data` if handling partial data is **not** important
    *
    * Note: A future version could use [Definitely non nullable types](https://github.com/Kotlin/KEEP/pull/269)
    * to implement something like `ApolloResponse<D>.assertNoErrors(): ApolloResponse<D & Any>`

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -49,8 +49,26 @@ class ApolloResponse<out D : Operation.Data>(
   /**
    * A shorthand property to get a non-nullable if handling partial data is not important
    */
+  @Deprecated("Please use dataAssertNoErrors methods instead. This will be removed in v3.0.0.",
+  ReplaceWith("dataAssertNoErrors"))
   @get:JvmName("dataOrThrow")
   val dataOrThrow: D
+    get() {
+      return if (hasErrors()) {
+        throw ApolloException("The response has errors: $errors")
+      } else {
+        data ?: throw  ApolloException("The server did not return any data")
+      }
+    }
+
+  /**
+   * A shorthand property to get a non-nullable if handling partial data is **not** important
+   *
+   * Note: A future version could use [Definitely non nullable types](https://github.com/Kotlin/KEEP/pull/269)
+   * to implement something like `ApolloResponse<D>.assertNoErrors(): ApolloResponse<D & Any>`
+   */
+  @get:JvmName("dataAssertNoErrors")
+  val dataAssertNoErrors: D
     get() {
       return if (hasErrors()) {
         throw ApolloException("The response has errors: $errors")

--- a/docs/source/essentials/01-errors.mdx
+++ b/docs/source/essentials/01-errors.mdx
@@ -1,6 +1,5 @@
 ---
-title: Error handling in Apollo Android
-sidebar_title: Errors
+title: Error handling
 ---
 
 Whenever you execute a GraphQL operation with Apollo Android (or any other GraphQL client), two high-level types of errors can occur:
@@ -21,7 +20,7 @@ try {
 }
 ```
 
-### Possible causes
+**Non-exhaustive list of possible causes:**
 
 * The app is offline or doesn't have access to the network.
 * A DNS error occurred, making it impossible to look up the host.
@@ -31,6 +30,7 @@ try {
 * The server didn't respond with valid JSON.
 * The response JSON doesn't satisfy the schema and cannot be parsed.
 * A request was specified as CacheOnly but the data wasn't cached.
+* ...
 
 Examine the exception to get more detailed information about the actual error happening.
 
@@ -103,11 +103,13 @@ if (person != null) {
 }
 ```
 
-If you don't want to handle partial responses, you can use `dataOrThrow()`. This returns a non-nullable `data` and throws if there are any errors:
+## Ignoring partial data
+
+If you don't want to handle partial responses, you can simplify your error handling logic.`ApolloResponse.dataAssertNoErrors` will return a non-nullable `data` and throws if there are any errors so that you can handle all eroors in a single `catch {}` block. :
 
 ```
 val data = try {
-  apolloClient.query(query).execute().dataOrThrow
+  apolloClient.query(query).execute().dataAssertNoErrors
 } catch(exception: ApolloException) {
   // All network or GraphQL errors are handled here
   throw exception
@@ -117,4 +119,4 @@ val data = try {
 val title = data.film?.title
 ```
 
-Note that the safe call is still required on `film` because this field has a nullable type in the GraphQL schema. There are ways to override this in codegen. For details, see [@nonnull](../advanced/nonnull).
+Note that the safe call is still required on `film` because this field has a nullable type in the GraphQL schema. There are ways to override this in codegen. For more details, see [@nonnull](../advanced/nonnull).

--- a/docs/source/essentials/01-errors.mdx
+++ b/docs/source/essentials/01-errors.mdx
@@ -105,11 +105,11 @@ if (person != null) {
 
 ## Ignoring partial data
 
-If you don't want to handle partial responses, you can simplify your error handling logic.`ApolloResponse.dataAssertNoErrors` will return a non-nullable `data` and throws if there are any errors so that you can handle all eroors in a single `catch {}` block. :
+If you don't want to handle partial responses, you can simplify your error handling logic.`ApolloResponse.dataOrThrow` will return a non-nullable `data` and throws if there are any errors so that you can handle all eroors in a single `catch {}` block. :
 
 ```
 val data = try {
-  apolloClient.query(query).execute().dataAssertNoErrors
+  apolloClient.query(query).execute().dataOrThrow
 } catch(exception: ApolloException) {
   // All network or GraphQL errors are handled here
   throw exception

--- a/docs/source/essentials/01-errors.mdx
+++ b/docs/source/essentials/01-errors.mdx
@@ -109,7 +109,7 @@ If you don't want to handle partial responses, you can simplify your error handl
 
 ```
 val data = try {
-  apolloClient.query(query).execute().dataOrThrow
+  apolloClient.query(query).execute().dataAssertNoErrors
 } catch(exception: ApolloException) {
   // All network or GraphQL errors are handled here
   throw exception

--- a/docs/source/essentials/01-errors.mdx
+++ b/docs/source/essentials/01-errors.mdx
@@ -105,7 +105,7 @@ if (person != null) {
 
 ## Ignoring partial data
 
-If you don't want to handle partial responses, you can simplify your error handling logic.`ApolloResponse.dataOrThrow` will return a non-nullable `data` and throws if there are any errors so that you can handle all eroors in a single `catch {}` block. :
+If you don't want to handle partial responses, you can simplify your error handling logic. `ApolloResponse.dataOrThrow` will return a non-nullable `data` and throw if there are any errors. This way, you can handle all errors in a single `catch {}` block:
 
 ```
 val data = try {

--- a/docs/source/essentials/01-errors.mdx
+++ b/docs/source/essentials/01-errors.mdx
@@ -109,7 +109,7 @@ If you don't want to handle partial responses, you can simplify your error handl
 
 ```
 val data = try {
-  apolloClient.query(query).execute().dataAssertNoErrors
+  apolloClient.query(query).execute().dataOrThrow
 } catch(exception: ApolloException) {
   // All network or GraphQL errors are handled here
   throw exception

--- a/tests/coroutines-mt/src/macosX64Test/kotlin/macos/app/MainTest.kt
+++ b/tests/coroutines-mt/src/macosX64Test/kotlin/macos/app/MainTest.kt
@@ -35,7 +35,7 @@ class MainTest {
             .build()
             .query(GetRandomQuery())
             .execute()
-        check(response.dataOrThrow.random == 42)
+        check(response.dataAssertNoErrors.random == 42)
       }
     }
   }
@@ -60,7 +60,7 @@ class MainTest {
     withContext(Dispatchers.Default) {
       withContext(Dispatchers.Main) {
         val response = client.query(GetRandomQuery()).execute()
-        check(response.dataOrThrow.random == 42)
+        check(response.dataAssertNoErrors.random == 42)
       }
     }
   }

--- a/tests/integration-tests/src/commonTest/kotlin/test/ScalarAdapterTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ScalarAdapterTest.kt
@@ -67,7 +67,7 @@ class ScalarAdapterTest {
     val request = mockServer.takeRequest()
     assertTrue(request.body.utf8().contains(""""variables":{"date":"2001-6-23"}"""))
 
-    assertEquals(MyDate(1978, 4, 27), response.dataOrThrow.launchByDate?.date)
+    assertEquals(MyDate(1978, 4, 27), response.dataAssertNoErrors.launchByDate?.date)
   }
 
   @Test
@@ -84,6 +84,6 @@ class ScalarAdapterTest {
     val request = mockServer.takeRequest()
     assertTrue(request.body.utf8().contains(""""variables":{"date":"2001-6-23"}"""))
 
-    assertEquals(MyDate(1978, 4, 27), response.dataOrThrow.launchByDate?.date)
+    assertEquals(MyDate(1978, 4, 27), response.dataAssertNoErrors.launchByDate?.date)
   }
 }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -43,6 +43,6 @@ public class ClientTest {
     mockServer.enqueue(new MockResponse("{\"data\": {\"random\": 42}}"));
 
     ApolloResponse<GetRandomQuery.Data> response = Rx2Apollo.rxSingle(apolloClient.query(new GetRandomQuery())).blockingGet();
-    Truth.assertThat(response.dataOrThrow().random).isEqualTo(42);
+    Truth.assertThat(response.dataAssertNoErrors().random).isEqualTo(42);
   }
 }

--- a/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
+++ b/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
@@ -10,7 +10,6 @@ class OutOfBoundsTest {
   fun checkOutOfBounds() {
     val data = GetAnimalQuery().parseJsonResponse(
         string = File("src/main/json/response.json").readText(),
-    ).dataOrThrow
-    println(data)
+    ).dataAssertNoErrors
   }
 }


### PR DESCRIPTION
The doc was mostly up to date, mostly cosmetic changes.

I took this opportunity to rename `dataOrThrow` -> `dataAssertNoErrors` that I feel conveys what it's doing more explicitely. 