### PR TITLE
Use only one VM for the push workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Build with Gradle
         run: |
           ulimit -c unlimited
+          # Workaround an issue where kotlinNpmInstall outputs
+          # 'Resolving NPM dependencies using yarn' returns 137
+          ./gradlew compileKotlinJsIr compileKotlinJsLegacy
+          ./gradlew --stop
           ./gradlew ciTestsGradle
       - name: Collect Diagnostics
         if: always()

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,7 @@ on:
     branches: [ dev-3.x ]
 
 jobs:
-  tests-all:
+  push:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
@@ -17,37 +17,22 @@ jobs:
         run: |
           ulimit -c unlimited
           ./gradlew -p tests ciTestsAll
+          ./gradlew dokkaHtmlMultiModule
+          ./gradlew ciPublishSnapshot
+        env:
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          COM_APOLLOGRAPHQL_PROFILE_ID: ${{ secrets.COM_APOLLOGRAPHQL_PROFILE_ID }}
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
       - uses: actions/upload-artifact@v2.2.4
         if: always()
         with:
-          name: test-all.zip
-          path: test-all.zip
-  gh-pages:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build Kdoc
-        run: ./gradlew dokkaHtmlMultiModule
+          name: push.zip
+          path: push.zip
       - name: Deploy Kdoc to github pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: gh-pages # The branch the action should deploy to.
           folder: build/dokkaHtml # The folder the action should deploy.
-  snapshot:
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v2
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: Publish Snapshot
-        run: |
-          ./gradlew ciPublishSnapshot
-        env:
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          COM_APOLLOGRAPHQL_PROFILE_ID: ${{ secrets.COM_APOLLOGRAPHQL_PROFILE_ID }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Build with Gradle
         run: |
           ulimit -c unlimited
+          # Workaround an issue where kotlinNpmInstall outputs
+          # 'Resolving NPM dependencies using yarn' returns 137
+          ./gradlew compileKotlinJsIr compileKotlinJsLegacy
+          ./gradlew --stop
           ./gradlew -p tests ciTestsAll
           ./gradlew dokkaHtmlMultiModule
           ./gradlew ciPublishSnapshot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ following events:
 
 **Workflow:** [`pr.yml`](https://github.com/apollographql/apollo-android/blob/dev-3.x/.github/workflows/pr.yml)
 
-**Jobs:**
+**Jobs (run in parallel):**
 
 - `tests-gradle`
     - Slow gradle tests
@@ -113,22 +113,20 @@ _(Will be replaced to "on pushes to `main` branch" after v3 is released.)_
 
 **Workflow:** [`push.yml`](https://github.com/apollographql/apollo-android/blob/dev-3.x/.github/workflows/push.yml)
 
-**Jobs:**
+**Job:**
 
-- `tests-all`
+- `push`
     - Runs on macOS
     - Slow
     - Run all tests
-- `gh-pages`
-    - Publish KDoc
-- `snapshot`
     - Publish Snapshot to Sonatype
+    - Publish KDoc
 
 ### On new tags
 
 **Workflow:** [`tag.yml`](https://github.com/apollographql/apollo-android/blob/dev-3.x/.github/workflows/tag.yml)
 
-**Jobs:**
+**Job:**
 
 - `publish`
     - Publish to Maven Central


### PR DESCRIPTION
Contrary to the PR workflow, the Push workflow doesn't need to be fast. Run everything in the same machine so that it uses less CPU time overall (no need to checkout 3 times, run dokka 3 times, etc...)

Also, the Push workflow doesn't cancel the previous ones as it can be usefull to have all SNAPSHOTs if we ever need to bisect a regression