### PR TITLE
Rename httpHeader() to addHttpHeader()

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -759,6 +759,9 @@ public abstract interface class com/apollographql/apollo3/api/http/HttpBody {
 }
 
 public final class com/apollographql/apollo3/api/http/HttpContextKt {
+	public static final fun addHttpHeader (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Lcom/apollographql/apollo3/api/http/HttpHeader;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
+	public static final fun addHttpHeader (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
+	public static final fun addHttpHeaders (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Ljava/util/List;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun getHttpHeaders (Lcom/apollographql/apollo3/api/HasExecutionContext;)Ljava/util/List;
 	public static final fun getHttpMethod (Lcom/apollographql/apollo3/api/HasExecutionContext;)Lcom/apollographql/apollo3/api/http/HttpMethod;
 	public static final fun getSendApqExtensions (Lcom/apollographql/apollo3/api/HasExecutionContext;)Z

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
-import com.apollographql.apollo3.api.http.httpHeader
-import com.apollographql.apollo3.api.http.httpHeaders
+import com.apollographql.apollo3.api.http.addHttpHeader
+import com.apollographql.apollo3.api.http.addHttpHeaders
 import com.apollographql.apollo3.api.http.httpMethod
 import com.apollographql.apollo3.api.http.sendApqExtensions
 import com.apollographql.apollo3.api.http.sendDocument
@@ -65,13 +65,13 @@ class ApolloRequest<D : Operation.Data> @Deprecated("Please use ApolloRequest.Bu
 fun <D : Operation.Data> ApolloRequest<D>.withHttpMethod(httpMethod: HttpMethod) = newBuilder().httpMethod(httpMethod).build()
 
 @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
-fun <D : Operation.Data> ApolloRequest<D>.withHttpHeaders(httpHeaders: List<HttpHeader>) = newBuilder().httpHeaders(httpHeaders).build()
+fun <D : Operation.Data> ApolloRequest<D>.withHttpHeaders(httpHeaders: List<HttpHeader>) = newBuilder().addHttpHeaders(httpHeaders).build()
 
 @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
-fun <D : Operation.Data> ApolloRequest<D>.withHttpHeader(httpHeader: HttpHeader) = newBuilder().httpHeader(httpHeader).build()
+fun <D : Operation.Data> ApolloRequest<D>.withHttpHeader(httpHeader: HttpHeader) = newBuilder().addHttpHeader(httpHeader).build()
 
 @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
-fun <D : Operation.Data> ApolloRequest<D>.withHttpHeader(name: String, value: String) = newBuilder().httpHeader(name, value).build()
+fun <D : Operation.Data> ApolloRequest<D>.withHttpHeader(name: String, value: String) = newBuilder().addHttpHeader(name, value).build()
 
 @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
 fun <D : Operation.Data> ApolloRequest<D>.withSendApqExtensions(sendApqExtensions: Boolean) = newBuilder().sendApqExtensions(sendApqExtensions).build()

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/HttpContext.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/HttpContext.kt
@@ -20,17 +20,23 @@ val HasExecutionContext.sendDocument get() = executionContext[SendDocumentContex
 fun <T> HasMutableExecutionContext<T>.httpMethod(httpMethod: HttpMethod) where T : HasMutableExecutionContext<T> = addExecutionContext(executionContext + HttpMethodContext(httpMethod))
 
 /**
- *
+ * Add HTTP headers to be sent with the request.
  */
-fun <T> HasMutableExecutionContext<T>.httpHeaders(httpHeaders: List<HttpHeader>) where T : HasMutableExecutionContext<T> = addExecutionContext(
-    executionContext + HttpHeadersContext(this@httpHeaders.httpHeaders + httpHeaders)
+fun <T> HasMutableExecutionContext<T>.addHttpHeaders(httpHeaders: List<HttpHeader>) where T : HasMutableExecutionContext<T> = addExecutionContext(
+    executionContext + HttpHeadersContext(this.httpHeaders + httpHeaders)
 )
 
-fun <T> HasMutableExecutionContext<T>.httpHeader(httpHeader: HttpHeader) where T : HasMutableExecutionContext<T> = addExecutionContext(
+/**
+ * Add an HTTP header to be sent with the request.
+ */
+fun <T> HasMutableExecutionContext<T>.addHttpHeader(httpHeader: HttpHeader) where T : HasMutableExecutionContext<T> = addExecutionContext(
     executionContext + HttpHeadersContext(httpHeaders + httpHeader)
 )
 
-fun <T> HasMutableExecutionContext<T>.httpHeader(name: String, value: String) where T : HasMutableExecutionContext<T> = httpHeader(
+/**
+ * Add an HTTP header to be sent with the request.
+ */
+fun <T> HasMutableExecutionContext<T>.addHttpHeader(name: String, value: String) where T : HasMutableExecutionContext<T> = addHttpHeader(
     HttpHeader(name, value)
 )
 
@@ -69,3 +75,16 @@ internal class HttpHeadersContext(val value: List<HttpHeader>) : ExecutionContex
 
   companion object Key : ExecutionContext.Key<HttpHeadersContext>
 }
+
+
+@Deprecated("Please use addHttpHeaders instead. This will be removed in v3.0.0.", ReplaceWith("addHttpHeaders(httpHeaders)"))
+fun <T> HasMutableExecutionContext<T>.httpHeaders(httpHeaders: List<HttpHeader>) where T : HasMutableExecutionContext<T> = addHttpHeaders(httpHeaders)
+
+@Deprecated("Please use addHttpHeader instead. This will be removed in v3.0.0.", ReplaceWith("addHttpHeader(httpHeader)"))
+fun <T> HasMutableExecutionContext<T>.httpHeader(httpHeader: HttpHeader) where T : HasMutableExecutionContext<T> = addHttpHeader(httpHeader)
+
+@Deprecated("Please use addHttpHeader instead. This will be removed in v3.0.0.", ReplaceWith("addHttpHeader(name, value)"))
+fun <T> HasMutableExecutionContext<T>.httpHeader(
+    name: String,
+    value: String,
+) where T : HasMutableExecutionContext<T> = addHttpHeader(name, value)

--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.HasMutableExecutionContext
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.http.httpHeader
+import com.apollographql.apollo3.api.http.addHttpHeader
 import com.apollographql.apollo3.network.http.HttpInfo
 import com.apollographql.apollo3.network.http.HttpEngine
 import java.io.File
@@ -73,7 +73,7 @@ fun <T> HasMutableExecutionContext<T>.httpFetchPolicy(httpFetchPolicy: HttpFetch
     HttpFetchPolicy.NetworkOnly -> CachingHttpEngine.NETWORK_ONLY
   }
 
-  return httpHeader(
+  return addHttpHeader(
       CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, policyStr
   )
 }
@@ -81,21 +81,21 @@ fun <T> HasMutableExecutionContext<T>.httpFetchPolicy(httpFetchPolicy: HttpFetch
 /**
  * Configures httpExpireTimeout. Entries will be removed from the cache after this timeout.
  */
-fun <T> HasMutableExecutionContext<T>.httpExpireTimeout(httpExpireTimeout: Long) where T : HasMutableExecutionContext<T> = httpHeader(
+fun <T> HasMutableExecutionContext<T>.httpExpireTimeout(httpExpireTimeout: Long) where T : HasMutableExecutionContext<T> = addHttpHeader(
     CachingHttpEngine.CACHE_EXPIRE_TIMEOUT_HEADER, httpExpireTimeout.toString()
 )
 
 /**
  * Configures httpExpireAfterRead. Entries will be removed from the cache after read if set to true.
  */
-fun <T> HasMutableExecutionContext<T>.httpExpireAfterRead(httpExpireAfterRead: Boolean) where T : HasMutableExecutionContext<T> = httpHeader(
+fun <T> HasMutableExecutionContext<T>.httpExpireAfterRead(httpExpireAfterRead: Boolean) where T : HasMutableExecutionContext<T> = addHttpHeader(
     CachingHttpEngine.CACHE_EXPIRE_AFTER_READ_HEADER, httpExpireAfterRead.toString()
 )
 
 /**
  * Configures httpDoNotStore. Entries will never be stored if set to true.
  */
-fun <T> HasMutableExecutionContext<T>.httpDoNotStore(httpDoNotStore: Boolean) where T : HasMutableExecutionContext<T> = httpHeader(
+fun <T> HasMutableExecutionContext<T>.httpDoNotStore(httpDoNotStore: Boolean) where T : HasMutableExecutionContext<T> = addHttpHeader(
     CachingHttpEngine.CACHE_DO_NOT_STORE, httpDoNotStore.toString()
 )
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -46,7 +46,7 @@ class ApolloQueryCall<D: Query.Data>(apolloClient: ApolloClient, query: Query<D>
    * Example:
    * ```
    * val response = apolloClient.query(HeroQuery())
-   *                  .httpHeader("Authorization", myToken)
+   *                  .addHttpHeader("Authorization", myToken)
    *                  .fetchPolicy(FetchPolicy.NetworkOnly)
    *                  .execute()
    * ```
@@ -74,7 +74,7 @@ class ApolloMutationCall<D: Mutation.Data>(apolloClient: ApolloClient, mutation:
    * Example:
    * ```
    * val response = apolloClient.mutate(SetHeroName("Luke"))
-   *                  .httpHeader("Authorization", myToken)
+   *                  .addHttpHeader("Authorization", myToken)
    *                  .optimisticData(data)
    *                  .execute()
    * ```

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -16,8 +16,8 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
-import com.apollographql.apollo3.api.http.httpHeader
-import com.apollographql.apollo3.api.http.httpHeaders
+import com.apollographql.apollo3.api.http.addHttpHeader
+import com.apollographql.apollo3.api.http.addHttpHeaders
 import com.apollographql.apollo3.api.http.httpMethod
 import com.apollographql.apollo3.api.http.sendApqExtensions
 import com.apollographql.apollo3.api.http.sendDocument
@@ -380,13 +380,13 @@ fun ApolloClient.withAutoPersistedQueries(
 fun ApolloClient.withHttpMethod(httpMethod: HttpMethod) = newBuilder().httpMethod(httpMethod).build()
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
-fun ApolloClient.withHttpHeaders(httpHeaders: List<HttpHeader>) = newBuilder().httpHeaders(httpHeaders).build()
+fun ApolloClient.withHttpHeaders(httpHeaders: List<HttpHeader>) = newBuilder().addHttpHeaders(httpHeaders).build()
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
-fun ApolloClient.withHttpHeader(httpHeader: HttpHeader) = newBuilder().httpHeader(httpHeader).build()
+fun ApolloClient.withHttpHeader(httpHeader: HttpHeader) = newBuilder().addHttpHeader(httpHeader).build()
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
-fun ApolloClient.withHttpHeader(name: String, value: String) = newBuilder().httpHeader(name, value).build()
+fun ApolloClient.withHttpHeader(name: String, value: String) = newBuilder().addHttpHeader(name, value).build()
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
 fun ApolloClient.withSendApqExtensions(sendApqExtensions: Boolean) = newBuilder().sendApqExtensions(sendApqExtensions).build()

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.http.HttpBody
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.api.http.httpHeader
+import com.apollographql.apollo3.api.http.addHttpHeader
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.api.internal.json.BufferedSinkJsonWriter
 import com.apollographql.apollo3.api.internal.json.BufferedSourceJsonReader
@@ -210,7 +210,7 @@ class BatchingHttpEngine(
   }
 }
 
-fun <T> HasMutableExecutionContext<T>.canBeBatched(canBeBatched: Boolean) where T : HasMutableExecutionContext<T> = httpHeader(
+fun <T> HasMutableExecutionContext<T>.canBeBatched(canBeBatched: Boolean) where T : HasMutableExecutionContext<T> = addHttpHeader(
     CAN_BE_BATCHED, canBeBatched.toString()
 )
 

--- a/design-docs/Builders.md
+++ b/design-docs/Builders.md
@@ -235,7 +235,7 @@ class MyInterceptor : ApolloInterceptor {
     chain.proceed(
       request
         .newBuilder()
-        .httpHeader("myHeader", "value")
+        .addHttpHeader("myHeader", "value")
         .build()
     )
   }

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpRequestComposerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpRequestComposerTest.kt
@@ -4,7 +4,7 @@ import checkTestFixture
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.http.ApolloHttpRequestComposer
-import com.apollographql.apollo3.api.http.httpHeader
+import com.apollographql.apollo3.api.http.addHttpHeader
 import com.apollographql.apollo3.integration.httpcache.AllPlanetsQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -42,7 +42,7 @@ class HttpRequestComposerTest {
     kotlin.runCatching {
       // No need to enqueue a successful response, we just want to make sure our headers reached the server
       mockServer.enqueue("error")
-      apolloClient.query(AllPlanetsQuery()).httpHeader("test", "is passing").execute()
+      apolloClient.query(AllPlanetsQuery()).addHttpHeader("test", "is passing").execute()
     }
 
     val response = mockServer.takeRequest()


### PR DESCRIPTION
To be consistent with the other similar APIs (good catch by @martinbonnin!)