### PR TITLE
Handle experimental opt ins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ files.
 ## Experimental / internal APIs
 
 Using Kotlin's (or other dependencies') experimental or internal APIs, such as the ones marked
-with `@ExperimentalCoroutinesApi` should be avoided as much as possible (exceptions can be made when no other option is
+with `@ExperimentalCoroutinesApi` should be avoided as much as possible (exceptions can be made for native/JS targets only when no other option is
 available). Indeed, applications using a certain version of Apollo Android could use a more up-to-date version of these
 APIs than the one used when building the library, causing crashes or other issues.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,17 @@ allowed and any public API change will fail the build.
 If that happens, you will need to run `./gradlew apiDump` and check for any incompatible changes before commiting these
 files.
 
+## Experimental / internal APIs
+
+Using Kotlin's (or other dependencies') experimental or internal APIs, such as the ones marked
+with `@ExperimentalCoroutinesApi` should be avoided as much as possible (exceptions can be made when no other option is
+available). Indeed, applications using a certain version of Apollo Android could use a more up-to-date version of these
+APIs than the one used when building the library, causing crashes or other issues.
+
+We also have the `@ApolloExperimental` annotation which can be used to mark APIs as experimental, for instance when
+feedback is wanted from the community on new APIs. This can also be used as a warning that APIs are using experimental
+features of Kotlin/Coroutines/etc. and therefore may break in certain situations.
+
 ## Releasing
 
 Releasing is done using Github Actions. The CI contains credentials to upload artifacts to Sonatype and the Gradle

--- a/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -30,7 +30,6 @@ import kotlin.native.concurrent.freeze
  * @param acceptDelayMillis: an artificial delay introduced before each `accept()`
  * call. Can be used to simulate slow connections.
  */
-@OptIn(ExperimentalUnsignedTypes::class)
 class NativeMockServer(
     private val acceptDelayMillis: Long = 0
 ): MockServer {

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -377,12 +377,6 @@ public final class com/apollographql/apollo3/network/ws/GraphQLWsProtocol$Factor
 	public fun getName ()Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine : com/apollographql/apollo3/network/ws/WebSocketEngine {
-	public fun <init> ()V
-	public fun <init> (Lokhttp3/WebSocket$Factory;)V
-	public fun open (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class com/apollographql/apollo3/network/ws/OkHttpWebSocketEngineKt {
 	public static final fun WebSocketEngine ()Lcom/apollographql/apollo3/network/ws/WebSocketEngine;
 }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -377,6 +377,12 @@ public final class com/apollographql/apollo3/network/ws/GraphQLWsProtocol$Factor
 	public fun getName ()Ljava/lang/String;
 }
 
+public final class com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine : com/apollographql/apollo3/network/ws/WebSocketEngine {
+	public fun <init> ()V
+	public fun <init> (Lokhttp3/WebSocket$Factory;)V
+	public fun open (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class com/apollographql/apollo3/network/ws/OkHttpWebSocketEngineKt {
 	public static final fun WebSocketEngine ()Lcom/apollographql/apollo3/network/ws/WebSocketEngine;
 }

--- a/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHttpEngine.kt
+++ b/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHttpEngine.kt
@@ -95,7 +95,6 @@ class NSURLSessionHttpEngine(
   }
 }
 
-@OptIn(ExperimentalUnsignedTypes::class)
 private fun buildHttpResponse(
     data: NSData?,
     httpResponse: NSHTTPURLResponse?,
@@ -149,7 +148,7 @@ private fun buildHttpResponse(
   )
 }
 
-private class DefaultDataTaskFactory() : DataTaskFactory {
+private class DefaultDataTaskFactory : DataTaskFactory {
   private val nsurlSession = NSURLSession.sessionWithConfiguration(NSURLSessionConfiguration.defaultSessionConfiguration())
 
   override fun dataTask(request: NSURLRequest, completionHandler: UrlSessionDataTaskCompletionHandler): NSURLSessionDataTask {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -35,7 +35,6 @@ import com.apollographql.apollo3.network.ws.WebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlin.jvm.JvmOverloads
@@ -138,7 +137,6 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
    * For more advanced use cases like watchers or subscriptions, it may contain any number of elements and never
    * finish. You can cancel the corresponding coroutine to terminate the [Flow] in this case.
    */
-  @OptIn(ExperimentalCoroutinesApi::class, kotlinx.coroutines.FlowPreview::class)
   fun <D : Operation.Data> executeAsFlow(apolloRequest: ApolloRequest<D>): Flow<ApolloResponse<D>> {
     assertMainThreadOnNative()
     val executionContext = concurrencyInfo + customScalarAdapters + executionContext + apolloRequest.executionContext

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/ChannelWrapper.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/ChannelWrapper.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.channels.Channel
 
 /**
  * A wrapper for [Channel] that adds a method equivalent to [invokeOnClose], which is marked [ExperimentalCoroutinesApi].
- * There is a risk this API will be removed or changed in the future, which could break consumers of this library
- * - that is why we use our own method.
+ * There is a risk this API will be removed or changed in the future, which could break consumers of this library - that is why we use our
+ * own method.
+ *
+ * [Original source](https://github.com/Kotlin/kotlinx.coroutines/blob/version-1.5.2/kotlinx-coroutines-core/common/src/channels/AbstractChannel.kt#L286)
  *
  * TODO: remove when Channel.invokeOnClose is no longer marked ExperimentalCoroutinesApi.
  */

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/ChannelWrapper.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/ChannelWrapper.kt
@@ -1,0 +1,33 @@
+package com.apollographql.apollo3.internal
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+
+/**
+ * A wrapper for [Channel] that adds a method equivalent to [invokeOnClose], which is marked [ExperimentalCoroutinesApi].
+ * There is a risk this API will be removed or changed in the future, which could break consumers of this library
+ * - that is why we use our own method.
+ *
+ * TODO: remove when Channel.invokeOnClose is no longer marked ExperimentalCoroutinesApi.
+ */
+internal class ChannelWrapper<E>(private val wrapped: Channel<E>) : Channel<E> by wrapped {
+  private var handler: ((cause: Throwable?) -> Unit)? = null
+
+  var isClosed: Boolean = false
+    private set
+
+  /**
+   * See [invokeOnClose].
+   */
+  fun setInvokeOnClose(handler: (cause: Throwable?) -> Unit) {
+    this.handler = handler
+  }
+
+  override fun close(cause: Throwable?): Boolean {
+    isClosed = true
+    val closeAdded = wrapped.close(cause)
+    if (closeAdded) handler?.invoke(cause)
+    handler = null
+    return closeAdded
+  }
+}

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.internal
 
-import com.apollographql.apollo3.api.ApolloInternal
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -15,7 +14,6 @@ import kotlinx.coroutines.flow.flow
  *
  * TODO: remove when kotlinx.coroutines.flow.Flow.transformWhile is no longer marked ExperimentalCoroutinesApi.
  */
-@ApolloInternal
 internal fun <T, R> Flow<T>.transformWhile(
     transform: suspend FlowCollector<R>.(value: T) -> Boolean,
 ): Flow<R> =

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
@@ -1,0 +1,51 @@
+package com.apollographql.apollo3.internal
+
+import com.apollographql.apollo3.api.ApolloInternal
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+
+/**
+ * This is copied from [Flow], which is marked [ExperimentalCoroutinesApi].
+ * There is a risk this API will be removed or changed in the future, which could break consumers of this library
+ * - that is why we use our own copy.
+ *
+ * TODO: remove when kotlinx.coroutines.flow.Flow.transformWhile is no longer marked ExperimentalCoroutinesApi.
+ */
+@ApolloInternal
+internal fun <T, R> Flow<T>.transformWhile(
+    transform: suspend FlowCollector<R>.(value: T) -> Boolean,
+): Flow<R> =
+    flow {
+      return@flow collectWhile { value ->
+        transform(value)
+      }
+    }
+
+private suspend inline fun <T> Flow<T>.collectWhile(crossinline predicate: suspend (value: T) -> Boolean) {
+  val collector = object : FlowCollector<T> {
+    override suspend fun emit(value: T) {
+      if (!predicate(value)) {
+        throw AbortFlowException(this)
+      }
+    }
+  }
+  try {
+    collect {
+      collector.emit(it)
+    }
+  } catch (e: AbortFlowException) {
+    e.checkOwnership(collector)
+  }
+}
+
+private class AbortFlowException(
+    val owner: FlowCollector<*>,
+) : CancellationException("Flow was aborted, no more elements needed") {
+  fun checkOwnership(owner: FlowCollector<*>) {
+    if (this.owner !== owner) throw this
+  }
+}

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/flows.kt
@@ -9,8 +9,10 @@ import kotlinx.coroutines.flow.flow
 
 /**
  * This is copied from [Flow], which is marked [ExperimentalCoroutinesApi].
- * There is a risk this API will be removed or changed in the future, which could break consumers of this library
- * - that is why we use our own copy.
+ * There is a risk this API will be removed or changed in the future, which could break consumers of this library - that is why we use our
+ * own copy.
+ *
+ * [Original source](https://github.com/Kotlin/kotlinx.coroutines/blob/version-1.5.2/kotlinx-coroutines-core/common/src/flow/operators/Limit.kt#L116)
  *
  * TODO: remove when kotlinx.coroutines.flow.Flow.transformWhile is no longer marked ExperimentalCoroutinesApi.
  */

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.network.ws
 
-import com.apollographql.apollo3.api.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -162,7 +161,6 @@ class WebSocketNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder in
     }
   }
 
-  @OptIn(ApolloInternal::class)
   override fun <D : Operation.Data> execute(
       request: ApolloRequest<D>,
   ): Flow<ApolloResponse<D>> {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.network.ws
 
+import com.apollographql.apollo3.api.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -7,9 +8,9 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.internal.ResponseBodyParser
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.internal.BackgroundDispatcher
+import com.apollographql.apollo3.internal.transformWhile
 import com.apollographql.apollo3.network.NetworkTransport
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -23,7 +24,6 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onSubscription
-import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.launch
 
 /**
@@ -162,7 +162,7 @@ class WebSocketNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder in
     }
   }
 
-  @OptIn(ExperimentalCoroutinesApi::class)
+  @OptIn(ApolloInternal::class)
   override fun <D : Operation.Data> execute(
       request: ApolloRequest<D>,
   ): Flow<ApolloResponse<D>> {
@@ -170,7 +170,7 @@ class WebSocketNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder in
       commands.send(StartOperation(request))
     }.filter {
       it.id == request.requestUuid.toString() || it.id == null
-    }.transformWhile {
+    }.transformWhile<Event, Event> {
       when (it) {
         is OperationComplete -> {
           false
@@ -268,4 +268,3 @@ class WebSocketNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder in
     }
   }
 }
-

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
@@ -12,7 +12,7 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 
-internal class OkHttpWebSocketEngine(
+class OkHttpWebSocketEngine(
     private val webSocketFactory: WebSocket.Factory,
 ) : WebSocketEngine {
 


### PR DESCRIPTION
See #3395

- [x] remove 2 instances of `ExperimentalUnsignedTypes`, and `ExperimentalCoroutinesApi` on `ApolloClient.executeAsFlow` (no impact)
- [x] refact `NSURLSessionWebSocketEngine` / `OkHttpWebSocketEngine` to avoid `invokeOnClose`, then remove annotation
- [x] refact `WebSocketNetworkTransport.execute` to avoid `transformWhile`, then remove annotation
- [ ] Apple's `DefaultDispatcher` relying on `Delay`: not sure what to do!