### PR TITLE
Improve java usability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,8 @@ The coding style employed here is fairly conventional Kotlin - indentations are 
 identifiers and methods are camelCased.
 
 * Use primary constructors when there is at most one optional parameter.
-* Use the `Builder` pattern else.
+* Use the `Builder` pattern because it's a well recognized pattern that interops well with Java (see https://github.com/apollographql/apollo-android/issues/3301).
+* Functions with optional parameters are nice. Use `@JvmOverloads` for better Java interop.
 * Parameters using milliseconds should have the "Millis" suffix.
 * Else use [kotlin.time.Duration]
 

--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -299,7 +299,6 @@ public final class com/apollographql/apollo3/api/CompiledGraphQL {
 	public static final field CompiledTypeType Lcom/apollographql/apollo3/api/ObjectType;
 	public static final fun isComposite (Lcom/apollographql/apollo3/api/CompiledNamedType;)Z
 	public static final fun keyFields (Lcom/apollographql/apollo3/api/CompiledNamedType;)Ljava/util/List;
-	public static final fun leafType (Lcom/apollographql/apollo3/api/CompiledType;)Lcom/apollographql/apollo3/api/CompiledNamedType;
 	public static final fun list (Lcom/apollographql/apollo3/api/CompiledType;)Lcom/apollographql/apollo3/api/CompiledListType;
 	public static final fun notNull (Lcom/apollographql/apollo3/api/CompiledType;)Lcom/apollographql/apollo3/api/CompiledNotNullType;
 }
@@ -307,22 +306,26 @@ public final class com/apollographql/apollo3/api/CompiledGraphQL {
 public final class com/apollographql/apollo3/api/CompiledListType : com/apollographql/apollo3/api/CompiledType {
 	public fun <init> (Lcom/apollographql/apollo3/api/CompiledType;)V
 	public final fun getOfType ()Lcom/apollographql/apollo3/api/CompiledType;
+	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public abstract class com/apollographql/apollo3/api/CompiledNamedType : com/apollographql/apollo3/api/CompiledType {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
+	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public final class com/apollographql/apollo3/api/CompiledNotNullType : com/apollographql/apollo3/api/CompiledType {
 	public fun <init> (Lcom/apollographql/apollo3/api/CompiledType;)V
 	public final fun getOfType ()Lcom/apollographql/apollo3/api/CompiledType;
+	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public abstract class com/apollographql/apollo3/api/CompiledSelection {
 }
 
 public abstract class com/apollographql/apollo3/api/CompiledType {
+	public abstract fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public final class com/apollographql/apollo3/api/CompiledVariable {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -142,12 +142,21 @@ class CompiledFragment internal constructor(
 
 data class CompiledCondition(val name: String, val inverted: Boolean)
 
-sealed class CompiledType
+sealed class CompiledType {
+  abstract fun leafType(): CompiledNamedType
+}
 
-class CompiledNotNullType(val ofType: CompiledType) : CompiledType()
-class CompiledListType(val ofType: CompiledType) : CompiledType()
+class CompiledNotNullType(val ofType: CompiledType) : CompiledType() {
+  override fun leafType() = ofType.leafType()
+}
 
-sealed class CompiledNamedType(val name: String) : CompiledType()
+class CompiledListType(val ofType: CompiledType) : CompiledType() {
+  override fun leafType() = ofType.leafType()
+}
+
+sealed class CompiledNamedType(val name: String) : CompiledType() {
+  override fun leafType() = this
+}
 
 class CustomScalarType(
     /**
@@ -240,14 +249,6 @@ class CompiledArgument(val name: String, val value: Any?, val isKey: Boolean = f
         else -> value
       }
     }
-  }
-}
-
-fun CompiledType.leafType(): CompiledNamedType {
-  return when (this) {
-    is CompiledNotNullType -> ofType.leafType()
-    is CompiledListType -> ofType.leafType()
-    is CompiledNamedType -> this
   }
 }
 

--- a/apollo-http-cache/api/apollo-http-cache.api
+++ b/apollo-http-cache/api/apollo-http-cache.api
@@ -35,7 +35,7 @@ public final class com/apollographql/apollo3/cache/http/DiskLruHttpCache {
 public final class com/apollographql/apollo3/cache/http/DiskLruHttpCache$Companion {
 }
 
-public final class com/apollographql/apollo3/cache/http/HttpCacheExtensionsKt {
+public final class com/apollographql/apollo3/cache/http/HttpCacheExtensions {
 	public static final fun httpCache (Lcom/apollographql/apollo3/ApolloClient$Builder;Ljava/io/File;J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun httpDoNotStore (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun httpExpireAfterRead (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;

--- a/apollo-http-cache/api/apollo-http-cache.api
+++ b/apollo-http-cache/api/apollo-http-cache.api
@@ -35,8 +35,8 @@ public final class com/apollographql/apollo3/cache/http/DiskLruHttpCache {
 public final class com/apollographql/apollo3/cache/http/DiskLruHttpCache$Companion {
 }
 
-public final class com/apollographql/apollo3/cache/http/HttpCacheExtensions {
-	public static final fun httpCache (Lcom/apollographql/apollo3/ApolloClient$Builder;Ljava/io/File;J)Lcom/apollographql/apollo3/ApolloClient$Builder;
+public final class com/apollographql/apollo3/cache/http/HttpCache {
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Ljava/io/File;J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun httpDoNotStore (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun httpExpireAfterRead (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun httpExpireTimeout (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;J)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;

--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -1,3 +1,5 @@
+@file:JvmName("HttpCacheExtensions")
+
 package com.apollographql.apollo3.cache.http
 
 import com.apollographql.apollo3.ApolloClient
@@ -6,8 +8,8 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.HasMutableExecutionContext
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.addHttpHeader
-import com.apollographql.apollo3.network.http.HttpInfo
 import com.apollographql.apollo3.network.http.HttpEngine
+import com.apollographql.apollo3.network.http.HttpInfo
 import java.io.File
 
 enum class HttpFetchPolicy {

--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -1,4 +1,4 @@
-@file:JvmName("HttpCacheExtensions")
+@file:JvmName("HttpCache")
 
 package com.apollographql.apollo3.cache.http
 
@@ -44,6 +44,7 @@ enum class HttpFetchPolicy {
  *
  * See also [ApolloClient.Builder.httpEngine] and [ApolloClient.Builder.networkTransport]
  */
+@JvmName("configureApolloClientBuilder")
 fun ApolloClient.Builder.httpCache(
     directory: File,
     maxSize: Long,

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
@@ -3,7 +3,6 @@ package com.apollographql.apollo3.cache.normalized.api
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.keyFields
-import com.apollographql.apollo3.api.leafType
 
 /**
  * An [CacheKeyGenerator] is responsible for finding an id for a given object

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.CompiledNamedType
 import com.apollographql.apollo3.api.CompiledNotNullType
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.isComposite
+import kotlin.jvm.JvmSuppressWildcards
 
 /**
  * A [CacheResolver] that resolves objects and list of objects and fallbacks to the default resolver for scalar fields.
@@ -40,7 +41,12 @@ abstract class CacheKeyResolver : CacheResolver {
    */
   open fun listOfCacheKeysForField(field: CompiledField, variables: Executable.Variables): List<CacheKey?>? = null
 
-  final override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
+  final override fun resolveField(
+      field: CompiledField,
+      variables: Executable.Variables,
+      parent: Map<String, @JvmSuppressWildcards Any?>,
+      parentId: String,
+  ): Any? {
     var type = field.type
     if (type is CompiledNotNullType) {
       type = type.ofType

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -3,7 +3,6 @@ package com.apollographql.apollo3.cache.normalized.api
 import com.apollographql.apollo3.api.CompiledArgument
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.Executable
-import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.exception.CacheMissException
 import kotlin.jvm.JvmSuppressWildcards
 

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -50,18 +50,30 @@ public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/ap
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
 }
 
-public final class com/apollographql/apollo3/cache/normalized/ClientCacheExtensionsKt {
+public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java/lang/Enum {
+	public static final field CacheFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+	public static final field CacheOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+	public static final field NetworkFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+	public static final field NetworkOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
+}
+
+public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun apolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
 	public static final fun cacheHeaders (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun clearNormalizedCache (Lcom/apollographql/apollo3/ApolloClient;)Z
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static synthetic fun configureApolloClientBuilder$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun doNotStore (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun executeCacheAndNetwork (Lcom/apollographql/apollo3/ApolloQueryCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun fetchPolicy (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun getApolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
 	public static final fun getCacheInfo (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
 	public static final fun isFromCache (Lcom/apollographql/apollo3/api/ApolloResponse;)Z
-	public static final fun normalizedCache (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public static synthetic fun normalizedCache$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/ApolloMutationCall;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/ApolloMutationCall;
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/api/ApolloRequest$Builder;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public static final fun refetchPolicy (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
@@ -87,14 +99,5 @@ public final class com/apollographql/apollo3/cache/normalized/ClientCacheExtensi
 	public static final fun withWriteToCacheAsynchronously (Lcom/apollographql/apollo3/ApolloClient;Z)Lcom/apollographql/apollo3/ApolloClient;
 	public static final fun withWriteToCacheAsynchronously (Lcom/apollographql/apollo3/api/ApolloRequest;Z)Lcom/apollographql/apollo3/api/ApolloRequest;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
-}
-
-public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java/lang/Enum {
-	public static final field CacheFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
-	public static final field CacheOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
-	public static final field NetworkFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
-	public static final field NetworkOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
-	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
-	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -1,3 +1,5 @@
+@file:JvmName("NormalizedCacheExtensions")
+
 package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.ApolloClient
@@ -10,17 +12,19 @@ import com.apollographql.apollo3.api.HasMutableExecutionContext
 import com.apollographql.apollo3.api.Mutation
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheInterceptor
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
+import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheInterceptor
 import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.exception.ApolloException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 
 enum class FetchPolicy {
   /**
@@ -58,6 +62,7 @@ enum class FetchPolicy {
  * @param writeToCacheAsynchronously set to true to write to the cache after the response has been emitted.
  * This allows to display results faster
  */
+@JvmOverloads
 fun ApolloClient.Builder.normalizedCache(
     normalizedCacheFactory: NormalizedCacheFactory,
     cacheKeyGenerator: CacheKeyGenerator = TypePolicyCacheKeyGenerator,
@@ -163,6 +168,7 @@ fun <T : HasMutableExecutionContext<T>> HasMutableExecutionContext<T>.writeToCac
 fun <D : Mutation.Data> ApolloRequest.Builder<D>.optimisticUpdates(data: D) = addExecutionContext(
     OptimisticUpdatesContext(data)
 )
+
 fun <D : Mutation.Data> ApolloMutationCall<D>.optimisticUpdates(data: D) = addExecutionContext(
     OptimisticUpdatesContext(data)
 )

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -1,4 +1,4 @@
-@file:JvmName("NormalizedCacheExtensions")
+@file:JvmName("NormalizedCache")
 
 package com.apollographql.apollo3.cache.normalized
 
@@ -63,6 +63,7 @@ enum class FetchPolicy {
  * This allows to display results faster
  */
 @JvmOverloads
+@JvmName("configureApolloClientBuilder")
 fun ApolloClient.Builder.normalizedCache(
     normalizedCacheFactory: NormalizedCacheFactory,
     cacheKeyGenerator: CacheKeyGenerator = TypePolicyCacheKeyGenerator,

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -202,8 +202,8 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : c
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;J)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JI)V
 	public synthetic fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)Lcom/apollographql/apollo3/ApolloCall;
-	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)V
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)V
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBatchIntervalMillis ()J
@@ -212,8 +212,8 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : c
 }
 
 public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$Companion {
-	public final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)Lcom/apollographql/apollo3/ApolloCall;
-	public final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)V
+	public final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)V
 }
 
 public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$PendingRequest {

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -198,6 +198,8 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : c
 	public static final field CAN_BE_BATCHED Ljava/lang/String;
 	public static final field Companion Lcom/apollographql/apollo3/network/http/BatchingHttpEngine$Companion;
 	public fun <init> ()V
+	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;)V
+	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;J)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JI)V
 	public synthetic fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun dispose ()V
@@ -216,7 +218,7 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$Pen
 	public final fun getRequest ()Lcom/apollographql/apollo3/api/http/HttpRequest;
 }
 
-public final class com/apollographql/apollo3/network/http/BatchingHttpEngineKt {
+public final class com/apollographql/apollo3/network/http/BatchingHttpEngineExtensions {
 	public static final fun canBeBatched (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun withCanBeBatched (Lcom/apollographql/apollo3/ApolloClient;Z)Lcom/apollographql/apollo3/ApolloClient;
 	public static final fun withCanBeBatched (Lcom/apollographql/apollo3/api/ApolloRequest;Z)Lcom/apollographql/apollo3/api/ApolloRequest;
@@ -331,6 +333,7 @@ public final class com/apollographql/apollo3/network/http/OkHttpEngine : com/apo
 }
 
 public final class com/apollographql/apollo3/network/http/OkHttpEngineKt {
+	public static final fun HttpEngine ()Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun HttpEngine (J)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static synthetic fun HttpEngine$default (JILjava/lang/Object;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -202,6 +202,8 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : c
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;J)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JI)V
 	public synthetic fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)Lcom/apollographql/apollo3/ApolloCall;
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getBatchIntervalMillis ()J
@@ -210,6 +212,8 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : c
 }
 
 public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$Companion {
+	public final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)Lcom/apollographql/apollo3/ApolloCall;
+	public final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
 
 public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$PendingRequest {

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -42,6 +42,11 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public synthetic fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public final fun addInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun addInterceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun autoPersistedQueries ()Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun autoPersistedQueries (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun autoPersistedQueries (Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun autoPersistedQueries (Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static synthetic fun autoPersistedQueries$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/ApolloClient;
 	public final fun customScalarAdapters (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun executionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -64,8 +69,6 @@ public final class com/apollographql/apollo3/ApolloClient$Companion {
 }
 
 public final class com/apollographql/apollo3/ApolloClientKt {
-	public static final fun autoPersistedQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public static synthetic fun autoPersistedQueries$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun useHttpGetMethodForPersistedQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun useHttpGetMethodForQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun withAutoPersistedQueries (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -215,15 +215,12 @@ class BatchingHttpEngine @JvmOverloads constructor(
     const val CAN_BE_BATCHED = "X-APOLLO-CAN-BE-BATCHED"
 
     @JvmStatic
-    fun configureApolloClientBuilder(apolloClientBuilder: ApolloClient.Builder, canBeBatched: Boolean) = apolloClientBuilder.apply {
+    fun configureApolloClientBuilder(apolloClientBuilder: ApolloClient.Builder, canBeBatched: Boolean) {
       apolloClientBuilder.canBeBatched(canBeBatched)
     }
 
     @JvmStatic
-    fun <D : Operation.Data, E : HasMutableExecutionContext<E>, C : ApolloCall<D, E>> configureApolloCall(
-        apolloCall: C,
-        canBeBatched: Boolean,
-    ) = apolloCall.apply {
+    fun configureApolloCall(apolloCall: ApolloCall<*, *>, canBeBatched: Boolean) {
       apolloCall.canBeBatched(canBeBatched)
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -2,6 +2,7 @@
 
 package com.apollographql.apollo3.network.http
 
+import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.ApolloRequest
@@ -35,6 +36,7 @@ import okio.Buffer
 import okio.BufferedSink
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
 
 /**
  * An [HttpEngine] that wraps another one and batches HTTP queries to execute multiple
@@ -211,6 +213,19 @@ class BatchingHttpEngine @JvmOverloads constructor(
 
   companion object {
     const val CAN_BE_BATCHED = "X-APOLLO-CAN-BE-BATCHED"
+
+    @JvmStatic
+    fun configureApolloClientBuilder(apolloClientBuilder: ApolloClient.Builder, canBeBatched: Boolean) = apolloClientBuilder.apply {
+      apolloClientBuilder.canBeBatched(canBeBatched)
+    }
+
+    @JvmStatic
+    fun <D : Operation.Data, E : HasMutableExecutionContext<E>, C : ApolloCall<D, E>> configureApolloCall(
+        apolloCall: C,
+        canBeBatched: Boolean,
+    ) = apolloCall.apply {
+      apolloCall.canBeBatched(canBeBatched)
+    }
   }
 }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -1,3 +1,5 @@
+@file:JvmName("BatchingHttpEngineExtensions")
+
 package com.apollographql.apollo3.network.http
 
 import com.apollographql.apollo3.ApolloClient
@@ -31,6 +33,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import okio.Buffer
 import okio.BufferedSink
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
 
 /**
  * An [HttpEngine] that wraps another one and batches HTTP queries to execute multiple
@@ -50,7 +54,7 @@ import okio.BufferedSink
  * @param batchIntervalMillis the interval between two batches
  * @param maxBatchSize always send the batch when this threshold is reached
  */
-class BatchingHttpEngine(
+class BatchingHttpEngine @JvmOverloads constructor(
     val delegate: HttpEngine = HttpEngine(),
     val batchIntervalMillis: Long = 10,
     val maxBatchSize: Int = 10,

--- a/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
+++ b/apollo-runtime/src/jvmMain/kotlin/com/apollographql/apollo3/network/http/OkHttpEngine.kt
@@ -105,6 +105,7 @@ class OkHttpEngine(
   }
 }
 
+@JvmOverloads
 actual fun HttpEngine(
     timeoutMillis: Long,
 ): HttpEngine {

--- a/apollo-rx2-support/api/apollo-rx2-support.api
+++ b/apollo-rx2-support/api/apollo-rx2-support.api
@@ -1,13 +1,13 @@
 public final class com/apollographql/apollo3/rx2/Rx2Apollo {
-	public static final fun rxFlowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/Flowable;
-	public static final fun rxFlowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
-	public static synthetic fun rxFlowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
-	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
-	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
 	public static final fun toRx2ApolloInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/Scheduler;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptor;
 	public static synthetic fun toRx2ApolloInterceptor$default (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptor;
 	public static final fun toRx2ApolloInterceptorChain (Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;Lio/reactivex/Scheduler;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptorChain;

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
@@ -16,8 +16,8 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
@@ -155,14 +155,17 @@ class Rx2ApolloStore(
 }
 
 @JvmOverloads
+@JvmName("single")
 fun <D: Query.Data> ApolloQueryCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
 @JvmOverloads
+@JvmName("single")
 fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
 @JvmOverloads
+@JvmName("flowable")
 fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = execute().asFlowable(scheduler.asCoroutineDispatcher())

--- a/apollo-rx3-support/api/apollo-rx3-support.api
+++ b/apollo-rx3-support/api/apollo-rx3-support.api
@@ -1,13 +1,13 @@
 public final class com/apollographql/apollo3/rx3/Rx3Apollo {
-	public static final fun rxFlowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/rxjava3/core/Flowable;
-	public static final fun rxFlowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
-	public static synthetic fun rxFlowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun rxSingle (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
-	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
-	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
 	public static final fun toRx3ApolloInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/rxjava3/core/Scheduler;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptor;
 	public static synthetic fun toRx3ApolloInterceptor$default (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptor;
 	public static final fun toRx3ApolloInterceptorChain (Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;Lio/reactivex/rxjava3/core/Scheduler;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptorChain;

--- a/apollo-rx3-support/build.gradle.kts
+++ b/apollo-rx3-support/build.gradle.kts
@@ -19,6 +19,3 @@ val jar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.rx3")
   }
 }
-
-
-

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
@@ -19,8 +19,8 @@ import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
@@ -81,7 +81,6 @@ class Rx3ApolloStore(
 ) {
   private val dispatcher = scheduler.asCoroutineDispatcher()
 
-  @ApolloExperimental
   fun <D : Operation.Data> rxReadOperation(
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters,
@@ -90,7 +89,6 @@ class Rx3ApolloStore(
     delegate.readOperation(operation, customScalarAdapters, cacheHeaders)
   }
 
-  @ApolloExperimental
   fun <D : Fragment.Data> rxReadFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
@@ -100,7 +98,6 @@ class Rx3ApolloStore(
     delegate.readFragment(fragment, cacheKey, customScalarAdapters, cacheHeaders)
   }
 
-  @ApolloExperimental
   fun <D : Operation.Data> rxWriteOperation(
       operation: Operation<D>,
       operationData: D,
@@ -111,7 +108,6 @@ class Rx3ApolloStore(
     delegate.writeOperation(operation, operationData, customScalarAdapters, cacheHeaders, publish)
   }
 
-  @ApolloExperimental
   fun <D : Fragment.Data> rxWriteFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
@@ -123,7 +119,6 @@ class Rx3ApolloStore(
     delegate.writeFragment(fragment, cacheKey, fragmentData, customScalarAdapters, cacheHeaders, publish)
   }
 
-  @ApolloExperimental
   fun <D : Operation.Data> rxWriteOptimisticUpdates(
       operation: Operation<D>,
       operationData: D,
@@ -134,7 +129,6 @@ class Rx3ApolloStore(
     delegate.writeOptimisticUpdates(operation, operationData, mutationId, customScalarAdapters, publish)
   }
 
-  @ApolloExperimental
   fun rxRollbackOptimisticUpdates(
       mutationId: Uuid,
       publish: Boolean = true,
@@ -142,41 +136,39 @@ class Rx3ApolloStore(
     delegate.rollbackOptimisticUpdates(mutationId, publish)
   }
 
-  @ApolloExperimental
   fun rxRemove(cacheKey: CacheKey, cascade: Boolean = true) = rxSingle(dispatcher) {
     delegate.remove(cacheKey, cascade)
   }
 
-  @ApolloExperimental
   fun rxRemove(cacheKeys: List<CacheKey>, cascade: Boolean = true) = rxSingle(dispatcher) {
     delegate.remove(cacheKeys, cascade)
   }
 
-  @ApolloExperimental
   fun rxPublish(keys: Set<String>) = rxCompletable(dispatcher) {
     delegate.publish(keys)
   }
 
-  @ApolloExperimental
   fun <R : Any> rxAccessCache(block: (NormalizedCache) -> R) = rxSingle(dispatcher) {
     delegate.accessCache(block)
   }
 
-  @ApolloExperimental
   fun rxDump() = rxSingle(dispatcher) {
     delegate.dump()
   }
 }
 
 @JvmOverloads
+@JvmName("single")
 fun <D: Query.Data> ApolloQueryCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
 @JvmOverloads
+@JvmName("single")
 fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
 @JvmOverloads
+@JvmName("flowable")
 fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = execute().asFlowable(scheduler.asCoroutineDispatcher())

--- a/docs/source/advanced/client-awareness.mdx
+++ b/docs/source/advanced/client-awareness.mdx
@@ -11,10 +11,10 @@ Enable it by adding an `ApolloClientAwarenessInterceptor` to your `OkHttpClient`
 ```kotlin
 val apolloClient = ApolloClient.Builder()
     .networkTransport(
-        HttpNetworkTransport(
-            serverUrl = "https://",
-            interceptors = listOf(ApolloClientAwarenessInterceptor(BuildConfig.APPLICATION_ID, BuildConfig.VERSION_NAME))
-        )
+        HttpNetworkTransport.Builder()
+            .serverUrl("https://")
+            .addInterceptor(ApolloClientAwarenessInterceptor(BuildConfig.APPLICATION_ID, BuildConfig.VERSION_NAME))
+            .build()
     )
     .build()
 ```

--- a/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
@@ -2,7 +2,6 @@ package test
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.http.HttpMethod
-import com.apollographql.apollo3.autoPersistedQueries
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue

--- a/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
@@ -3,7 +3,6 @@ package test.declarativecache
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Executable
-import com.apollographql.apollo3.api.leafType
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver

--- a/tests/java-tests/README.md
+++ b/tests/java-tests/README.md
@@ -1,1 +1,4 @@
-Tests written in Java. This module doesn't apply the Kotlin plugin. This is useful to test how APIs, extension functions, etc... are seen from Java
+Tests written in Java. This module doesn't apply the Kotlin plugin. This is useful to test how APIs, extension
+functions, etc... are seen from Java.
+
+Note: some of these tests don't actually test anything, they are just here to see how the API is usable from Java.

--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
   implementation("com.apollographql.apollo3:apollo-runtime")
+  implementation("com.apollographql.apollo3:apollo-http-cache")
   implementation("com.apollographql.apollo3:apollo-normalized-cache")
   implementation("com.apollographql.apollo3:apollo-mockserver")
   implementation("com.apollographql.apollo3:apollo-rx2-support")

--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
   implementation("com.apollographql.apollo3:apollo-runtime")
   implementation("com.apollographql.apollo3:apollo-http-cache")
   implementation("com.apollographql.apollo3:apollo-normalized-cache")
+  implementation("com.apollographql.apollo3:apollo-normalized-cache-sqlite")
   implementation("com.apollographql.apollo3:apollo-mockserver")
   implementation("com.apollographql.apollo3:apollo-rx2-support")
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))

--- a/tests/java-tests/src/main/graphql/operations.graphql
+++ b/tests/java-tests/src/main/graphql/operations.graphql
@@ -18,3 +18,20 @@ fragment catFragment on Cat {
     temperature
   }
 }
+
+mutation CreateCat {
+  createAnimal(
+    input: {
+      class: MAMMAL
+      name: "cat"
+    }
+  ) {
+    ...catFragment
+  }
+}
+
+subscription AnimalCreated {
+  animalCreated {
+    ...catFragment
+  }
+}

--- a/tests/java-tests/src/main/graphql/operations.graphql
+++ b/tests/java-tests/src/main/graphql/operations.graphql
@@ -35,3 +35,7 @@ subscription AnimalCreated {
     ...catFragment
   }
 }
+
+query Location {
+  location
+}

--- a/tests/java-tests/src/main/graphql/schema.graphqls
+++ b/tests/java-tests/src/main/graphql/schema.graphqls
@@ -1,6 +1,7 @@
 type Query {
   random: Int!
   animal: Animal
+  location: GeoPoint
 }
 
 type Mutation {
@@ -42,3 +43,5 @@ enum AnimalClass {
   BIRD
   INSECT
 }
+
+scalar GeoPoint

--- a/tests/java-tests/src/main/graphql/schema.graphqls
+++ b/tests/java-tests/src/main/graphql/schema.graphqls
@@ -3,6 +3,14 @@ type Query {
   animal: Animal
 }
 
+type Mutation {
+  createAnimal(input: AnimalInput!): Animal
+}
+
+type Subscription {
+  animalCreated: Animal
+}
+
 interface Animal {
   species: String
   habitat: Habitat
@@ -21,4 +29,16 @@ type Dog implements Animal {
 type Cat implements Animal {
   species: String
   habitat: Habitat
+}
+
+input AnimalInput {
+  class: AnimalClass!
+  name: String!
+}
+
+enum AnimalClass {
+  MAMMAL
+  FISH
+  BIRD
+  INSECT
 }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Executable;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.apollographql.apollo3.cache.http.HttpCacheExtensionsKt;
+import com.apollographql.apollo3.cache.http.HttpCacheExtensions;
 import com.apollographql.apollo3.cache.http.HttpFetchPolicy;
 import com.apollographql.apollo3.cache.normalized.ClientCacheExtensionsKt;
 import com.apollographql.apollo3.cache.normalized.api.CacheKey;
@@ -112,13 +112,13 @@ public class ClientTest {
   private void httpCache() {
     File cacheDir = new File("/tmp/apollo-cache");
     long cacheSize = 10_000_000;
-    apolloClient = HttpCacheExtensionsKt.httpCache(
+    apolloClient = HttpCacheExtensions.httpCache(
         new ApolloClient.Builder().serverUrl("https://localhost"),
         cacheDir,
         cacheSize
     ).build();
 
-    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(HttpCacheExtensionsKt.httpFetchPolicy(
+    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(HttpCacheExtensions.httpFetchPolicy(
         apolloClient.query(new GetRandomQuery()),
         HttpFetchPolicy.NetworkOnly
     )).blockingGet();

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -1,7 +1,9 @@
 package test;
 
 import com.apollographql.apollo3.ApolloClient;
+import com.apollographql.apollo3.ApolloClientKt;
 import com.apollographql.apollo3.api.ApolloResponse;
+import com.apollographql.apollo3.api.http.HttpMethod;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
 import com.apollographql.apollo3.mockserver.MockServerKt;
@@ -62,4 +64,12 @@ public class ClientTest {
     });
   }
 
+  private void autoPersistedQueries() {
+    apolloClient = ApolloClientKt.autoPersistedQueries(
+        new ApolloClient.Builder().serverUrl("https://localhost"),
+        HttpMethod.Get,
+        HttpMethod.Post,
+        true
+    ).build();
+  }
 }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -26,8 +26,10 @@ import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
 import com.apollographql.apollo3.mockserver.MockServerKt;
+import com.apollographql.apollo3.network.http.ApolloClientAwarenessInterceptor;
 import com.apollographql.apollo3.network.http.BatchingHttpEngine;
 import com.apollographql.apollo3.network.http.BatchingHttpEngineKt;
+import com.apollographql.apollo3.network.http.HttpNetworkTransport;
 import com.apollographql.apollo3.network.http.OkHttpEngineKt;
 import com.apollographql.apollo3.rx2.Rx2Apollo;
 import com.google.common.truth.Truth;
@@ -219,6 +221,17 @@ public class ClientTest {
     apolloClient = new ApolloClient.Builder()
         .serverUrl("https://localhost")
         .addCustomScalarAdapter(javatest.type.GeoPoint.type, geoPointAdapter)
+        .build();
+  }
+
+  private void clientAwareness() {
+    apolloClient = new ApolloClient.Builder()
+        .networkTransport(
+            new HttpNetworkTransport.Builder()
+                .serverUrl("https://localhost")
+                .addInterceptor(new ApolloClientAwarenessInterceptor("clientName", "clientVersion"))
+                .build()
+        )
         .build();
   }
 }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -26,9 +26,8 @@ import com.apollographql.apollo3.mockserver.MockServer;
 import com.apollographql.apollo3.mockserver.MockServerKt;
 import com.apollographql.apollo3.network.http.ApolloClientAwarenessInterceptor;
 import com.apollographql.apollo3.network.http.BatchingHttpEngine;
-import com.apollographql.apollo3.network.http.BatchingHttpEngineKt;
+import com.apollographql.apollo3.network.http.BatchingHttpEngineExtensions;
 import com.apollographql.apollo3.network.http.HttpNetworkTransport;
-import com.apollographql.apollo3.network.http.OkHttpEngineKt;
 import com.apollographql.apollo3.rx2.Rx2Apollo;
 import com.google.common.truth.Truth;
 import io.reactivex.disposables.Disposable;
@@ -97,20 +96,14 @@ public class ClientTest {
   }
 
   private void queryBatching() {
-    apolloClient = BatchingHttpEngineKt.canBeBatched(
+    apolloClient = BatchingHttpEngineExtensions.canBeBatched(
         new ApolloClient.Builder()
             .serverUrl("https://localhost")
-            .httpEngine(
-                new BatchingHttpEngine(
-                    OkHttpEngineKt.HttpEngine(60_000),
-                    10,
-                    10
-                )
-            ),
+            .httpEngine(new BatchingHttpEngine()),
         false
     ).build();
 
-    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(BatchingHttpEngineKt.canBeBatched(
+    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(BatchingHttpEngineExtensions.canBeBatched(
         apolloClient.query(new GetRandomQuery()),
         true
     )).blockingGet();

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -67,18 +67,18 @@ public class ClientTest {
   @Test
   public void simple() {
     mockServer.enqueue(new MockResponse("{\"data\": {\"random\": 42}}"));
-    ApolloResponse<GetRandomQuery.Data> queryResponse = Rx2Apollo.rxSingle(
+    ApolloResponse<GetRandomQuery.Data> queryResponse = Rx2Apollo.single(
         apolloClient.query(new GetRandomQuery())
     ).blockingGet();
     Truth.assertThat(queryResponse.dataAssertNoErrors().random).isEqualTo(42);
 
     mockServer.enqueue(new MockResponse("{\"data\": {\"createAnimal\": {\"__typename\": \"Cat\", \"species\": \"cat\", \"habitat\": {\"temperature\": 10.5}}}}"));
-    ApolloResponse<CreateCatMutation.Data> mutationResponse = Rx2Apollo.rxSingle(
+    ApolloResponse<CreateCatMutation.Data> mutationResponse = Rx2Apollo.single(
         apolloClient.mutate(new CreateCatMutation())
     ).blockingGet();
     Truth.assertThat(mutationResponse.dataAssertNoErrors().createAnimal.catFragment.species).isEqualTo("cat");
 
-    Disposable disposable = Rx2Apollo.rxFlowable(
+    Disposable disposable = Rx2Apollo.flowable(
         apolloClient.subscribe(new AnimalCreatedSubscription())
     ).subscribe(result -> {
       String species = result.dataAssertNoErrors().animalCreated.catFragment.species;
@@ -100,7 +100,7 @@ public class ClientTest {
         false
     ).build();
 
-    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(BatchingHttpEngineExtensions.canBeBatched(
+    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.single(BatchingHttpEngineExtensions.canBeBatched(
         apolloClient.query(new GetRandomQuery()),
         true
     )).blockingGet();
@@ -115,7 +115,7 @@ public class ClientTest {
         cacheSize
     ).build();
 
-    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(HttpCacheExtensions.httpFetchPolicy(
+    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.single(HttpCacheExtensions.httpFetchPolicy(
         apolloClient.query(new GetRandomQuery()),
         HttpFetchPolicy.NetworkOnly
     )).blockingGet();

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -7,6 +7,9 @@ import com.apollographql.apollo3.api.http.HttpMethod;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
 import com.apollographql.apollo3.mockserver.MockServerKt;
+import com.apollographql.apollo3.network.http.BatchingHttpEngine;
+import com.apollographql.apollo3.network.http.BatchingHttpEngineKt;
+import com.apollographql.apollo3.network.http.OkHttpEngineKt;
 import com.apollographql.apollo3.rx2.Rx2Apollo;
 import com.google.common.truth.Truth;
 import io.reactivex.disposables.Disposable;
@@ -71,5 +74,25 @@ public class ClientTest {
         HttpMethod.Post,
         true
     ).build();
+  }
+
+  private void queryBatching() {
+    apolloClient = BatchingHttpEngineKt.canBeBatched(
+        new ApolloClient.Builder()
+            .serverUrl("https://localhost")
+            .httpEngine(
+                new BatchingHttpEngine(
+                    OkHttpEngineKt.HttpEngine(60_000),
+                    10,
+                    10
+                )
+            ),
+        false
+    ).build();
+
+    ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.rxSingle(BatchingHttpEngineKt.canBeBatched(
+        apolloClient.query(new GetRandomQuery()),
+        true
+    )).blockingGet();
   }
 }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -1,14 +1,12 @@
 package test;
 
 import com.apollographql.apollo3.ApolloClient;
-import com.apollographql.apollo3.ApolloClientKt;
 import com.apollographql.apollo3.api.Adapter;
 import com.apollographql.apollo3.api.ApolloResponse;
 import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledGraphQL;
 import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Executable;
-import com.apollographql.apollo3.api.http.HttpMethod;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
 import com.apollographql.apollo3.cache.http.HttpCacheExtensionsKt;
@@ -92,12 +90,10 @@ public class ClientTest {
   }
 
   private void autoPersistedQueries() {
-    apolloClient = ApolloClientKt.autoPersistedQueries(
-        new ApolloClient.Builder().serverUrl("https://localhost"),
-        HttpMethod.Get,
-        HttpMethod.Post,
-        true
-    ).build();
+    apolloClient = new ApolloClient.Builder()
+        .serverUrl("https://localhost")
+        .autoPersistedQueries()
+        .build();
   }
 
   private void queryBatching() {

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -13,11 +13,11 @@ import com.apollographql.apollo3.cache.http.HttpCache;
 import com.apollographql.apollo3.cache.http.HttpFetchPolicy;
 import com.apollographql.apollo3.cache.normalized.NormalizedCache;
 import com.apollographql.apollo3.cache.normalized.api.CacheKey;
+import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator;
+import com.apollographql.apollo3.cache.normalized.api.CacheKeyGeneratorContext;
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyResolver;
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory;
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory;
-import com.apollographql.apollo3.cache.normalized.api.ObjectIdGenerator;
-import com.apollographql.apollo3.cache.normalized.api.ObjectIdGeneratorContext;
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
@@ -123,13 +123,13 @@ public class ClientTest {
         new SqlNormalizedCacheFactory("jdbc:sqlite:apollo.db")
     );
 
-    // Using default objectIdGenerator/cacheResolver
+    // Using default cacheKeyGenerator/cacheResolver
     NormalizedCache.configureApolloClientBuilder(apolloClientBuilder, cacheFactory);
 
-    // Using custom objectIdGenerator/cacheResolver
+    // Using custom cacheKeyGenerator/cacheResolver
 
-    ObjectIdGenerator objectIdGenerator = new ObjectIdGenerator() {
-      @Override public CacheKey cacheKeyForObject(@NotNull Map<String, ?> obj, @NotNull ObjectIdGeneratorContext context) {
+    CacheKeyGenerator cacheKeyGenerator = new CacheKeyGenerator() {
+      @Override public CacheKey cacheKeyForObject(@NotNull Map<String, ?> obj, @NotNull CacheKeyGeneratorContext context) {
         return new CacheKey(obj.get("id").toString());
       }
     };
@@ -145,7 +145,7 @@ public class ClientTest {
       }
     };
 
-    NormalizedCache.configureApolloClientBuilder(apolloClientBuilder, cacheFactory, objectIdGenerator, cacheKeyResolver);
+    NormalizedCache.configureApolloClientBuilder(apolloClientBuilder, cacheFactory, cacheKeyGenerator, cacheKeyResolver);
 
     apolloClient = apolloClientBuilder.build();
   }

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -4,22 +4,19 @@ import com.apollographql.apollo3.ApolloClient;
 import com.apollographql.apollo3.api.Adapter;
 import com.apollographql.apollo3.api.ApolloResponse;
 import com.apollographql.apollo3.api.CompiledField;
-import com.apollographql.apollo3.api.CompiledGraphQL;
 import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Executable;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
 import com.apollographql.apollo3.cache.http.HttpCacheExtensions;
 import com.apollographql.apollo3.cache.http.HttpFetchPolicy;
-import com.apollographql.apollo3.cache.normalized.ClientCacheExtensionsKt;
+import com.apollographql.apollo3.cache.normalized.NormalizedCacheExtensions;
 import com.apollographql.apollo3.cache.normalized.api.CacheKey;
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyResolver;
-import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver;
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory;
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory;
 import com.apollographql.apollo3.cache.normalized.api.ObjectIdGenerator;
 import com.apollographql.apollo3.cache.normalized.api.ObjectIdGeneratorContext;
-import com.apollographql.apollo3.cache.normalized.api.TypePolicyObjectIdGenerator;
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
@@ -130,12 +127,9 @@ public class ClientTest {
     );
 
     // Using default objectIdGenerator/cacheResolver
-    apolloClient = ClientCacheExtensionsKt.normalizedCache(
+    apolloClient = NormalizedCacheExtensions.normalizedCache(
         new ApolloClient.Builder().serverUrl("https://localhost"),
-        cacheFactory,
-        TypePolicyObjectIdGenerator.INSTANCE,
-        FieldPolicyCacheResolver.INSTANCE,
-        false
+        cacheFactory
     ).build();
 
     // Using custom objectIdGenerator/cacheResolver
@@ -148,7 +142,7 @@ public class ClientTest {
 
     CacheKeyResolver cacheKeyResolver = new CacheKeyResolver() {
       @Override public CacheKey cacheKeyForField(@NotNull CompiledField field, @NotNull Executable.Variables variables) {
-        String typename = CompiledGraphQL.leafType(field.getType()).getName();
+        String typename = field.getType().leafType().getName();
         Object id = field.resolveArgument("id", variables);
         if (id instanceof String) {
           return new CacheKey(typename, id.toString());
@@ -157,12 +151,11 @@ public class ClientTest {
       }
     };
 
-    apolloClient = ClientCacheExtensionsKt.normalizedCache(
+    apolloClient = NormalizedCacheExtensions.normalizedCache(
         new ApolloClient.Builder().serverUrl("https://localhost"),
         cacheFactory,
         objectIdGenerator,
-        cacheKeyResolver,
-        false
+        cacheKeyResolver
     ).build();
   }
 

--- a/tests/jpms/src/main/java/com/example/app/Main.java
+++ b/tests/jpms/src/main/java/com/example/app/Main.java
@@ -25,13 +25,13 @@ public class Main {
       );
         ApolloClient apolloClient = apolloClientBuilder.build();
 
-        Rx2Apollo.rxSingle(apolloClient.query(new GetHelloQuery())).subscribe(
-                response -> {
-                    System.out.println(response.data.hello);
-                },
-                throwable -> {
-                    System.out.println(throwable.getMessage());
-                }
+        Rx2Apollo.single(apolloClient.query(new GetHelloQuery())).subscribe(
+            response -> {
+              System.out.println(response.data.hello);
+            },
+            throwable -> {
+              System.out.println(throwable.getMessage());
+            }
         );
 
         apolloClient.dispose();

--- a/tests/jpms/src/main/java/com/example/app/Main.java
+++ b/tests/jpms/src/main/java/com/example/app/Main.java
@@ -2,7 +2,7 @@ package com.example.app;
 
 import com.apollographql.apollo3.ApolloClient;
 import com.apollographql.apollo3.api.Query;
-import com.apollographql.apollo3.cache.normalized.NormalizedCacheExtensions;
+import com.apollographql.apollo3.cache.normalized.NormalizedCache;
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver;
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory;
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator;
@@ -16,7 +16,7 @@ public class Main {
         ApolloClient.Builder apolloClientBuilder = ApolloClient.builder()
                 .serverUrl("https://example.com");
 
-      NormalizedCacheExtensions.normalizedCache(
+      NormalizedCache.configureApolloClientBuilder(
           apolloClientBuilder,
           new MemoryCacheFactory(),
           TypePolicyCacheKeyGenerator.INSTANCE,

--- a/tests/jpms/src/main/java/com/example/app/Main.java
+++ b/tests/jpms/src/main/java/com/example/app/Main.java
@@ -2,7 +2,7 @@ package com.example.app;
 
 import com.apollographql.apollo3.ApolloClient;
 import com.apollographql.apollo3.api.Query;
-import com.apollographql.apollo3.cache.normalized.ClientCacheExtensionsKt;
+import com.apollographql.apollo3.cache.normalized.NormalizedCacheExtensions;
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver;
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory;
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator;
@@ -16,13 +16,13 @@ public class Main {
         ApolloClient.Builder apolloClientBuilder = ApolloClient.builder()
                 .serverUrl("https://example.com");
 
-        ClientCacheExtensionsKt.normalizedCache(
-                apolloClientBuilder,
-                new MemoryCacheFactory(),
-                TypePolicyCacheKeyGenerator.INSTANCE,
-                FieldPolicyCacheResolver.INSTANCE,
-                false
-        );
+      NormalizedCacheExtensions.normalizedCache(
+          apolloClientBuilder,
+          new MemoryCacheFactory(),
+          TypePolicyCacheKeyGenerator.INSTANCE,
+          FieldPolicyCacheResolver.INSTANCE,
+          false
+      );
         ApolloClient apolloClient = apolloClientBuilder.build();
 
         Rx2Apollo.rxSingle(apolloClient.query(new GetHelloQuery())).subscribe(


### PR DESCRIPTION
Related to #3572

- Adds a few Java tests (actually most of them don't _test_ anything, they only show how to use the APIs from Java)
- Make a few adjustments to the APIs to make them nicer to use from Java:
    - Name files with `@JvmName` to avoid the not very intuitive `Kt` names
    - Change extensions into member methods where possible
    - Use `@JvmOverloads` to allow not passing default values

A before/after can be seen [here](https://github.com/apollographql/apollo-android/compare/92a3dbd2c5e6367008b9a15811e339b5a6f7e0cf...2dc3e30d3d0f015adec2a5c3d12917002a7df4da).