### PR TITLE
Add 2.x compat mode for useHttpGetMethodForQueries and useHttpGetMethodForPersistedQueries

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -66,6 +66,8 @@ public final class com/apollographql/apollo3/ApolloClient$Companion {
 public final class com/apollographql/apollo3/ApolloClientKt {
 	public static final fun autoPersistedQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun autoPersistedQueries$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun useHttpGetMethodForPersistedQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static final fun useHttpGetMethodForQueries (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun withAutoPersistedQueries (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient;
 	public static synthetic fun withAutoPersistedQueries$default (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient;
 	public static final fun withHttpHeader (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/http/HttpHeader;)Lcom/apollographql/apollo3/ApolloClient;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -393,3 +393,13 @@ fun ApolloClient.withSendApqExtensions(sendApqExtensions: Boolean) = newBuilder(
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
 fun ApolloClient.withSendDocument(sendDocument: Boolean) = newBuilder().sendDocument(sendDocument).build()
+
+@Deprecated("Used for backward compatibility with 2.x", ReplaceWith("httpMethod(HttpMethod.Get)", "com.apollographql.apollo3.api.http.httpMethod", "com.apollographql.apollo3.api.http.HttpMethod"))
+fun ApolloClient.Builder.useHttpGetMethodForQueries(
+    useHttpGetMethodForQueries: Boolean,
+) = httpMethod(if (useHttpGetMethodForQueries) HttpMethod.Get else HttpMethod.Post)
+
+@Deprecated("Used for backward compatibility with 2.x", ReplaceWith("autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Get)", "com.apollographql.apollo3.api.http.HttpMethod", "com.apollographql.apollo3.api.http.HttpMethod"))
+fun ApolloClient.Builder.useHttpGetMethodForPersistedQueries(
+    useHttpGetMethodForQueries: Boolean,
+) = autoPersistedQueries(httpMethodForHashedQueries = if (useHttpGetMethodForQueries) HttpMethod.Get else HttpMethod.Post)


### PR DESCRIPTION
See #3570.

Honestly I'm not sure about `useHttpGetMethodForPersistedQueries` as the semantics are not the same. Maybe the fact that it's deprecated is enough but maybe that could create more problems than it's solving?