### PR TITLE
Enable JVM default methods

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,12 @@ The coding style employed here is fairly conventional Kotlin - indentations are 
 identifiers and methods are camelCased.
 
 * Use primary constructors when there is at most one optional parameter.
-* Use the `Builder` pattern because it's a well recognized pattern that interops well with Java (see https://github.com/apollographql/apollo-android/issues/3301).
+* Use the `Builder` pattern in other places because it's a well recognized pattern that interops well with Java and doesn't copy too much (see https://github.com/apollographql/apollo-android/issues/3301).
 * Functions with optional parameters are nice. Use `@JvmOverloads` for better Java interop.
+* Interface default function don't support `@JvmOverloads`. (See https://youtrack.jetbrains.com/issue/KT-36102) Try to limit the number of optional parameters when possible.
+* Avoid extension functions when possible because they are awkward to use in Java.
+* The exception to the above rule is when adding function in other modules. `ApolloClient.Builder` extensions are a good example of that.
+* If some extensions do not make sense in Java, mark them with `@JvmName("-$methodName")` to hide them from Java
 * Parameters using milliseconds should have the "Millis" suffix.
 * Else use [kotlin.time.Duration]
 

--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -337,12 +337,8 @@ public final class com/apollographql/apollo3/api/CustomScalarAdapters : com/apol
 	public static final field Empty Lcom/apollographql/apollo3/api/CustomScalarAdapters;
 	public static final field Key Lcom/apollographql/apollo3/api/CustomScalarAdapters$Key;
 	public fun <init> (Ljava/util/Map;)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
 	public final fun newBuilder ()Lcom/apollographql/apollo3/api/CustomScalarAdapters$Builder;
-	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 	public final fun responseAdapterFor (Lcom/apollographql/apollo3/api/CustomScalarType;)Lcom/apollographql/apollo3/api/Adapter;
 }
 
@@ -458,28 +454,17 @@ public abstract interface class com/apollographql/apollo3/api/ExecutionContext {
 	public abstract fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public abstract fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public abstract fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public abstract fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
+	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public final class com/apollographql/apollo3/api/ExecutionContext$Companion {
 }
 
-public final class com/apollographql/apollo3/api/ExecutionContext$DefaultImpls {
-	public static fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
-}
-
 public abstract interface class com/apollographql/apollo3/api/ExecutionContext$Element : com/apollographql/apollo3/api/ExecutionContext {
-	public abstract fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public abstract fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
+	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public abstract fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public abstract fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-}
-
-public final class com/apollographql/apollo3/api/ExecutionContext$Element$DefaultImpls {
-	public static fun fold (Lcom/apollographql/apollo3/api/ExecutionContext$Element;Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public static fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Element;Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
-	public static fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Element;Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public static fun plus (Lcom/apollographql/apollo3/api/ExecutionContext$Element;Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
+	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public abstract interface class com/apollographql/apollo3/api/ExecutionContext$Key {
@@ -615,41 +600,39 @@ public final class com/apollographql/apollo3/api/ObjectType : com/apollographql/
 
 public abstract interface class com/apollographql/apollo3/api/Operation : com/apollographql/apollo3/api/Executable {
 	public abstract fun adapter ()Lcom/apollographql/apollo3/api/Adapter;
+	public fun composeJsonData (Lcom/apollographql/apollo3/api/Operation$Data;)Ljava/lang/String;
+	public fun composeJsonData (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
+	public fun composeJsonData (Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;)V
+	public fun composeJsonData (Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)V
+	public fun composeJsonRequest ()Ljava/lang/String;
+	public fun composeJsonRequest (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/String;
+	public fun composeJsonRequest (Lokio/BufferedSink;)V
+	public fun composeJsonRequest (Lokio/BufferedSink;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
+	public static synthetic fun composeJsonRequest$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Ljava/lang/String;
+	public fun composeJsonResponse (Lcom/apollographql/apollo3/api/Operation$Data;)Ljava/lang/String;
+	public fun composeJsonResponse (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
+	public fun composeJsonResponse (Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;)V
+	public fun composeJsonResponse (Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)V
 	public abstract fun document ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;
 	public abstract fun name ()Ljava/lang/String;
+	public fun parseJsonData (Ljava/lang/String;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonData (Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonData (Lokio/BufferedSource;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonData (Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonData (Lokio/ByteString;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonData (Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public fun parseJsonResponse (Ljava/lang/String;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public fun parseJsonResponse (Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public fun parseJsonResponse (Lokio/BufferedSource;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public fun parseJsonResponse (Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public fun parseJsonResponse (Lokio/ByteString;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public fun parseJsonResponse (Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
 	public abstract fun selections ()Ljava/util/List;
 	public abstract fun serializeVariables (Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
 }
 
 public abstract interface class com/apollographql/apollo3/api/Operation$Data : com/apollographql/apollo3/api/Executable$Data {
-}
-
-public final class com/apollographql/apollo3/api/OperationKt {
-	public static final fun composeJsonData (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun composeJsonData (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)V
-	public static synthetic fun composeJsonData$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun composeJsonData$default (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun composeJsonRequest (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/String;
-	public static final fun composeJsonRequest (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
-	public static synthetic fun composeJsonRequest$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun composeJsonRequest$default (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)V
-	public static final fun composeJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun composeJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)V
-	public static synthetic fun composeJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun composeJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSink;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)V
-	public static final fun parseJsonData (Lcom/apollographql/apollo3/api/Operation;Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static final fun parseJsonData (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static final fun parseJsonData (Lcom/apollographql/apollo3/api/Operation;Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static synthetic fun parseJsonData$default (Lcom/apollographql/apollo3/api/Operation;Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static synthetic fun parseJsonData$default (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static synthetic fun parseJsonData$default (Lcom/apollographql/apollo3/api/Operation;Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Operation$Data;
-	public static final fun parseJsonResponse (Lcom/apollographql/apollo3/api/Operation;Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static final fun parseJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static final fun parseJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static synthetic fun parseJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Ljava/lang/String;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static synthetic fun parseJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Lokio/BufferedSource;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static synthetic fun parseJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Lokio/ByteString;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
 }
 
 public abstract class com/apollographql/apollo3/api/Optional {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operation.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operation.kt
@@ -10,6 +10,7 @@ import okio.BufferedSink
 import okio.BufferedSource
 import okio.ByteString
 import kotlin.js.JsName
+import kotlin.jvm.JvmOverloads
 
 /**
  * Represents a GraphQL operation (mutation, query or subscription).
@@ -44,181 +45,278 @@ interface Operation<D : Operation.Data> : Executable<D> {
    * Marker interface for generated models built from data returned by the server in response to this operation.
    */
   interface Data : Executable.Data
-}
 
-/**
- * Reads a GraphQL Json response like below to a [ApolloResponse]
- * ```
- * {
- *  "data": ...
- *  "errors": ...
- *  "extensions": ...
- * }
- * ```
- */
-fun <D : Operation.Data> Operation<D>.parseJsonResponse(
-    source: BufferedSource,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): ApolloResponse<D> {
-  return ResponseBodyParser.parse(source, this, customScalarAdapters)
-}
-
-/**
- * See [parseJsonResponse]
- */
-fun <D : Operation.Data> Operation<D>.parseJsonResponse(
-    byteString: ByteString,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): ApolloResponse<D> {
-  return parseJsonResponse(Buffer().write(byteString), customScalarAdapters)
-}
-
-/**
- * See [parseJsonResponse]
- */
-fun <D : Operation.Data> Operation<D>.parseJsonResponse(
-    string: String,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): ApolloResponse<D> {
-  return parseJsonResponse(Buffer().writeUtf8(string), customScalarAdapters)
-}
-
-/**
- * Reads only the "data" part of a GraphQL Json response
- */
-fun <D : Operation.Data> Operation<D>.parseJsonData(
-    source: BufferedSource,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): D {
-  return adapter().fromJson(source, customScalarAdapters)
-}
-
-/**
- * see [parseJsonResponse]
- */
-fun <D : Operation.Data> Operation<D>.parseJsonData(
-    byteString: ByteString,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): D {
-  return adapter().fromJson(Buffer().write(byteString), customScalarAdapters)
-}
-
-/**
- * see [parseJsonData]
- */
-fun <D : Operation.Data> Operation<D>.parseJsonData(
-    string: String,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): D {
-  return adapter().fromJson(string, customScalarAdapters)
-}
-
-
-/**
- * writes a successful GraphQL Json response containing "data" to the given sink.
- *
- * Use this for testing/mocking a valid GraphQL response
- */
-fun <D : Operation.Data> Operation<D>.composeJsonResponse(
-    sink: BufferedSink,
-    data: D,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-    indent: String = "",
-) {
-  val writer = BufferedSinkJsonWriter(sink)
-  writer.indent = indent
-  writer.writeObject {
-    name("data")
-    adapter().toJson(this, customScalarAdapters, data)
+  /**
+   * Reads a GraphQL Json response like below to a [ApolloResponse]
+   * ```
+   * {
+   *  "data": ...
+   *  "errors": ...
+   *  "extensions": ...
+   * }
+   * ```
+   */
+  fun parseJsonResponse(
+      source: BufferedSource,
+      customScalarAdapters: CustomScalarAdapters,
+  ): ApolloResponse<D> {
+    return ResponseBodyParser.parse(source, this, customScalarAdapters)
   }
-}
 
-/**
- * see [composeJsonResponse]
- */
-fun <D : Operation.Data> Operation<D>.composeJsonResponse(
-    data: D,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-    indent: String = "",
-): String {
-  val buffer = Buffer()
-
-  composeJsonResponse(
-      sink = buffer,
-      data = data,
-      customScalarAdapters = customScalarAdapters,
-      indent = indent
-  )
-
-  return buffer.readUtf8()
-}
-
-/**
- * writes operation data to the given sink
- *
- * Use this for testing/mocking a valid GraphQL response
- */
-fun <D : Operation.Data> Operation<D>.composeJsonData(
-    sink: BufferedSink,
-    data: D,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-    indent: String = "",
-) {
-  val writer = BufferedSinkJsonWriter(sink)
-  writer.indent = indent
-  adapter().toJson(writer, customScalarAdapters, data)
-}
-
-/**
- * See [composeJsonData]
- */
-fun <D : Operation.Data> Operation<D>.composeJsonData(
-    data: D,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-    indent: String = "",
-): String {
-  val buffer = Buffer()
-  composeJsonData(
-      sink = buffer,
-      data = data,
-      customScalarAdapters = customScalarAdapters,
-      indent = indent
-  )
-  return buffer.readUtf8()
-}
+  /**
+   * See [parseJsonResponse]
+   */
+  fun parseJsonResponse(
+      source: BufferedSource,
+  ): ApolloResponse<D> {
+    return ResponseBodyParser.parse(source, this, CustomScalarAdapters.Empty)
+  }
 
 
-/**
- * writes the body of a GraphQL json request like below:
- * {
- *  "query": ...
- *  "variables": ...
- *  "extensions": ...
- * }
- */
-fun <D : Operation.Data> Operation<D>.composeJsonRequest(
-    sink: BufferedSink,
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-) {
-  val composer = ApolloHttpRequestComposer("unused")
+  /**
+   * See [parseJsonResponse]
+   */
+  fun parseJsonResponse(
+      byteString: ByteString,
+      customScalarAdapters: CustomScalarAdapters,
+  ): ApolloResponse<D> {
+    return parseJsonResponse(Buffer().write(byteString), customScalarAdapters)
+  }
 
-  val request = composer.compose(
-      ApolloRequest.Builder(operation = this)
-          .addExecutionContext(customScalarAdapters)
-          .build()
-  )
+  /**
+   * See [parseJsonResponse]
+   */
+  fun parseJsonResponse(
+      byteString: ByteString,
+  ): ApolloResponse<D> {
+    return parseJsonResponse(Buffer().write(byteString), CustomScalarAdapters.Empty)
+  }
 
-  request.body!!.writeTo(sink)
-}
+  /**
+   * See [parseJsonResponse]
+   */
+  fun parseJsonResponse(
+      string: String,
+      customScalarAdapters: CustomScalarAdapters,
+  ): ApolloResponse<D> {
+    return parseJsonResponse(Buffer().writeUtf8(string), customScalarAdapters)
+  }
 
-/**
- * see [composeJsonRequest]
- */
-fun <D : Operation.Data> Operation<D>.composeJsonRequest(
-    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
-): String {
-  return Buffer().apply {
-    composeJsonRequest(this, customScalarAdapters)
-  }.readUtf8()
+  /**
+   * See [parseJsonResponse]
+   */
+  fun parseJsonResponse(
+      string: String,
+  ): ApolloResponse<D> {
+    return parseJsonResponse(Buffer().writeUtf8(string), CustomScalarAdapters.Empty)
+  }
+
+  /**
+   * Reads only the "data" part of a GraphQL Json response
+   */
+  fun parseJsonData(
+      source: BufferedSource,
+      customScalarAdapters: CustomScalarAdapters,
+  ): D {
+    return adapter().fromJson(source, customScalarAdapters)
+  }
+
+  /**
+   * Reads only the "data" part of a GraphQL Json response
+   */
+  fun parseJsonData(
+      source: BufferedSource,
+  ): D {
+    return adapter().fromJson(source, CustomScalarAdapters.Empty)
+  }
+
+  /**
+   * see [parseJsonResponse]
+   */
+  fun parseJsonData(
+      byteString: ByteString,
+      customScalarAdapters: CustomScalarAdapters,
+  ): D {
+    return adapter().fromJson(Buffer().write(byteString), customScalarAdapters)
+  }
+
+  /**
+   * see [parseJsonResponse]
+   */
+  fun parseJsonData(
+      byteString: ByteString,
+  ): D {
+    return adapter().fromJson(Buffer().write(byteString), CustomScalarAdapters.Empty)
+  }
+
+  /**
+   * see [parseJsonData]
+   */
+  fun parseJsonData(
+      string: String,
+      customScalarAdapters: CustomScalarAdapters,
+  ): D {
+    return adapter().fromJson(string, customScalarAdapters)
+  }
+
+  /**
+   * see [parseJsonData]
+   */
+  fun parseJsonData(
+      string: String,
+  ): D {
+    return adapter().fromJson(string, CustomScalarAdapters.Empty)
+  }
+
+
+  /**
+   * writes a successful GraphQL Json response containing "data" to the given sink.
+   *
+   * Use this for testing/mocking a valid GraphQL response
+   */
+  fun composeJsonResponse(
+      sink: BufferedSink,
+      data: D,
+      customScalarAdapters: CustomScalarAdapters,
+      indent: String,
+  ) {
+    val writer = BufferedSinkJsonWriter(sink)
+    writer.indent = indent
+    writer.writeObject {
+      name("data")
+      adapter().toJson(this, customScalarAdapters, data)
+    }
+  }
+
+  /**
+   * see [composeJsonResponse]
+   */
+  fun composeJsonResponse(
+      sink: BufferedSink,
+      data: D,
+  ) = composeJsonResponse(sink, data, CustomScalarAdapters.Empty, "  ")
+
+  /**
+   * see [composeJsonResponse]
+   */
+  fun composeJsonResponse(
+      data: D,
+      customScalarAdapters: CustomScalarAdapters,
+      indent: String,
+  ): String {
+    val buffer = Buffer()
+
+    composeJsonResponse(
+        sink = buffer,
+        data = data,
+        customScalarAdapters = customScalarAdapters,
+        indent = indent
+    )
+
+    return buffer.readUtf8()
+  }
+
+  /**
+   * see [composeJsonResponse]
+   */
+  fun composeJsonResponse(
+      data: D,
+  ): String = composeJsonResponse(data, CustomScalarAdapters.Empty, "  ")
+
+  /**
+   * writes operation data to the given sink
+   *
+   * Use this for testing/mocking a valid GraphQL response
+   */
+  fun composeJsonData(
+      sink: BufferedSink,
+      data: D,
+      customScalarAdapters: CustomScalarAdapters,
+      indent: String,
+  ) {
+    val writer = BufferedSinkJsonWriter(sink)
+    writer.indent = indent
+    adapter().toJson(writer, customScalarAdapters, data)
+  }
+
+  /**
+   * See [composeJsonData]
+   */
+  fun composeJsonData(
+      sink: BufferedSink,
+      data: D,
+  ) = composeJsonData(sink, data, CustomScalarAdapters.Empty, "  ")
+
+  /**
+   * See [composeJsonData]
+   */
+  fun composeJsonData(
+      data: D,
+      customScalarAdapters: CustomScalarAdapters,
+      indent: String,
+  ): String {
+    val buffer = Buffer()
+    composeJsonData(
+        sink = buffer,
+        data = data,
+        customScalarAdapters = customScalarAdapters,
+        indent = indent
+    )
+    return buffer.readUtf8()
+  }
+
+  /**
+   * See [composeJsonData]
+   */
+  fun composeJsonData(
+      data: D,
+  ): String = composeJsonData(data, CustomScalarAdapters.Empty, "  ")
+
+
+  /**
+   * writes the body of a GraphQL json request like below:
+   * {
+   *  "query": ...
+   *  "variables": ...
+   *  "extensions": ...
+   * }
+   */
+  fun composeJsonRequest(
+      sink: BufferedSink,
+      customScalarAdapters: CustomScalarAdapters,
+  ) {
+    val composer = ApolloHttpRequestComposer("unused")
+
+    val request = composer.compose(
+        ApolloRequest.Builder(operation = this)
+            .addExecutionContext(customScalarAdapters)
+            .build()
+    )
+
+    request.body!!.writeTo(sink)
+  }
+
+  /**
+   * See [composeJsonRequest]
+   */
+  fun composeJsonRequest(
+      sink: BufferedSink,
+  ): Unit = composeJsonRequest(sink, CustomScalarAdapters.Empty)
+
+  /**
+   * see [composeJsonRequest]
+   */
+  fun composeJsonRequest(
+      customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
+  ): String {
+    return Buffer().apply {
+      composeJsonRequest(this, customScalarAdapters)
+    }.readUtf8()
+  }
+
+  /**
+   * see [composeJsonRequest]
+   */
+  fun composeJsonRequest(): String = composeJsonRequest(CustomScalarAdapters.Empty)
 }
 

--- a/apollo-gradle-plugin/api/apollo-gradle-plugin.api
+++ b/apollo-gradle-plugin/api/apollo-gradle-plugin.api
@@ -97,15 +97,12 @@ public abstract interface class com/apollographql/apollo3/gradle/api/Service {
 	public abstract fun operationOutputConnection (Lorg/gradle/api/Action;)V
 	public abstract fun outputDirConnection (Lorg/gradle/api/Action;)V
 	public abstract fun packageNamesFromFilePaths (Ljava/lang/String;)V
+	public static synthetic fun packageNamesFromFilePaths$default (Lcom/apollographql/apollo3/gradle/api/Service;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun registerOperations (Lorg/gradle/api/Action;)V
 	public abstract fun registry (Lorg/gradle/api/Action;)V
 	public abstract fun srcDir (Ljava/lang/Object;)V
 	public abstract fun testDirConnection (Lorg/gradle/api/Action;)V
 	public abstract fun useVersion2Compat (Ljava/lang/String;)V
-}
-
-public final class com/apollographql/apollo3/gradle/api/Service$DefaultImpls {
-	public static synthetic fun packageNamesFromFilePaths$default (Lcom/apollographql/apollo3/gradle/api/Service;Ljava/lang/String;ILjava/lang/Object;)V
 	public static synthetic fun useVersion2Compat$default (Lcom/apollographql/apollo3/gradle/api/Service;Ljava/lang/String;ILjava/lang/Object;)V
 }
 

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -7,23 +7,20 @@ public abstract interface class com/apollographql/apollo3/cache/normalized/Apoll
 	public abstract fun normalize (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/util/Map;
 	public abstract fun publish (Ljava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun readFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun readOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun remove (Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun remove (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun rollbackOptimisticUpdates (Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun writeFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun writeOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/cache/normalized/ApolloStore$DefaultImpls {
-	public static synthetic fun readFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun readOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun rollbackOptimisticUpdates (Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun rollbackOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun writeFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun writeFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun writeOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun writeOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun writeOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
@@ -35,16 +32,12 @@ public final class com/apollographql/apollo3/cache/normalized/ApolloStoreKt {
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Key;
 	public fun <init> (JJZLjava/lang/String;Ljava/lang/String;)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getHit ()Z
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
 	public final fun getMillisEnd ()J
 	public final fun getMillisStart ()J
 	public final fun getMissedField ()Ljava/lang/String;
 	public final fun getMissedKey ()Ljava/lang/String;
-	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -102,12 +102,8 @@ public final class com/apollographql/apollo3/ApolloSubscriptionCall : com/apollo
 public final class com/apollographql/apollo3/AutoPersistedQueryInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/AutoPersistedQueryInfo$Key;
 	public fun <init> (Z)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getHit ()Z
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public final class com/apollographql/apollo3/AutoPersistedQueryInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
@@ -124,13 +120,9 @@ public final class com/apollographql/apollo3/AutoPersistedQueryInfoKt {
 public final class com/apollographql/apollo3/ConcurrencyInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/ConcurrencyInfo$Key;
 	public fun <init> (Lkotlinx/coroutines/CoroutineDispatcher;Lkotlinx/coroutines/CoroutineScope;)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getCoroutineScope ()Lkotlinx/coroutines/CoroutineScope;
 	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public final class com/apollographql/apollo3/ConcurrencyInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
@@ -263,15 +255,11 @@ public final class com/apollographql/apollo3/network/http/HttpEngineKt {
 public final class com/apollographql/apollo3/network/http/HttpInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/network/http/HttpInfo$Key;
 	public fun <init> (JJILjava/util/List;)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getHeaders ()Ljava/util/List;
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
 	public final fun getMillisEnd ()J
 	public final fun getMillisStart ()J
 	public final fun getStatusCode ()I
-	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
-	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
 }
 
 public final class com/apollographql/apollo3/network/http/HttpInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
@@ -425,9 +413,6 @@ public abstract interface class com/apollographql/apollo3/network/ws/WebSocketCo
 
 public abstract interface class com/apollographql/apollo3/network/ws/WebSocketEngine {
 	public abstract fun open (Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/network/ws/WebSocketEngine$DefaultImpls {
 	public static synthetic fun open$default (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloParseException

--- a/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
+++ b/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
 
@@ -12,7 +11,7 @@ fun <D : Operation.Data> MockServer.enqueue(
     customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
     delayMs: Long = 0
 ) {
-  val json = operation.composeJsonResponse(data, customScalarAdapters = customScalarAdapters)
+  val json = operation.composeJsonResponse(data, customScalarAdapters = customScalarAdapters, indent = "  ")
   enqueue(json, delayMs)
 }
 

--- a/build-logic/src/main/kotlin/TargetCompatibility.kt
+++ b/build-logic/src/main/kotlin/TargetCompatibility.kt
@@ -10,7 +10,7 @@ fun Project.configureJavaAndKotlinCompilers() {
     // For Kotlin JVM projects
     tasks.withType(KotlinCompile::class.java) {
       it.kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn" + "-Xjvm-default=all"
         apiVersion = "1.5"
         languageVersion = "1.5"
       }

--- a/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockResponse

--- a/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -2,7 +2,6 @@ package test
 
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory

--- a/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.fromJson
 import com.apollographql.apollo3.api.internal.json.BufferedSinkJsonWriter
 import com.apollographql.apollo3.api.json.use
-import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.api.toJson
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.integration.httpcache.AllFilmsQuery

--- a/tests/integration-tests/src/commonTest/kotlin/test/nonnull/NonNullTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/nonnull/NonNullTest.kt
@@ -1,6 +1,5 @@
 package test.nonnull
 
-import com.apollographql.apollo3.api.parseJsonData
 import nonnull.NonNullField1Query
 import nonnull.NonNullField2Query
 import nonnull.NullableField1Query

--- a/tests/integration-tests/src/jvmTest/kotlin/test/CookiesTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/CookiesTest.kt
@@ -1,7 +1,6 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.composeJsonData
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer

--- a/tests/java-tests/src/test/java/test/OperationTest.java
+++ b/tests/java-tests/src/test/java/test/OperationTest.java
@@ -1,0 +1,20 @@
+package test;
+
+import com.apollographql.apollo3.api.CustomScalarAdapters;
+import com.google.common.truth.Truth;
+import javatest.GetRandomQuery;
+import org.junit.Test;
+
+public class OperationTest {
+  @Test
+  public void canUseDefaultFunctions() {
+    GetRandomQuery query = new GetRandomQuery();
+
+    GetRandomQuery.Data data = new GetRandomQuery.Data(42);
+    String json = query.composeJsonData(data, CustomScalarAdapters.Empty, "");
+    // We don't want to test indentation here so we replace newlines
+    Truth.assertThat(json.replace("\n", ""))
+        .isEqualTo("{\"random\":42}");
+  }
+
+}

--- a/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -2,9 +2,7 @@ package test
 
 import codegen.models.AllPlanetsQuery
 import com.apollographql.apollo3.api.AnyAdapter
-import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.internal.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
 import okio.Buffer
 import readJson
 import kotlin.test.Test
@@ -46,7 +44,7 @@ class ParseResponseBodyTest {
     val expected = readJson("OperationJsonWriter.json")
     val query = AllPlanetsQuery()
     val data = query.parseJsonResponse(expected).data
-    val actual = query.composeJsonResponse(data!!, indent = "  ")
+    val actual = query.composeJsonResponse(data!!)
 
     /**
      * operationBased models do not respect the order of fields

--- a/tests/models-operation-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -2,9 +2,7 @@ package test
 
 import codegen.models.AllPlanetsQuery
 import com.apollographql.apollo3.api.AnyAdapter
-import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.internal.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
 import okio.Buffer
 import readJson
 import kotlin.test.Test
@@ -46,7 +44,7 @@ class ParseResponseBodyTest {
     val expected = readJson("OperationJsonWriter.json")
     val query = AllPlanetsQuery()
     val data = query.parseJsonResponse(expected).data
-    val actual = query.composeJsonResponse(data!!, indent = "  ")
+    val actual = query.composeJsonResponse(data!!)
 
     /**
      * operationBased models do not respect the order of fields

--- a/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -4,8 +4,6 @@ import codegen.models.AllPlanetsQuery
 import codegen.models.AllPlanetsQuery.Data.AllPlanets.Planet.Companion.planetFragment
 import codegen.models.AllPlanetsQuery.Data.AllPlanets.Planet.FilmConnection.Film.Companion.filmFragment
 import codegen.models.fragment.PlanetFragment
-import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.mpp.platform
 import readJson
@@ -48,7 +46,7 @@ class ParseResponseBodyTest {
     val expected = readJson("OperationJsonWriter.json")
     val query = AllPlanetsQuery()
     val data = query.parseJsonResponse(expected).data
-    val actual = query.composeJsonResponse(data!!, indent = "  ")
+    val actual = query.composeJsonResponse(data!!)
     if (platform() != Platform.Js) {
       // Do not check strings on JS because of https://youtrack.jetbrains.com/issue/KT-33358#focus=Comments-27-3656643.0-0
       assertEquals(expected, actual)

--- a/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
+++ b/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
@@ -1,6 +1,5 @@
-package test.outofbounds
+package test
 
-import com.apollographql.apollo3.api.parseJsonResponse
 import org.junit.Test
 import outofbounds.GetAnimalQuery
 import java.io.File


### PR DESCRIPTION
This PR enables `-Xjvm-default=all` in the whole project. This is a big change in the binary API so now it's now or never. 

This forces Java8 but Android supports it (it's on by default since AGP 4.2) and we generate Java8 bytecode already anyways.

Besides removing all the `DefaultImpls` classes, this allows moving some extensions to interfaces, making them way easier to call from Java (See `OperationTests`).

For more background about `@JvmDefault`: https://www.zacsweers.dev/jvmdefault-more-useful/