### PR TITLE
Renames in ApolloCall and ApolloClient

### DIFF
--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -82,7 +82,7 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
  * Overriding the [FetchPolicy] will change how the result is first queried.
  */
 fun <D : Query.Data> ApolloQueryCall<D>.watch(): Flow<ApolloResponse<D>> {
-  return copy().addExecutionContext(WatchContext(true)).executeAsFlow()
+  return copy().addExecutionContext(WatchContext(true)).toFlow()
 }
 
 /**

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -26,9 +26,11 @@ public final class com/apollographql/apollo3/ApolloClient : com/apollographql/ap
 	public final fun getInterceptors ()Ljava/util/List;
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
 	public final fun mutate (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloMutationCall;
+	public final fun mutation (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloMutationCall;
 	public final fun newBuilder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun query (Lcom/apollographql/apollo3/api/Query;)Lcom/apollographql/apollo3/ApolloQueryCall;
 	public final fun subscribe (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloSubscriptionCall;
+	public final fun subscription (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloSubscriptionCall;
 	public final fun withCustomScalarAdapter (Lcom/apollographql/apollo3/api/CustomScalarType;Lcom/apollographql/apollo3/api/Adapter;)Lcom/apollographql/apollo3/ApolloClient;
 	public final fun withExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloClient;
 	public final fun withInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Lcom/apollographql/apollo3/ApolloClient;

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -6,6 +6,7 @@ public abstract class com/apollographql/apollo3/ApolloCall : com/apollographql/a
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public final fun getOperation ()Lcom/apollographql/apollo3/api/Operation;
 	public fun setExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)V
+	public final fun toFlow ()Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/apollographql/apollo3/ApolloClient : com/apollographql/apollo3/api/HasExecutionContext {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -23,7 +23,7 @@ abstract class ApolloCall<D : Operation.Data, E : HasMutableExecutionContext<E>>
   }
 
   /**
-   * Returns a Flow with the results of this [ApolloCall].
+   * Returns a cold Flow that produces [ApolloResponse]s for this [ApolloCall].
    * Note that the execution happens when collecting the Flow.
    * This method can be called several times to execute a call again.
    *

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -29,7 +29,7 @@ abstract class ApolloCall<D : Operation.Data, E : HasMutableExecutionContext<E>>
    *
    * Example:
    * ```
-   * apolloClient.subscribe(NewOrders())
+   * apolloClient.subscription(NewOrders())
    *                  .toFlow()
    *                  .collect {
    *                    println("order received: ${it.data?.order?.id"})
@@ -88,7 +88,7 @@ class ApolloMutationCall<D : Mutation.Data>(apolloClient: ApolloClient, mutation
    *
    * Example:
    * ```
-   * val response = apolloClient.mutate(SetHeroName("Luke"))
+   * val response = apolloClient.mutation(SetHeroName("Luke"))
    *                  .addHttpHeader("Authorization", myToken)
    *                  .optimisticData(data)
    *                  .execute()

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3
 
-import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -83,16 +83,22 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
   /**
    * Creates a new [ApolloMutationCall] that you can customize and/or execute.
    */
-  fun <D : Mutation.Data> mutate(mutation: Mutation<D>): ApolloMutationCall<D> {
+  fun <D : Mutation.Data> mutation(mutation: Mutation<D>): ApolloMutationCall<D> {
     return ApolloMutationCall(this, mutation)
   }
+
+  @Deprecated("Please use mutation instead. This will be removed in v3.0.0.", ReplaceWith("mutation(mutation)"))
+  fun <D : Mutation.Data> mutate(mutation: Mutation<D>): ApolloMutationCall<D> = mutation(mutation)
 
   /**
    * Creates a new [ApolloSubscriptionCall] that you can customize and/or execute.
    */
-  fun <D : Subscription.Data> subscribe(subscription: Subscription<D>): ApolloSubscriptionCall<D> {
+  fun <D : Subscription.Data> subscription(subscription: Subscription<D>): ApolloSubscriptionCall<D> {
     return ApolloSubscriptionCall(this, subscription)
   }
+
+  @Deprecated("Please use subscription instead. This will be removed in v3.0.0.", ReplaceWith("subscription(subscription)"))
+  fun <D : Subscription.Data> subscribe(subscription: Subscription<D>): ApolloSubscriptionCall<D> = subscription(subscription)
 
   fun dispose() {
     concurrencyInfo.coroutineScope.cancel()
@@ -131,7 +137,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
   /**
    * Low level API to execute the given [apolloRequest] and return a [Flow].
    *
-   * Prefer [query], [mutate] or [subscribe] when possible.
+   * Prefer [query], [mutation] or [subscription] when possible.
    *
    * For simple queries, the returned [Flow] will contain only one element.
    * For more advanced use cases like watchers or subscriptions, it may contain any number of elements and never

--- a/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
@@ -73,7 +73,7 @@ class ExceptionsTest {
 
     val response = apolloClient
         .query(query)
-        .executeAsFlow()
+        .toFlow()
         .retryWhen { _, attempt -> attempt == 0L }
         .single()
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/FileUploadTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FileUploadTest.kt
@@ -77,7 +77,7 @@ class FileUploadTest {
   @Test
   @Throws(Exception::class)
   fun single() = runTest(before = { setUp() }, after = { tearDown() }) {
-    apolloClient.mutate(mutationSingle).execute()
+    apolloClient.mutation(mutationSingle).execute()
 
     val request = mockServer.takeRequest()
     val parts = request.parts()
@@ -92,7 +92,7 @@ class FileUploadTest {
   @Test
   @Throws(Exception::class)
   fun twice() = runTest(before = { setUp() }, after = { tearDown() }) {
-    apolloClient.mutate(mutationTwice).execute()
+    apolloClient.mutation(mutationTwice).execute()
 
     val request = mockServer.takeRequest()
     val parts = request.parts()
@@ -107,7 +107,7 @@ class FileUploadTest {
   @Test
   @Throws(Exception::class)
   fun multiple() = runTest(before = { setUp() }, after = { tearDown() }) {
-    apolloClient.mutate(mutationMultiple).execute()
+    apolloClient.mutation(mutationMultiple).execute()
 
     val request = mockServer.takeRequest()
     val parts = request.parts()
@@ -122,7 +122,7 @@ class FileUploadTest {
   @Test
   @Throws(Exception::class)
   fun nested() = runTest(before = { setUp() }, after = { tearDown() }) {
-    apolloClient.mutate(mutationNested).execute()
+    apolloClient.mutation(mutationNested).execute()
 
     val request = mockServer.takeRequest()
     val parts = request.parts()

--- a/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -246,7 +246,7 @@ class OptimisticCacheTest {
             )
         )
     )
-    apolloClient.mutate(updateReviewMutation).optimisticUpdates(
+    apolloClient.mutation(updateReviewMutation).optimisticUpdates(
         UpdateReviewMutation.Data(
             UpdateReviewMutation.UpdateReview(
                 "empireReview2",

--- a/tests/optimistic-data/src/test/kotlin/test/OptimisticDataTest.kt
+++ b/tests/optimistic-data/src/test/kotlin/test/OptimisticDataTest.kt
@@ -2,9 +2,7 @@ package test
 
 import app.cash.turbine.test
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.cache.normalized.optimisticUpdates
 import com.apollographql.apollo3.cache.normalized.watch
@@ -86,7 +84,7 @@ class OptimisticDataTest {
           launch {
             val mutation = UpdateAnimalNameMutation(AnimalInput("Irrelevant"))
             try {
-              apolloClient.mutate(mutation)
+              apolloClient.mutation(mutation)
                   .optimisticUpdates(optimisticNameData("Medor"))
                   .execute()
             } catch (e: Exception) {
@@ -98,7 +96,7 @@ class OptimisticDataTest {
           val job = launch {
             delay(100)
             val mutation = UpdateAnimalSpeciesMutation(AnimalInput("Irrelevant"))
-            apolloClient.mutate(mutation)
+            apolloClient.mutation(mutation)
                 .optimisticUpdates(optimisticSpeciesData("Dog"))
                 .execute()
           }

--- a/tests/websockets/src/commonTest/kotlin/AppSyncTest.kt
+++ b/tests/websockets/src/commonTest/kotlin/AppSyncTest.kt
@@ -37,7 +37,7 @@ class AppSyncTest {
         ).build()
     ).build()
 
-    apolloClient.subscribe(CommentsSubscription()).execute()
+    apolloClient.subscription(CommentsSubscription()).execute()
         .collect {
           println("comment: ${it.data?.subscribeToEventComments?.content}")
         }

--- a/tests/websockets/src/commonTest/kotlin/FullStackTest.kt
+++ b/tests/websockets/src/commonTest/kotlin/FullStackTest.kt
@@ -16,7 +16,7 @@ class FullStackTest {
         .serverUrl("https://apollo-fullstack-tutorial.herokuapp.com/graphql")
         .build()
 
-    apolloClient.subscribe(TripsBookedSubscription())
+    apolloClient.subscription(TripsBookedSubscription())
         .execute()
         .collect {
           println("trips booked: ${it.data?.tripsBooked}")

--- a/tests/websockets/src/commonTest/kotlin/GraphQLWsTest.kt
+++ b/tests/websockets/src/commonTest/kotlin/GraphQLWsTest.kt
@@ -42,7 +42,7 @@ class GraphQLWsTest {
         )
         .build()
 
-    assertEquals("Hello Mutation!", apolloClient.mutate(SetHelloMutation()).execute().data?.hello)
+    assertEquals("Hello Mutation!", apolloClient.mutation(SetHelloMutation()).execute().data?.hello)
   }
 
 
@@ -58,7 +58,7 @@ class GraphQLWsTest {
         )
         .build()
 
-    val list = apolloClient.subscribe(GreetingsSubscription())
+    val list = apolloClient.subscription(GreetingsSubscription())
         .execute()
         .toList()
     assertEquals(listOf("Hi", "Bonjour", "Hola", "Ciao", "Zdravo"), list.map { it.data?.greetings })

--- a/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
@@ -67,7 +67,7 @@ class CachedSubscriptionTest {
       assertEquals(0, channel.receive())
 
       println("starting subscription")
-      apolloClient.subscribe(TimeSubscription())
+      apolloClient.subscription(TimeSubscription())
           .execute()
           .take(3)
           .map { it.data!!.time }

--- a/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
@@ -48,7 +48,7 @@ class SampleServerTest {
         .build()
 
     runBlocking {
-      val list = apolloClient.subscribe(CountSubscription(5, 0))
+      val list = apolloClient.subscription(CountSubscription(5, 0))
           .execute()
           .map { it.data!!.count }
           .toList()
@@ -65,14 +65,14 @@ class SampleServerTest {
     runBlocking {
       val items = mutableListOf<Int>()
       launch {
-        apolloClient.subscribe(CountSubscription(5, 1000))
+        apolloClient.subscription(CountSubscription(5, 1000))
             .execute()
             .collect {
               items.add(it.data!!.count * 2)
             }
       }
       delay(500)
-      apolloClient.subscribe(CountSubscription(5, 1000))
+      apolloClient.subscription(CountSubscription(5, 1000))
           .execute()
           .collect {
             items.add(2 * it.data!!.count + 1)
@@ -94,14 +94,14 @@ class SampleServerTest {
         .build()
 
     runBlocking {
-      apolloClient.subscribe(CountSubscription(50, 1000)).execute().first()
+      apolloClient.subscription(CountSubscription(50, 1000)).execute().first()
 
       withTimeout(500) {
         transport.subscriptionCount.first { it == 0 }
       }
 
       delay(1500)
-      val number = apolloClient.subscribe(CountSubscription(50, 0)).execute().drop(3).first().data?.count
+      val number = apolloClient.subscription(CountSubscription(50, 0)).execute().drop(3).first().data?.count
       assertEquals(3, number)
     }
   }
@@ -116,7 +116,7 @@ class SampleServerTest {
        * During that time, the server should continue sending. Then resume reading as fast as we can
        * (which is still probably slower than the server) and make sure we didn't drop any items
        */
-      val number = apolloClient.subscribe(CountSubscription(1000, 0))
+      val number = apolloClient.subscription(CountSubscription(1000, 0))
           .execute()
           .map { it.data!!.count }
           .onEach {
@@ -146,7 +146,7 @@ class SampleServerTest {
       /**
        * Collect all items the server sends us
        */
-      apolloClient.subscribe(CountSubscription(50, 0)).execute().toList()
+      apolloClient.subscription(CountSubscription(50, 0)).execute().toList()
 
       /**
        * Make sure we're unsubscribed
@@ -165,7 +165,7 @@ class SampleServerTest {
 
     runBlocking {
       var caught: Throwable? = null
-      apolloClient.subscribe(OperationErrorSubscription())
+      apolloClient.subscription(OperationErrorSubscription())
           .execute()
           .catch {
             caught = it


### PR DESCRIPTION
Related to #3494

1. Rename `executeAsFlow` to `toFlow`
2. Rename `mutate` to `mutation`, `subscribe` to `subscription`

Maybe 2. is too much?  Let me know what you think.
