### PR TITLE
Mutate and subscribe deprecation message

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -86,12 +86,14 @@ public final class com/apollographql/apollo3/ApolloClientKt {
 
 public final class com/apollographql/apollo3/ApolloMutationCall : com/apollographql/apollo3/ApolloCall {
 	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Mutation;)V
+	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun copy ()Lcom/apollographql/apollo3/ApolloMutationCall;
 	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/ApolloQueryCall : com/apollographql/apollo3/ApolloCall {
 	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Query;)V
+	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun copy ()Lcom/apollographql/apollo3/ApolloQueryCall;
 	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -70,6 +70,9 @@ class ApolloQueryCall<D : Query.Data>(apolloClient: ApolloClient, query: Query<D
     return toFlow().single()
   }
 
+  @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("execute()"))
+  suspend fun await(): ApolloResponse<D> = execute()
+
   fun copy(): ApolloQueryCall<D> {
     return ApolloQueryCall(apolloClient, operation as Query<D>).addExecutionContext(executionContext)
   }
@@ -97,6 +100,9 @@ class ApolloMutationCall<D : Mutation.Data>(apolloClient: ApolloClient, mutation
   suspend fun execute(): ApolloResponse<D> {
     return toFlow().single()
   }
+
+  @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("execute()"))
+  suspend fun await(): ApolloResponse<D> = execute()
 
   fun copy(): ApolloMutationCall<D> {
     return ApolloMutationCall(apolloClient, operation as Mutation<D>).addExecutionContext(executionContext)

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -87,7 +87,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
     return ApolloMutationCall(this, mutation)
   }
 
-  @Deprecated("Please use mutation instead. This will be removed in v3.0.0.", ReplaceWith("mutation(mutation)"))
+  @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("mutation(mutation)"))
   fun <D : Mutation.Data> mutate(mutation: Mutation<D>): ApolloMutationCall<D> = mutation(mutation)
 
   /**
@@ -97,7 +97,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
     return ApolloSubscriptionCall(this, subscription)
   }
 
-  @Deprecated("Please use subscription instead. This will be removed in v3.0.0.", ReplaceWith("subscription(subscription)"))
+  @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("subscription(subscription)"))
   fun <D : Subscription.Data> subscribe(subscription: Subscription<D>): ApolloSubscriptionCall<D> = subscription(subscription)
 
   fun dispose() {


### PR DESCRIPTION
Actually we can keep `mutate` and `subscribe` a bit longer since it helps migration from 2.x.