### PR TITLE
Fix CustomTypeAdapter compat

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -359,11 +359,11 @@ public abstract interface class com/apollographql/apollo3/api/CustomTypeAdapter 
 	public abstract fun encode (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/CustomTypeValue;
 }
 
-public class com/apollographql/apollo3/api/CustomTypeValue {
+public abstract class com/apollographql/apollo3/api/CustomTypeValue {
 	public static final field Companion Lcom/apollographql/apollo3/api/CustomTypeValue$Companion;
-	public fun <init> (Ljava/lang/Object;)V
+	public final field value Ljava/lang/Object;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun fromRawValue (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/CustomTypeValue;
-	public final fun getValue ()Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/api/CustomTypeValue$Companion {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Version2CustomTypeAdapter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Version2CustomTypeAdapter.kt
@@ -2,6 +2,7 @@
 
 package com.apollographql.apollo3.api
 
+import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 /**
@@ -25,7 +26,7 @@ interface CustomTypeAdapter<T> {
  * `com.apollographql.apollo3.api` to use this version.
  */
 @Deprecated("Used for backward compatibility with 2.x, use Adapter instead")
-open class CustomTypeValue<T>(val value: T) {
+sealed class CustomTypeValue<T>(@JvmField val value: T) {
   object GraphQLNull : CustomTypeValue<Unit>(Unit)
   class GraphQLString(value: String) : CustomTypeValue<String>(value)
   class GraphQLBoolean(value: Boolean) : CustomTypeValue<Boolean>(value)
@@ -36,7 +37,7 @@ open class CustomTypeValue<T>(val value: T) {
   companion object {
     @JvmStatic
     @Suppress("UNCHECKED_CAST")
-    fun fromRawValue(value: Any): CustomTypeValue<*> {
+    fun fromRawValue(value: Any?): CustomTypeValue<*> {
       return when (value) {
         is Map<*, *> -> GraphQLJsonObject(value as Map<String, Any>)
         is List<*> -> GraphQLJsonList(value as List<Any>)
@@ -44,6 +45,7 @@ open class CustomTypeValue<T>(val value: T) {
         // Not supported as we are in common code here
         /* is BigDecimal -> GraphQLNumber(value.toNumber()) */
         is Number -> GraphQLNumber(value)
+        null -> GraphQLNull
         else -> GraphQLString(value.toString())
       }
     }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/Version2CustomTypeAdapterToAdapter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/Version2CustomTypeAdapterToAdapter.kt
@@ -17,7 +17,7 @@ class Version2CustomTypeAdapterToAdapter<T>(
 ) : Adapter<T> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): T {
     val value: Any? = NullableAnyAdapter.fromJson(reader, customScalarAdapters)
-    return v2CustomTypeAdapter.decode(CustomTypeValue(value))
+    return v2CustomTypeAdapter.decode(CustomTypeValue.fromRawValue(value))
   }
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: T) {

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -39,7 +39,6 @@ public final class com/apollographql/apollo3/ApolloClient : com/apollographql/ap
 public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollographql/apollo3/api/HasMutableExecutionContext {
 	public fun <init> ()V
 	public final fun addCustomScalarAdapter (Lcom/apollographql/apollo3/api/CustomScalarType;Lcom/apollographql/apollo3/api/Adapter;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun addCustomTypeAdapter (Lcom/apollographql/apollo3/api/CustomScalarType;Lcom/apollographql/apollo3/api/Adapter;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun addCustomTypeAdapter (Lcom/apollographql/apollo3/api/CustomScalarType;Lcom/apollographql/apollo3/api/CustomTypeAdapter;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -234,12 +234,6 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
       customScalarAdaptersBuilder.add(customScalarType, customScalarAdapter)
     }
 
-    @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("addCustomScalarAdapter"))
-    fun <T> addCustomTypeAdapter(
-        customScalarType: CustomScalarType,
-        customScalarAdapter: Adapter<T>,
-    ) = addCustomScalarAdapter(customScalarType, customScalarAdapter)
-
     @OptIn(ApolloInternal::class)
     @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("addCustomScalarAdapter"))
     fun <T> addCustomTypeAdapter(

--- a/tests/custom-scalars/build.gradle.kts
+++ b/tests/custom-scalars/build.gradle.kts
@@ -15,4 +15,5 @@ apollo {
   customScalarsMapping.put("CustomFloat", "kotlin.Float")
   customScalarsMapping.put("Any", "kotlin.Any")
   customScalarsMapping.put("GeoPoint", "kotlin.Any")
+  customScalarsMapping.put("Address", "custom.scalars.Address")
 }

--- a/tests/custom-scalars/src/main/graphql/operation.graphql
+++ b/tests/custom-scalars/src/main/graphql/operation.graphql
@@ -4,3 +4,7 @@ query GetAll {
   any
   geoPoints
 }
+
+query GetAddress {
+  address
+}

--- a/tests/custom-scalars/src/main/graphql/schema.graphqls
+++ b/tests/custom-scalars/src/main/graphql/schema.graphqls
@@ -2,11 +2,13 @@ scalar CustomFloat
 scalar Long
 scalar Any
 scalar GeoPoint
+scalar Address
 
 type Query {
   float: CustomFloat
   long: Long
   any: Any
   geoPoints: [GeoPoint]
+  address: Address
 }
 

--- a/tests/custom-scalars/src/main/kotlin/custom/scalars/Address.kt
+++ b/tests/custom-scalars/src/main/kotlin/custom/scalars/Address.kt
@@ -1,0 +1,3 @@
+package custom.scalars
+
+data class Address(val street: String, val number: Int)

--- a/tests/custom-scalars/src/test/kotlin/test/CustomScalarTest.kt
+++ b/tests/custom-scalars/src/test/kotlin/test/CustomScalarTest.kt
@@ -1,16 +1,20 @@
 package test.customscalars
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.CustomTypeAdapter
+import com.apollographql.apollo3.api.CustomTypeValue
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
 import com.apollographql.apollo3.testing.runTest
+import custom.scalars.Address
+import custom.scalars.GetAddressQuery
 import custom.scalars.GetAllQuery
 import org.junit.Test
 import kotlin.test.assertEquals
 
 class CustomScalarTest {
   @Test
-  fun adaptersDontNeedToBeRegistered() = runTest{
+  fun adaptersDontNeedToBeRegistered() = runTest {
     val server = MockServer()
     server.enqueue("""
       {
@@ -38,5 +42,50 @@ class CustomScalarTest {
         mapOf("lat" to 1, "lon" to 2),
         mapOf("lat" to 3, "lon" to 4),
     ), data.geoPoints)
+  }
+
+  @Test
+  fun addCustomTypeAdapter() = runTest {
+    val server = MockServer()
+    server.enqueue("""
+      {
+        "data": {
+          "address": {
+            "street": "Downing Street",
+            "number": 10
+          }
+        }
+      }
+    """.trimIndent())
+
+    val customTypeAdapter = object: CustomTypeAdapter<Address> {
+      override fun decode(value: CustomTypeValue<*>): Address {
+        check (value is CustomTypeValue.GraphQLJsonObject)
+
+        /**
+         * XXX: For consistency, a [CustomTypeValue.GraphQLJsonObject] should contain `GraphQLFoo`
+         * but in 2.x it contains primitive instead so keep that behaviour
+         */
+        val street = value.value["street"] as String
+        val number = value.value["number"] as Int
+        return Address(street, number)
+      }
+
+      override fun encode(value: Address): CustomTypeValue<*> {
+        return CustomTypeValue.GraphQLJsonObject(mapOf(
+            "street" to value.street,
+            "number" to value.number
+        ))
+      }
+    }
+    val data = ApolloClient.Builder()
+        .serverUrl(serverUrl = server.url())
+        .addCustomTypeAdapter(custom.scalars.type.Address.type, customTypeAdapter)
+        .build()
+        .query(GetAddressQuery())
+        .execute()
+        .dataAssertNoErrors
+
+    assertEquals(Address("Downing Street", 10), data.address)
   }
 }

--- a/tests/custom-scalars/src/test/kotlin/test/CustomScalarTest.kt
+++ b/tests/custom-scalars/src/test/kotlin/test/CustomScalarTest.kt
@@ -1,4 +1,4 @@
-package test.customscalars
+package test
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.CustomTypeAdapter


### PR DESCRIPTION
2.x expects `value` to be one of the sealed classes and not a direct instance of `GraphQLFoo`