### PR TITLE
🧼 🪣  Polishing of the ApolloResponse API

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -70,12 +70,21 @@ public final class com/apollographql/apollo3/api/ApolloResponse {
 	public final field requestUuid Ljava/util/UUID;
 	public fun <init> (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;)V
 	public synthetic fun <init> (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Ljava/lang/Object;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/ApolloResponse;Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Ljava/lang/Object;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
 	public final fun dataAssertNoErrors ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun dataOrThrow ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun hasErrors ()Z
+	public final fun newBuilder ()Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun withExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse;
+}
+
+public final class com/apollographql/apollo3/api/ApolloResponse$Builder {
+	public fun <init> (Lcom/apollographql/apollo3/api/Operation;)V
+	public final fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
+	public final fun build ()Lcom/apollographql/apollo3/api/ApolloResponse;
+	public final fun data (Lcom/apollographql/apollo3/api/Operation$Data;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
+	public final fun errors (Ljava/util/List;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
+	public final fun extensions (Ljava/util/Map;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
+	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 }
 
 public final class com/apollographql/apollo3/api/Assertions {

--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -69,7 +69,6 @@ public final class com/apollographql/apollo3/api/ApolloResponse {
 	public final field operation Lcom/apollographql/apollo3/api/Operation;
 	public final field requestUuid Ljava/util/UUID;
 	public fun <init> (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;)V
-	public synthetic fun <init> (Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;Lcom/apollographql/apollo3/api/ExecutionContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun dataAssertNoErrors ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun dataOrThrow ()Lcom/apollographql/apollo3/api/Operation$Data;
 	public final fun hasErrors ()Z
@@ -78,10 +77,9 @@ public final class com/apollographql/apollo3/api/ApolloResponse {
 }
 
 public final class com/apollographql/apollo3/api/ApolloResponse$Builder {
-	public fun <init> (Lcom/apollographql/apollo3/api/Operation;)V
+	public fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation$Data;)V
 	public final fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/api/ApolloResponse;
-	public final fun data (Lcom/apollographql/apollo3/api/Operation$Data;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun errors (Ljava/util/List;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun extensions (Ljava/util/Map;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapter.kt
@@ -1,13 +1,7 @@
 package com.apollographql.apollo3.api
 
-import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
-import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.api.json.MapJsonReader
-import okio.Buffer
-import okio.BufferedSink
-import okio.BufferedSource
 import okio.IOException
 
 /**

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -8,7 +8,7 @@ import kotlin.jvm.JvmName
 /**
  * Represents a GraphQL response. GraphQL responses can be be partial responses so it is valid to have both data != null and errors
  */
-class ApolloResponse<D : Operation.Data> @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.") constructor(
+class ApolloResponse<D : Operation.Data> @Deprecated("Please use ApolloResponse.Builder methods instead. This will be removed in v3.0.0.") constructor(
     @JvmField
     val requestUuid: Uuid,
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -2,14 +2,13 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.exception.ApolloException
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
 
 /**
  * Represents a GraphQL response. GraphQL responses can be be partial responses so it is valid to have both data != null and errors
  */
-class ApolloResponse<D : Operation.Data>(
+class ApolloResponse<D : Operation.Data> @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.") constructor(
     @JvmField
     val requestUuid: Uuid,
 
@@ -28,23 +27,23 @@ class ApolloResponse<D : Operation.Data>(
 
     /**
      * GraphQL [operation] execution errors returned by the server to let client know that something has gone wrong.
-     * This can either be null or empty depending what you server sends back
+     * This can either be null or empty depending on what your server sends back
      */
     @JvmField
-    val errors: List<Error>? = null,
+    val errors: List<Error>?,
 
     /**
      * Extensions of GraphQL protocol, arbitrary map of key [String] / value [Any] sent by server along with the response.
      */
     @JvmField
-    val extensions: Map<String, Any?> = emptyMap(),
+    val extensions: Map<String, Any?>,
 
     /**
      * The context of GraphQL [operation] execution.
      * This can contain additional data contributed by interceptors.
      */
     @JvmField
-    val executionContext: ExecutionContext = ExecutionContext.Empty,
+    val executionContext: ExecutionContext,
 ) {
   /**
    * A shorthand property to get a non-nullable `data` if handling partial data is not important
@@ -83,26 +82,20 @@ class ApolloResponse<D : Operation.Data>(
   fun withExecutionContext(executionContext: ExecutionContext) = newBuilder().addExecutionContext(executionContext).build()
 
   fun newBuilder(): Builder<D> {
-    return Builder(operation)
-        .data(data)
+    return Builder(operation, requestUuid, data)
         .errors(errors)
         .extensions(extensions)
         .addExecutionContext(executionContext)
-        .requestUuid(requestUuid)
   }
 
   class Builder<D : Operation.Data>(
-      private var operation: Operation<D>,
+      private val operation: Operation<D>,
+      private var requestUuid: Uuid,
+      private val data: D?,
   ) {
-    private var requestUuid: Uuid? = null
     private var executionContext: ExecutionContext = ExecutionContext.Empty
     private var errors: List<Error>? = null
     private var extensions: Map<String, Any?>? = null
-    private var data: D? = null
-
-    fun data(data: D?) = apply {
-      this.data = data
-    }
 
     fun addExecutionContext(executionContext: ExecutionContext) = apply {
       this.executionContext = this.executionContext + executionContext
@@ -112,7 +105,7 @@ class ApolloResponse<D : Operation.Data>(
       this.errors = errors
     }
 
-    fun extensions(extensions: Map<String, Any?>) = apply {
+    fun extensions(extensions: Map<String, Any?>?) = apply {
       this.extensions = extensions
     }
 
@@ -124,11 +117,11 @@ class ApolloResponse<D : Operation.Data>(
       @Suppress("DEPRECATION")
       return ApolloResponse(
           operation = operation,
-          requestUuid = requestUuid ?: uuid4(),
-          executionContext = executionContext,
+          requestUuid = requestUuid,
           data = data,
-          errors = errors,
-          extensions = extensions ?: emptyMap()
+          executionContext = executionContext,
+          extensions = extensions ?: emptyMap(),
+          errors = errors ,
       )
     }
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -78,7 +78,7 @@ class ApolloResponse<D : Operation.Data> @Deprecated("Please use ApolloRequest.B
 
   fun hasErrors(): Boolean = !errors.isNullOrEmpty()
 
-  @Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
+  @Deprecated("Please use ApolloResponse.Builder methods instead. This will be removed in v3.0.0.")
   fun withExecutionContext(executionContext: ExecutionContext) = newBuilder().addExecutionContext(executionContext).build()
 
   fun newBuilder(): Builder<D> {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -293,12 +293,12 @@ internal class ApolloCacheInterceptor(
     }
 
     val response = if (data != null) {
-      ApolloResponse(
+      ApolloResponse.Builder(
           requestUuid = request.requestUuid,
           operation = operation,
           data = data,
-          executionContext = request.executionContext
-      )
+      ).addExecutionContext(request.executionContext)
+          .build()
     } else {
       null
     }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -121,15 +121,17 @@ class HttpNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder instead
       }
 
       emit(
-          response.copy(
-              requestUuid = request.requestUuid,
-              executionContext = request.executionContext + HttpInfo(
-                  millisStart = millisStart,
-                  millisEnd = currentTimeMillis(),
-                  statusCode = httpResponse.statusCode,
-                  headers = httpResponse.headers
+          response.newBuilder()
+              .requestUuid(request.requestUuid)
+              .addExecutionContext(
+                  HttpInfo(
+                      millisStart = millisStart,
+                      millisEnd = currentTimeMillis(),
+                      statusCode = httpResponse.statusCode,
+                      headers = httpResponse.headers
+                  )
               )
-          )
+              .build()
       )
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -191,10 +191,11 @@ class WebSocketNetworkTransport @Deprecated("Use HttpNetworkTransport.Builder in
       }
     }.map {
       when (it) {
-        is OperationResponse -> request.operation.parseJsonResponse(
-            it.payload,
-            request.executionContext[CustomScalarAdapters]!!
-        ).copy(requestUuid = request.requestUuid)
+        is OperationResponse -> request.operation
+            .parseJsonResponse(it.payload, request.executionContext[CustomScalarAdapters]!!)
+            .newBuilder()
+            .requestUuid(request.requestUuid)
+            .build()
         is OperationError -> throw ApolloNetworkException("Cannot start operation ${request.operation.name()}: ${it.payload}")
         is NetworkError -> throw ApolloNetworkException("Network error while executing ${request.operation.name()}", it.cause)
 


### PR DESCRIPTION
Add `ApolloResponse.Builder`

For this, I had to make `D` invariant in `ApolloResponse<D>`. I'm not sure why it was made covariant in the first place and can't find a use case where there would be an inheritance relation between two `Operation.Data` so I think this is ok.