### PR TITLE
Remove apollo-api from the apollo-compiler dependencies

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -451,11 +451,16 @@ public abstract interface class com/apollographql/apollo3/api/ExecutionContext$K
 }
 
 public final class com/apollographql/apollo3/api/FileUpload : com/apollographql/apollo3/api/Upload {
+	public static final field Companion Lcom/apollographql/apollo3/api/FileUpload$Companion;
 	public fun <init> (Ljava/io/File;Ljava/lang/String;)V
 	public fun getContentLength ()J
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFileName ()Ljava/lang/String;
 	public fun writeTo (Lokio/BufferedSink;)V
+}
+
+public final class com/apollographql/apollo3/api/FileUpload$Companion {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/FileUpload;
 }
 
 public abstract interface class com/apollographql/apollo3/api/Fragment : com/apollographql/apollo3/api/Executable {
@@ -635,6 +640,11 @@ public final class com/apollographql/apollo3/api/QueryDocumentMinifier {
 
 public final class com/apollographql/apollo3/api/ScalarType : com/apollographql/apollo3/api/CompiledNamedType {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class com/apollographql/apollo3/api/ScalarTypeAdapters {
+	public fun <init> (Ljava/util/Map;)V
+	public final fun getCustomAdapters ()Ljava/util/Map;
 }
 
 public abstract interface class com/apollographql/apollo3/api/Subscription : com/apollographql/apollo3/api/Operation {

--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -383,7 +383,6 @@ public final class com/apollographql/apollo3/api/EnumType : com/apollographql/ap
 
 public final class com/apollographql/apollo3/api/Error {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getExtensions ()Ljava/util/Map;
 	public final fun getLocations ()Ljava/util/List;
 	public final fun getMessage ()Ljava/lang/String;
@@ -413,7 +412,7 @@ public final class com/apollographql/apollo3/api/Executable$Variables {
 	public final fun getValueMap ()Ljava/util/Map;
 }
 
-public final class com/apollographql/apollo3/api/ExecutableKt {
+public final class com/apollographql/apollo3/api/Executables {
 	public static final fun variables (Lcom/apollographql/apollo3/api/Executable;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/Executable$Variables;
 	public static final fun variablesJson (Lcom/apollographql/apollo3/api/Executable;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/String;
 }
@@ -451,8 +450,12 @@ public final class com/apollographql/apollo3/api/ExecutionContext$Element$Defaul
 public abstract interface class com/apollographql/apollo3/api/ExecutionContext$Key {
 }
 
-public final class com/apollographql/apollo3/api/FileUploadKt {
-	public static final fun fromFile (Lcom/apollographql/apollo3/api/Upload$Companion;Ljava/io/File;Ljava/lang/String;)Lcom/apollographql/apollo3/api/Upload;
+public final class com/apollographql/apollo3/api/FileUpload : com/apollographql/apollo3/api/Upload {
+	public fun <init> (Ljava/io/File;Ljava/lang/String;)V
+	public fun getContentLength ()J
+	public fun getContentType ()Ljava/lang/String;
+	public fun getFileName ()Ljava/lang/String;
+	public fun writeTo (Lokio/BufferedSink;)V
 }
 
 public abstract interface class com/apollographql/apollo3/api/Fragment : com/apollographql/apollo3/api/Executable {
@@ -493,8 +496,8 @@ public final class com/apollographql/apollo3/api/Input$Companion {
 }
 
 public final class com/apollographql/apollo3/api/InputKt {
-	public static final fun toInput (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
-	public static final fun toInputOrAbsent (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
+	public static final fun -toInput (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
+	public static final fun -toInputOrAbsent (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
 }
 
 public final class com/apollographql/apollo3/api/InputObjectType : com/apollographql/apollo3/api/CompiledNamedType {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -126,3 +126,10 @@ class ApolloResponse<D : Operation.Data> @Deprecated("Please use ApolloResponse.
     }
   }
 }
+
+@Deprecated("This is a helper typealias to help migrating to 3.x " +
+    "and will be removed in a future version",
+    ReplaceWith("ApolloResponse"),
+    DeprecationLevel.ERROR
+)
+typealias Response<D> = ApolloResponse<D>

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -8,7 +8,6 @@ import com.apollographql.apollo3.api.json.internal.Utils
 import okio.Buffer
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName
-import kotlin.jvm.JvmStatic
 import kotlin.native.concurrent.SharedImmutable
 
 sealed class CompiledSelection

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
@@ -14,24 +14,24 @@ class Error(
      * Locations of the errors in the GraphQL operation
      * It may be null if the location cannot be determined
      */
-    val locations: List<Location>? = null,
+    val locations: List<Location>?,
 
     /**
      * If this error comes from a field, the path of the field where the error happened.
      * Values in the list can be either Strings or Int
      * Can be null if the error doesn't come from a field, like validation errors.
      */
-    val path: List<Any>? = null,
+    val path: List<Any>?,
 
     /**
      * Extensions if any.
      */
-    val extensions: Map<String, Any?>? = null,
+    val extensions: Map<String, Any?>?,
 
     /**
      * Other non-standard fields (discouraged but allowed in the spec), if any.
      */
-    val nonStandardFields: Map<String, Any?>? = null,
+    val nonStandardFields: Map<String, Any?>?,
 ) {
 
   override fun toString(): String {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executable.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executable.kt
@@ -42,23 +42,3 @@ interface Executable<D: Executable.Data> {
    */
   class Variables(val valueMap: Map<String, Any?>)
 }
-
-@Suppress("UNCHECKED_CAST")
-fun <D : Executable.Data> Executable<D>.variables(customScalarAdapters: CustomScalarAdapters): Variables {
-  val valueMap = MapJsonWriter().apply {
-    beginObject()
-    serializeVariables(this, customScalarAdapters)
-    endObject()
-  }.root() as Map<String, Any?>
-  return Variables(valueMap)
-}
-
-fun <D : Executable.Data> Executable<D>.variablesJson(customScalarAdapters: CustomScalarAdapters): String {
-  val buffer = Buffer()
-  BufferedSinkJsonWriter(buffer).apply {
-    beginObject()
-    serializeVariables(this, customScalarAdapters)
-    endObject()
-  }
-  return buffer.readUtf8()
-}

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executables.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Executables.kt
@@ -1,0 +1,28 @@
+@file:JvmName("Executables")
+
+package com.apollographql.apollo3.api
+
+import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
+import com.apollographql.apollo3.api.json.MapJsonWriter
+import okio.Buffer
+import kotlin.jvm.JvmName
+
+@Suppress("UNCHECKED_CAST")
+fun <D : Executable.Data> Executable<D>.variables(customScalarAdapters: CustomScalarAdapters): Executable.Variables {
+  val valueMap = MapJsonWriter().apply {
+    beginObject()
+    serializeVariables(this, customScalarAdapters)
+    endObject()
+  }.root() as Map<String, Any?>
+  return Executable.Variables(valueMap)
+}
+
+fun <D : Executable.Data> Executable<D>.variablesJson(customScalarAdapters: CustomScalarAdapters): String {
+  val buffer = Buffer()
+  BufferedSinkJsonWriter(buffer).apply {
+    beginObject()
+    serializeVariables(this, customScalarAdapters)
+    endObject()
+  }
+  return buffer.readUtf8()
+}

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Input.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Input.kt
@@ -32,10 +32,10 @@ class Input {
 
 @Deprecated("toInput() is a helper function to help migrating to 3.x " +
     "and will be removed in a future version", ReplaceWith("Optional.presentIfNotNull(this)"))
-@JvmName("toInputOrAbsent")
+@JvmName("-toInputOrAbsent")
 fun <T> T.toInput(): Optional<T> = Optional.presentIfNotNull(this)
 
 @Deprecated("toInput() is a helper function to help migrating to 3.x " +
     "and will be removed in a future version", ReplaceWith("Optional.Present(this)"))
-@JvmName("toInput")
+@JvmName("-toInput")
 fun <T : Any> T.toInput(): Optional<T> = Optional.Present(this)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -12,7 +12,6 @@ import okio.BufferedSource
 import okio.ByteString
 import kotlin.jvm.JvmName
 
-
 /**
  * Reads a GraphQL Json response like below to a [ApolloResponse]
  * ```

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Version2CustomTypeAdapter.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Version2CustomTypeAdapter.kt
@@ -2,6 +2,8 @@
 
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.api.internal.Version2CustomTypeAdapterToAdapter
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
@@ -49,5 +51,21 @@ sealed class CustomTypeValue<T>(@JvmField val value: T) {
         else -> GraphQLString(value.toString())
       }
     }
+  }
+}
+
+/**
+ * A replica of Apollo Android v2's ScalarTypeAdapters, to ease migration from v2 to v3.
+ *
+ * In your [CustomTypeAdapter], update the imports from `com.apollographql.apollo.api` to
+ * `com.apollographql.apollo3.api` to use this version.
+ */
+@Deprecated(
+    message = "Used for backward compatibility with 2.x, use Adapter instead",
+    level = DeprecationLevel.ERROR
+)
+class ScalarTypeAdapters(val customAdapters: Map<CustomScalarType, CustomTypeAdapter<*>>) {
+  init {
+    throw NotImplementedError("Use CustomScalarAdapters instead")
   }
 }

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
@@ -14,4 +14,10 @@ class FileUpload(private val file: File, override val contentType: String) : Upl
       sink.writeAll(it)
     }
   }
+
+  companion object {
+    @Deprecated("This is a helper function to help migrating to 3.x " +
+        "and will be removed in a future version", ReplaceWith("FileUpload(File(filePath), mimetype)"))
+    fun create(mimetype: String, filePath: String): FileUpload = FileUpload(File(filePath), mimetype)
+  }
 }

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
@@ -5,8 +5,7 @@ import okio.buffer
 import okio.source
 import java.io.File
 
-fun Upload.Companion.fromFile(file: File, contentType: String) = object : Upload {
-  override val contentType = contentType
+class FileUpload(private val file: File, override val contentType: String) : Upload {
   override val contentLength = file.length()
   override val fileName = file.name
 

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Throws.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Throws.kt
@@ -1,2 +1,0 @@
-package com.apollographql.apollo3.api
-

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 dependencies {
-  implementation(projects.apolloApi)
   implementation(projects.apolloAst)
   implementation(projects.apolloNormalizedCacheApi) {
     because("To generate the CacheResolver")

--- a/tests/java-tests/src/test/java/test/AdapterTest.java
+++ b/tests/java-tests/src/test/java/test/AdapterTest.java
@@ -1,11 +1,9 @@
 package test;
 
 import com.apollographql.apollo3.api.Adapters;
-import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.NullableAdapter;
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader;
-import kotlin.jvm.Throws;
 import okio.Okio;
 import org.junit.Test;
 


### PR DESCRIPTION
- remove default parameters
- More polishing
- add FileUpload.creat compat
- added compat errors for Response and ScalarTypeAdapters
- upadte apiDump
- remove apollo-api from the apollo-compiler dependencies
