### PR TITLE
Enable allWarningsAsErrors

### DIFF
--- a/apollo-adapters/build.gradle.kts
+++ b/apollo-adapters/build.gradle.kts
@@ -25,3 +25,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.adapter")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-annotations/build.gradle.kts
+++ b/apollo-annotations/build.gradle.kts
@@ -16,3 +16,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.annotations")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloExperimental.kt
+++ b/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloExperimental.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.annotations
 
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
-    message = "This API is experimental and can be changed in a backwards-incompatible manner."
+    message = "ApolloGraphQL: This API is experimental and can be changed in a backwards-incompatible manner."
 )
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)

--- a/apollo-api/build.gradle.kts
+++ b/apollo-api/build.gradle.kts
@@ -21,3 +21,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.api")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-ast/build.gradle.kts
+++ b/apollo-ast/build.gradle.kts
@@ -24,6 +24,9 @@ tasks.withType(KotlinCompile::class.java) {
   // This used to work and fails now. Strangely enough, it fails on both `dev-3.x` and `main` as of writing while both these branches have
   // compiled successfully before...
   dependsOn("generateGrammarSource")
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
 }
 
 val jar by tasks.getting(Jar::class) {

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SDLWriter.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SDLWriter.kt
@@ -31,7 +31,7 @@ open class SDLWriter(
           sink.writeUtf8(indent)
         }
       }
-      sink.writeUtf8CodePoint(it.toInt())
+      sink.writeUtf8CodePoint(it.code)
     }
   }
 

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.ast
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
 /**
  * A wrapper around a schema GQLDocument that:
  * - always contain builtin types contrary to introspection that will not contain directives and SDL that will not contain
@@ -142,6 +144,7 @@ class Schema(
     if (directives.isEmpty()) {
       return null
     }
+    @OptIn(ApolloExperimental::class)
     return directives.flatMap {
       (it.arguments!!.arguments.first().value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().map {
         // No need to check here, this should be done during validation

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqlstrings.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqlstrings.kt
@@ -29,11 +29,11 @@ fun String.decodeAsGraphQLSingleQuoted(): String {
         i += 1
       }
       'f' -> {
-        writer.append('\u000C'.toInt())
+        writer.append('\u000C'.code)
         i += 1
       }
       'n' -> {
-        writer.append('\n'.toInt())
+        writer.append('\n'.code)
         i += 1
       }
       'r' -> {

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqltypedefinition.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqltypedefinition.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.ast
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
 // 5.5.2.3 Fragment spread is possible
 internal fun GQLTypeDefinition.sharesPossibleTypesWith(other: GQLTypeDefinition, schema: Schema): Boolean {
   return schema.possibleTypes(this).intersect(schema.possibleTypes(other)).isNotEmpty()
@@ -21,6 +23,7 @@ fun GQLTypeDefinition.isFieldNonNull(fieldName: String): Boolean {
 
   val stringValue = (directive.arguments!!.arguments.first().value as GQLStringValue).value
 
+  @OptIn(ApolloExperimental::class)
   val selections = stringValue.parseAsGQLSelections().getOrNull() ?: error("'$stringValue' is not a valid selectionSet")
 
   return selections.filterIsInstance<GQLField>()

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -106,7 +106,7 @@ internal class ExecutableValidationScope(
     name.forEach {
       builder.append(if (!isDecapitalized && it.isLetter()) {
         isDecapitalized = true
-        it.toString().toLowerCase(Locale.US)
+        it.toString().lowercase()
       } else {
         it.toString()
       })

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/AntlrParseTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/AntlrParseTest.kt
@@ -1,9 +1,11 @@
 package com.apollographql.apollo3.graphql.ast.test
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import org.junit.Test
 import kotlin.test.fail
 
+@OptIn(ApolloExperimental::class)
 class AntlrParseTest {
   @Test
   fun extraTokensAtEndOfFileAreDetected() {

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SchemaTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SchemaTest.kt
@@ -1,8 +1,10 @@
 package com.apollographql.apollo3.graphql.ast.test
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.toSchema
 import org.junit.Test
 
+@OptIn(ApolloExperimental::class)
 class SchemaTest {
   @Test
   fun schemaMayContainBuiltinDirectives() {

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/TransformTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/TransformTest.kt
@@ -1,5 +1,6 @@
-package com.apollographql.apollo3.ast.test
+package com.apollographql.apollo3.graphql.ast.test
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.GQLField
 import com.apollographql.apollo3.ast.GQLIntValue
 import com.apollographql.apollo3.ast.TransformResult
@@ -10,6 +11,7 @@ import com.apollographql.apollo3.ast.transform
 import org.junit.Test
 import kotlin.test.assertEquals
 
+@OptIn(ApolloExperimental::class)
 class TransformTest {
   private val query = """
         query GetRepo {

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -64,6 +64,12 @@ tasks.withType(KotlinCompile::class.java) {
   dependsOn(pluginVersionTaskProvider)
 }
 
+tasks.withType(KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}
+
 // since test/graphql is not an input to Test tasks, they're not run with the changes made in there.
 tasks.withType<Test>().configureEach {
   inputs.dir("src/test/graphql")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt
@@ -10,12 +10,12 @@ import java.util.regex.Pattern
  */
 
 internal fun String.singularize(): String {
-  if (uncountable.contains(this.toLowerCase(Locale.US))) return this
+  if (uncountable.contains(this.lowercase())) return this
 
-  if (exclude.contains(this.toLowerCase(Locale.US))) return this
+  if (exclude.contains(this.lowercase())) return this
 
   val capitalized = first().isUpperCase()
-  val irregular = irregular.firstOrNull { this.toLowerCase(Locale.US) == it.component2() }
+  val irregular = irregular.firstOrNull { this.lowercase() == it.component2() }
   if (irregular != null) return irregular.component1().let {
     if (capitalized) it.capitalizeFirstLetter() else it
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
@@ -1,13 +1,10 @@
 package com.apollographql.apollo3.compiler
 
-import java.util.Locale
-
-
 /**
  * A variation of [String.capitalize] that:
  * - skips initial underscore, especially found in introspection queries
- * - works with Kotlin 1.3 to be compatible with Gradle 6
- * - is Locale independent so that the compiler can
+ * - is Locale independent so that it works the same way on all machines, including in the turkish locale
+ * that uses a different 'I'
  */
 fun String.capitalizeFirstLetter(): String {
   val builder = StringBuilder(length)
@@ -15,7 +12,7 @@ fun String.capitalizeFirstLetter(): String {
   forEach {
     builder.append(if (!isCapitalized && it.isLetter()) {
       isCapitalized = true
-      it.toString().toUpperCase(Locale.US)
+      it.toString().uppercase()
     } else {
       it.toString()
     })
@@ -26,8 +23,8 @@ fun String.capitalizeFirstLetter(): String {
 /**
  * A variation of [String.decapitalize] that:
  * - skips initial underscore, especially found in introspection queries
- * - works with Kotlin 1.3 to be compatible with Gradle 6
- * - is Locale independent so that the compiler can
+ * - is Locale independent so that it works the same way on all machines, including in the turkish locale
+ * that uses a different 'I'
  */
 fun String.decapitalizeFirstLetter(): String {
   val builder = StringBuilder(length)
@@ -35,7 +32,7 @@ fun String.decapitalizeFirstLetter(): String {
   forEach {
     builder.append(if (!isDecapitalized && it.isLetter()) {
       isDecapitalized = true
-      it.toString().toLowerCase(Locale.US)
+      it.toString().lowercase()
     } else {
       it.toString()
     })

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -75,6 +75,7 @@ internal class IrBuilder(
     )
 
   private val builder = when(codegenModels) {
+    @Suppress("DEPRECATION")
     MODELS_COMPAT -> OperationBasedModelGroupBuilder(
         schema = schema,
         allFragmentDefinitions = allFragmentDefinitions,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
@@ -14,8 +14,10 @@ import com.apollographql.apollo3.ast.GQLNonNullType
 import com.apollographql.apollo3.ast.GQLSelection
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.transformation.mergeTrivialInlineFragments
+import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.lowerCamelCaseIgnoringNonLetters
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.modelName
+import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
 import com.apollographql.apollo3.compiler.escapeKotlinReservedWord
 
 internal class OperationBasedModelGroupBuilder(
@@ -116,12 +118,12 @@ internal class OperationBasedModelGroupBuilder(
     is BooleanExpression.And -> this.operands.joinToString("And") { it.toName() }
     is BooleanExpression.Or -> this.operands.joinToString("Or") { it.toName() }
     is BooleanExpression.Not -> "Not${this.operand.toName()}"
-    is BooleanExpression.Element -> this.value.name.capitalize()
+    is BooleanExpression.Element -> this.value.name.capitalizeFirstLetter()
     else -> error("")
   }
 
   private fun InlineFragmentKey.toName(): String = buildString {
-    append(typeCondition.capitalize())
+    append(typeCondition.capitalizeFirstLetter())
     if (condition != BooleanExpression.True) {
       append("If")
       append(condition.toName())
@@ -300,7 +302,7 @@ internal class OperationBasedModelGroupBuilder(
           }
 
           val childInfo = IrFieldInfo(
-              responseName = first.name.decapitalize().escapeKotlinReservedWord(),
+              responseName = first.name.decapitalizeFirstLetter().escapeKotlinReservedWord(),
               description = "Synthetic field for '${first.name}'",
               deprecationReason = null,
               type = type,

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.GQLFragmentSpread
 import com.apollographql.apollo3.ast.GQLInlineFragment
 import com.apollographql.apollo3.ast.GQLNode
@@ -21,7 +22,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
 @RunWith(TestParameterInjector::class)
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, ApolloExperimental::class)
 class CodegenTest {
   private class Measurement(
       val name: String,
@@ -181,6 +182,7 @@ class CodegenTest {
 
             when {
               hasFragments -> {
+                @Suppress("DEPRECATION")
                 val list = listOf(
                     Parameters(file, MODELS_OPERATION_BASED, true),
                     Parameters(file, MODELS_COMPAT, true)
@@ -316,9 +318,12 @@ class CodegenTest {
 
       val targetLanguage = if (generateKotlinModels) KOTLIN_1_5 else JAVA
       val targetLanguagePath = if (generateKotlinModels) "kotlin" else "java"
-      val flattenModels = when {
-        targetLanguage == JAVA -> true
-        else -> codegenModels == MODELS_COMPAT
+      val flattenModels = when (targetLanguage) {
+        JAVA -> true
+        else -> {
+          @Suppress("DEPRECATION")
+          codegenModels == MODELS_COMPAT
+        }
       }
 
       return Options(

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.SourceAwareException
 import com.apollographql.apollo3.ast.toSchema
@@ -10,6 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 
+@OptIn(ApolloExperimental::class)
 class MetadataTest {
   private val buildDir = File("build/metadata-test/")
   private val rootSchemaFile = File(buildDir, "root/graphql/schema.sdl")

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/PossibleTypesTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/PossibleTypesTest.kt
@@ -1,11 +1,12 @@
 package com.apollographql.apollo3.compiler
 
-import com.apollographql.apollo3.ast.possibleTypes
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.toSchema
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.io.File
 
+@OptIn(ApolloExperimental::class)
 class PossibleTypesTest {
   @Test
   fun testPossibleTypes() {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/SdlWritingTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/SdlWritingTest.kt
@@ -1,15 +1,16 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.toUtf8
-import com.apollographql.apollo3.compiler.introspection.IntrospectionSchema
 import com.apollographql.apollo3.compiler.introspection.toGQLDocument
 import com.apollographql.apollo3.compiler.introspection.toIntrospectionSchema
-import junit.framework.Assert.assertTrue
 import org.junit.Assert
 import org.junit.Test
 import java.io.File
+import kotlin.test.assertTrue
 
+@OptIn(ApolloExperimental::class)
 class SdlWritingTest {
 
   /**

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/StringEncodingTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/StringEncodingTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
 import com.apollographql.apollo3.ast.GQLStringValue
 import com.apollographql.apollo3.ast.GQLTypeDefinition
@@ -9,6 +10,7 @@ import com.google.common.truth.Truth
 import org.junit.Test
 import kotlin.test.assertEquals
 
+@OptIn(ApolloExperimental::class)
 class StringEncodingTest {
   @Test
   fun `single_quotes quotes are escaped`() {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.compiler.introspection.toIntrospectionSchema
 import com.apollographql.apollo3.compiler.introspection.toSchema
 import com.apollographql.apollo3.ast.Schema
@@ -7,6 +8,7 @@ import com.apollographql.apollo3.ast.toSchema
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 
+@OptIn(ApolloExperimental::class)
 internal object TestUtils {
   internal fun shouldUpdateTestFixtures(): Boolean {
     return when (System.getProperty("updateTestFixtures")?.trim()) {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TypenameTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TypenameTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.GQLDocument
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLOperationDefinition
@@ -15,6 +16,7 @@ import java.io.File
 
 @Suppress("UNUSED_PARAMETER")
 @RunWith(Parameterized::class)
+@OptIn(ApolloExperimental::class)
 class TypenameTest(val name: String, private val graphQLFile: File) {
 
   @Test

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.ParseResult
 import com.apollographql.apollo3.ast.parseAsGQLDocument
@@ -14,6 +15,7 @@ import java.io.File
 
 @Suppress("UNUSED_PARAMETER")
 @RunWith(Parameterized::class)
+@OptIn(ApolloExperimental::class)
 class ValidationTest(name: String, private val graphQLFile: File) {
   private val separator = "\n------------\n"
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler.conditionalFragments
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.compiler.ApolloCompiler
 import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED
 import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
@@ -9,6 +10,7 @@ import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 
+@OptIn(ApolloExperimental::class)
 class ConditionalFragmentsTest {
   @Test
   fun `responseBased codegen fails with conditional fragments`() {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler.keyfields
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.GQLOperationDefinition
 import com.apollographql.apollo3.ast.transformation.addRequiredFields
 import com.apollographql.apollo3.ast.checkKeyFields
@@ -9,6 +10,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import java.io.File
 
+@OptIn(ApolloExperimental::class)
 class KeyFieldsTest {
   @Test
   fun test() {

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -118,7 +118,7 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
 
     schema.parentFile?.mkdirs()
 
-    if (schema.extension.toLowerCase(Locale.US) == "json") {
+    if (schema.extension.lowercase() == "json") {
       if (introspectionSchema == null) {
         introspectionSchema = gqlSchema!!.toSchema().toIntrospectionSchema()
       }

--- a/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/RegisterOperations.kt
+++ b/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo3/gradle/internal/RegisterOperations.kt
@@ -19,7 +19,6 @@ import com.apollographql.apollo3.ast.GQLSelectionSet
 import com.apollographql.apollo3.ast.GQLStringValue
 import com.apollographql.apollo3.ast.GQLVariableDefinition
 import com.apollographql.apollo3.ast.NodeContainer
-import com.apollographql.apollo3.ast.NodeTransformer
 import com.apollographql.apollo3.ast.SDLWriter
 import com.apollographql.apollo3.ast.TransformResult
 import com.apollographql.apollo3.ast.toGQLDocument
@@ -244,7 +243,7 @@ object RegisterOperations {
      */
     val sortedDocument = hiddenLiterals!!.sort()
 
-    val minimized = printDocument(sortedDocument!!)
+    val minimized = printDocument(sortedDocument)
         .replace(Regex("\\s+"), " ")
         .replace(Regex("([^_a-zA-Z0-9]) ")) { it.groupValues[1] }
         .replace(Regex(" ([^_a-zA-Z0-9])")) { it.groupValues[1] }

--- a/apollo-http-cache/build.gradle.kts
+++ b/apollo-http-cache/build.gradle.kts
@@ -19,3 +19,9 @@ val jar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.cache.http")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpEngineTest.kt
+++ b/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpEngineTest.kt
@@ -16,8 +16,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class CachingHttpEngineTest {
-  lateinit var mockServer: MockServer
-  lateinit var engine: CachingHttpEngine
+  private lateinit var mockServer: MockServer
+  private lateinit var engine: CachingHttpEngine
 
   @Before
   fun before() {
@@ -32,12 +32,11 @@ class CachingHttpEngineTest {
     mockServer.enqueue(MockResponse(statusCode = 200, body = "success"))
 
     runBlocking {
-      val request = HttpRequest(
+      val request = HttpRequest.Builder(
           method = HttpMethod.Get,
           url = mockServer.url(),
-          body = null,
-          headers = emptyList()
-      )
+      ).build()
+
       var response = engine.execute(request)
       assertEquals("success", response.body?.readUtf8())
 
@@ -53,12 +52,10 @@ class CachingHttpEngineTest {
     mockServer.enqueue(MockResponse(statusCode = 500, body = "error"))
 
     runBlocking {
-      val request = HttpRequest(
+      val request = HttpRequest.Builder(
           method = HttpMethod.Get,
           url = mockServer.url(),
-          body = null,
-          headers = emptyList()
-      )
+      ).build()
 
       // Warm the cache
       val response = engine.execute(request)
@@ -76,12 +73,10 @@ class CachingHttpEngineTest {
     mockServer.enqueue(MockResponse(statusCode = 200, body = "success"))
 
     runBlocking {
-      val request = HttpRequest(
+      val request = HttpRequest.Builder(
           method = HttpMethod.Get,
           url = mockServer.url(),
-          body = null,
-          headers = emptyList()
-      )
+      ).build()
 
       // Warm the cache
       var response = engine.execute(request)

--- a/apollo-idling-resource/build.gradle.kts
+++ b/apollo-idling-resource/build.gradle.kts
@@ -16,3 +16,9 @@ android {
     targetSdkVersion(groovy.util.Eval.x(project, "x.androidConfig.targetSdkVersion").toString().toInt())
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -46,3 +46,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.mockserver")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
@@ -24,7 +24,7 @@ class SocketTest {
     mockServer.enqueue(MockResponse(body = builder.toString().encodeUtf8()))
     val str = builder.toString()
     val engine = HttpEngine()
-    val response = engine.execute(HttpRequest(HttpMethod.Get, mockServer.url(), emptyList(), null))
+    val response = engine.execute(HttpRequest.Builder(HttpMethod.Get, mockServer.url()).build())
 
     assertEquals(response.body!!.readUtf8(), str)
 

--- a/apollo-mpp-utils/build.gradle.kts
+++ b/apollo-mpp-utils/build.gradle.kts
@@ -14,3 +14,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.mpp")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-normalized-cache-api/build.gradle.kts
+++ b/apollo-normalized-cache-api/build.gradle.kts
@@ -22,3 +22,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.cache.normalized.api")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
@@ -48,7 +48,7 @@ object TypePolicyCacheKeyGenerator : CacheKeyGenerator {
     val keyFields = context.field.type.leafType().keyFields()
 
     return if (keyFields.isNotEmpty()) {
-      CacheKey.from(obj["__typename"].toString(), keyFields.map { obj[it].toString() })
+      CacheKey(obj["__typename"].toString(), keyFields.map { obj[it].toString() })
     } else {
       null
     }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -78,10 +78,12 @@ interface CacheResolver {
 }
 
 /**
- * A cache resolver that uses the parent to resolve fields. [parent] is a [Map] that
- * can contain the same values as [Record]
+ * A cache resolver that uses the parent to resolve fields.
  */
 object DefaultCacheResolver: CacheResolver {
+  /**
+   * @param parent a [Map] that represent the object containing this field. The map values can have the same types as the ones in  [Record]
+   */
   override fun resolveField(
       field: CompiledField,
       variables: Executable.Variables,

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -114,7 +114,7 @@ object FieldPolicyCacheResolver: CacheResolver {
     }
 
     if (keyArgsValues.isNotEmpty()) {
-      return CacheKey.from(field.type.leafType().name, keyArgsValues)
+      return CacheKey(field.type.leafType().name, keyArgsValues)
     }
 
     return DefaultCacheResolver.resolveField(field, variables, parent, parentId)

--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -85,3 +85,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.cache.normalized.sql")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-normalized-cache/build.gradle.kts
+++ b/apollo-normalized-cache/build.gradle.kts
@@ -22,3 +22,8 @@ val jvmJar by tasks.getting(Jar::class) {
   }
 }
 
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -53,7 +53,8 @@ enum class FetchPolicy {
 /**
  * Configures an [ApolloClient] with a normalized cache.
  *
- * @param normalizedCacheFactory a factory that creates a [NormalizedCache]. It will only be called once.
+ * @param normalizedCacheFactory a factory that creates a [com.apollographql.apollo3.cache.normalized.api.NormalizedCache].
+ * It will only be called once.
  * The reason this is a factory is to enforce creating the cache from a non-main thread. For native the thread
  * where the cache is created will also be isolated so that the cache can be mutated.
  *
@@ -89,7 +90,7 @@ fun <D : Query.Data> ApolloQueryCall<D>.watch(): Flow<ApolloResponse<D>> {
  * Gets the result from the cache first and always fetch from the network. Use this to get an early
  * cached result while also updating the network values.
  *
- * Any [FetchPolicy] on [queryRequest] will be ignored
+ * Any [FetchPolicy] previously set will be ignored
  */
 fun <D : Query.Data> ApolloQueryCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {
   return flow {
@@ -218,7 +219,7 @@ val <D : Operation.Data> ApolloResponse<D>.isFromCache
 val <D : Operation.Data> ApolloResponse<D>.cacheInfo
   get() = executionContext[CacheInfo]
 
-internal fun <D : Operation.Data> ApolloResponse<D>.withCacheInfo(cacheInfo: CacheInfo) = withExecutionContext(cacheInfo)
+internal fun <D : Operation.Data> ApolloResponse<D>.withCacheInfo(cacheInfo: CacheInfo) = newBuilder().addExecutionContext(cacheInfo).build()
 
 internal class FetchPolicyContext(val value: FetchPolicy) : ExecutionContext.Element {
   override val key: ExecutionContext.Key<*>

--- a/apollo-runtime/build.gradle.kts
+++ b/apollo-runtime/build.gradle.kts
@@ -58,3 +58,9 @@ val jvmJar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.runtime")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.CustomScalarType
-import com.apollographql.apollo3.api.CustomTypeAdapter
+import com.apollographql.apollo3.api.*
 import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.HasExecutionContext
 import com.apollographql.apollo3.api.HasMutableExecutionContext
@@ -398,6 +398,7 @@ fun ApolloClient.Builder.useHttpGetMethodForQueries(
 ) = httpMethod(if (useHttpGetMethodForQueries) HttpMethod.Get else HttpMethod.Post)
 
 @Deprecated("Used for backward compatibility with 2.x. This method throws immediately", ReplaceWith("autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Get)", "com.apollographql.apollo3.api.http.HttpMethod", "com.apollographql.apollo3.api.http.HttpMethod"))
+@Suppress("UNUSED_PARAMETER")
 fun ApolloClient.Builder.useHttpGetMethodForPersistedQueries(
     useHttpGetMethodForQueries: Boolean,
 ) = apply {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/AutoPersistedQueryInfo.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/AutoPersistedQueryInfo.kt
@@ -26,7 +26,9 @@ class AutoPersistedQueryInfo(
 val <D : Operation.Data> ApolloResponse<D>.autoPersistedQueryInfo
   get() = executionContext[AutoPersistedQueryInfo]
 
-fun <D : Operation.Data> ApolloResponse<D>.withAutoPersistedQueryInfo(hit: Boolean) = withExecutionContext(AutoPersistedQueryInfo(hit))
+fun <D : Operation.Data> ApolloResponse<D>.withAutoPersistedQueryInfo(hit: Boolean) = newBuilder()
+    .addExecutionContext(AutoPersistedQueryInfo(hit))
+    .build()
 
 
 /**

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WsProtocol.kt
@@ -90,6 +90,7 @@ abstract class WsProtocol(
     AnyAdapter.toJson(this, CustomScalarAdapters.Empty, this@toUtf8)
   }
 
+  @Suppress("UNCHECKED_CAST")
   protected fun String.toMessageMap() = AnyAdapter.fromJson(
       BufferedSourceJsonReader(Buffer().writeUtf8(this)),
       CustomScalarAdapters.Empty

--- a/apollo-rx2-support/build.gradle.kts
+++ b/apollo-rx2-support/build.gradle.kts
@@ -16,3 +16,9 @@ val jar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.rx2")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
@@ -168,4 +168,4 @@ fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Sch
 
 @JvmOverloads
 @JvmName("flowable")
-fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = execute().asFlowable(scheduler.asCoroutineDispatcher())
+fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())

--- a/apollo-rx3-support/build.gradle.kts
+++ b/apollo-rx3-support/build.gradle.kts
@@ -19,3 +19,9 @@ val jar by tasks.getting(Jar::class) {
     attributes("Automatic-Module-Name" to "com.apollographql.apollo3.rx3")
   }
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
@@ -171,4 +171,4 @@ fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Sch
 
 @JvmOverloads
 @JvmName("flowable")
-fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = execute().asFlowable(scheduler.asCoroutineDispatcher())
+fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -44,3 +44,9 @@ java {
   sourceCompatibility = JavaVersion.VERSION_1_8
   targetCompatibility = JavaVersion.VERSION_1_8
 }
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java) {
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
+}


### PR DESCRIPTION
Enable allWarningsAsErrors for all root modules except `apollo-gradle-plugin`