### PR TITLE
Simplify APQ configuration

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -118,11 +118,10 @@ public final class com/apollographql/apollo3/AutoPersistedQueryInfo$Key : com/ap
 }
 
 public final class com/apollographql/apollo3/AutoPersistedQueryInfoKt {
+	public static final fun enableAutoPersistedQueries (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
 	public static final fun getAutoPersistedQueryInfo (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/AutoPersistedQueryInfo;
-	public static final fun hashedQuery (Lcom/apollographql/apollo3/api/HasMutableExecutionContext;Z)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
-	public static final fun withAutoPersistedQueryInfo (Lcom/apollographql/apollo3/api/ApolloResponse;Z)Lcom/apollographql/apollo3/api/ApolloResponse;
-	public static final fun withHashedQuery (Lcom/apollographql/apollo3/ApolloClient;Z)Lcom/apollographql/apollo3/ApolloClient;
-	public static final fun withHashedQuery (Lcom/apollographql/apollo3/api/ApolloRequest;Z)Lcom/apollographql/apollo3/api/ApolloRequest;
+	public static final fun withHashedQuery (Lcom/apollographql/apollo3/ApolloClient;Z)Ljava/lang/Void;
+	public static final fun withHashedQuery (Lcom/apollographql/apollo3/api/ApolloRequest;Z)Ljava/lang/Void;
 }
 
 public final class com/apollographql/apollo3/ConcurrencyInfo : com/apollographql/apollo3/api/ExecutionContext$Element {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -273,14 +273,13 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
      *
      * @param httpMethodForHashedQueries: the [HttpMethod] to use for the initial hashed query that does not send the actual Graphql document.
      * [HttpMethod.Get] allows to use caching when available while [HttpMethod.Post] usually allows bigger document sizes.
-     * Only used if [hashByDefault] is true
      * Default: [HttpMethod.Get]
      *
      * @param httpMethodForDocumentQueries: the [HttpMethod] to use for the follow up query that sends the full document if the initial
      * hashed query was not found.
      * Default: [HttpMethod.Post]
      *
-     * @param hashByDefault: whether to enable Auto Persisted Queries by default. If true, it will set httpMethodForHashedQueries,
+     * @param enableByDefault: whether to enable Auto Persisted Queries by default. If true, it will set httpMethodForHashedQueries,
      * sendApqExtensions=true and sendDocument=false.
      * If false it will leave them untouched. You can later use [hashedQuery] to enable them
      */
@@ -288,13 +287,11 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
     fun autoPersistedQueries(
         httpMethodForHashedQueries: HttpMethod = HttpMethod.Get,
         httpMethodForDocumentQueries: HttpMethod = HttpMethod.Post,
-        hashByDefault: Boolean = true,
+        enableByDefault: Boolean = true,
     ) = apply {
       addInterceptor(AutoPersistedQueryInterceptor(httpMethodForDocumentQueries))
-      if (hashByDefault) {
-        httpMethod(httpMethodForHashedQueries)
-        hashedQuery(true)
-      }
+      addExecutionContext(AutoPersistedQueryConfiguration(httpMethodForHashedQueries))
+      enableAutoPersistedQueries(enableByDefault)
     }
 
     fun build(): ApolloClient {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -281,7 +281,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
      *
      * @param enableByDefault: whether to enable Auto Persisted Queries by default. If true, it will set httpMethodForHashedQueries,
      * sendApqExtensions=true and sendDocument=false.
-     * If false it will leave them untouched. You can later use [hashedQuery] to enable them
+     * If false it will leave them untouched. You can later use [enableAutoPersistedQueries] to enable them
      */
     @JvmOverloads
     fun autoPersistedQueries(

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/AutoPersistedQueryInfo.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/AutoPersistedQueryInfo.kt
@@ -5,8 +5,27 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.HasMutableExecutionContext
 import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.sendApqExtensions
 import com.apollographql.apollo3.api.http.sendDocument
+
+internal class AutoPersistedQueryConfiguration(
+    val httpMethodForHashedQueries: HttpMethod,
+) : ExecutionContext.Element {
+  override val key: ExecutionContext.Key<*>
+    get() = Key
+
+  companion object Key : ExecutionContext.Key<AutoPersistedQueryConfiguration>
+}
+
+internal class AutoPersistedQueryContext(
+    val enabled: Boolean,
+) : ExecutionContext.Element {
+  override val key: ExecutionContext.Key<*>
+    get() = Key
+
+  companion object Key : ExecutionContext.Key<AutoPersistedQueryContext>
+}
 
 /**
  * Information about auto persisted queries
@@ -22,22 +41,20 @@ class AutoPersistedQueryInfo(
   companion object Key : ExecutionContext.Key<AutoPersistedQueryInfo>
 }
 
-
 val <D : Operation.Data> ApolloResponse<D>.autoPersistedQueryInfo
   get() = executionContext[AutoPersistedQueryInfo]
 
-fun <D : Operation.Data> ApolloResponse<D>.withAutoPersistedQueryInfo(hit: Boolean) = newBuilder()
-    .addExecutionContext(AutoPersistedQueryInfo(hit))
-    .build()
-
-
 /**
- * A shorthand method that sets sendDocument and sendApqExtensions at the same time.
+ * Enable autoPersistedQueries
  */
-fun <T> HasMutableExecutionContext<T>.hashedQuery(hashed: Boolean) where T : HasMutableExecutionContext<T> = sendDocument(!hashed).sendApqExtensions(hashed)
+fun <T> HasMutableExecutionContext<T>.enableAutoPersistedQueries(enable: Boolean): T where T : HasMutableExecutionContext<T>  {
+  return addExecutionContext(AutoPersistedQueryContext(enable))
+}
 
-@Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")
-fun ApolloClient.withHashedQuery(hashed: Boolean) = newBuilder().hashedQuery(hashed).build()
+@Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.", level = DeprecationLevel.ERROR)
+@Suppress("UNUSED_PARAMETER")
+fun ApolloClient.withHashedQuery(hashed: Boolean): Nothing = throw NotImplementedError()
 
-@Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.")
-fun <D : Operation.Data> ApolloRequest<D>.withHashedQuery(hashed: Boolean) = newBuilder().hashedQuery(hashed).build()
+@Deprecated("Please use ApolloRequest.Builder methods instead. This will be removed in v3.0.0.", level = DeprecationLevel.ERROR)
+@Suppress("UNUSED_PARAMETER")
+fun <D : Operation.Data> ApolloRequest<D>.withHashedQuery(hashed: Boolean): Nothing = throw NotImplementedError()

--- a/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
@@ -3,6 +3,7 @@ package test
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.http.HttpMethod
+import com.apollographql.apollo3.enableAutoPersistedQueries
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -35,6 +36,22 @@ class AutoPersistedQueriesTest {
     val request = mockServer.takeRequest()
 
     assertFalse(request.body.utf8().contains("query"))
+  }
+
+  @Test
+  fun canDisableApqsPerQuery() = runTest(before = { setUp() }, after = { tearDown() }) {
+    mockServer.enqueue(testFixtureToUtf8("HeroNameResponse.json"))
+
+    val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Get).build()
+
+    apolloClient.query(HeroNameQuery())
+        .enableAutoPersistedQueries(false)
+        .execute()
+
+    val request = mockServer.takeRequest()
+
+    assertTrue(request.method.lowercase() == "post")
+    assertTrue(request.body.utf8().contains("query"))
   }
 
   @Test


### PR DESCRIPTION
The previous `.hashedQueries()` was not only very easy to find but it also did not reset the HTTP method. Instead, replace it with `.enableAutoPersistedQueries(Boolean)` 

Many thanks to @CoreFloDev for spotting this 💜 
