### PR TITLE
Move the HTTP cache to a HttpInterceptor

### DIFF
--- a/apollo-http-cache/api/apollo-http-cache.api
+++ b/apollo-http-cache/api/apollo-http-cache.api
@@ -1,4 +1,4 @@
-public final class com/apollographql/apollo3/cache/http/CachingHttpEngine : com/apollographql/apollo3/network/http/HttpEngine {
+public final class com/apollographql/apollo3/cache/http/CachingHttpInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public static final field CACHE_DO_NOT_STORE Ljava/lang/String;
 	public static final field CACHE_EXPIRE_AFTER_READ_HEADER Ljava/lang/String;
 	public static final field CACHE_EXPIRE_TIMEOUT_HEADER Ljava/lang/String;
@@ -7,19 +7,18 @@ public final class com/apollographql/apollo3/cache/http/CachingHttpEngine : com/
 	public static final field CACHE_KEY_HEADER Ljava/lang/String;
 	public static final field CACHE_ONLY Ljava/lang/String;
 	public static final field CACHE_SERVED_DATE_HEADER Ljava/lang/String;
-	public static final field Companion Lcom/apollographql/apollo3/cache/http/CachingHttpEngine$Companion;
+	public static final field Companion Lcom/apollographql/apollo3/cache/http/CachingHttpInterceptor$Companion;
 	public static final field FROM_CACHE Ljava/lang/String;
 	public static final field NETWORK_FIRST Ljava/lang/String;
 	public static final field NETWORK_ONLY Ljava/lang/String;
-	public fun <init> (Ljava/io/File;JLokio/FileSystem;Lcom/apollographql/apollo3/network/http/HttpEngine;)V
-	public synthetic fun <init> (Ljava/io/File;JLokio/FileSystem;Lcom/apollographql/apollo3/network/http/HttpEngine;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/io/File;JLokio/FileSystem;)V
+	public synthetic fun <init> (Ljava/io/File;JLokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun delete ()V
-	public fun dispose ()V
-	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun remove (Ljava/lang/String;)V
 }
 
-public final class com/apollographql/apollo3/cache/http/CachingHttpEngine$Companion {
+public final class com/apollographql/apollo3/cache/http/CachingHttpInterceptor$Companion {
 	public final fun cacheKey (Lcom/apollographql/apollo3/api/http/HttpRequest;)Ljava/lang/String;
 }
 

--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.api.HasMutableExecutionContext
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.addHttpHeader
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
-import com.apollographql.apollo3.network.http.HttpEngine
 import com.apollographql.apollo3.network.http.HttpInfo
 import java.io.File
 
@@ -51,11 +50,10 @@ fun ApolloClient.Builder.httpCache(
     maxSize: Long,
 ): ApolloClient.Builder {
 
-  return httpEngine(
-      httpEngine = CachingHttpEngine(
+  return addHttpInterceptor(
+      CachingHttpInterceptor(
           directory = directory,
           maxSize = maxSize,
-          delegate = DefaultHttpEngine()
       )
   )
 }
@@ -63,7 +61,7 @@ fun ApolloClient.Builder.httpCache(
 val <D : Operation.Data> ApolloResponse<D>.isFromHttpCache
   get() = executionContext[HttpInfo]?.headers?.any {
     // This will return true whatever the value in the header. We might want to fine tune this
-    it.name == CachingHttpEngine.FROM_CACHE
+    it.name == CachingHttpInterceptor.FROM_CACHE
   } ?: false
 
 /**
@@ -71,14 +69,14 @@ val <D : Operation.Data> ApolloResponse<D>.isFromHttpCache
  */
 fun <T> HasMutableExecutionContext<T>.httpFetchPolicy(httpFetchPolicy: HttpFetchPolicy): T where T : HasMutableExecutionContext<T> {
   val policyStr = when (httpFetchPolicy) {
-    HttpFetchPolicy.CacheFirst -> CachingHttpEngine.CACHE_FIRST
-    HttpFetchPolicy.CacheOnly -> CachingHttpEngine.CACHE_ONLY
-    HttpFetchPolicy.NetworkFirst -> CachingHttpEngine.NETWORK_FIRST
-    HttpFetchPolicy.NetworkOnly -> CachingHttpEngine.NETWORK_ONLY
+    HttpFetchPolicy.CacheFirst -> CachingHttpInterceptor.CACHE_FIRST
+    HttpFetchPolicy.CacheOnly -> CachingHttpInterceptor.CACHE_ONLY
+    HttpFetchPolicy.NetworkFirst -> CachingHttpInterceptor.NETWORK_FIRST
+    HttpFetchPolicy.NetworkOnly -> CachingHttpInterceptor.NETWORK_ONLY
   }
 
   return addHttpHeader(
-      CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, policyStr
+      CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, policyStr
   )
 }
 
@@ -86,21 +84,21 @@ fun <T> HasMutableExecutionContext<T>.httpFetchPolicy(httpFetchPolicy: HttpFetch
  * Configures httpExpireTimeout. Entries will be removed from the cache after this timeout.
  */
 fun <T> HasMutableExecutionContext<T>.httpExpireTimeout(httpExpireTimeout: Long) where T : HasMutableExecutionContext<T> = addHttpHeader(
-    CachingHttpEngine.CACHE_EXPIRE_TIMEOUT_HEADER, httpExpireTimeout.toString()
+    CachingHttpInterceptor.CACHE_EXPIRE_TIMEOUT_HEADER, httpExpireTimeout.toString()
 )
 
 /**
  * Configures httpExpireAfterRead. Entries will be removed from the cache after read if set to true.
  */
 fun <T> HasMutableExecutionContext<T>.httpExpireAfterRead(httpExpireAfterRead: Boolean) where T : HasMutableExecutionContext<T> = addHttpHeader(
-    CachingHttpEngine.CACHE_EXPIRE_AFTER_READ_HEADER, httpExpireAfterRead.toString()
+    CachingHttpInterceptor.CACHE_EXPIRE_AFTER_READ_HEADER, httpExpireAfterRead.toString()
 )
 
 /**
  * Configures httpDoNotStore. Entries will never be stored if set to true.
  */
 fun <T> HasMutableExecutionContext<T>.httpDoNotStore(httpDoNotStore: Boolean) where T : HasMutableExecutionContext<T> = addHttpHeader(
-    CachingHttpEngine.CACHE_DO_NOT_STORE, httpDoNotStore.toString()
+    CachingHttpInterceptor.CACHE_DO_NOT_STORE, httpDoNotStore.toString()
 )
 
 @Deprecated("Please use ApolloClient.Builder methods instead. This will be removed in v3.0.0.")

--- a/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpInterceptorTest.kt
+++ b/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpInterceptorTest.kt
@@ -2,11 +2,17 @@ package com.apollographql.apollo3.cache.http.internal
 
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.cache.http.CachingHttpInterceptor
 import com.apollographql.apollo3.exception.HttpCacheMissException
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.network.NetworkTransport
+import com.apollographql.apollo3.network.http.DefaultHttpEngine
+import com.apollographql.apollo3.network.http.HttpInterceptor
+import com.apollographql.apollo3.network.http.HttpInterceptorChain
+import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -17,14 +23,16 @@ import kotlin.test.assertFailsWith
 
 class CachingHttpInterceptorTest {
   private lateinit var mockServer: MockServer
-  private lateinit var engine: CachingHttpInterceptor
+  private lateinit var interceptor: CachingHttpInterceptor
+  private lateinit var chain: HttpInterceptorChain
 
   @Before
   fun before() {
     mockServer = MockServer()
     val dir = File("build/httpCache")
     dir.deleteRecursively()
-    engine = CachingHttpInterceptor(dir, Long.MAX_VALUE)
+    interceptor = CachingHttpInterceptor(dir, Long.MAX_VALUE)
+    chain = TestHttpInterceptorChain()
   }
 
   @Test
@@ -37,11 +45,16 @@ class CachingHttpInterceptorTest {
           url = mockServer.url(),
       ).build()
 
-      var response = engine.execute(request)
+      var response = interceptor.intercept(request, chain)
       assertEquals("success", response.body?.readUtf8())
 
       // 2nd request should hit the cache
-      response = engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
+      response = interceptor.intercept(
+          request.newBuilder()
+              .addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY)
+              .build(),
+          chain
+      )
       assertEquals("success", response.body?.readUtf8())
       assertEquals("true", response.headers.valueOf(CachingHttpInterceptor.FROM_CACHE))
     }
@@ -58,12 +71,17 @@ class CachingHttpInterceptorTest {
       ).build()
 
       // Warm the cache
-      val response = engine.execute(request)
+      val response = interceptor.intercept(request, chain)
       assertEquals("error", response.body?.readUtf8())
 
       // 2nd request should trigger a cache miss
       assertFailsWith(HttpCacheMissException::class) {
-        engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
+        interceptor.intercept(
+            request.newBuilder()
+                .addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY)
+                .build(),
+            chain
+        )
       }
     }
   }
@@ -79,23 +97,37 @@ class CachingHttpInterceptorTest {
       ).build()
 
       // Warm the cache
-      var response = engine.execute(request)
+      var response = interceptor.intercept(request, chain)
       assertEquals("success", response.body?.readUtf8())
 
       // 2nd request should hit the cache
-      response = engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
+      response = interceptor.intercept(
+          request.newBuilder()
+              .addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY)
+              .build(),
+          chain
+      )
       assertEquals("success", response.body?.readUtf8())
 
       delay(1000)
       // 3rd request with a 500ms timeout should miss
       assertFailsWith(HttpCacheMissException::class) {
-        engine.execute(
+        interceptor.intercept(
             request.newBuilder()
                 .addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY)
                 .addHeader(CachingHttpInterceptor.CACHE_EXPIRE_TIMEOUT_HEADER, "500")
-                .build()
+                .build(),
+            chain
         )
       }
     }
+  }
+}
+
+private class TestHttpInterceptorChain : HttpInterceptorChain {
+  val engine = DefaultHttpEngine()
+
+  override suspend fun proceed(request: HttpRequest): HttpResponse {
+    return engine.execute(request)
   }
 }

--- a/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpInterceptorTest.kt
+++ b/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/CachingHttpInterceptorTest.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.cache.http.internal
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.valueOf
-import com.apollographql.apollo3.cache.http.CachingHttpEngine
+import com.apollographql.apollo3.cache.http.CachingHttpInterceptor
 import com.apollographql.apollo3.exception.HttpCacheMissException
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
@@ -15,16 +15,16 @@ import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class CachingHttpEngineTest {
+class CachingHttpInterceptorTest {
   private lateinit var mockServer: MockServer
-  private lateinit var engine: CachingHttpEngine
+  private lateinit var engine: CachingHttpInterceptor
 
   @Before
   fun before() {
     mockServer = MockServer()
     val dir = File("build/httpCache")
     dir.deleteRecursively()
-    engine = CachingHttpEngine(dir, Long.MAX_VALUE)
+    engine = CachingHttpInterceptor(dir, Long.MAX_VALUE)
   }
 
   @Test
@@ -41,9 +41,9 @@ class CachingHttpEngineTest {
       assertEquals("success", response.body?.readUtf8())
 
       // 2nd request should hit the cache
-      response = engine.execute(request.newBuilder().addHeader(CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, CachingHttpEngine.CACHE_ONLY).build())
+      response = engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
       assertEquals("success", response.body?.readUtf8())
-      assertEquals("true", response.headers.valueOf(CachingHttpEngine.FROM_CACHE))
+      assertEquals("true", response.headers.valueOf(CachingHttpInterceptor.FROM_CACHE))
     }
   }
 
@@ -63,7 +63,7 @@ class CachingHttpEngineTest {
 
       // 2nd request should trigger a cache miss
       assertFailsWith(HttpCacheMissException::class) {
-        engine.execute(request.newBuilder().addHeader(CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, CachingHttpEngine.CACHE_ONLY).build())
+        engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
       }
     }
   }
@@ -83,7 +83,7 @@ class CachingHttpEngineTest {
       assertEquals("success", response.body?.readUtf8())
 
       // 2nd request should hit the cache
-      response = engine.execute(request.newBuilder().addHeader(CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, CachingHttpEngine.CACHE_ONLY).build())
+      response = engine.execute(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY).build())
       assertEquals("success", response.body?.readUtf8())
 
       delay(1000)
@@ -91,8 +91,8 @@ class CachingHttpEngineTest {
       assertFailsWith(HttpCacheMissException::class) {
         engine.execute(
             request.newBuilder()
-                .addHeader(CachingHttpEngine.CACHE_FETCH_POLICY_HEADER, CachingHttpEngine.CACHE_ONLY)
-                .addHeader(CachingHttpEngine.CACHE_EXPIRE_TIMEOUT_HEADER, "500")
+                .addHeader(CachingHttpInterceptor.CACHE_FETCH_POLICY_HEADER, CachingHttpInterceptor.CACHE_ONLY)
+                .addHeader(CachingHttpInterceptor.CACHE_EXPIRE_TIMEOUT_HEADER, "500")
                 .build()
         )
       }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -42,6 +42,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun addCustomTypeAdapter (Lcom/apollographql/apollo3/api/CustomScalarType;Lcom/apollographql/apollo3/api/CustomTypeAdapter;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/HasMutableExecutionContext;
+	public final fun addHttpInterceptor (Lcom/apollographql/apollo3/network/http/HttpInterceptor;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun addInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun addInterceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun autoPersistedQueries ()Lcom/apollographql/apollo3/ApolloClient$Builder;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -31,6 +31,7 @@ import com.apollographql.apollo3.mpp.assertMainThreadOnNative
 import com.apollographql.apollo3.network.NetworkTransport
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.network.http.HttpEngine
+import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import com.apollographql.apollo3.network.ws.DefaultWebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketEngine
@@ -164,6 +165,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
     private val customScalarAdaptersBuilder = CustomScalarAdapters.Builder()
     private val _interceptors: MutableList<ApolloInterceptor> = mutableListOf()
     val interceptors: List<ApolloInterceptor> = _interceptors
+    private val httpInterceptors: MutableList<HttpInterceptor> = mutableListOf()
     private var requestedDispatcher: CoroutineDispatcher? = null
     override var executionContext: ExecutionContext = ExecutionContext.Empty
     private var httpServerUrl: String? = null
@@ -247,6 +249,10 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
       _interceptors += interceptor
     }
 
+    fun addHttpInterceptor(httpInterceptor: HttpInterceptor) = apply {
+      httpInterceptors += httpInterceptor
+    }
+
     fun addInterceptors(interceptors: List<ApolloInterceptor>) = apply {
       this._interceptors += interceptors
     }
@@ -305,6 +311,9 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
         check(httpEngine == null) {
           "Apollo: 'httpEngine' has no effect if 'networkTransport' is set"
         }
+        check (httpInterceptors.isEmpty()) {
+          "Apollo: 'addHttpInterceptor' has no effect if 'networkTransport' is set"
+        }
         _networkTransport!!
       } else {
         check(httpServerUrl != null) {
@@ -313,6 +322,7 @@ class ApolloClient @JvmOverloads @Deprecated("Please use ApolloClient.Builder in
         HttpNetworkTransport.Builder()
             .serverUrl(httpServerUrl!!)
             .httpEngine(httpEngine ?: DefaultHttpEngine())
+            .interceptors(httpInterceptors)
             .build()
       }
 

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -145,5 +145,20 @@ class HttpCacheTest {
       assertEquals(false, response2.isFromHttpCache)
     }
   }
+
+  @Test
+  fun HttpCacheDoesNotOverrideOkHttpClient() = runTest {
+    mockServer.enqueue(response)
+
+    runBlocking {
+      var response = apolloClient.query(GetRandomQuery()).execute()
+      assertEquals(42, response.data?.random)
+      assertEquals(false, response.isFromHttpCache)
+
+      response = apolloClient.query(GetRandomQuery()).execute()
+      assertEquals(42, response.data?.random)
+      assertEquals(true, response.isFromHttpCache)
+    }
+  }
 }
 


### PR DESCRIPTION
This fixes a case where calling `httpCache` would overwrite the `okHttpClient` and it's overall more flexible as it potentially allows using the HttpCacheInterceptor together with other kinds of HttpInterceptors

Thanks @CoreFloDev for catching this.