### PR TITLE
URLEncode more characters for NSURL to not crash

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/internal/UrlEncode.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/internal/UrlEncode.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.api.http.internal
 import kotlin.native.concurrent.SharedImmutable
 
 @SharedImmutable
-private val RESERVED_CHARS = "!#\$&'()*+,/:;=?@[]"
+private val RESERVED_CHARS = "!#\$&'\"()*+,/:;=?@[]{}"
 
 /**
  * A very simple urlEncode

--- a/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/AutoPersistedQueriesTest.kt
@@ -42,7 +42,7 @@ class AutoPersistedQueriesTest {
   fun canDisableApqsPerQuery() = runTest(before = { setUp() }, after = { tearDown() }) {
     mockServer.enqueue(testFixtureToUtf8("HeroNameResponse.json"))
 
-    val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Get).build()
+    val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).autoPersistedQueries().build()
 
     apolloClient.query(HeroNameQuery())
         .enableAutoPersistedQueries(false)
@@ -69,7 +69,7 @@ class AutoPersistedQueriesTest {
 
     mockServer.enqueue(testFixtureToUtf8("HeroNameResponse.json"))
 
-    val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Post).build()
+    val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).autoPersistedQueries().build()
 
     apolloClient.query(HeroNameQuery()).execute()
 


### PR DESCRIPTION
A crash was happening at [this line](https://github.com/apollographql/apollo-android/blob/584d5a5ae94e6deb13568552bfa8d19f389ed588/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHttpEngine.kt#L62) when using auto persisted queries on Apple (this was reported by a community member using a KMP framework), the reason being `NSURL` doesn't allow specific characters to not be URLEncoded, otherwise its constructor returns `null`.

The reason this was not triggered in the existing unit tests is that we tested the GET method in the "disabled" scenario so this part of the code never ran.