### PR TITLE
Fix restarting a websocket after a network error

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler
 
-import java.util.Locale
 import java.util.regex.Pattern
 
 /**

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -304,7 +304,7 @@ public final class com/apollographql/apollo3/network/ws/AppSyncWsProtocol$Compan
 public final class com/apollographql/apollo3/network/ws/AppSyncWsProtocol$Factory : com/apollographql/apollo3/network/ws/WsProtocol$Factory {
 	public fun <init> (Ljava/util/Map;J)V
 	public synthetic fun <init> (Ljava/util/Map;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
+	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
 	public fun getName ()Ljava/lang/String;
 }
 
@@ -315,11 +315,11 @@ public final class com/apollographql/apollo3/network/ws/DefaultWebSocketEngine :
 }
 
 public final class com/apollographql/apollo3/network/ws/GraphQLWsProtocol : com/apollographql/apollo3/network/ws/WsProtocol {
-	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;JJLcom/apollographql/apollo3/network/ws/WsFrameType;Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)V
-	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;JJLcom/apollographql/apollo3/network/ws/WsFrameType;Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;JJLcom/apollographql/apollo3/network/ws/WsFrameType;Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;JJLcom/apollographql/apollo3/network/ws/WsFrameType;Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun connectionInit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handleServerMessage (Ljava/util/Map;)V
-	public fun run (Lkotlinx/coroutines/CoroutineScope;)V
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun startOperation (Lcom/apollographql/apollo3/api/ApolloRequest;)V
 	public fun stopOperation (Lcom/apollographql/apollo3/api/ApolloRequest;)V
 }
@@ -328,7 +328,7 @@ public final class com/apollographql/apollo3/network/ws/GraphQLWsProtocol$Factor
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;JLjava/util/Map;Ljava/util/Map;JLcom/apollographql/apollo3/network/ws/WsFrameType;)V
 	public synthetic fun <init> (Ljava/util/Map;JLjava/util/Map;Ljava/util/Map;JLcom/apollographql/apollo3/network/ws/WsFrameType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
+	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
 	public fun getName ()Ljava/lang/String;
 }
 
@@ -345,7 +345,7 @@ public final class com/apollographql/apollo3/network/ws/SubscriptionWsProtocol$F
 	public fun <init> ()V
 	public fun <init> (JLkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
+	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
 	public fun getName ()Ljava/lang/String;
 }
 
@@ -369,16 +369,11 @@ public final class com/apollographql/apollo3/network/ws/WebSocketEngineKt {
 	public static final field CLOSE_NORMAL I
 }
 
-public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport : com/apollographql/apollo3/network/NetworkTransport, com/apollographql/apollo3/network/ws/WsProtocol$Listener {
+public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport : com/apollographql/apollo3/network/NetworkTransport {
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/network/ws/WebSocketEngine;JLcom/apollographql/apollo3/network/ws/WsProtocol$Factory;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;
-	public fun generalError (Ljava/util/Map;)V
 	public final fun getSubscriptionCount ()Lkotlinx/coroutines/flow/StateFlow;
-	public fun networkError (Ljava/lang/Throwable;)V
-	public fun operationComplete (Ljava/lang/String;)V
-	public fun operationError (Ljava/lang/String;Ljava/util/Map;)V
-	public fun operationResponse (Ljava/lang/String;Ljava/util/Map;)V
 }
 
 public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder {
@@ -390,16 +385,6 @@ public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTranspor
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 }
 
-public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport$StartOperation : com/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Command {
-	public fun <init> (Lcom/apollographql/apollo3/api/ApolloRequest;)V
-	public final fun getRequest ()Lcom/apollographql/apollo3/api/ApolloRequest;
-}
-
-public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport$StopOperation : com/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Command {
-	public fun <init> (Lcom/apollographql/apollo3/api/ApolloRequest;)V
-	public final fun getRequest ()Lcom/apollographql/apollo3/api/ApolloRequest;
-}
-
 public final class com/apollographql/apollo3/network/ws/WsFrameType : java/lang/Enum {
 	public static final field Binary Lcom/apollographql/apollo3/network/ws/WsFrameType;
 	public static final field Text Lcom/apollographql/apollo3/network/ws/WsFrameType;
@@ -409,12 +394,13 @@ public final class com/apollographql/apollo3/network/ws/WsFrameType : java/lang/
 
 public abstract class com/apollographql/apollo3/network/ws/WsProtocol {
 	public fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)V
+	public fun close ()V
 	public abstract fun connectionInit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun getListener ()Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;
 	protected final fun getWebSocketConnection ()Lcom/apollographql/apollo3/network/ws/WebSocketConnection;
 	public abstract fun handleServerMessage (Ljava/util/Map;)V
 	protected final fun receiveMessageMap (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun run (Lkotlinx/coroutines/CoroutineScope;)V
+	public fun run (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	protected final fun sendMessageMap (Ljava/util/Map;Lcom/apollographql/apollo3/network/ws/WsFrameType;)V
 	protected final fun sendMessageMapBinary (Ljava/util/Map;)V
 	protected final fun sendMessageMapText (Ljava/util/Map;)V
@@ -426,7 +412,7 @@ public abstract class com/apollographql/apollo3/network/ws/WsProtocol {
 }
 
 public abstract interface class com/apollographql/apollo3/network/ws/WsProtocol$Factory {
-	public abstract fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
+	public abstract fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
 	public abstract fun getName ()Ljava/lang/String;
 }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/AppSyncWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/AppSyncWsProtocol.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.api.json.internal.buildJsonByteString
 import com.apollographql.apollo3.api.json.internal.writeAny
 import com.apollographql.apollo3.api.toJsonString
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -102,7 +103,11 @@ class AppSyncWsProtocol(
     override val name: String
       get() = "graphql-ws"
 
-    override fun create(webSocketConnection: WebSocketConnection, listener: Listener): WsProtocol {
+    override fun create(
+        webSocketConnection: WebSocketConnection,
+        listener: Listener,
+        scope: CoroutineScope
+    ): WsProtocol {
       return AppSyncWsProtocol(
           authorization = authorization,
           webSocketConnection = webSocketConnection,

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/GraphQLWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/GraphQLWsProtocol.kt
@@ -24,6 +24,7 @@ class GraphQLWsProtocol(
     private val frameType: WsFrameType,
     webSocketConnection: WebSocketConnection,
     listener: Listener,
+    private val scope: CoroutineScope
 ) : WsProtocol(webSocketConnection, listener) {
 
   override suspend fun connectionInit() {
@@ -67,7 +68,7 @@ class GraphQLWsProtocol(
     )
   }
 
-  override fun run(scope: CoroutineScope) {
+  override suspend fun run() {
     if (pingIntervalMillis > 0) {
       scope.launch {
         val map = mutableMapOf<String, Any?>(
@@ -83,7 +84,7 @@ class GraphQLWsProtocol(
         }
       }
     }
-    super.run(scope)
+    super.run()
   }
 
   override fun handleServerMessage(messageMap: Map<String, Any?>) {
@@ -125,7 +126,7 @@ class GraphQLWsProtocol(
     override val name: String
       get() = "graphql-transport-ws"
 
-    override fun create(webSocketConnection: WebSocketConnection, listener: Listener): WsProtocol {
+    override fun create(webSocketConnection: WebSocketConnection, listener: Listener, scope: CoroutineScope): WsProtocol {
       return GraphQLWsProtocol(
           connectionPayload = connectionPayload,
           pingPayload = pingPayload,
@@ -134,7 +135,8 @@ class GraphQLWsProtocol(
           pingIntervalMillis = pingIntervalMillis,
           frameType = frameType,
           webSocketConnection = webSocketConnection,
-          listener = listener
+          listener = listener,
+          scope = scope
       )
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withTimeout
 
 /**
@@ -84,6 +85,7 @@ class SubscriptionWsProtocol(
     override fun create(
         webSocketConnection: WebSocketConnection,
         listener: Listener,
+        scope: CoroutineScope
     ): WsProtocol {
       return SubscriptionWsProtocol(
           connectionPayload = connectionPayload,

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -160,6 +160,12 @@ private constructor(
               continue
             }
 
+            /**
+             * We start as [CoroutineStart.UNDISPATCHED] to make sure protocol.run() is always be called.
+             * I'm not 100% sure if protocol could be reset before starting to execute the coroutine
+             * so added this as an extra precaution. Maybe it's not required, but it shouldn't hurt
+             * so better safe than sorry...
+             */
             connectionJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
               protocol.run()
             }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/internal/WsMessage.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/internal/WsMessage.kt
@@ -2,10 +2,6 @@ package com.apollographql.apollo3.network.ws.internal
 
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.Operation
-import kotlinx.coroutines.channels.Channel
-
-internal class ConnectionHolder(val events: Channel<Event>) {
-}
 
 internal sealed interface Message
 internal sealed interface Command : Message

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/internal/WsMessage.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/internal/WsMessage.kt
@@ -1,0 +1,32 @@
+package com.apollographql.apollo3.network.ws.internal
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+import kotlinx.coroutines.channels.Channel
+
+internal class ConnectionHolder(val events: Channel<Event>) {
+}
+
+internal sealed interface Message
+internal sealed interface Command : Message
+internal class StartOperation<D : Operation.Data>(val request: ApolloRequest<D>) : Command
+internal class StopOperation<D : Operation.Data>(val request: ApolloRequest<D>) : Command
+
+internal sealed interface Event : Message {
+  /**
+   * the id of the operation
+   * Might be null for general errors or network errors that are broadcast to all listeners
+   */
+  val id: String?
+}
+
+internal class OperationResponse(override val id: String?, val payload: Map<String, Any?>) : Event
+internal class OperationError(override val id: String?, val payload: Map<String, Any?>?) : Event
+internal class OperationComplete(override val id: String?) : Event
+internal class GeneralError(val payload: Map<String, Any?>?) : Event {
+  override val id: String? = null
+}
+
+internal class NetworkError(val cause: Throwable?) : Event {
+  override val id: String? = null
+}

--- a/docs/source/advanced/using-aliases.mdx
+++ b/docs/source/advanced/using-aliases.mdx
@@ -79,6 +79,6 @@ query GetContacts {
 
 ## Using aliases to fix singularization rules
 
-The [singularization code](https://github.com/martinbonnin/apollo-android/blob/main/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt) works most of the time but does not contain all the exceptions in the English dictionary.
+The [singularization code](https://github.com/apollographql/apollo-android/blob/d77b73f6f387ab474045f0db3c568d251ef55932/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Inflector.kt) works most of the time but does not contain all the exceptions in the English dictionary.
 
 If you encounter one, please let us know so we can put a valid example here (we usually fix those issues as we go but there certainly are a few left in the wild). Until we fix it in the singularization code, you can use an alias to control the name of the model in your code.

--- a/tests/kotlin-codegen/src/test/kotlin/test/Variables.kt
+++ b/tests/kotlin-codegen/src/test/kotlin/test/Variables.kt
@@ -19,6 +19,7 @@ class VariablesTest {
     assertEquals(null, NullableVariableQuery(null).param)
   }
 
+
   @Test
   fun nullableVariableWithOptionalDirectivesGeneratesOptional() {
     /**


### PR DESCRIPTION
This PR serializes all messages from the `WsProtocol` in the "supervisor". 

What I call "supervisor" is a long-lived coroutine that:
- receives `Commands` from the various subscription `Flow`s, creates a `WsProtocol` when needed and forwards the commands
- receives `Events` from the `WsProtocol` and forwards them back to the various subscription `Flow`s

The `WsProtocol` owns the `WebSocketConnection`. The "supervisor" owns the `WsProtocol` and closes it after `idleTimeout`. 

The problem this PR adresses is that there was no way previously to know if a `WsProtocol` ended as an error and therefore was never re-created. With these changes, `WsProtocol.run` is required to send a terminal `NetworkError` event that will be received by the "supervisor" that can then reset its state.

Fixes https://github.com/apollographql/apollo-android/issues/3634

