### PR TITLE
Expose more configuration options on ApolloClient.Builder

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -53,7 +53,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public fun setExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)V
 	public final fun subscriptionNetworkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun webSocketIdleTimeout (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketIdleTimeoutMillis (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun wsProtocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -53,7 +53,9 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public fun setExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)V
 	public final fun subscriptionNetworkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketIdleTimeout (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun wsProtocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
 
 public final class com/apollographql/apollo3/ApolloClient$Companion {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -23,11 +23,9 @@ import com.apollographql.apollo3.interceptor.NetworkInterceptor
 import com.apollographql.apollo3.internal.defaultDispatcher
 import com.apollographql.apollo3.mpp.assertMainThreadOnNative
 import com.apollographql.apollo3.network.NetworkTransport
-import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.network.http.HttpEngine
 import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
-import com.apollographql.apollo3.network.ws.DefaultWebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
 import com.apollographql.apollo3.network.ws.WsProtocol
@@ -132,7 +130,7 @@ private constructor(
     override var executionContext: ExecutionContext = ExecutionContext.Empty
     private var httpServerUrl: String? = null
     private var webSocketServerUrl: String? = null
-    private var webSocketIdleTimeout: Long? = null
+    private var webSocketIdleTimeoutMillis: Long? = null
     private var wsProtocolFactory: WsProtocol.Factory? = null
     private var httpEngine: HttpEngine? = null
     private var webSocketEngine: WebSocketEngine? = null
@@ -189,8 +187,8 @@ private constructor(
      *
      * See also [subscriptionNetworkTransport] for more customization
      */
-    fun webSocketIdleTimeout(webSocketIdleTimeout: Long) = apply {
-      this.webSocketIdleTimeout = webSocketIdleTimeout
+    fun webSocketIdleTimeoutMillis(webSocketIdleTimeoutMillis: Long) = apply {
+      this.webSocketIdleTimeoutMillis = webSocketIdleTimeoutMillis
     }
 
     /**
@@ -331,8 +329,8 @@ private constructor(
         check(webSocketEngine == null) {
           "Apollo: 'webSocketEngine' has no effect if 'subscriptionNetworkTransport' is set"
         }
-        check(webSocketIdleTimeout == null) {
-          "Apollo: 'webSocketIdleTimeout' has no effect if 'subscriptionNetworkTransport' is set"
+        check(webSocketIdleTimeoutMillis == null) {
+          "Apollo: 'webSocketIdleTimeoutMillis' has no effect if 'subscriptionNetworkTransport' is set"
         }
         check(wsProtocolFactory == null) {
           "Apollo: 'wsProtocolFactory' has no effect if 'subscriptionNetworkTransport' is set"
@@ -351,8 +349,8 @@ private constructor(
                 if (webSocketEngine != null) {
                   webSocketEngine(webSocketEngine!!)
                 }
-                if (webSocketIdleTimeout != null) {
-                  idleTimeoutMillis(webSocketIdleTimeout!!)
+                if (webSocketIdleTimeoutMillis != null) {
+                  idleTimeoutMillis(webSocketIdleTimeoutMillis!!)
                 }
                 if (wsProtocolFactory != null) {
                   protocol(wsProtocolFactory!!)

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -30,6 +30,7 @@ import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import com.apollographql.apollo3.network.ws.DefaultWebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
+import com.apollographql.apollo3.network.ws.WsProtocol
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
@@ -131,44 +132,80 @@ private constructor(
     override var executionContext: ExecutionContext = ExecutionContext.Empty
     private var httpServerUrl: String? = null
     private var webSocketServerUrl: String? = null
+    private var webSocketIdleTimeout: Long? = null
+    private var wsProtocolFactory: WsProtocol.Factory? = null
     private var httpEngine: HttpEngine? = null
     private var webSocketEngine: WebSocketEngine? = null
 
     /**
-     * The url of the GraphQL server used for both HTTP and WebSockets
+     * The url of the GraphQL server used for HTTP
+     *
+     * This is the same as [httpServerUrl]
+     *
+     * See also [networkTransport] for more customization
      */
     fun serverUrl(serverUrl: String) = apply {
       httpServerUrl = serverUrl
-      webSocketServerUrl = serverUrl
     }
 
     /**
      * The url of the GraphQL server used for HTTP
+     *
+     * See also [networkTransport] for more customization
      */
     fun httpServerUrl(httpServerUrl: String) = apply {
       this.httpServerUrl = httpServerUrl
     }
 
     /**
-     * The url of the GraphQL server used for WebSockets
-     */
-    fun webSocketServerUrl(webSocketServerUrl: String) = apply {
-      this.webSocketServerUrl = webSocketServerUrl
-    }
-
-    /**
      * The [HttpEngine] to use for HTTP requests
      *
-     * For more customization, see also [networkTransport]
+     * See also [networkTransport] for more customization
      */
     fun httpEngine(httpEngine: HttpEngine) = apply {
       this.httpEngine = httpEngine
     }
 
     /**
+     * Adds [httpInterceptor] to the list of HTTP interceptors
+     *
+     * See also [networkTransport] for more customization
+     */
+    fun addHttpInterceptor(httpInterceptor: HttpInterceptor) = apply {
+      httpInterceptors += httpInterceptor
+    }
+
+    /**
+     * The url of the GraphQL server used for WebSockets
+     *
+     * See also [subscriptionNetworkTransport] for more customization
+     */
+    fun webSocketServerUrl(webSocketServerUrl: String) = apply {
+      this.webSocketServerUrl = webSocketServerUrl
+    }
+
+    /**
+     * The timeout after which an inactive WebSocket will be closed
+     *
+     * See also [subscriptionNetworkTransport] for more customization
+     */
+    fun webSocketIdleTimeout(webSocketIdleTimeout: Long) = apply {
+      this.webSocketIdleTimeout = webSocketIdleTimeout
+    }
+
+    /**
+     * The [WsProtocol.Factory] to use for websockets
+     *
+     * See also [subscriptionNetworkTransport] for more customization
+     */
+    fun wsProtocol(wsProtocolFactory: WsProtocol.Factory) = apply {
+      this.wsProtocolFactory = wsProtocolFactory
+    }
+
+    /**
      * The [WebSocketEngine] to use for WebSocket requests
      *
-     * For more customization, see also [subscriptionNetworkTransport]
+     * See also [subscriptionNetworkTransport] for more customization
      */
     fun webSocketEngine(webSocketEngine: WebSocketEngine) = apply {
       this.webSocketEngine = webSocketEngine
@@ -208,10 +245,6 @@ private constructor(
 
     fun addInterceptor(interceptor: ApolloInterceptor) = apply {
       _interceptors += interceptor
-    }
-
-    fun addHttpInterceptor(httpInterceptor: HttpInterceptor) = apply {
-      httpInterceptors += httpInterceptor
     }
 
     fun addInterceptors(interceptors: List<ApolloInterceptor>) = apply {
@@ -261,6 +294,9 @@ private constructor(
       enableAutoPersistedQueries(enableByDefault)
     }
 
+    /**
+     * Creates an [ApolloClient] from this [Builder]
+     */
     fun build(): ApolloClient {
       val networkTransport = if (_networkTransport != null) {
         check(httpServerUrl == null) {
@@ -279,7 +315,11 @@ private constructor(
         }
         HttpNetworkTransport.Builder()
             .serverUrl(httpServerUrl!!)
-            .httpEngine(httpEngine ?: DefaultHttpEngine())
+            .apply {
+              if (httpEngine != null) {
+                httpEngine(httpEngine!!)
+              }
+            }
             .interceptors(httpInterceptors)
             .build()
       }
@@ -291,17 +331,33 @@ private constructor(
         check(webSocketEngine == null) {
           "Apollo: 'webSocketEngine' has no effect if 'subscriptionNetworkTransport' is set"
         }
+        check(webSocketIdleTimeout == null) {
+          "Apollo: 'webSocketIdleTimeout' has no effect if 'subscriptionNetworkTransport' is set"
+        }
+        check(wsProtocolFactory == null) {
+          "Apollo: 'wsProtocolFactory' has no effect if 'subscriptionNetworkTransport' is set"
+        }
         subscriptionNetworkTransport!!
       } else {
         val url = webSocketServerUrl ?: httpServerUrl
         if (url == null) {
           // Fallback to the regular [NetworkTransport]. This is unlikely to work but chances are
-          // that the user is not going to use subscription so it's better than failing
+          // that the user is not going to use subscription, so it's better than failing
           networkTransport
         } else {
           WebSocketNetworkTransport.Builder()
               .serverUrl(webSocketServerUrl!!)
-              .webSocketEngine(webSocketEngine ?: DefaultWebSocketEngine())
+              .apply {
+                if (webSocketEngine != null) {
+                  webSocketEngine(webSocketEngine!!)
+                }
+                if (webSocketIdleTimeout != null) {
+                  idleTimeoutMillis(webSocketIdleTimeout!!)
+                }
+                if (wsProtocolFactory != null) {
+                  protocol(wsProtocolFactory!!)
+                }
+              }
               .build()
         }
       }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -346,7 +346,7 @@ private constructor(
           networkTransport
         } else {
           WebSocketNetworkTransport.Builder()
-              .serverUrl(webSocketServerUrl!!)
+              .serverUrl(url)
               .apply {
                 if (webSocketEngine != null) {
                   webSocketEngine(webSocketEngine!!)


### PR DESCRIPTION
Expose all the `DefaultHttpNetworkTransport` and `DefaultWebSocketNetworkTransport` options on `ApolloClient.Builder`. For the vast majority of use cases, this is easier to use than having to call a `NetworkTransport` constructor:

```kotlin
val apolloClient = ApolloClient.Builder()
                .webSocketIdleTimeout(...)
                .wsProtocol(...)
                .webSocketServerUrl(...)
                .httpServerUrl(...)
                .addHttpInterceptor(...)
                // ...
                .build()
```

Passing a custom `NetworkTransport` is still possible but will throw if it conflicts with any of the top level properties