### PR TITLE
Fix DiskLruHttpCache concurrency

### DIFF
--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/DiskLruHttpCache.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/DiskLruHttpCache.kt
@@ -44,36 +44,34 @@ class DiskLruHttpCache(private val fileSystem: FileSystem, private val directory
   }
 
   fun write(response: HttpResponse, cacheKey: String) {
-    val editor = cacheLock.read {
+    val editor = cacheLock.write {
       cache.edit(cacheKey)
-    }
+    } ?: return
 
-    if (editor == null) {
-      return
-    }
-
-    try {
-      editor.newSink(ENTRY_HEADERS).buffer().use {
-        val map = mapOf(
-            "statusCode" to response.statusCode.toString(),
-            "headers" to response.headers.map { httpHeader ->
-              // Moshi doesn't serialize Pairs by default (https://github.com/square/moshi/issues/508) so
-              // we use a Map with a single entry
-              mapOf(httpHeader.name to httpHeader.value)
-            },
-        )
-        adapter.toJson(it, map)
-      }
-      editor.newSink(ENTRY_BODY).buffer().use {
-        val responseBody = response.body
-        if (responseBody != null) {
-          it.writeAll(responseBody)
-          responseBody.close()
+    cacheLock.write {
+      try {
+        editor.newSink(ENTRY_HEADERS).buffer().use {
+          val map = mapOf(
+              "statusCode" to response.statusCode.toString(),
+              "headers" to response.headers.map { httpHeader ->
+                // Moshi doesn't serialize Pairs by default (https://github.com/square/moshi/issues/508) so
+                // we use a Map with a single entry
+                mapOf(httpHeader.name to httpHeader.value)
+              },
+          )
+          adapter.toJson(it, map)
         }
+        editor.newSink(ENTRY_BODY).buffer().use {
+          val responseBody = response.body
+          if (responseBody != null) {
+            it.writeAll(responseBody)
+            responseBody.close()
+          }
+        }
+        editor.commit()
+      } catch (e: Exception) {
+        editor.abort()
       }
-      editor.commit()
-    } catch (e: Exception) {
-      editor.abort()
     }
   }
 


### PR DESCRIPTION
Fix for #3664.

When `networkMightThrow` is called by 2 threads in parallel we could easily arrive at a situation where `DiskLruHttpCache.write` would return `null` immediately (`cache.edit` being in the "another edit is in progress" case), which in turn would make the `DiskLruHttpCache.read` right after it throw an error.

Moving the whole write under the write lock fixes the issue.