### PR TITLE
Move BatchingHttpEngine to a HttpInterceptor

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -48,6 +48,8 @@ public final class com/apollographql/apollo3/api/ApolloRequest$Builder : com/apo
 	public fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
 	public final fun build ()Lcom/apollographql/apollo3/api/ApolloRequest;
+	public fun canBeBatched (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
+	public synthetic fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public final fun executionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
@@ -483,12 +485,18 @@ public abstract interface class com/apollographql/apollo3/api/ExecutionContext$K
 }
 
 public abstract interface class com/apollographql/apollo3/api/ExecutionOptions {
+	public static final field CAN_BE_BATCHED Ljava/lang/String;
+	public static final field Companion Lcom/apollographql/apollo3/api/ExecutionOptions$Companion;
 	public abstract fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public abstract fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public abstract fun getHttpHeaders ()Ljava/util/List;
 	public abstract fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
 	public abstract fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public abstract fun getSendDocument ()Ljava/lang/Boolean;
+}
+
+public final class com/apollographql/apollo3/api/ExecutionOptions$Companion {
+	public static final field CAN_BE_BATCHED Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/FileUpload {
@@ -552,6 +560,7 @@ public final class com/apollographql/apollo3/api/ListAdapter : com/apollographql
 public abstract interface class com/apollographql/apollo3/api/MutableExecutionOptions : com/apollographql/apollo3/api/ExecutionOptions {
 	public abstract fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Ljava/lang/Object;
 	public abstract fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public abstract fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public abstract fun httpHeaders (Ljava/util/List;)Ljava/lang/Object;
 	public abstract fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -73,6 +73,10 @@ private constructor(
       this.enableAutoPersistedQueries = enableAutoPersistedQueries
     }
 
+    override fun canBeBatched(canBeBatched: Boolean?): Builder<D> = apply {
+      if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
+    }
+
     fun requestUuid(requestUuid: Uuid) = apply {
       this.requestUuid = requestUuid
     }
@@ -95,7 +99,7 @@ private constructor(
           httpHeaders = httpHeaders,
           sendApqExtensions = sendApqExtensions,
           sendDocument = sendDocument,
-          enableAutoPersistedQueries = enableAutoPersistedQueries
+          enableAutoPersistedQueries = enableAutoPersistedQueries,
       )
     }
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
@@ -30,6 +30,13 @@ interface ExecutionOptions {
    * Used by [com.apollographql.apollo3.interceptor.AutoPersistedQueryInterceptor]
    */
   val enableAutoPersistedQueries: Boolean?
+
+  companion object {
+    /**
+     * Used by [com.apollographql.apollo3.network.http.BatchingHttpInterceptor]
+     */
+    const val CAN_BE_BATCHED = "X-APOLLO-CAN-BE-BATCHED"
+  }
 }
 
 
@@ -59,4 +66,6 @@ interface MutableExecutionOptions<T> : ExecutionOptions {
   fun sendDocument(sendDocument: Boolean?): T
 
   fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): T
+
+  fun canBeBatched(canBeBatched: Boolean?): T
 }

--- a/apollo-http-cache/api/apollo-http-cache.api
+++ b/apollo-http-cache/api/apollo-http-cache.api
@@ -14,6 +14,7 @@ public final class com/apollographql/apollo3/cache/http/CachingHttpInterceptor :
 	public fun <init> (Ljava/io/File;JLokio/FileSystem;)V
 	public synthetic fun <init> (Ljava/io/File;JLokio/FileSystem;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun delete ()V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun remove (Ljava/lang/String;)V
 }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -2,6 +2,7 @@ public abstract class com/apollographql/apollo3/ApolloCall : com/apollographql/a
 	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Operation;)V
 	public fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Ljava/lang/Object;
 	public fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public final fun getApolloClient ()Lcom/apollographql/apollo3/ApolloClient;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
@@ -63,6 +64,8 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun autoPersistedQueries (Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun autoPersistedQueries$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/api/http/HttpMethod;Lcom/apollographql/apollo3/api/http/HttpMethod;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/ApolloClient;
+	public fun canBeBatched (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public synthetic fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public final fun customScalarAdapters (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
@@ -74,6 +77,11 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun getInterceptors ()Ljava/util/List;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
+	public final fun httpBatching ()Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun httpBatching (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun httpBatching (JI)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun httpBatching (JIZ)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static synthetic fun httpBatching$default (Lcom/apollographql/apollo3/ApolloClient$Builder;JIZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpEngine (Lcom/apollographql/apollo3/network/http/HttpEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpExposeErrorBody (Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun httpHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -183,43 +191,49 @@ public final class com/apollographql/apollo3/network/OkHttpExtensionsKt {
 
 public final class com/apollographql/apollo3/network/http/ApolloClientAwarenessInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/network/http/BatchingHttpEngine : com/apollographql/apollo3/network/http/HttpEngine {
-	public static final field CAN_BE_BATCHED Ljava/lang/String;
-	public static final field Companion Lcom/apollographql/apollo3/network/http/BatchingHttpEngine$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;J)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JI)V
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JIZ)V
 	public synthetic fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;JIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)V
-	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)V
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getBatchIntervalMillis ()J
 	public final fun getDelegate ()Lcom/apollographql/apollo3/network/http/HttpEngine;
 }
 
-public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$Companion {
+public final class com/apollographql/apollo3/network/http/BatchingHttpInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
+	public static final field Companion Lcom/apollographql/apollo3/network/http/BatchingHttpInterceptor$Companion;
+	public fun <init> ()V
+	public fun <init> (J)V
+	public fun <init> (JI)V
+	public fun <init> (JIZ)V
+	public synthetic fun <init> (JIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)V
+	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)V
+	public fun dispose ()V
+	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/apollographql/apollo3/network/http/BatchingHttpInterceptor$Companion {
 	public final fun configureApolloCall (Lcom/apollographql/apollo3/ApolloCall;Z)V
 	public final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Z)V
 }
 
-public final class com/apollographql/apollo3/network/http/BatchingHttpEngine$PendingRequest {
+public final class com/apollographql/apollo3/network/http/BatchingHttpInterceptor$PendingRequest {
 	public fun <init> (Lcom/apollographql/apollo3/api/http/HttpRequest;)V
 	public final fun getDeferred ()Lkotlinx/coroutines/CompletableDeferred;
 	public final fun getRequest ()Lcom/apollographql/apollo3/api/http/HttpRequest;
 }
 
-public final class com/apollographql/apollo3/network/http/BatchingHttpEngineExtensions {
-	public static final fun canBeBatched (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-}
-
 public final class com/apollographql/apollo3/network/http/BearerTokenInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public fun <init> (Lcom/apollographql/apollo3/network/http/TokenProvider;)V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -235,6 +249,7 @@ public final class com/apollographql/apollo3/network/http/DefaultHttpEngine : co
 
 public final class com/apollographql/apollo3/network/http/HeadersInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public fun <init> (Ljava/util/List;)V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -275,7 +290,12 @@ public final class com/apollographql/apollo3/network/http/HttpInfo$Key : com/apo
 }
 
 public abstract interface class com/apollographql/apollo3/network/http/HttpInterceptor {
+	public abstract fun dispose ()V
 	public abstract fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/apollographql/apollo3/network/http/HttpInterceptor$DefaultImpls {
+	public static fun dispose (Lcom/apollographql/apollo3/network/http/HttpInterceptor;)V
 }
 
 public abstract interface class com/apollographql/apollo3/network/http/HttpInterceptorChain {
@@ -311,6 +331,7 @@ public final class com/apollographql/apollo3/network/http/HttpNetworkTransport$C
 
 public final class com/apollographql/apollo3/network/http/HttpNetworkTransport$EngineInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpNetworkTransport;)V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -318,6 +339,7 @@ public final class com/apollographql/apollo3/network/http/LoggingInterceptor : c
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun dispose ()V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -64,8 +64,14 @@ abstract class ApolloCall<D : Operation.Data, E>(val apolloClient: ApolloClient,
 
   override var enableAutoPersistedQueries: Boolean? = null
 
-  override fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): E  {
+  override fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): E {
     this.enableAutoPersistedQueries = enableAutoPersistedQueries
+    @Suppress("UNCHECKED_CAST")
+    return this as E
+  }
+
+  override fun canBeBatched(canBeBatched: Boolean?): E {
+    if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
     @Suppress("UNCHECKED_CAST")
     return this as E
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -28,7 +28,6 @@ import com.apollographql.apollo3.network.http.BatchingHttpInterceptor
 import com.apollographql.apollo3.network.http.HttpEngine
 import com.apollographql.apollo3.network.http.HttpInterceptor
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
-import com.apollographql.apollo3.network.http.canBeBatched
 import com.apollographql.apollo3.network.ws.WebSocketEngine
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
 import com.apollographql.apollo3.network.ws.WsProtocol
@@ -202,6 +201,10 @@ private constructor(
 
     override fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): Builder = apply {
       this.enableAutoPersistedQueries = enableAutoPersistedQueries
+    }
+
+    override fun canBeBatched(canBeBatched: Boolean?): Builder = apply {
+      if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
     }
 
     /**
@@ -389,7 +392,7 @@ private constructor(
      * See also [BatchingHttpInterceptor]
      */
     @JvmOverloads
-    fun batching(
+    fun httpBatching(
         batchIntervalMillis: Long = 10,
         maxBatchSize: Int = 10,
         enableByDefault: Boolean = true,
@@ -497,7 +500,7 @@ private constructor(
           httpHeaders = httpHeaders,
           sendApqExtensions = sendApqExtensions,
           sendDocument = sendDocument,
-          enableAutoPersistedQueries = enableAutoPersistedQueries
+          enableAutoPersistedQueries = enableAutoPersistedQueries,
       )
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -386,10 +386,10 @@ private constructor(
      * Some servers might have a per-HTTP-call cache making it faster to resolve 1 big array
      * of n queries compared to resolving the n queries separately.
      *
+     * See also [BatchingHttpInterceptor]
+     *
      * @param batchIntervalMillis the interval between two batches
      * @param maxBatchSize always send the batch when this threshold is reached
-     *
-     * See also [BatchingHttpInterceptor]
      */
     @JvmOverloads
     fun httpBatching(

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpEngine.kt
@@ -1,251 +1,33 @@
-@file:JvmName("BatchingHttpEngineExtensions")
-
 package com.apollographql.apollo3.network.http
 
-import com.apollographql.apollo3.ApolloCall
-import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.annotations.ApolloInternal
-import com.apollographql.apollo3.api.AnyAdapter
-import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.MutableExecutionOptions
-import com.apollographql.apollo3.api.http.HttpBody
-import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
-import com.apollographql.apollo3.api.http.valueOf
-import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
-import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.writeArray
-import com.apollographql.apollo3.exception.ApolloException
-import com.apollographql.apollo3.exception.ApolloHttpException
-import com.apollographql.apollo3.internal.BackgroundDispatcher
-import com.apollographql.apollo3.mpp.ensureNeverFrozen
-import com.apollographql.apollo3.mpp.freeze
-import com.apollographql.apollo3.network.http.BatchingHttpEngine.Companion.CAN_BE_BATCHED
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import okio.Buffer
-import okio.BufferedSink
-import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
-import kotlin.jvm.JvmStatic
 
-/**
- * An [HttpEngine] that wraps another one and batches HTTP queries to execute multiple
- * at once. This reduces the number of HTTP round trips at the price of increased latency as
- * every request in the batch is now as slow as the slowest one.
- * Some servers might have a per-HTTP-call cache making it faster to resolve 1 big array
- * of n queries compared to resolving the n queries separately.
- *
- * Because [com.apollographql.apollo3.ApolloQueryCall.execute] suspends, it only makes sense to use query batching when queries are
- * executed from different coroutines. Use [async] to create a new coroutine if needed
- *
- * [BatchingHttpEngine] buffers the whole response, so it might additionally introduce some
- * client-side latency as it cannot amortize parsing/building the models during network I/O.
- *
- * [BatchingHttpEngine] only works with Post requests. Trying to batch a Get requests is undefined.
- *
- * @param batchIntervalMillis the interval between two batches
- * @param maxBatchSize always send the batch when this threshold is reached
- * @param exposeErrorBody configures whether to expose the error body in [ApolloHttpException].
- *
- * If you're setting this to `true`, you **must** catch [ApolloHttpException] and close the body explicitly
- * to avoid sockets and other resources leaking.
- *
- * Default: false
- */
+@Deprecated("Use ApolloClient.Builder.batching instead")
 class BatchingHttpEngine @JvmOverloads constructor(
     val delegate: HttpEngine = DefaultHttpEngine(),
-    val batchIntervalMillis: Long = 10,
-    private val maxBatchSize: Int = 10,
-    private val exposeErrorBody: Boolean = false
+    batchIntervalMillis: Long = 10,
+    maxBatchSize: Int = 10,
+    exposeErrorBody: Boolean = false,
 ) : HttpEngine {
-  private val dispatcher = BackgroundDispatcher()
-  private val scope = CoroutineScope(dispatcher.coroutineDispatcher)
-  private val mutex = Mutex()
-  private var disposed = false
 
-  private val job: Job
-
-  init {
-    ensureNeverFrozen(this)
-    job = scope.launch {
-      while (true) {
-        delay(batchIntervalMillis)
-        executePendingRequests()
-      }
+  private val batchingHttpInterceptor = BatchingHttpInterceptor(batchIntervalMillis, maxBatchSize, exposeErrorBody)
+  private val engineInterceptor = object : HttpInterceptor {
+    override suspend fun intercept(request: HttpRequest, chain: HttpInterceptorChain): HttpResponse {
+      return delegate.execute(request)
     }
   }
-
-  class PendingRequest(
-      val request: HttpRequest,
-  ) {
-    val deferred = CompletableDeferred<HttpResponse>()
-  }
-
-  private val pendingRequests = mutableListOf<PendingRequest>()
+  private val interceptorChain = DefaultHttpInterceptorChain(
+      interceptors = listOf(engineInterceptor),
+      index = 0,
+  )
 
   override suspend fun execute(request: HttpRequest): HttpResponse {
-    // Batching is enabled by default, unless explicitly disabled
-    val canBeBatched = request.headers.valueOf(CAN_BE_BATCHED)?.toBoolean() ?: true
-
-    if (!canBeBatched) {
-      // Remove the CAN_BE_BATCHED header and forward directly
-      return delegate.execute(request.newBuilder().addHeaders(headers = request.headers.filter { it.name != CAN_BE_BATCHED }).build())
-    }
-
-    val pendingRequest = PendingRequest(request)
-
-    val sendNow = mutex.withLock {
-      // if there was an error, the previous job was already canceled, ignore that error
-      pendingRequests.add(pendingRequest)
-      pendingRequests.size >= maxBatchSize
-    }
-    if (sendNow) {
-      executePendingRequests()
-    }
-
-    return pendingRequest.deferred.await()
-  }
-
-  private suspend fun executePendingRequests() {
-    val pending = mutex.withLock {
-      val copy = pendingRequests.toList()
-      pendingRequests.clear()
-      copy
-    }
-
-    if (pending.isEmpty()) {
-      return
-    }
-
-    val firstRequest = pending.first().request
-
-    val allLengths = pending.map { it.request.headers.valueOf("Content-Length")?.toLongOrNull() ?: -1L }
-    val contentLength = if (allLengths.contains(-1)) {
-      -1
-    } else {
-      allLengths.sum()
-    }
-
-    val allBodies = pending.map { it.request.body ?: error("empty body while batching queries") }
-
-    val body = object : HttpBody {
-      override val contentType = "application/json"
-      override val contentLength = contentLength
-      override fun writeTo(bufferedSink: BufferedSink) {
-        val writer = BufferedSinkJsonWriter(bufferedSink)
-        @OptIn(ApolloInternal::class)
-        writer.writeArray {
-          this as BufferedSinkJsonWriter
-          allBodies.forEach { body ->
-            val buffer = Buffer()
-            body.writeTo(buffer)
-            jsonValue(buffer.readUtf8())
-          }
-        }
-      }
-    }
-
-    val request = HttpRequest.Builder(
-        method = HttpMethod.Post,
-        url = firstRequest.url,
-    ).body(
-        body = body,
-    ).build()
-
-    freeze(request)
-
-    var exception: ApolloException? = null
-    val result = try {
-      val response = delegate.execute(request)
-      if (response.statusCode !in 200..299) {
-        val maybeBody = if (exposeErrorBody) {
-          response.body
-        } else {
-          response.body?.close()
-          null
-        }
-        throw ApolloHttpException(
-            response.statusCode,
-            response.headers,
-            maybeBody,
-            "HTTP error ${response.statusCode} while executing batched query"
-        )
-      }
-      val responseBody = response.body ?: throw ApolloException("null body when executing batched query")
-
-      // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
-      val list = AnyAdapter.fromJson(BufferedSourceJsonReader(responseBody), CustomScalarAdapters.Empty)
-      if (list !is List<*>) throw ApolloException("batched query response is not a list when executing batched query")
-
-      if (list.size != pending.size) {
-        throw ApolloException("batched query response count (${list.size}) does not match the requested queries (${pending.size})")
-      }
-
-      list.map {
-        if (it == null) {
-          throw ApolloException("batched query response contains a null item")
-        }
-        @OptIn(ApolloInternal::class)
-        buildJsonByteString {
-          AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
-        }
-      }
-    } catch (e: ApolloException) {
-      exception = e
-      null
-    }
-
-    if (exception != null) {
-      pending.forEach {
-        it.deferred.completeExceptionally(exception)
-      }
-      return
-    } else {
-      result!!.forEachIndexed { index, byteString ->
-        // This works because the server must return the responses in order
-        pending[index].deferred.complete(
-            HttpResponse.Builder(statusCode = 200)
-                .body(byteString)
-                .build()
-        )
-      }
-    }
+    return batchingHttpInterceptor.intercept(request, interceptorChain)
   }
 
   override fun dispose() {
-    if (!disposed) {
-      delegate.dispose()
-      scope.cancel()
-      dispatcher.dispose()
-      disposed = true
-    }
-  }
-
-  companion object {
-    const val CAN_BE_BATCHED = "X-APOLLO-CAN-BE-BATCHED"
-
-    @JvmStatic
-    fun configureApolloClientBuilder(apolloClientBuilder: ApolloClient.Builder, canBeBatched: Boolean) {
-      apolloClientBuilder.canBeBatched(canBeBatched)
-    }
-
-    @JvmStatic
-    fun configureApolloCall(apolloCall: ApolloCall<*, *>, canBeBatched: Boolean) {
-      apolloCall.canBeBatched(canBeBatched)
-    }
+    delegate.dispose()
   }
 }
-
-fun <T> MutableExecutionOptions<T>.canBeBatched(canBeBatched: Boolean) = addHttpHeader(
-    CAN_BE_BATCHED, canBeBatched.toString()
-)

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -1,0 +1,252 @@
+package com.apollographql.apollo3.network.http
+
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.api.AnyAdapter
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.MutableExecutionOptions
+import com.apollographql.apollo3.api.http.HttpBody
+import com.apollographql.apollo3.api.http.HttpMethod
+import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.api.http.HttpResponse
+import com.apollographql.apollo3.api.http.valueOf
+import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
+import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
+import com.apollographql.apollo3.api.json.internal.buildJsonByteString
+import com.apollographql.apollo3.api.json.internal.writeArray
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.internal.BackgroundDispatcher
+import com.apollographql.apollo3.mpp.ensureNeverFrozen
+import com.apollographql.apollo3.mpp.freeze
+import com.apollographql.apollo3.network.http.BatchingHttpInterceptor.Companion.CAN_BE_BATCHED
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okio.Buffer
+import okio.BufferedSink
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
+
+/**
+ * An [HttpInterceptor] that batches HTTP queries to execute multiple at once.
+ * This reduces the number of HTTP round trips at the price of increased latency as
+ * every request in the batch is now as slow as the slowest one.
+ * Some servers might have a per-HTTP-call cache making it faster to resolve 1 big array
+ * of n queries compared to resolving the n queries separately.
+ *
+ * Because [com.apollographql.apollo3.ApolloQueryCall.execute] suspends, it only makes sense to use query batching when queries are
+ * executed from different coroutines. Use [async] to create a new coroutine if needed
+ *
+ * [BatchingHttpInterceptor] buffers the whole response, so it might additionally introduce some
+ * client-side latency as it cannot amortize parsing/building the models during network I/O.
+ *
+ * [BatchingHttpInterceptor] only works with Post requests. Trying to batch a Get requests is undefined.
+ *
+ * @param batchIntervalMillis the interval between two batches
+ * @param maxBatchSize always send the batch when this threshold is reached
+ * @param exposeErrorBody configures whether to expose the error body in [ApolloHttpException].
+ *
+ * If you're setting this to `true`, you **must** catch [ApolloHttpException] and close the body explicitly
+ * to avoid sockets and other resources leaking.
+ *
+ * Default: false
+ */
+class BatchingHttpInterceptor @JvmOverloads constructor(
+    private val batchIntervalMillis: Long = 10,
+    private val maxBatchSize: Int = 10,
+    private val exposeErrorBody: Boolean = false
+) : HttpInterceptor {
+  private val dispatcher = BackgroundDispatcher()
+  private val scope = CoroutineScope(dispatcher.coroutineDispatcher)
+  private val mutex = Mutex()
+  private var disposed = false
+
+  private val job: Job
+
+  private var interceptorChain: HttpInterceptorChain? = null
+
+  init {
+    ensureNeverFrozen(this)
+    job = scope.launch {
+      while (true) {
+        delay(batchIntervalMillis)
+        executePendingRequests()
+      }
+    }
+  }
+
+  class PendingRequest(
+      val request: HttpRequest,
+  ) {
+    val deferred = CompletableDeferred<HttpResponse>()
+  }
+
+  private val pendingRequests = mutableListOf<PendingRequest>()
+
+  override suspend fun intercept(request: HttpRequest, chain: HttpInterceptorChain): HttpResponse {
+    // Batching is enabled by default, unless explicitly disabled
+    val canBeBatched = request.headers.valueOf(CAN_BE_BATCHED)?.toBoolean() ?: true
+
+    if (!canBeBatched) {
+      // Remove the CAN_BE_BATCHED header and forward directly
+      return chain.proceed(request.newBuilder().addHeaders(headers = request.headers.filter { it.name != CAN_BE_BATCHED }).build())
+    }
+
+    // Keep the chain for later
+    interceptorChain = chain
+
+    val pendingRequest = PendingRequest(request)
+
+    val sendNow = mutex.withLock {
+      // if there was an error, the previous job was already canceled, ignore that error
+      pendingRequests.add(pendingRequest)
+      pendingRequests.size >= maxBatchSize
+    }
+    if (sendNow) {
+      executePendingRequests()
+    }
+
+    return pendingRequest.deferred.await()
+  }
+
+  private suspend fun executePendingRequests() {
+    val pending = mutex.withLock {
+      val copy = pendingRequests.toList()
+      pendingRequests.clear()
+      copy
+    }
+
+    if (pending.isEmpty()) {
+      return
+    }
+
+    val firstRequest = pending.first().request
+
+    val allLengths = pending.map { it.request.headers.valueOf("Content-Length")?.toLongOrNull() ?: -1L }
+    val contentLength = if (allLengths.contains(-1)) {
+      -1
+    } else {
+      allLengths.sum()
+    }
+
+    val allBodies = pending.map { it.request.body ?: error("empty body while batching queries") }
+
+    val body = object : HttpBody {
+      override val contentType = "application/json"
+      override val contentLength = contentLength
+      override fun writeTo(bufferedSink: BufferedSink) {
+        val writer = BufferedSinkJsonWriter(bufferedSink)
+        @OptIn(ApolloInternal::class)
+        writer.writeArray {
+          this as BufferedSinkJsonWriter
+          allBodies.forEach { body ->
+            val buffer = Buffer()
+            body.writeTo(buffer)
+            jsonValue(buffer.readUtf8())
+          }
+        }
+      }
+    }
+
+    val request = HttpRequest.Builder(
+        method = HttpMethod.Post,
+        url = firstRequest.url,
+    ).body(
+        body = body,
+    ).build()
+
+    freeze(request)
+
+    var exception: ApolloException? = null
+    val result = try {
+      val response = interceptorChain!!.proceed(request)
+      if (response.statusCode !in 200..299) {
+        val maybeBody = if (exposeErrorBody) {
+          response.body
+        } else {
+          response.body?.close()
+          null
+        }
+        throw ApolloHttpException(
+            response.statusCode,
+            response.headers,
+            maybeBody,
+            "HTTP error ${response.statusCode} while executing batched query"
+        )
+      }
+      val responseBody = response.body ?: throw ApolloException("null body when executing batched query")
+
+      // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
+      val list = AnyAdapter.fromJson(BufferedSourceJsonReader(responseBody), CustomScalarAdapters.Empty)
+      if (list !is List<*>) throw ApolloException("batched query response is not a list when executing batched query")
+
+      if (list.size != pending.size) {
+        throw ApolloException("batched query response count (${list.size}) does not match the requested queries (${pending.size})")
+      }
+
+      list.map {
+        if (it == null) {
+          throw ApolloException("batched query response contains a null item")
+        }
+        @OptIn(ApolloInternal::class)
+        buildJsonByteString {
+          AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
+        }
+      }
+    } catch (e: ApolloException) {
+      exception = e
+      null
+    }
+
+    if (exception != null) {
+      pending.forEach {
+        it.deferred.completeExceptionally(exception)
+      }
+      return
+    } else {
+      result!!.forEachIndexed { index, byteString ->
+        // This works because the server must return the responses in order
+        pending[index].deferred.complete(
+            HttpResponse.Builder(statusCode = 200)
+                .body(byteString)
+                .build()
+        )
+      }
+    }
+  }
+
+  override fun dispose() {
+    if (!disposed) {
+      interceptorChain = null
+      scope.cancel()
+      dispatcher.dispose()
+      disposed = true
+    }
+  }
+
+  companion object {
+    const val CAN_BE_BATCHED = "X-APOLLO-CAN-BE-BATCHED"
+
+    @JvmStatic
+    fun configureApolloClientBuilder(apolloClientBuilder: ApolloClient.Builder, canBeBatched: Boolean) {
+      apolloClientBuilder.canBeBatched(canBeBatched)
+    }
+
+    @JvmStatic
+    fun configureApolloCall(apolloCall: ApolloCall<*, *>, canBeBatched: Boolean) {
+      apolloCall.canBeBatched(canBeBatched)
+    }
+  }
+}
+
+fun <T> MutableExecutionOptions<T>.canBeBatched(canBeBatched: Boolean) = addHttpHeader(
+    CAN_BE_BATCHED, canBeBatched.toString()
+)

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -48,10 +48,10 @@ import kotlin.jvm.JvmStatic
  * [BatchingHttpInterceptor] buffers the whole response, so it might additionally introduce some
  * client-side latency as it cannot amortize parsing/building the models during network I/O.
  *
- * [BatchingHttpInterceptor] only works with Post requests. Trying to batch a Get requests is undefined.
+ * [BatchingHttpInterceptor] only works with Post requests. Trying to batch a Get request is undefined.
  *
- * @param batchIntervalMillis the interval between two batches
- * @param maxBatchSize always send the batch when this threshold is reached
+ * @param batchIntervalMillis the maximum time interval before a new batch is sent
+ * @param maxBatchSize the maximum number of requests queued before a new batch is sent
  * @param exposeErrorBody configures whether to expose the error body in [ApolloHttpException].
  *
  * If you're setting this to `true`, you **must** catch [ApolloHttpException] and close the body explicitly

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpInterceptor.kt
@@ -9,6 +9,7 @@ interface HttpInterceptorChain {
 
 interface HttpInterceptor {
   suspend fun intercept(request: HttpRequest, chain: HttpInterceptorChain): HttpResponse
+  fun dispose() {}
 }
 
 internal class DefaultHttpInterceptorChain(

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -103,6 +103,7 @@ private constructor(
   }
 
   override fun dispose() {
+    interceptors.forEach { it.dispose() }
     engine.dispose()
   }
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
-import com.apollographql.apollo3.network.http.BatchingHttpEngine
 import com.apollographql.apollo3.network.http.canBeBatched
 import com.apollographql.apollo3.testing.runTest
 import kotlinx.coroutines.async
@@ -32,7 +31,7 @@ class QueryBatchingTest {
 
   private suspend fun tearDown() {
     mockServer.stop()
-    // This is important. JS will hang if the BatchingHttpEngine scope is not cancelled
+    // This is important. JS will hang if the BatchingHttpInterceptor scope is not cancelled
     apolloClient.dispose()
   }
 
@@ -41,7 +40,7 @@ class QueryBatchingTest {
   fun testAgainstARealServer() = runTest(before = { setUp() }, after = { tearDown() }) {
     apolloClient = ApolloClient.Builder()
         .serverUrl("https://apollo-fullstack-tutorial.herokuapp.com/graphql")
-        .httpEngine(BatchingHttpEngine())
+        .batching()
         .build()
 
     val result1 = async {
@@ -63,7 +62,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpEngine(BatchingHttpEngine(batchIntervalMillis = 300))
+        .batching(batchIntervalMillis = 300)
         .build()
 
     val result1 = async {
@@ -99,7 +98,7 @@ class QueryBatchingTest {
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpEngine(BatchingHttpEngine(batchIntervalMillis = 10))
+        .batching(batchIntervalMillis = 10)
         .build()
 
     val result1 = async {
@@ -124,7 +123,7 @@ class QueryBatchingTest {
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpEngine(BatchingHttpEngine(batchIntervalMillis = 300))
+        .batching(batchIntervalMillis = 300)
         .build()
 
     val result1 = async {
@@ -152,7 +151,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpEngine(BatchingHttpEngine(batchIntervalMillis = 300))
+        .batching(batchIntervalMillis = 300)
         // Opt out by default
         .canBeBatched(false)
         .build()

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
-import com.apollographql.apollo3.network.http.canBeBatched
 import com.apollographql.apollo3.testing.runTest
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -40,7 +39,7 @@ class QueryBatchingTest {
   fun testAgainstARealServer() = runTest(before = { setUp() }, after = { tearDown() }) {
     apolloClient = ApolloClient.Builder()
         .serverUrl("https://apollo-fullstack-tutorial.herokuapp.com/graphql")
-        .batching()
+        .httpBatching()
         .build()
 
     val result1 = async {
@@ -62,7 +61,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .batching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 300)
         .build()
 
     val result1 = async {
@@ -98,7 +97,7 @@ class QueryBatchingTest {
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .batching(batchIntervalMillis = 10)
+        .httpBatching(batchIntervalMillis = 10)
         .build()
 
     val result1 = async {
@@ -123,7 +122,7 @@ class QueryBatchingTest {
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .batching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 300)
         .build()
 
     val result1 = async {
@@ -151,7 +150,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .batching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 300)
         // Opt out by default
         .canBeBatched(false)
         .build()

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -95,7 +95,7 @@ public class ClientTest {
   private void queryBatching() {
     ApolloClient.Builder apolloClientBuilder = new ApolloClient.Builder()
         .serverUrl("https://localhost")
-        .batching();
+        .httpBatching();
     BatchingHttpInterceptor.configureApolloClientBuilder(apolloClientBuilder, false);
     apolloClient = apolloClientBuilder.build();
 

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -22,7 +22,7 @@ import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
 import com.apollographql.apollo3.network.http.ApolloClientAwarenessInterceptor;
-import com.apollographql.apollo3.network.http.BatchingHttpEngine;
+import com.apollographql.apollo3.network.http.BatchingHttpInterceptor;
 import com.apollographql.apollo3.network.http.HttpNetworkTransport;
 import com.apollographql.apollo3.rx2.Rx2Apollo;
 import com.google.common.truth.Truth;
@@ -95,12 +95,12 @@ public class ClientTest {
   private void queryBatching() {
     ApolloClient.Builder apolloClientBuilder = new ApolloClient.Builder()
         .serverUrl("https://localhost")
-        .httpEngine(new BatchingHttpEngine());
-    BatchingHttpEngine.configureApolloClientBuilder(apolloClientBuilder, false);
+        .batching();
+    BatchingHttpInterceptor.configureApolloClientBuilder(apolloClientBuilder, false);
     apolloClient = apolloClientBuilder.build();
 
     ApolloQueryCall<GetRandomQuery.Data> call = apolloClient.query(new GetRandomQuery());
-    BatchingHttpEngine.configureApolloCall(call, true);
+    BatchingHttpInterceptor.configureApolloCall(call, true);
     ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.single(call).blockingGet();
   }
 


### PR DESCRIPTION
Related to #3660

- Make `BatchingHttpEngine` an `HttpIntereptor`
  - I needed a `dispose` so I added it to the interface, with a default implementation in order to not break the API
  - `HttpNetworkTransport` has the responsibility to call `dispose` on its interceptors
- Also added a `batching` method on the client builder
- To keep compatibility with the RC I created a deprecated `BatchingHttpEngine` that delegates to the interceptor. That's a bit unfortunate, maybe we don't really need it? LMK what you think! (and I'm sorry because of this the diff is not nice to read)

Docs will need to be updated.