### PR TITLE
Update migration file with http cache information

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -432,6 +432,15 @@ val response = apolloClient.query(request)
 
 #### HTTP cache
 
+To add http cache support, add the dependency to your gradle file:
+
+```kotlin
+dependencies {
+  // Add
+  implementation("com.apollographql.apollo3:apollo-http-cache:$version") // Gives access to `httpCache` and `httpFetchPolicy`
+}
+```
+
 Similarly, the HTTP cache is configurable through extension functions:
 
 ```kotlin


### PR DESCRIPTION
Adds a text very similar to the explanation for the normalized cache section.

To give some context. I was having trouble performing the migration because I was missing the `httpCache` and `httpFetchPolicy` methods. I hadn't found this dependency mentioned anywhere on the migration logs, nor in the readme on the tag 3.0.0-rc01 so I thought I'd contribute this. If I understood something wrong or you feel like it could be worded better, please feel free to act as you think is best. Just want to make this migration easier for other devs too.