### PR TITLE
Merge ApolloQueryCall, ApolloSubscriptionCall, ApolloMutationCall

### DIFF
--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -69,18 +69,18 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun configureApolloClientBuilder$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun doNotStore (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-	public static final fun executeCacheAndNetwork (Lcom/apollographql/apollo3/ApolloQueryCall;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun executeCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun fetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
 	public static final fun getApolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
 	public static final fun getCacheInfo (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
 	public static final fun isFromCache (Lcom/apollographql/apollo3/api/ApolloResponse;)Z
-	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/ApolloMutationCall;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/ApolloMutationCall;
+	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/ApolloCall;
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/api/ApolloRequest$Builder;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public static final fun refetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
 	public static final fun store (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloQueryCall;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -2,9 +2,8 @@
 
 package com.apollographql.apollo3.cache.normalized
 
+import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.ApolloMutationCall
-import com.apollographql.apollo3.ApolloQueryCall
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.ExecutionContext
@@ -82,7 +81,7 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
  * Gets the result from the network, then observes the cache for any changes.
  * Overriding the [FetchPolicy] will change how the result is first queried.
  */
-fun <D : Query.Data> ApolloQueryCall<D>.watch(): Flow<ApolloResponse<D>> {
+fun <D : Query.Data> ApolloCall<D>.watch(): Flow<ApolloResponse<D>> {
   return copy().addExecutionContext(WatchContext(true)).toFlow()
 }
 
@@ -92,7 +91,7 @@ fun <D : Query.Data> ApolloQueryCall<D>.watch(): Flow<ApolloResponse<D>> {
  *
  * Any [FetchPolicy] previously set will be ignored
  */
-fun <D : Query.Data> ApolloQueryCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {
+fun <D : Query.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {
   return flow {
     var cacheException: ApolloException? = null
     var networkException: ApolloException? = null
@@ -195,7 +194,7 @@ fun <D : Mutation.Data> ApolloRequest.Builder<D>.optimisticUpdates(data: D) = ad
     OptimisticUpdatesContext(data)
 )
 
-fun <D : Mutation.Data> ApolloMutationCall<D>.optimisticUpdates(data: D) = addExecutionContext(
+fun <D : Mutation.Data> ApolloCall<D>.optimisticUpdates(data: D) = addExecutionContext(
     OptimisticUpdatesContext(data)
 )
 

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -1,21 +1,28 @@
-public abstract class com/apollographql/apollo3/ApolloCall : com/apollographql/apollo3/api/MutableExecutionOptions {
-	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Operation;)V
-	public fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Ljava/lang/Object;
-	public fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
-	public fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
-	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
-	public final fun getApolloClient ()Lcom/apollographql/apollo3/ApolloClient;
+public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apollo3/api/MutableExecutionOptions {
+	public fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Ljava/lang/Object;
+	public fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun addHttpHeader (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public fun canBeBatched (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun copy ()Lcom/apollographql/apollo3/ApolloCall;
+	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun getHttpHeaders ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
-	public final fun getOperation ()Lcom/apollographql/apollo3/api/Operation;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
-	public fun httpHeaders (Ljava/util/List;)Ljava/lang/Object;
-	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
-	public fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
-	public fun sendDocument (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public fun httpHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun httpHeaders (Ljava/util/List;)Ljava/lang/Object;
+	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
+	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun sendDocument (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun setEnableAutoPersistedQueries (Ljava/lang/Boolean;)V
 	public fun setExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)V
 	public fun setHttpHeaders (Ljava/util/List;)V
@@ -39,12 +46,12 @@ public final class com/apollographql/apollo3/ApolloClient : com/apollographql/ap
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
-	public final fun mutate (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloMutationCall;
-	public final fun mutation (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloMutationCall;
+	public final fun mutate (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloCall;
+	public final fun mutation (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/ApolloCall;
 	public final fun newBuilder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun query (Lcom/apollographql/apollo3/api/Query;)Lcom/apollographql/apollo3/ApolloQueryCall;
-	public final fun subscribe (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloSubscriptionCall;
-	public final fun subscription (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloSubscriptionCall;
+	public final fun query (Lcom/apollographql/apollo3/api/Query;)Lcom/apollographql/apollo3/ApolloCall;
+	public final fun subscribe (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloCall;
+	public final fun subscription (Lcom/apollographql/apollo3/api/Subscription;)Lcom/apollographql/apollo3/ApolloCall;
 }
 
 public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollographql/apollo3/api/MutableExecutionOptions {
@@ -114,25 +121,6 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 
 public final class com/apollographql/apollo3/ApolloClient$Companion {
 	public final fun builder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
-}
-
-public final class com/apollographql/apollo3/ApolloMutationCall : com/apollographql/apollo3/ApolloCall {
-	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Mutation;)V
-	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun copy ()Lcom/apollographql/apollo3/ApolloMutationCall;
-	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/ApolloQueryCall : com/apollographql/apollo3/ApolloCall {
-	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Query;)V
-	public final fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun copy ()Lcom/apollographql/apollo3/ApolloQueryCall;
-	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/ApolloSubscriptionCall : com/apollographql/apollo3/ApolloCall {
-	public fun <init> (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Subscription;)V
-	public final fun copy ()Lcom/apollographql/apollo3/ApolloSubscriptionCall;
 }
 
 public final class com/apollographql/apollo3/AutoPersistedQueryInfo : com/apollographql/apollo3/api/ExecutionContext$Element {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo3
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.ExecutionContext
+import com.apollographql.apollo3.api.ExecutionOptions
 import com.apollographql.apollo3.api.MutableExecutionOptions
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpHeader
@@ -49,6 +50,11 @@ class ApolloCall<D : Operation.Data> internal constructor(
     this.enableAutoPersistedQueries = enableAutoPersistedQueries
   }
 
+  override fun canBeBatched(canBeBatched: Boolean?) = apply {
+    if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
+  }
+
+
   fun copy(): ApolloCall<D> {
     return ApolloCall(apolloClient, operation)
         .addExecutionContext(executionContext)
@@ -57,12 +63,6 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendApqExtensions(sendApqExtensions)
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
-  }
-
-  override fun canBeBatched(canBeBatched: Boolean?): E {
-    if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
-    @Suppress("UNCHECKED_CAST")
-    return this as E
   }
 
   /**

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -92,7 +92,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
   }
 
   /**
-   * A shorthand for `toFlow().execute()`.
+   * A shorthand for `toFlow().single()`.
    * Use this for queries and mutation to get a single [ApolloResponse] from the network or the cache.
    * For subscriptions, you usually want to use [toFlow] instead to listen to all values.
    */

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -65,31 +65,31 @@ private constructor(
   }
 
   /**
-   * Creates a new [ApolloQueryCall] that you can customize and/or execute.
+   * Creates a new [ApolloCall] that you can customize and/or execute.
    */
-  fun <D : Query.Data> query(query: Query<D>): ApolloQueryCall<D> {
-    return ApolloQueryCall(this, query)
+  fun <D : Query.Data> query(query: Query<D>): ApolloCall<D> {
+    return ApolloCall(this, query)
   }
 
   /**
-   * Creates a new [ApolloMutationCall] that you can customize and/or execute.
+   * Creates a new [ApolloCall] that you can customize and/or execute.
    */
-  fun <D : Mutation.Data> mutation(mutation: Mutation<D>): ApolloMutationCall<D> {
-    return ApolloMutationCall(this, mutation)
+  fun <D : Mutation.Data> mutation(mutation: Mutation<D>): ApolloCall<D> {
+    return ApolloCall(this, mutation)
   }
 
   @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("mutation(mutation)"))
-  fun <D : Mutation.Data> mutate(mutation: Mutation<D>): ApolloMutationCall<D> = mutation(mutation)
+  fun <D : Mutation.Data> mutate(mutation: Mutation<D>): ApolloCall<D> = mutation(mutation)
 
   /**
-   * Creates a new [ApolloSubscriptionCall] that you can customize and/or execute.
+   * Creates a new [ApolloCall] that you can customize and/or execute.
    */
-  fun <D : Subscription.Data> subscription(subscription: Subscription<D>): ApolloSubscriptionCall<D> {
-    return ApolloSubscriptionCall(this, subscription)
+  fun <D : Subscription.Data> subscription(subscription: Subscription<D>): ApolloCall<D> {
+    return ApolloCall(this, subscription)
   }
 
   @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("subscription(subscription)"))
-  fun <D : Subscription.Data> subscribe(subscription: Subscription<D>): ApolloSubscriptionCall<D> = subscription(subscription)
+  fun <D : Subscription.Data> subscribe(subscription: Subscription<D>): ApolloCall<D> = subscription(subscription)
 
   fun dispose() {
     concurrencyInfo.coroutineScope.cancel()

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -238,7 +238,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     }
 
     @JvmStatic
-    fun configureApolloCall(apolloCall: ApolloCall<*, *>, canBeBatched: Boolean) {
+    fun configureApolloCall(apolloCall: ApolloCall<*>, canBeBatched: Boolean) {
       apolloCall.canBeBatched(canBeBatched)
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.ExecutionOptions
+import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpBody
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
@@ -61,7 +62,7 @@ import kotlin.jvm.JvmStatic
 class BatchingHttpInterceptor @JvmOverloads constructor(
     private val batchIntervalMillis: Long = 10,
     private val maxBatchSize: Int = 10,
-    private val exposeErrorBody: Boolean = false
+    private val exposeErrorBody: Boolean = false,
 ) : HttpInterceptor {
   private val dispatcher = BackgroundDispatcher()
   private val scope = CoroutineScope(dispatcher.coroutineDispatcher)
@@ -238,7 +239,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     }
 
     @JvmStatic
-    fun configureApolloCall(apolloCall: ApolloCall<*>, canBeBatched: Boolean) {
+    fun <D : Operation.Data> configureApolloCall(apolloCall: ApolloCall<D>, canBeBatched: Boolean) {
       apolloCall.canBeBatched(canBeBatched)
     }
   }

--- a/apollo-rx2-support/api/apollo-rx2-support.api
+++ b/apollo-rx2-support/api/apollo-rx2-support.api
@@ -1,13 +1,10 @@
 public final class com/apollographql/apollo3/rx2/Rx2Apollo {
-	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/Flowable;
-	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
-	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
-	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
-	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
 	public static final fun toRx2ApolloInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/Scheduler;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptor;
 	public static synthetic fun toRx2ApolloInterceptor$default (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptor;
 	public static final fun toRx2ApolloInterceptorChain (Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;Lio/reactivex/Scheduler;)Lcom/apollographql/apollo3/rx2/Rx2ApolloInterceptorChain;

--- a/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
+++ b/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/toRx2.kt
@@ -2,18 +2,13 @@
 
 package com.apollographql.apollo3.rx2
 
-import com.apollographql.apollo3.ApolloMutationCall
-import com.apollographql.apollo3.ApolloQueryCall
-import com.apollographql.apollo3.ApolloSubscriptionCall
+import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
-import com.apollographql.apollo3.api.Mutation
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
@@ -156,16 +151,10 @@ class Rx2ApolloStore(
 
 @JvmOverloads
 @JvmName("single")
-fun <D: Query.Data> ApolloQueryCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
-  execute()
-}
-
-@JvmOverloads
-@JvmName("single")
-fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
+fun <D: Operation.Data> ApolloCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
 @JvmOverloads
 @JvmName("flowable")
-fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+fun <D: Operation.Data> ApolloCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())

--- a/apollo-rx3-support/api/apollo-rx3-support.api
+++ b/apollo-rx3-support/api/apollo-rx3-support.api
@@ -1,13 +1,10 @@
 public final class com/apollographql/apollo3/rx3/Rx3Apollo {
-	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;)Lio/reactivex/rxjava3/core/Flowable;
-	public static final fun flowable (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
-	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloSubscriptionCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;)Lio/reactivex/rxjava3/core/Single;
-	public static final fun single (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
-	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloMutationCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
-	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloQueryCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
 	public static final fun toRx3ApolloInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/rxjava3/core/Scheduler;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptor;
 	public static synthetic fun toRx3ApolloInterceptor$default (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptor;
 	public static final fun toRx3ApolloInterceptorChain (Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;Lio/reactivex/rxjava3/core/Scheduler;)Lcom/apollographql/apollo3/rx3/Rx3ApolloInterceptorChain;

--- a/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
+++ b/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/toRx3.kt
@@ -5,18 +5,13 @@
 
 package com.apollographql.apollo3.rx3
 
-import com.apollographql.apollo3.ApolloMutationCall
-import com.apollographql.apollo3.ApolloQueryCall
-import com.apollographql.apollo3.ApolloSubscriptionCall
+import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
-import com.apollographql.apollo3.api.Mutation
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
@@ -159,16 +154,11 @@ class Rx3ApolloStore(
 
 @JvmOverloads
 @JvmName("single")
-fun <D: Query.Data> ApolloQueryCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
+fun <D: Operation.Data> ApolloCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
   execute()
 }
 
-@JvmOverloads
-@JvmName("single")
-fun <D: Mutation.Data> ApolloMutationCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()) = rxSingle(scheduler.asCoroutineDispatcher()) {
-  execute()
-}
 
 @JvmOverloads
 @JvmName("flowable")
-fun <D: Subscription.Data> ApolloSubscriptionCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+fun <D: Operation.Data> ApolloCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()) = toFlow().asFlowable(scheduler.asCoroutineDispatcher())

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -1,7 +1,7 @@
 package test;
 
+import com.apollographql.apollo3.ApolloCall;
 import com.apollographql.apollo3.ApolloClient;
-import com.apollographql.apollo3.ApolloQueryCall;
 import com.apollographql.apollo3.api.Adapter;
 import com.apollographql.apollo3.api.ApolloResponse;
 import com.apollographql.apollo3.api.CompiledField;
@@ -99,7 +99,7 @@ public class ClientTest {
     BatchingHttpInterceptor.configureApolloClientBuilder(apolloClientBuilder, false);
     apolloClient = apolloClientBuilder.build();
 
-    ApolloQueryCall<GetRandomQuery.Data> call = apolloClient.query(new GetRandomQuery());
+    ApolloCall<GetRandomQuery.Data> call = apolloClient.query(new GetRandomQuery());
     BatchingHttpInterceptor.configureApolloCall(call, true);
     ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.single(call).blockingGet();
   }
@@ -111,7 +111,7 @@ public class ClientTest {
     HttpCache.configureApolloClientBuilder(apolloClientBuilder, cacheDir, cacheSize);
     apolloClient = apolloClientBuilder.build();
 
-    ApolloQueryCall<GetRandomQuery.Data> call = apolloClient.query(new GetRandomQuery());
+    ApolloCall<GetRandomQuery.Data> call = apolloClient.query(new GetRandomQuery());
     HttpCache.httpFetchPolicy(call, HttpFetchPolicy.NetworkOnly);
     ApolloResponse<GetRandomQuery.Data> result = Rx2Apollo.single(call).blockingGet();
   }


### PR DESCRIPTION
Last minute breaking change to remove `ApolloQueryCall`, `ApolloSubscriptionCall` and `ApolloMutationCall` in favor of just `ApolloCall<D>`.

**Rationale**:

From the caller point of view, having a second `E` type parameter was confusing as it wasn't super clear what it was for. Using `ApolloCall<D>` reduces the cognitive load around this.

The only thing that `ApolloQueryCall`, `ApolloSubscriptionCall` and `ApolloMutationCall` allowed previously was preventing using `.execute()` for subscriptions but we find that in practice, it shouldn't be a big issue as it's clear from the function signature that calling `.execute()` on a subscription will return a single value. There might even be valid use cases to do so?

Having a single `ApolloCall<D>` is symmetric with `ApolloRequest<D>` and `ApolloResponse<D>` so the API is overall more consistent.

It's still possible to restrict some calls like `fetchPolicy()` for an example using extension functions:

```kotlin
fun <D: Query.Data>ApolloCall<D>.fetchPolicy(fetchPolicy: FetchPolicy) {
  // 
}
```

Out of curiosity, I opened [this question](https://discuss.kotlinlang.org/t/restrict-calling-some-functions-of-a-class-with-generic-type-parameters/23643) to investigate whether we can do so without extension functions but I don't have many hopes there. 

All in all, code is simpler to maintain, cognitive load is smaller for users and we don't lose much type safety, might even gain some flexibility so I think it's a win. Feedbacks welcome