### PR TITLE
Add ApolloIdlingResource migration guide

### DIFF
--- a/apollo-idling-resource/api/apollo-idling-resource.api
+++ b/apollo-idling-resource/api/apollo-idling-resource.api
@@ -1,10 +1,16 @@
 public final class com/apollographql/apollo3/android/ApolloIdlingResource : androidx/test/espresso/IdlingResource {
+	public static final field Companion Lcom/apollographql/apollo3/android/ApolloIdlingResource$Companion;
 	public fun <init> (Ljava/lang/String;)V
+	public static final fun create (Ljava/lang/String;Lcom/apollographql/apollo3/ApolloClient;)V
 	public fun getName ()Ljava/lang/String;
 	public fun isIdleNow ()Z
 	public final fun operationEnd ()V
 	public final fun operationStart ()V
 	public fun registerIdleTransitionCallback (Landroidx/test/espresso/IdlingResource$ResourceCallback;)V
+}
+
+public final class com/apollographql/apollo3/android/ApolloIdlingResource$Companion {
+	public final fun create (Ljava/lang/String;Lcom/apollographql/apollo3/ApolloClient;)V
 }
 
 public final class com/apollographql/apollo3/android/ApolloIdlingResourceKt {

--- a/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt
+++ b/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt
@@ -42,6 +42,19 @@ class ApolloIdlingResource(
   override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
     this.callback = callback
   }
+
+  companion object {
+    @JvmStatic
+    @Deprecated(
+        message = "Used for backward compatibility with 2.x. You now need to pass your ApolloIdlingResource to your ApolloClient.Builder." +
+            " See https://www.apollographql.com/docs/android/v3/migration/3.0/ for more details.",
+        ReplaceWith("ApolloIdlingResource(name)")
+    )
+    @Suppress("UNUSED_PARAMETER")
+    fun create(name: String, apolloClient: ApolloClient) {
+      throw NotImplementedError()
+    }
+  }
 }
 
 fun ApolloClient.Builder.idlingResource(idlingResource: ApolloIdlingResource): ApolloClient.Builder {

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -603,6 +603,26 @@ enum Direction {
 
 See [#3035](https://github.com/apollographql/apollo-android/issues/3035) for more details
 
+### IdlingResource
+
+In Apollo Android 2.x, you can pass an `ApolloClient` to `ApolloIdlingResource.create()` and the `ApolloClient` will be modified to register an idle callback.
+
+In Apollo Android 3, an `ApolloClient` is immutable once instantiated so it's not possible to register callbacks/interceptors once it is instantiated. Instead, you can create your `ApolloIdlingResource` as a first step and then pass it to your `ApolloClient.Builder` like so:
+
+```kotlin
+// Replace
+val idlingResource = ApolloIdlingResource.create("ApolloIdlingResource", apolloClient)
+IdlingRegistry.getInstance().register(idlingResource)
+
+// With
+val idlingResource = ApolloIdlingResource("ApolloIdlingResource")
+IdlingRegistry.getInstance().register(idlingResource)
+val apolloClient = ApolloClient.Builder()
+    .serverUrl("https://example.com/graphql")
+    .idlingResource(idlingResource)
+    .build()
+```
+
 ### BigDecimal
 
 By default, Apollo Android 2.x internally maps all numbers to a custom `BigDecimal` value.


### PR DESCRIPTION
Also add `ApolloIdlingResource.create` with `DeprecationLevel.Error` to point to the migration guide.

Thanks again @michgauz for catching this 🙏 