### PR TITLE
Fix `replapcing` typo

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -58,7 +58,7 @@ Apollo Android 3.0 uses a new identifier for its package name, Gradle plugin id,
 
 This change avoids dependency conflicts as encouraged in [Java Interoperability Policy for Major Version Updates](https://jakewharton.com/java-interoperability-policy-for-major-version-updates/). It also allows to run version 2 and version 3 side by side if needed.
 
-> In most cases, you can update the identifier throughout your project by performing a find-and-replace and replapcing `com.apollographql.apollo` with `com.apollographql.apollo3`.
+> In most cases, you can update the identifier throughout your project by performing a find-and-replace and replacing `com.apollographql.apollo` with `com.apollographql.apollo3`.
 
 #### Group id
 


### PR DESCRIPTION
I started going through migration guide and noticed a typo that doesn't seem to be fixed in any of opened PRs. Please let my know if there is another way of reporting typos or if you simply don't want to see such nitpicky changes at this moment 😬 