### PR TITLE
Add Gitleaks allowlist file

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,8 +1,25 @@
+# This file exists primarily to influence scheduled scans that Apollo runs of all repos in Apollo-managed orgs. 
+# This is an Apollo-Internal link, but more information about these scans is available here:
+# https://apollographql.atlassian.net/wiki/spaces/SecOps/pages/81330213/Everything+Static+Application+Security+Testing#Scheduled-Scans.1
+# 
+# Apollo is using Gitleaks (https://github.com/gitleaks/gitleaks) to run these scans.
+# However, this file is not something that Gitleaks natively consumes. This file is an
+# Apollo-convention. Prior to scanning a repo, Apollo merges
+# our standard Gitleaks configuration (which is largely just the Gitleaks-default config) with
+# this file if it exists in a repo. The combined config is then used to scan a repo.
+# 
+# We did this because the natively-supported allowlisting functionality in Gitleaks didn't do everything we wanted
+# or wasn't as robust as we needed. For example, one of the allowlisting options offered by Gitleaks depends on the line number
+# on which a false positive secret exists to allowlist it. (https://github.com/gitleaks/gitleaks#gitleaksignore).
+# This creates a fairly fragile allowlisting mechanism. This file allows us to leverage the full capabilities of the Gitleaks rule syntax
+# to create allowlisting functionality.
 
 [[ rules ]]
     id = "high-entropy-base64"
     [ rules.allowlist ]
         commits = [
+            # Allowlist https://github.com/apollographql/apollo-kotlin/blob/3f7083f676edf920931f06b053f4a062802a9e54/docs/_config.yml#L49
+            # This is a segment key that Apollo SecOps was unable to utilize with Segment
             "3f7083f676edf920931f06b053f4a062802a9e54",
             
         ]
@@ -11,6 +28,10 @@
     id = "generic-api-key"
     [ rules.allowlist ]
         commits = [
+            # Allowlist https://github.com/apollographql/apollo-kotlin/blob/11ac2f0ca2b914f50ba4cc182855637a4e55168c/apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/DiskLruCacheTest.kt#L183, 
+            # https://github.com/apollographql/apollo-kotlin/blob/77b4034e08e0981cabb8aa75310f85e3334a9622/deprecated-apollo-http-cache/src/test/kotlin/com/apollographql/apollo3/cache/http/internal/DiskLruCacheTest.kt#L183, and 
+            # https://github.com/apollographql/apollo-kotlin/blob/06acab79ca711901cf22fb1dcf431f35145caedd/apollo-http-cache/src/test/java/com/apollographql/apollo/cache/http/internal/DiskLruCacheTest.java#L182
+            # All are the same value and are test data
             "11ac2f0ca2b914f50ba4cc182855637a4e55168c",
             "77b4034e08e0981cabb8aa75310f85e3334a9622",
             "06acab79ca711901cf22fb1dcf431f35145caedd",


### PR DESCRIPTION
## Motivation / Implements

This PR adds `.gitleaks.toml` to the root of this repo. This file is consumed by the secret-scanning tool that Apollo's SecOps team uses to check for secrets in our source.

This file is being added with the required configuration to tell the scanning tool to ignore values that SecOps has confirmed as false positives.

I will follow up on this PR, but if a maintainer on this repo wants to get ahead of me, this PR is safe to merge at your convenience. Let us know in #security if you have any issues or questions!

Thank you!
