### PR TITLE
[IJ plugin] Fix a crash when loading plugin

### DIFF
--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -276,6 +276,7 @@
     <action
         id="SendTelemetryAction"
         class="com.apollographql.ijplugin.telemetry.SendTelemetryAction"
+        internal="true"
     >
       <add-to-group group-id="ApolloInternalActionGroup" />
     </action>
@@ -284,6 +285,7 @@
     <action
         id="ThrowAction"
         class="com.apollographql.ijplugin.error.ThrowAction"
+        internal="true"
     >
       <add-to-group group-id="ApolloInternalActionGroup" />
     </action>


### PR DESCRIPTION
Fix for `com.intellij.diagnostic.PluginException: com.apollographql.ijplugin.telemetry.SendTelemetryAction (SendTelemetryAction): group with id "ApolloInternalActionGroup" isn't registered; action will be added to the "Other" group`.

Actions in an internal group must be internal.