### PR TITLE
Sign the next snapshot just for testing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           LIBRARIAN_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           LIBRARIAN_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.SONATYPE_GPG_KEY }}
+          GPG_PRIVATE_KEY_PASSWORD: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts


### PR DESCRIPTION
I just want to test the org-level signing keys without having to make a new release, I'll revert that.