### PR TITLE
Remove unused ApolloStoreInterceptor

### DIFF
--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.Fragment
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.json.JsonNumber
+import com.apollographql.apollo.cache.normalized.ApolloStore.Companion.ALL_KEYS
 import com.apollographql.apollo.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo.cache.normalized.api.CacheKey
 import com.apollographql.apollo.cache.normalized.api.CacheKeyGenerator
@@ -14,7 +15,6 @@ import com.apollographql.apollo.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo.cache.normalized.api.Record
 import com.apollographql.apollo.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo.cache.normalized.internal.DefaultApolloStore
-import com.apollographql.apollo.interceptor.ApolloInterceptor
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.reflect.KClass
@@ -280,11 +280,6 @@ fun ApolloStore(
     cacheKeyGenerator: CacheKeyGenerator = TypePolicyCacheKeyGenerator,
     cacheResolver: CacheResolver = FieldPolicyCacheResolver,
 ): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyGenerator, cacheResolver)
-
-/**
- * Interface that marks all interceptors added when configuring a `store()` on ApolloClient.Builder.
- */
-internal interface ApolloStoreInterceptor : ApolloInterceptor
 
 internal fun ApolloStore.cacheDumpProvider(): () -> Map<String, Map<String, Pair<Int, Map<String, Any?>>>> {
   return {

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/FetchPolicyInterceptors.kt
@@ -129,7 +129,7 @@ val CacheAndNetworkInterceptor = object : ApolloInterceptor {
   }
 }
 
-internal object FetchPolicyRouterInterceptor : ApolloInterceptor, ApolloStoreInterceptor {
+internal object FetchPolicyRouterInterceptor : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {
       // Subscriptions and Mutations do not support fetchPolicies

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Query
 import com.apollographql.apollo.api.Subscription
 import com.apollographql.apollo.cache.normalized.ApolloStore
-import com.apollographql.apollo.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo.cache.normalized.CacheInfo
 import com.apollographql.apollo.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.apollo.cache.normalized.api.CacheHeaders
@@ -38,7 +37,7 @@ import kotlinx.coroutines.launch
 
 internal class ApolloCacheInterceptor(
     val store: ApolloStore,
-) : ApolloInterceptor, ApolloStoreInterceptor {
+) : ApolloInterceptor {
   private suspend fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: suspend () -> Unit) {
     if (request.writeToCacheAsynchronously) {
       val scope = request.executionContext[ConcurrencyInfo]!!.coroutineScope

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/WatcherInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/internal/WatcherInterceptor.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Query
 import com.apollographql.apollo.cache.normalized.ApolloStore
-import com.apollographql.apollo.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo.cache.normalized.api.dependentKeys
 import com.apollographql.apollo.cache.normalized.watchContext
 import com.apollographql.apollo.exception.DefaultApolloException
@@ -24,7 +23,7 @@ import kotlinx.coroutines.flow.onSubscription
 
 internal val WatcherSentinel = DefaultApolloException("The watcher has started")
 
-internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor, ApolloStoreInterceptor {
+internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     val watchContext = request.watchContext ?: return chain.proceed(request)
 


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/pull/6455#discussion_r2186687941

Not breaking because it was internal. 