### PR TITLE
[build] help the compiler find the correct symbol

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -61,7 +61,7 @@ abstract class CleanStaleTestProjects : DefaultTask() {
 
   @TaskAction
   fun taskAction() {
-    directory.listFiles { it.isDirectory && it.name.startsWith("testProject") }!!.forEach {
+    directory.listFiles { it: File -> it.isDirectory && it.name.startsWith("testProject") }!!.forEach {
       it.deleteRecursively()
     }
   }


### PR DESCRIPTION
There are 2 `listFiles()` function that both take a `FunctionInterface` Java interface. 

When using Apollo Kotlin as an included build, the compiler sometimes fail to find them. I'm not really sure why 🤷 
