### PR TITLE
Subscriptions: do not silently discard network exceptions

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
@@ -237,14 +237,23 @@ private constructor(
             }
           }
         }.catch { throwable ->
-          if (throwable is ApolloException) {
-            emit(
-                ApolloResponse.Builder(operation = operation, requestUuid = uuid4())
-                    .exception(throwable)
-                    .build()
-            )
-          }
+          emit(
+              ApolloResponse.Builder(operation = operation, requestUuid = uuid4())
+                  .exception(throwable.wrapIfNeeded())
+                  .build()
+          )
         }
+  }
+
+  private fun Throwable.wrapIfNeeded(): ApolloException {
+    return if (this is ApolloException) {
+      this
+    } else {
+      ApolloNetworkException(
+        message = "Error while reading response",
+        platformCause = this
+      )
+    }
   }
 
   private fun <D : Operation.Data> ApolloResponse<D>.withHttpInfo(


### PR DESCRIPTION
When a network error happens during `.select()`, it's an `IOException`, wrap it and forward it to the caller.