### PR TITLE
Update v5 migration guide to include `downloadApolloSchema`

### DIFF
--- a/docs/source/migration/5.0.mdx
+++ b/docs/source/migration/5.0.mdx
@@ -85,7 +85,7 @@ tasks.register("downloadSchema") {
 ```
 ## `apollo-idling-resource` 
 
-Apollo Kotlin 5 removes `apollo-idling-resource`. `ApolloIdlingResource`. `IdlingResource` usage has been slowly decreasing and there are now better alternatives to do your testing.
+Apollo Kotlin 5 removes the `apollo-idling-resource` artifact. Usage of `ApolloIdlingResource` has been decreasing, and better alternatives for testing are now available.
 
 For a good overview of alternative solutions, we recommend reading [this article from Jose Alcérreca](https://medium.com/androiddevelopers/alternatives-to-idling-resources-in-compose-tests-8ae71f9fc473).
 


### PR DESCRIPTION
This is a follow up to https://github.com/apollographql/apollo-kotlin/issues/6737