### PR TITLE
docs: Update `@defer` documentation

### DIFF
--- a/docs/source/fetching/defer.mdx
+++ b/docs/source/fetching/defer.mdx
@@ -5,7 +5,7 @@ description: 'Fetch slower schema fields asynchronously'
 
 <Note>
 
-The incremental delivery format used by `@defer` isn't yet standardized. There have been multiple proposals and Apollo Kotlin only supports [the format implemented by Apollo Router](https://www.apollographql.com/docs/graphos/routing/operations/defer#specification-status), which is described in this [specification](https://specs.apollo.dev/incremental/v0.1/).
+The incremental delivery format used by `@defer` [isn't yet standardized](https://github.com/graphql/defer-stream-wg). Apollo Kotlin supports [the format implemented by Apollo Router](https://www.apollographql.com/docs/graphos/routing/operations/defer#specification-status), which is described in this [specification](https://specs.apollo.dev/incremental/v0.1/).
 
 </Note>
 


### PR DESCRIPTION
Removes the 'experimental' designation.