### PR TITLE
JS: fix a timeout leak in the default HttpEngine

### DIFF
--- a/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo/network/http/DefaultHttpEngine.js.kt
+++ b/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo/network/http/DefaultHttpEngine.js.kt
@@ -121,5 +121,6 @@ private suspend fun readBody(body: dynamic, readTimeoutMillis: Long, abortContro
       throw cause
     }
   }
+  clearTimeout(readTimeoutId)
   return bufferedSource
 }


### PR DESCRIPTION
Not a huge deal but this was artificially increasing the JS tests duration by 1 min