### PR TITLE
Allow multiple success responses in ApolloCall.execute()

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
@@ -156,8 +156,8 @@ class ApolloCall<D : Operation.Data> internal constructor(
    *
    * [execute] calls [toFlow] and filters out cache or network errors to return a single success [ApolloResponse].
    *
-   * [execute] throws if more than one success [ApolloResponse] is returned, for an example, if [operation] is a subscription or a `@defer` query.
-   * In those cases use [toFlow] instead.
+   * If more than one success [ApolloResponse] is emitted, for an example, if [operation] is a subscription or a `@defer` query, the first one is returned.
+   * Prefer [toFlow] for those cases to handle all the responses.
    *
    * [execute] may fail due to an I/O error, a cache miss or other reasons. In that case, check [ApolloResponse.exception]:
    * ```
@@ -208,8 +208,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         }
       }
 
-      1 -> successResponses.first()
-      else -> throw DefaultApolloException("The operation returned multiple items, use .toFlow() instead of .execute()")
+      else -> successResponses.first()
     }
   }
 }


### PR DESCRIPTION
### Rationale / decision record
- Calling `execute()` on subscriptions or other multiple success responses cases makes little sense, which is why we were failing fast with a clear message
- However the cache's `CacheAndNetwork` fetch policy can emit 0, 1, or 2 success responses, so `execute()` may not always crash - e.g. it doesn't crash during tests, but crashes in production (aka, "foot gun").
	- User facing this: [Slack](https://kotlinlang.slack.com/archives/C01A6KM1SBZ/p1759483133440909)
- Recognizing this, in Cache [v1.0.0-alpha.5](https://github.com/apollographql/apollo-kotlin-normalized-cache/releases/tag/v1.0.0-alpha.5), `CacheAndNetwork` has been deprecated, noting that it is relatively trivial to re-implement it in user code
- However since projects are already using it, this raised concerns
	- https://github.com/apollographql/apollo-kotlin-normalized-cache/issues/213 (2 users)
	- User disappointed by the deprecation: [Slack](https://kotlinlang.slack.com/archives/C01A6KM1SBZ/p1755222156739529)
	- User currently using `CacheAndNetwork`: [Slack](https://androidstudygroup.slack.com/archives/C3J6A8A4A/p1761927076778819?thread_ts=1761925579.180689&cid=C3J6A8A4A)
	- Discussions with Deezer
- Decision:
	- Don't crash in `execute()` but rather return the first success response.
	- [Revert](https://github.com/apollographql/apollo-kotlin-normalized-cache/pull/253) `CacheAndNetwork` deprecation

That would be technically a behavior change, but one that can only have 'good' consequences?

### Pro/cons
- Pro: fewer crashes
- Con: `execute()` with multiple success responses still make little sense, but by not crashing we're not educating the user
