### PR TITLE
[4.x] Restore JsonReader state if a field throws in-flight 

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
@@ -30,11 +30,20 @@ class ListAdapter<T>(private val wrappedAdapter: Adapter<T>) : Adapter<List<@Jvm
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): List<T> {
     reader.beginArray()
     val list = mutableListOf<T>()
-    while (reader.hasNext()) {
-      list.add(wrappedAdapter.fromJson(reader, customScalarAdapters))
+    try {
+      while (reader.hasNext()) {
+        list.add(wrappedAdapter.fromJson(reader, customScalarAdapters))
+      }
+      reader.endArray()
+      return list
+    } catch (e: ApolloGraphQLException) {
+      // There was an error. Consume the remaining entries
+      while (reader.hasNext()) {
+        reader.skipValue()
+      }
+      reader.endArray()
+      throw e
     }
-    reader.endArray()
-    return list
   }
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: List<T>) {
@@ -356,8 +365,18 @@ class ObjectAdapter<T>(
       reader
     }
     actualReader.beginObject()
-    return wrappedAdapter.fromJson(actualReader, customScalarAdapters).also {
+    try {
+      val result = wrappedAdapter.fromJson(actualReader, customScalarAdapters)
       actualReader.endObject()
+      return result
+    } catch (e: ApolloGraphQLException) {
+      // There was an error. Consume the remaining entries of the object
+      while (actualReader.hasNext()) {
+        actualReader.nextName()
+        actualReader.skipValue()
+      }
+      actualReader.endObject()
+      throw e
     }
   }
 

--- a/tests/catch/build.gradle.kts
+++ b/tests/catch/build.gradle.kts
@@ -29,4 +29,8 @@ apollo {
     srcDir("src/main/graphql/result")
     packageName.set("result")
   }
+  service("fragments") {
+    srcDir("src/main/graphql/fragments")
+    packageName.set("fragments")
+  }
 }

--- a/tests/catch/src/main/graphql/fragments/operation.graphql
+++ b/tests/catch/src/main/graphql/fragments/operation.graphql
@@ -1,0 +1,8 @@
+query GetFoo {
+  foo @catch(to: RESULT) {
+    foo {
+      bar
+      bar2: bar
+    }
+  }
+}

--- a/tests/catch/src/main/graphql/fragments/schema.graphqls
+++ b/tests/catch/src/main/graphql/fragments/schema.graphqls
@@ -1,0 +1,12 @@
+extend schema @link(url: "https://specs.apollo.dev/nullability/v0.4", import: ["@semanticNonNullField", "@semanticNonNull", "@catch", "@catchByDefault"])
+extend schema @catchByDefault(to: THROW)
+
+type Query {
+  foo: Foo
+}
+
+type Foo {
+  bar: Int
+  foo: Foo
+}
+

--- a/tests/catch/src/test/kotlin/test/FragmentTest.kt
+++ b/tests/catch/src/test/kotlin/test/FragmentTest.kt
@@ -1,0 +1,36 @@
+package test
+
+import com.apollographql.apollo.api.FieldResult
+import com.apollographql.apollo.api.graphQLErrorOrNull
+import fragments.GetFooQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class FragmentTest {
+  @Test
+  fun test() {
+    // language=json
+    val json = """
+      {
+        "errors": [
+          { "message":  "Cannot return null for bar", "path": ["foo", "foo", "bar"] }        
+        ],
+        "data": {
+          "foo": {
+            "foo": {
+              "bar": null,
+              "bar2": 42
+            }
+          }        
+        }
+      }
+    """.trimIndent()
+
+    val response = GetFooQuery().parseResponse(json)
+    response.data?.foo.apply {
+      assertIs<FieldResult.Failure>(this)
+      assertEquals("Cannot return null for bar", this.graphQLErrorOrNull()?.message)
+    }
+  }
+}


### PR DESCRIPTION
Restore the JsonReader state if something throws in-flight (backport of #6775)