### PR TITLE
Remove duplicate pluginMarker

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -22,7 +22,6 @@ gratatouille {
   codeGeneration {
     addDependencies = false
   }
-  pluginMarker("com.apollographql.apollo")
 }
 
 val agpCompat = kotlin.target.compilations.create("agp-compat")


### PR DESCRIPTION
Newer versions of librarian can publish the markers automagically from the `@GPlugin` annotation.