### PR TITLE
Remove the external plugin marker as well

### DIFF
--- a/libraries/apollo-gradle-plugin-external/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin-external/build.gradle.kts
@@ -17,7 +17,6 @@ gratatouille {
   codeGeneration {
     addDependencies.set(false)
   }
-  pluginMarker("com.apollographql.apollo.external")
 }
 
 dependencies {


### PR DESCRIPTION
Follow up from https://github.com/apollographql/apollo-kotlin/pull/6786, there is a second plugin that needed to be removed.