### PR TITLE
Do not compute key fields and key args when the Cache compiler plugin is present

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrSchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrSchemaBuilder.kt
@@ -13,6 +13,7 @@ internal object IrSchemaBuilder {
   fun build(
       schema: Schema,
       usedCoordinates: UsedCoordinates,
+      computeKeyArgs: Boolean,
   ): IrSchema {
 
     val irEnums = mutableListOf<IrEnum>()
@@ -65,10 +66,10 @@ internal object IrSchemaBuilder {
           irUnions.add(typeDefinition.toIr())
         }
         typeDefinition is GQLInterfaceTypeDefinition -> {
-          irInterfaces.add(typeDefinition.toIr(schema, mergedUsedCoordinates))
+          irInterfaces.add(typeDefinition.toIr(schema, mergedUsedCoordinates, computeKeyArgs))
         }
         typeDefinition is GQLObjectTypeDefinition -> {
-          irObjects.add(typeDefinition.toIr(schema, mergedUsedCoordinates))
+          irObjects.add(typeDefinition.toIr(schema, mergedUsedCoordinates, computeKeyArgs))
         }
       }
     }


### PR DESCRIPTION
Fix https://github.com/apollographql/apollo-kotlin-normalized-cache/issues/252