### PR TITLE
Update preview version format in documentation

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -248,7 +248,7 @@ pluginManagement {
 }
 ```
 
-Previews are published every night 3am UTC time. You can get them by replacing `-SNAPSHOT` with the desired date (e.g. `4.0.2-2024.10.05`). They have 1 year retention.
+Previews are published every night 3am UTC time. You can get them by replacing `-SNAPSHOT` with the desired date (e.g. `4.3.4-20251124`). They have 1 year retention.
 
 ## Evolution policy
 


### PR DESCRIPTION
Noticed that preview versions no longer contain dots between parts of the date