### PR TITLE
Sync `main` with 4.x

### DIFF
--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -27,6 +27,7 @@ public final class com/apollographql/apollo/annotations/ApolloDeprecatedSince$Ve
 	public static final field v4_1_2 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static final field v4_2_1 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static final field v4_3_1 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
+	public static final field v4_3_4 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static final field v5_0_0 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;

--- a/libraries/apollo-annotations/api/apollo-annotations.klib.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.klib.api
@@ -40,6 +40,7 @@ open annotation class com.apollographql.apollo.annotations/ApolloDeprecatedSince
         enum entry v4_1_2 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v4_1_2|null[0]
         enum entry v4_2_1 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v4_2_1|null[0]
         enum entry v4_3_1 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v4_3_1|null[0]
+        enum entry v4_3_4 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v4_3_4|null[0]
         enum entry v5_0_0 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v5_0_0|null[0]
 
         final val entries // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.entries|#static{}entries[0]

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo/annotations/ApolloDeprecatedSince.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo/annotations/ApolloDeprecatedSince.kt
@@ -36,6 +36,7 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v4_1_2, // All symbols above are ERRORs in 5.0.0 except a few ones that are perpetual soft deprecations like SubscriptionWsProtocol (https://youtrack.jetbrains.com/issue/KT-54106)
     v4_2_1,
     v4_3_1,
+    v4_3_4,
     v5_0_0
   }
 }

--- a/libraries/apollo-gradle-plugin/src/agp-8/kotlin/com/apollographql/apollo/gradle/Agp8.kt
+++ b/libraries/apollo-gradle-plugin/src/agp-8/kotlin/com/apollographql/apollo/gradle/Agp8.kt
@@ -1,20 +1,18 @@
 @file:Suppress("DEPRECATION")
 
-package com.apollographql.com.apollographql.apollo
+package com.apollographql.apollo.gradle
 
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.BaseVariant
-import com.apollographql.apollo.AgpCompat
-import com.apollographql.apollo.AgpComponent
-import com.apollographql.apollo.ComponentFilter
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
-internal class Agp8(override val version: String, extension: Any): AgpCompat {
+@EmbeddedGradleSymbol
+class Agp8(override val version: String, extension: Any): AgpCompat {
   private val extension = extension as BaseExtension
 
   override fun compileSdk(): String? {
@@ -69,7 +67,8 @@ internal class Agp8(override val version: String, extension: Any): AgpCompat {
   }
 }
 
-internal class Agp8Component(private val base: BaseVariant): AgpComponent {
+@EmbeddedGradleSymbol
+class Agp8Component(private val base: BaseVariant): AgpComponent {
   override val name: String
     get() = base.name
 

--- a/libraries/apollo-gradle-plugin/src/agp-9/kotlin/com/apollographql/apollo/gradle/Agp9.kt
+++ b/libraries/apollo-gradle-plugin/src/agp-9/kotlin/com/apollographql/apollo/gradle/Agp9.kt
@@ -1,25 +1,22 @@
 @file:Suppress("DEPRECATION")
 
-package com.apollographql.com.apollographql.apollo
+package com.apollographql.apollo.gradle
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Component
-import com.android.build.api.variant.HasAndroidTest
 import com.android.build.api.variant.HasDeviceTests
 import com.android.build.api.variant.HasHostTests
-import com.apollographql.apollo.AgpCompat
-import com.apollographql.apollo.AgpComponent
-import com.apollographql.apollo.ComponentFilter
 import org.gradle.api.Task
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
-internal class Agp9(
+@EmbeddedGradleSymbol
+class Agp9(
     override val version: String,
     androidComponents: Any,
     android: Any?,
@@ -112,7 +109,8 @@ internal class Agp9(
   }
 }
 
-internal class Agp9Component(private val base: Component) : AgpComponent {
+@EmbeddedGradleSymbol
+class Agp9Component(private val base: Component) : AgpComponent {
   override val name: String
     get() = base.name
 

--- a/libraries/apollo-gradle-plugin/src/agp-compat/kotlin/com/apollographql/apollo/gradle/AgpCompat.kt
+++ b/libraries/apollo-gradle-plugin/src/agp-compat/kotlin/com/apollographql/apollo/gradle/AgpCompat.kt
@@ -1,6 +1,7 @@
-package com.apollographql.apollo
+package com.apollographql.apollo.gradle
 
-internal interface AgpCompat {
+@EmbeddedGradleSymbol
+interface AgpCompat {
   fun compileSdk(): String?
   fun targetSdk(): Int?
   fun minSdk(): Int?
@@ -10,13 +11,15 @@ internal interface AgpCompat {
   val version: String
 }
 
-internal enum class ComponentFilter {
+@EmbeddedGradleSymbol
+enum class ComponentFilter {
   All,
   Test,
   Main
 }
 
-internal interface AgpComponent {
+@EmbeddedGradleSymbol
+interface AgpComponent {
   /**
    * The name of the component ("prodDebug", "demoRelease", etc..)
    */

--- a/libraries/apollo-gradle-plugin/src/agp-compat/kotlin/com/apollographql/apollo/gradle/EmbeddedGradleSymbol.kt
+++ b/libraries/apollo-gradle-plugin/src/agp-compat/kotlin/com/apollographql/apollo/gradle/EmbeddedGradleSymbol.kt
@@ -1,0 +1,19 @@
+package com.apollographql.apollo.gradle
+
+import com.apollographql.apollo.annotations.ApolloInternal
+
+/**
+ * A substitute for Kotlin friend paths that works well in the IDE.
+ * Symbols annotated with [EmbeddedGradleSymbol] must be embedded in a fat jar so that they are not visible
+ * for outside consumers.
+ *
+ * See https://youtrack.jetbrains.com/issue/KTIJ-30664.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API should not be visible outside the Apollo codebase, file a bug if it is."
+)
+@Retention(AnnotationRetention.BINARY)
+@ApolloInternal
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CONSTRUCTOR, AnnotationTarget.TYPEALIAS)
+annotation class EmbeddedGradleSymbol

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -861,7 +861,7 @@ interface Service {
      * Connects the generated sources to the given Android variant.
      */
     @Deprecated("use connectToAndroidComponent() instead", ReplaceWith("connectToAndroidComponent(variant, true)"))
-    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_0)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_3_4)
     fun connectToAndroidVariant(variant: Any)
 
     /**
@@ -872,7 +872,7 @@ interface Service {
      * You can also use more qualified source sets like "demo", "debug" or "demoDebug"
      */
     @Deprecated("This function is deprecated and fails with AGP9+. Use connectToAndroidVariant instead")
-    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_0)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_3_4)
     fun connectToAndroidSourceSet(name: String)
 
     /**
@@ -884,7 +884,7 @@ interface Service {
      * @throws Exception if the Android plugin is not applied
      */
     @Deprecated("Use connectToAndroidVariants() instead")
-    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_0)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_3_4)
     fun connectToAllAndroidVariants()
 
     /**

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.AgpCompat
-import com.apollographql.apollo.ComponentFilter
+import com.apollographql.apollo.gradle.AgpCompat
+import com.apollographql.apollo.gradle.ComponentFilter
 import com.apollographql.apollo.gradle.api.ApolloDependencies
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.ApolloGradleToolingModel
@@ -24,10 +24,10 @@ import com.apollographql.apollo.gradle.task.registerApolloGenerateProjectModelTa
 import com.apollographql.apollo.gradle.task.registerApolloGenerateSourcesFromIrTask
 import com.apollographql.apollo.gradle.task.registerApolloGenerateSourcesTask
 import com.apollographql.apollo.gradle.task.registerApolloRegisterOperationsTask
-import com.apollographql.com.apollographql.apollo.Agp8
-import com.apollographql.com.apollographql.apollo.Agp8Component
-import com.apollographql.com.apollographql.apollo.Agp9
-import com.apollographql.com.apollographql.apollo.Agp9Component
+import com.apollographql.apollo.gradle.Agp8
+import com.apollographql.apollo.gradle.Agp8Component
+import com.apollographql.apollo.gradle.Agp9
+import com.apollographql.apollo.gradle.Agp9Component
 import gratatouille.wiring.capitalizeFirstLetter
 import org.gradle.api.Action
 import org.gradle.api.NamedDomainObjectProvider

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultDirectoryConnection.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultDirectoryConnection.kt
@@ -1,11 +1,11 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.AgpCompat
-import com.apollographql.apollo.ComponentFilter
+import com.apollographql.apollo.gradle.ComponentFilter
+import com.apollographql.apollo.gradle.AgpCompat
 import com.apollographql.apollo.gradle.api.Service
-import com.apollographql.com.apollographql.apollo.Agp8
-import com.apollographql.com.apollographql.apollo.Agp8Component
-import com.apollographql.com.apollographql.apollo.Agp9
+import com.apollographql.apollo.gradle.Agp8
+import com.apollographql.apollo.gradle.Agp8Component
+import com.apollographql.apollo.gradle.Agp9
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/actions/runs/21169108964/job/60881143163?pr=6845

* Do not use `associateWith()`
* Add `ApolloDeprecatedSince.Version.v4_3_4`
* Fix internal package name of the Gradle plugin