### PR TITLE
[4.x] Make the Gradle plugin portal notice more visible

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -95,7 +95,7 @@ gradlePlugin {
       id = "com.apollographql.apollo"
       displayName = "Apollo Kotlin GraphQL client plugin."
       description = """
-        ℹ️ Newer versions of the Apollo Kotlin Gradle Plugin (v5+) are only published on Maven Central.
+        ⚠️ Newer versions of the Apollo Kotlin Gradle Plugin (v5+) are only published on Maven Central.
          
         See https://github.com/gradle/plugin-portal-requests/issues/225 for more details and https://www.apollographql.com/docs/kotlin/advanced/plugin-configuration for documentation about the Gradle plugin.
         """.trimIndent()


### PR DESCRIPTION
Small patch to make the notice more visible. Right now it's very easy to miss it.

<img width="1236" height="711" alt="Screenshot 2026-01-21 at 11 20 39" src="https://github.com/user-attachments/assets/b2da7c66-7351-430c-8a74-feb2e6225fd8" />
