### PR TITLE
Field extensions: track the spec edits

### DIFF
--- a/libraries/apollo-ast/test-fixtures/merger/argument-default-value-error.expected.graphql
+++ b/libraries/apollo-ast/test-fixtures/merger/argument-default-value-error.expected.graphql
@@ -1,5 +1,5 @@
 OtherValidationIssue (8:10)
-Cannot merge argument 'id': default values cannot be merged
+Cannot merge argument 'id': default values are different
 type Query {
   random(id: ID!): Int
 }

--- a/libraries/apollo-ast/test-fixtures/merger/argument-description-error.expected.graphql
+++ b/libraries/apollo-ast/test-fixtures/merger/argument-description-error.expected.graphql
@@ -1,5 +1,5 @@
 OtherValidationIssue (8:10)
-Cannot merge argument 'id': descriptions cannot be merged
+Cannot merge argument 'id': descriptions are different
 type Query {
   random(id: ID!): Int
 }

--- a/libraries/apollo-ast/test-fixtures/merger/field-description-error.expected.graphql
+++ b/libraries/apollo-ast/test-fixtures/merger/field-description-error.expected.graphql
@@ -1,5 +1,5 @@
 OtherValidationIssue (8:3)
-Cannot merge field 'random': descriptions cannot be merged
+Cannot merge field 'random': descriptions are different
 type Query {
   random: Int
 }

--- a/libraries/apollo-ast/test-fixtures/merger/merge-descriptions-and-default-values.expected.graphql
+++ b/libraries/apollo-ast/test-fixtures/merger/merge-descriptions-and-default-values.expected.graphql
@@ -1,0 +1,7 @@
+
+type Query {
+  """
+  a field
+  """
+  random("an argument" id: ID!): Int @deprecated
+}

--- a/libraries/apollo-ast/test-fixtures/merger/merge-descriptions-and-default-values.graphql
+++ b/libraries/apollo-ast/test-fixtures/merger/merge-descriptions-and-default-values.graphql
@@ -1,0 +1,10 @@
+# PRAGMA allowMergingFieldDefinitions
+
+type Query {
+  "a field"
+  random("an argument" id: ID!): Int
+}
+extend type Query {
+  "a field"
+  random("an argument" id: ID!): Int @deprecated
+}


### PR DESCRIPTION
We allow descriptions and defaultValues if they match exactly the existing definition.