### PR TITLE
Use the same classloader than the one which loaded apollo-gradle-plugin to lookup the AGP version

### DIFF
--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/AgpVersion.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/AgpVersion.kt
@@ -4,7 +4,7 @@ package com.apollographql.apollo.gradle.internal
  * This function throws if AGP is not in the current context classloader
  */
 fun agpVersion(): String {
-  val version = Thread.currentThread().contextClassLoader.loadClass("com.android.Version")
+  val version = Class.forName("com.android.Version")
 
   val field = version.declaredFields.firstOrNull { it.name == "ANDROID_GRADLE_PLUGIN_VERSION" }
   check(field != null) {


### PR DESCRIPTION
When inside `afterEvaluate {}`, Gradle changes the current thread and it doesn't have the needed symbol

See #6876