### PR TITLE
Downgrade androidx-core version to 1.16.0 because compileSdk 36 requirement

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -60,7 +60,8 @@ android-plugin9 = { group = "com.android.tools.build", name = "gradle", version 
 androidx-test-uiautomator = "androidx.test.uiautomator:uiautomator:2.3.0"
 androidx-activity = "androidx.activity:activity-ktx:1.11.0"
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version = "1.9.1" }
-androidx-core = "androidx.core:core-ktx:1.17.0"
+#noinspection NewerVersionAvailable 1.16.0 is the last version compatible with compileSdk 35
+androidx-core = "androidx.core:core-ktx:1.16.0"
 androidx-lint-rules = "androidx.lint:lint-gradle:1.0.0-alpha05"
 androidx-lint-gradle-plugin = { module = "com.android.lint:com.android.lint.gradle.plugin", version.ref = "android-plugin" }
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"


### PR DESCRIPTION
We cannot use to `compileSdk = 36` because of some constraints very hard to solve with Unity. We're shipping our code as part of a SDK for Unity.

We have no control on the gradle project generated by Unity so we can't force dependencies here. We also can't ask our SDK user (Unity developers) to tweak gradle Unity export, it adds a lot of friction to them, most of the time they can't do it.

Unity have a bug/ui problem where they assume `targetSdk == compileSdk`, basically just one field in their UI for both. And we can't ask them to bump to `targetSdk = 36`.

Maybe Unity will fix their issue but in the meantime we're looking for a quick fix, downgrading `androidx-core` version to `1.16.0` (from `1.17.0`) is a quick fix, only this library requires `compileSdk = 36`.
