### PR TITLE
Change android-sdkversion-compile to 35

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -3,7 +3,8 @@
 # Can be as high as IJ supports.
 # See https://kotlinlang.org/docs/multiplatform-compatibility-guide.html#version-compatibility for compatibility with KGP
 android-plugin = "8.11.2"
-android-sdkversion-compile = "36"
+#noinspection NewerVersionAvailable maintaining compatibility with compileSdk 35 consumers
+android-sdkversion-compile = "35"
 android-sdkversion-compilebenchmark = "36"
 android-sdkversion-min = "16"
 android-sdkversion-compose-min = "21"


### PR DESCRIPTION
Since we downgraded `androix.core` to support `compileSdk = 35` I think it make sense to also downgrade Apollo's `compileSdk` too. That would help detect future dependency updates requiring higher `compileSdk`. 

Then when needed Apollo could update to 36 but I think there's no reason to use `compileSdk = 36` for now in Apollo.

See #6899 for reason to downgrade to 35.