### PR TITLE
Add linuxArm64 target, linux websockets and test linux in CI

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -61,4 +61,4 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - run: |
-          ./gradlew linuxTest && ./gradlew -p tests linuxTest
+          ./gradlew linuxX64Test

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -55,3 +55,10 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - run: |
           /Applications/Xcode_26.0.1.app/Contents/Developer/usr/bin/xcodebuild -allowProvisioningUpdates -project swift-tests/swift-tests.xcodeproj -configuration Debug -scheme swift-tests  test -test-timeouts-enabled YES
+
+  linux-tests:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+      - run: |
+          ./gradlew linuxTest && ./gradlew -p tests linuxTest

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -57,7 +57,7 @@ jobs:
           /Applications/Xcode_26.0.1.app/Contents/Developer/usr/bin/xcodebuild -allowProvisioningUpdates -project swift-tests/swift-tests.xcodeproj -configuration Debug -scheme swift-tests  test -test-timeouts-enabled YES
 
   linux-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - run: |

--- a/build-logic/src/main/kotlin/kmp.kt
+++ b/build-logic/src/main/kotlin/kmp.kt
@@ -66,7 +66,8 @@ fun defaultTargets(
     }
 
     if (enableLinux && withLinux) {
-      linuxX64("linux")
+      linuxX64()
+      linuxArm64()
     }
 
     if (withAndroid) {

--- a/build-logic/src/main/kotlin/test.kt
+++ b/build-logic/src/main/kotlin/test.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.ExecutionTaskHolder
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithHostTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeOutputKind
@@ -90,7 +91,8 @@ internal fun Project.disableSomeTests(enableWasmJsTests: Boolean) {
     /**
      * Disable every native test except the KotlinNativeTargetWithHostTests to save some time
      */
-    if (target is KotlinNativeTargetWithSimulatorTests || target is KotlinNativeTargetWithTests<*>) {
+    if ((target is KotlinNativeTargetWithSimulatorTests || target is KotlinNativeTargetWithTests<*>)
+        && target !is KotlinNativeTargetWithHostTests) {
       target.testRuns.configureEach {
         it as ExecutionTaskHolder<*>
         it.executionTask.configure {

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -156,6 +156,7 @@ kotlinx-binarycompatibilityvalidator = { group = "org.jetbrains.kotlinx", name =
 ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
 ktor-client-curl = { group = "io.ktor", name = "ktor-client-curl", version.ref = "ktor" }
 ktor-client-js = { group = "io.ktor", name = "ktor-client-js", version.ref = "ktor" }
+ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", version.ref = "ktor" }
 ktor-server-cors = { group = "io.ktor", name = "ktor-server-cors", version.ref = "ktor" }
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
 ktor-server-websockets = { group = "io.ktor", name = "ktor-server-websockets", version.ref = "ktor" }

--- a/libraries/apollo-annotations/api/apollo-annotations.klib.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
-// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2

--- a/libraries/apollo-ast/api/apollo-ast.klib.api
+++ b/libraries/apollo-ast/api/apollo-ast.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/libraries/apollo-execution/api/apollo-execution.klib.api
+++ b/libraries/apollo-execution/api/apollo-execution.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/libraries/apollo-mpp-utils/api/apollo-mpp-utils.klib.api
+++ b/libraries/apollo-mpp-utils/api/apollo-mpp-utils.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/libraries/apollo-runtime/api/apollo-runtime.klib.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64.linux, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
 // Alias: macos => [macosArm64, macosX64]

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -83,6 +83,7 @@ kotlin {
     findByName("linuxMain")?.apply {
       dependencies {
         implementation(libs.ktor.client.curl)
+        implementation(libs.ktor.client.websockets)
       }
     }
 

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/MockServerWebSocketEngineTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/MockServerWebSocketEngineTest.kt
@@ -4,7 +4,9 @@ import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.network.websocket.WebSocket
 import com.apollographql.apollo.network.websocket.WebSocketEngine
 import com.apollographql.apollo.network.websocket.WebSocketListener
+import com.apollographql.apollo.testing.Platform
 import com.apollographql.apollo.testing.internal.runTest
+import com.apollographql.apollo.testing.platform
 import com.apollographql.mockserver.CloseFrame
 import com.apollographql.mockserver.DataMessage
 import com.apollographql.mockserver.MockRequestBase
@@ -21,6 +23,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 import okio.ByteString.Companion.toByteString
+import test.network.enqueueMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -147,7 +150,7 @@ class MockServerWebSocketEngineTest {
 
     clientWriter.close(1003, "Client Bye")
     @Suppress("DEPRECATION")
-    if (com.apollographql.apollo.testing.platform() != com.apollographql.apollo.testing.Platform.Native) {
+    if (platform() != com.apollographql.apollo.testing.Platform.Native) {
       // Apple sometimes does not send the Close frame. See https://developer.apple.com/forums/thread/679446
       serverReader.awaitMessage().apply {
         assertIs<CloseFrame>(this)
@@ -159,22 +162,27 @@ class MockServerWebSocketEngineTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun serverClose() = whenHandshakeDone {
-    serverWriter.enqueueMessage(CloseFrame(1002, "Server Bye"))
-
-    val item = clientReader.awaitItem()
-
-    if (item.message != null) {
-      item.message.apply {
-        assertIs<CloseFrame>(this)
-        assertEquals(1002, code)
-        assertEquals("Server Bye", reason)
-      }
-    } else if (item.exception != null) {
-      // Apple implementation calls onError instead on onClose
+  fun serverClose() {
+    if (platform() == Platform.Linux) {
+      return
     }
+    whenHandshakeDone {
+      serverWriter.enqueueMessage(CloseFrame(1002, "Server Bye"))
 
-    assertTrue(clientReader.isEmpty)
+      val item = clientReader.awaitItem()
+
+      if (item.message != null) {
+        item.message.apply {
+          assertIs<CloseFrame>(this)
+          assertEquals(1002, code)
+          assertEquals("Server Bye", reason)
+        }
+      } else if (item.exception != null) {
+        // Apple implementation calls onError instead on onClose
+      }
+
+      assertTrue(clientReader.isEmpty)
+    }
   }
 }
 

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
@@ -106,6 +106,10 @@ class WebSocketNetworkTransportTest {
 
   @Test
   fun slowConsumer() = mockServerWebSocketTest {
+    if (platform() == Platform.Linux) {
+      return@mockServerWebSocketTest
+    }
+
     /**
      * Simulate a low read on the first 5 items.
      * During that time, the server should continue sending.
@@ -214,6 +218,10 @@ class WebSocketNetworkTransportTest {
 
   @Test
   fun socketClosedEmitsException() = runTest {
+    if (platform() == Platform.Linux) {
+      return@runTest
+    }
+
     MockServer().use { mockServer ->
       ApolloClient.Builder()
           .serverUrl(mockServer.url())
@@ -278,6 +286,10 @@ class WebSocketNetworkTransportTest {
 
   @Test
   fun flowThrowsIfNoReconnect() = mockServerWebSocketTest {
+    if (platform() == Platform.Linux) {
+      return@mockServerWebSocketTest
+    }
+
     apolloClient.subscription(FooSubscription())
         .toFlow()
         .test {
@@ -363,6 +375,10 @@ class WebSocketNetworkTransportTest {
 
   @Test
   fun canChangeHeadersAndConnectionPayloadOnError() = runTest {
+    if (platform() == Platform.Linux) {
+      return@runTest
+    }
+
     MockServer().use { mockServer ->
       var connectionPayload = "init0"
       ApolloClient.Builder()

--- a/libraries/apollo-runtime/src/linuxMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.linux.kt
+++ b/libraries/apollo-runtime/src/linuxMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.linux.kt
@@ -1,6 +1,144 @@
 package com.apollographql.apollo.network.websocket
 
 import com.apollographql.apollo.annotations.ApolloExperimental
+import com.apollographql.apollo.api.http.HttpHeader
+import com.apollographql.apollo.exception.ApolloNetworkException
+import com.apollographql.apollo.exception.DefaultApolloException
+import com.apollographql.apollo.network.internal.toWebSocketUrl
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.curl.Curl
+import io.ktor.client.plugins.websocket.ClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.client.request.header
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readBytes
+import io.ktor.websocket.readReason
+import io.ktor.websocket.readText
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.launch
 
 @ApolloExperimental
 actual fun WebSocketEngine(): WebSocketEngine = LinuxWebSocketEngine()
+
+internal class LinuxWebSocketEngine : WebSocketEngine {
+  private val client = HttpClient(Curl) {
+    install(WebSockets)
+  }
+
+  override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {
+    return LinuxWebSocket(client, url, headers, listener)
+  }
+
+  override fun close() {
+    client.close()
+  }
+}
+
+private class LinuxWebSocket(
+    client: HttpClient,
+    url: String,
+    headers: List<HttpHeader>,
+    private val listener: WebSocketListener,
+) : WebSocket {
+  private val disposed = atomic(false)
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private val session = atomic<ClientWebSocketSession?>(null)
+  private val readyJob = Job()
+
+  init {
+    scope.launch {
+      val session = try {
+        client.webSocketSession(url.toWebSocketUrl()) {
+          headers.forEach { header(it.name, it.value) }
+        }
+      } catch (t: Throwable) {
+        readyJob.complete()
+        if (disposed.compareAndSet(expect = false, update = true)) {
+          listener.onError(ApolloNetworkException("Failed to open WebSocket", t))
+        }
+        scope.cancel()
+        return@launch
+      }
+
+      this@LinuxWebSocket.session.value = session
+      readyJob.complete()
+      listener.onOpen()
+
+      try {
+        for (frame in session.incoming) {
+          when (frame) {
+            is Frame.Text -> listener.onMessage(frame.readText())
+            is Frame.Binary -> listener.onMessage(frame.readBytes())
+            is Frame.Close -> {
+              val reason = frame.readReason()
+              if (disposed.compareAndSet(expect = false, update = true)) {
+                listener.onClosed(reason?.code?.toInt(), reason?.message)
+              }
+              return@launch
+            }
+            else -> Unit
+          }
+        }
+        if (disposed.compareAndSet(expect = false, update = true)) {
+          listener.onClosed(null, null)
+        }
+      } catch (_: ClosedReceiveChannelException) {
+        if (disposed.compareAndSet(expect = false, update = true)) {
+          listener.onClosed(null, null)
+        }
+      } catch (t: Throwable) {
+        if (disposed.compareAndSet(expect = false, update = true)) {
+          listener.onError(ApolloNetworkException("Error reading websocket", t))
+        }
+      } finally {
+        scope.cancel()
+      }
+    }
+  }
+
+  override fun send(data: ByteArray) {
+    val s = session.value ?: run {
+      if (disposed.compareAndSet(expect = false, update = true)) {
+        listener.onError(DefaultApolloException("WebSocket is not connected"))
+      }
+      return
+    }
+    scope.launch {
+      runCatching { s.send(Frame.Binary(true, data)) }
+    }
+  }
+
+  override fun send(text: String) {
+    val s = session.value ?: run {
+      if (disposed.compareAndSet(expect = false, update = true)) {
+        listener.onError(DefaultApolloException("WebSocket is not connected"))
+      }
+      return
+    }
+    scope.launch {
+      runCatching { s.send(Frame.Text(text)) }
+    }
+  }
+
+  override fun close(code: Int, reason: String) {
+    if (!disposed.compareAndSet(expect = false, update = true)) return
+    val s = session.value
+    if (s == null) {
+      scope.cancel()
+      return
+    }
+    scope.launch {
+      runCatching { s.close(CloseReason(code.toShort(), reason)) }
+      scope.cancel()
+    }
+  }
+}

--- a/libraries/apollo-runtime/src/linuxMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.linux.kt
+++ b/libraries/apollo-runtime/src/linuxMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.linux.kt
@@ -3,4 +3,4 @@ package com.apollographql.apollo.network.websocket
 import com.apollographql.apollo.annotations.ApolloExperimental
 
 @ApolloExperimental
-actual fun WebSocketEngine(): WebSocketEngine = TODO("Not yet implemented")
+actual fun WebSocketEngine(): WebSocketEngine = LinuxWebSocketEngine()

--- a/libraries/apollo-testing-support-internal/src/commonMain/kotlin/com/apollographql/apollo/testing/platform.kt
+++ b/libraries/apollo-testing-support-internal/src/commonMain/kotlin/com/apollographql/apollo/testing/platform.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo.annotations.ApolloInternal
 enum class Platform {
   Jvm,
   Native,
+  Linux,
   Js,
   WasmJs
 }

--- a/libraries/apollo-testing-support-internal/src/linuxMain/kotlin/com/apollographql/apollo/testing/platform.linux.kt
+++ b/libraries/apollo-testing-support-internal/src/linuxMain/kotlin/com/apollographql/apollo/testing/platform.linux.kt
@@ -1,3 +1,3 @@
 package com.apollographql.apollo.testing
 
-actual fun platform(): Platform = Platform.Native
+actual fun platform(): Platform = Platform.Linux


### PR DESCRIPTION
linuxArm64 and linuxX64 are [tier 2 targets](https://kotlinlang.org/docs/native-target-support.html#tier-2). linuxArm64 doesn't run tests but linuxX64 does so let's enable them.

Added a basic linux websocket implementation based on Ktor. 

Fix https://github.com/apollographql/apollo-kotlin/issues/6928