### PR TITLE
Remove "built-in" from the caching docs since they are in an external repo now

### DIFF
--- a/docs/source/caching/introduction.mdx
+++ b/docs/source/caching/introduction.mdx
@@ -3,7 +3,7 @@ title: Caching in Apollo Kotlin
 description: Introduction
 ---
 
-Apollo Kotlin supports multiple forms of client-side caching for different purposes. Its built-in [normalized caches](./normalized-cache/) are especially useful for storing GraphQL operation results in an efficient, deduplicated way.
+Apollo Kotlin supports multiple forms of client-side caching for different purposes. Its  [normalized caches](./normalized-cache/) are especially useful for storing GraphQL operation results in an efficient, deduplicated way.
 
 > Additionally, Apollo Kotlin supports _server-side_ caching of operation strings via [persisted queries](../advanced/persisted-queries/).
 
@@ -11,8 +11,8 @@ Here's a summary of all supported caches:
 
 | Cache | Description |
 |-------|-------------|
-| Built-in [normalized caches](./normalized-cache/) | Deduplicates GraphQL response data, enabling your app to use it as a source of truth for your UI. Can also dynamically react to changes in that data. Both in-memory and SQLite caches are included, and you can use _both_ to combine in-memory speed with SQLite persistence. |
-| Built-in [HTTP cache](./http-cache/) | Caches response data at the HTTP level. Can be faster to get started with and uses less CPU than normalized caches, but duplicates data and can't act as a source of truth. |
+| [normalized caches](./normalized-cache/) | Deduplicates GraphQL response data, enabling your app to use it as a source of truth for your UI. Can also dynamically react to changes in that data. Both in-memory and SQLite caches are included, and you can use _both_ to combine in-memory speed with SQLite persistence. |
+| [HTTP cache](./http-cache/) | Caches response data at the HTTP level. Can be faster to get started with and uses less CPU than normalized caches, but duplicates data and can't act as a source of truth. |
 | External caches | If you're already using an external cache (such as Room or SQLDelight), you can use it with Apollo Kotlin. Instead of using Apollo for both the network and database domains, you use generated models for the network and map them to your own database models. |
 | [Persisted queries](../advanced/persisted-queries/) (APQ) | <p>With APQ, your client sends a _hash_ of most queries to the server instead of the query itself. This makes requests much smaller and enables the use of GET requests instead of POST. This in turn makes it possible to cache results at the CDN level. The server also caches your query strings, meaning it doesn't have to parse a particular query each time it's sent. </p> <p>Persisted queries can be [_automatic_ persisted queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) (which require little configuration), or you can use [custom persisted query IDs](../advanced/persisted-queries/#custom-id-for-persisted-queries).</p> |
 

--- a/docs/source/caching/normalized-cache.mdx
+++ b/docs/source/caching/normalized-cache.mdx
@@ -2,7 +2,7 @@
 title: Normalized caches in Apollo Kotlin
 ---
 
-Apollo Kotlin provides two built-in **normalized caches** for storing and reusing the results of GraphQL operations:
+Apollo Kotlin provides two **normalized caches** for storing and reusing the results of GraphQL operations:
 
 * An [in-memory cache](#in-memory-cache) (`MemoryCache`)
 * A [SQLite-backed cache](#sqlite-cache) (`SqlNormalizedCache`)


### PR DESCRIPTION
No strong opinion but this felt a bit weird