### PR TITLE
Fix link to cache migration guide in migration docs

### DIFF
--- a/docs/source/migration/5.0.mdx
+++ b/docs/source/migration/5.0.mdx
@@ -17,7 +17,7 @@ Read below for more details.
 
 The Normalized Cache that was part of the Apollo Kotlin repository has been deprecated and replaced by a new implementation hosted on a [separate repository](https://github.com/apollographql/apollo-kotlin-normalized-cache). The new cache supports more features such as pagination and expiration support, garbage collection and trimming, partial results, and more.
 
-Please consult the dedicated [cache migration guide](../cache/migration-guide/) for more details on how to migrate to this version.
+Please consult the dedicated [cache migration guide](../caching/migration-guide/) for more details on how to migrate to this version.
 
 ## `apollo-gradle-plugin-external`
 


### PR DESCRIPTION
Corrected the link to the cache migration guide in the documentation.