### PR TITLE
Fix `allowDirectivesOnDirectives` not being honored 

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -169,6 +169,8 @@ public final class com/apollographql/apollo/compiler/CodegenSchemaOptions {
 	public static final field Companion Lcom/apollographql/apollo/compiler/CodegenSchemaOptions$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/util/Map;Ljava/util/Map;Z)V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;ZZ)V
+	public final fun getAllowDirectivesOnDirectives ()Z
 	public final fun getGenerateDataBuilders ()Z
 	public final fun getScalarAdapterMapping ()Ljava/util/Map;
 	public final fun getScalarTypeMapping ()Ljava/util/Map;

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -14,9 +14,9 @@ import com.apollographql.apollo.ast.Issue
 import com.apollographql.apollo.ast.MergeOptions
 import com.apollographql.apollo.ast.ParserOptions
 import com.apollographql.apollo.ast.QueryDocumentMinifier
+import com.apollographql.apollo.ast.SchemaValidationOptions
 import com.apollographql.apollo.ast.builtinForeignSchemas
 import com.apollographql.apollo.ast.checkEmpty
-import com.apollographql.apollo.ast.SchemaValidationOptions
 import com.apollographql.apollo.ast.parseAsGQLDocument
 import com.apollographql.apollo.ast.pretty
 import com.apollographql.apollo.ast.toGQLDocument
@@ -104,7 +104,10 @@ object ApolloCompiler {
       schemaTransform: SchemaDocumentTransform?,
   ): CodegenSchema {
     val schemaDocuments = schemaFiles.map {
-      it.normalizedPath to it.file.toGQLDocument(allowJson = true)
+      it.normalizedPath to it.file.toGQLDocument(
+          allowJson = true,
+          options = ParserOptions.Builder().allowDirectivesOnDirectives(codegenSchemaOptions.allowDirectivesOnDirectives).build(),
+      )
     }
 
     if (schemaDocuments.isEmpty()) {
@@ -174,14 +177,18 @@ object ApolloCompiler {
           }) {
         if (cacheCompilerPluginHasCacheDirectives) {
           // The cache docs recommend importing @typePolicy and @fieldPolicy so we leave them with the default (long) import
-          appendLine("""
-            extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3", import: ["@optional", "@nonnull", "@requiresOptIn", "@targetName"])
-          """.trimIndent())
+          appendLine(
+              """
+                extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3", import: ["@optional", "@nonnull", "@requiresOptIn", "@targetName"])
+              """.trimIndent()
+          )
         } else {
           // No cache plugin, import everything
-          appendLine("""
-            extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3", import: ["@optional", "@nonnull", "@requiresOptIn", "@targetName", "@typePolicy", "@fieldPolicy"])
-          """.trimIndent())
+          appendLine(
+              """
+                extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3", import: ["@optional", "@nonnull", "@requiresOptIn", "@targetName", "@typePolicy", "@fieldPolicy"])
+              """.trimIndent()
+          )
         }
       }
     }
@@ -278,7 +285,6 @@ object ApolloCompiler {
     executableFiles.sortedBy { it.normalizedPath }.forEach { normalizedFile ->
       val parserOptions = ParserOptions.Builder()
           .allowFragmentArguments(options.allowFragmentArguments ?: false)
-          .allowDirectivesOnDirectives(options.allowDirectivesOnDirectives ?: false)
           .build()
       val fileDefinitions = normalizedFile.file.definitions(parserOptions)
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
@@ -3,9 +3,7 @@ package com.apollographql.apollo.compiler
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.ast.DeprecatedUsage
-import com.apollographql.apollo.ast.DirectiveRedefinition
 import com.apollographql.apollo.ast.IgnoredLinkDirective
-import com.apollographql.apollo.ast.IncompatibleDefinition
 import com.apollographql.apollo.ast.UnusedFragment
 import com.apollographql.apollo.ast.UnusedVariable
 import com.apollographql.apollo.compiler.internal.sha256
@@ -16,17 +14,22 @@ import kotlinx.serialization.Serializable
 
 @JvmField
 val MODELS_RESPONSE_BASED = "responseBased"
+
 @JvmField
 val MODELS_OPERATION_BASED = "operationBased"
+
 @JvmField
 val MODELS_OPERATION_BASED_WITH_INTERFACES = "experimental_operationBasedWithInterfaces"
 
 @JvmField
 val ADD_TYPENAME_IF_FRAGMENTS = "ifFragments"
+
 @JvmField
 val ADD_TYPENAME_IF_POLYMORPHIC = "ifPolymorphic"
+
 @JvmField
 val ADD_TYPENAME_IF_ABSTRACT = "ifAbstract"
+
 @JvmField
 val ADD_TYPENAME_ALWAYS = "always"
 
@@ -34,8 +37,10 @@ val ADD_TYPENAME_ALWAYS = "always"
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_1)
 @JvmField
 val MANIFEST_OPERATION_OUTPUT = "operationOutput"
+
 @JvmField
 val MANIFEST_PERSISTED_QUERY = "persistedQueryManifest"
+
 @JvmField
 val MANIFEST_NONE = "none"
 
@@ -158,8 +163,14 @@ class CodegenSchemaOptions(
     val scalarTypeMapping: Map<String, String>,
     val scalarAdapterMapping: Map<String, String>,
     val generateDataBuilders: Boolean,
+    val allowDirectivesOnDirectives: Boolean,
 ) {
-  constructor(): this(emptyMap(), emptyMap(), false)
+  constructor() : this(emptyMap(), emptyMap(), false, false)
+  constructor(
+      scalarTypeMapping: Map<String, String>,
+      scalarAdapterMapping: Map<String, String>,
+      generateDataBuilders: Boolean,
+  ) : this(scalarTypeMapping, scalarAdapterMapping, generateDataBuilders, false)
 }
 
 enum class IssueSeverity {
@@ -203,6 +214,7 @@ class IrOptions(
 
     val allowFragmentArguments: Boolean?,
 
+    @Deprecated("Unused, use CodegenSchemaOptions.allowDirectivesOnDirectives instead")
     val allowDirectivesOnDirectives: Boolean?,
 )
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
@@ -215,6 +215,7 @@ class IrOptions(
     val allowFragmentArguments: Boolean?,
 
     @Deprecated("Unused, use CodegenSchemaOptions.allowDirectivesOnDirectives instead")
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_0)
     val allowDirectivesOnDirectives: Boolean?,
 )
 

--- a/libraries/apollo-gradle-plugin-tasks/src/main/kotlin/com/apollographql/apollo/gradle/task/apolloGenerateOptions.kt
+++ b/libraries/apollo-gradle-plugin-tasks/src/main/kotlin/com/apollographql/apollo/gradle/task/apolloGenerateOptions.kt
@@ -101,6 +101,7 @@ internal fun apolloGenerateOptions(
       scalarTypeMapping = scalarTypeMapping ?: emptyMap(),
       scalarAdapterMapping = scalarAdapterMapping ?: emptyMap(),
       generateDataBuilders = generateDataBuilders ?: false,
+      allowDirectivesOnDirectives = allowDirectivesOnDirectives ?: false,
   ).writeTo(codegenSchemaOptionsFile)
 
   IrOptions(

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/ParserOptionsTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/ParserOptionsTests.kt
@@ -1,0 +1,32 @@
+package test
+
+import com.google.common.truth.Truth
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Test
+import util.TestUtils
+import util.replaceInText
+import java.io.File
+
+class ParserOptionsTests {
+  @Test
+  fun allowDirectivesOnDirectivesSetToTrueSucceeds() {
+    TestUtils.withTestProject("parser-options") { dir ->
+      TestUtils.executeTask("generateApolloSources", dir)
+    }
+  }
+
+  @Test
+  fun allowDirectivesOnDirectivesNotSetFails() {
+    TestUtils.withTestProject("parser-options") { dir ->
+      File(dir, "build.gradle.kts").apply {
+        replaceInText("@OptIn(ApolloExperimental::class)", "")
+        replaceInText("allowDirectivesOnDirectives.set(true)", "")
+      }
+      try {
+        TestUtils.executeTask("generateApolloSources", dir)
+      } catch (e: UnexpectedBuildFailure) {
+        Truth.assertThat(e.message).contains("Experimental `allowDirectivesOnDirectives` must be set to true")
+      }
+    }
+  }
+}

--- a/libraries/apollo-gradle-plugin/testProjects/parser-options/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/parser-options/build.gradle.kts
@@ -1,0 +1,25 @@
+import com.apollographql.apollo.annotations.ApolloExperimental
+
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.apollo)
+  alias(libs.plugins.compat.patrouille)
+}
+
+dependencies {
+  implementation(apollo.deps.api)
+}
+
+apollo {
+  service("service") {
+    packageName.set("test")
+
+    @OptIn(ApolloExperimental::class)
+    allowDirectivesOnDirectives.set(true)
+  }
+}
+
+compatPatrouille {
+  java(17)
+}
+

--- a/libraries/apollo-gradle-plugin/testProjects/parser-options/settings.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/parser-options/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "testProject"
+
+apply(from = "../../../../gradle/test.settings.gradle.kts")

--- a/libraries/apollo-gradle-plugin/testProjects/parser-options/src/main/graphql/operation.graphql
+++ b/libraries/apollo-gradle-plugin/testProjects/parser-options/src/main/graphql/operation.graphql
@@ -1,0 +1,3 @@
+query MyQuery {
+  hello
+}

--- a/libraries/apollo-gradle-plugin/testProjects/parser-options/src/main/graphql/schema.graphqls
+++ b/libraries/apollo-gradle-plugin/testProjects/parser-options/src/main/graphql/schema.graphqls
@@ -1,0 +1,10 @@
+type Query {
+  hello: String @testDirective
+}
+
+directive @testDirective @deprecated @testDirective2 on FIELD_DEFINITION
+
+#directive @deprecated @testDirective2 on FIELD_DEFINITION
+directive @deprecated(reason: String! = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE | DIRECTIVE_DEFINITION
+
+directive @testDirective2 on DIRECTIVE_DEFINITION


### PR DESCRIPTION
Make `allowDirectivesOnDirectives` a property of `CodegenSchemaOptions` instead of `IrOptions`.

Fixes #6952