### PR TITLE
Fix duplicate headers in Batching Interceptor

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
@@ -93,7 +93,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
 
     if (!canBeBatched) {
       // Remove the CAN_BE_BATCHED header and forward directly
-      return chain.proceed(request.newBuilder().addHeaders(headers = request.headers.filter { it.name != ExecutionOptions.CAN_BE_BATCHED }).build())
+      return chain.proceed(request.newBuilder().headers(request.headers.filter { it.name != ExecutionOptions.CAN_BE_BATCHED }).build())
     }
 
     // Keep the chain for later


### PR DESCRIPTION
Addresses https://github.com/apollographql/apollo-kotlin/issues/6960

Version
4.4.2

Summary
When using httpBatching and auto persisted queries together on the same Apollo call, the headers are being duplicated by BatchingHttpInterceptor (from what I can tell) when the APQ replay happens due to it adding headers without preventing duplicates here:

```
return chain.proceed(request.newBuilder().addHeaders(headers = request.headers.filter { it.name != ExecutionOptions.CAN_BE_BATCHED }).build())
```
Steps to reproduce the behavior
configure the apollo client with:

```
.httpBatching(enableByDefault = false)
.autoPersistedQueries(httpMethodForHashedQueries = HttpMethod.Post)
```

and make any call.