### PR TITLE
Add `ApolloClient` support for `onError`

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -82,7 +82,8 @@ apollo-normalizedcache-apollo-compiler-plugin-incubating = { group = "com.apollo
 apollo-runtime = { group = "com.apollographql.apollo", name = "apollo-runtime", version.ref = "apollo" }
 apollo-compiler = { group = "com.apollographql.apollo", name = "apollo-compiler", version.ref = "apollo" }
 apollo-ast = { group = "com.apollographql.apollo", name = "apollo-ast", version.ref = "apollo" }
-apollo-execution = { group = "com.apollographql.execution", name = "apollo-execution-runtime", version.ref = "apollo-execution" }
+apollo-execution = { group = "com.apollographql.apollo", name = "apollo-execution", version.ref = "apollo" }
+apollo-execution-runtime = { group = "com.apollographql.execution", name = "apollo-execution-runtime", version.ref = "apollo-execution" }
 apollo-execution-http4k = { group = "com.apollographql.execution", name = "apollo-execution-http4k", version.ref = "apollo-execution" }
 apollo-execution-gradle-plugin = { group = "com.apollographql.execution", name = "apollo-execution-gradle-plugin", version.ref = "apollo-execution" }
 # Used by the apollo-tooling project which uses a published version of Apollo

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -50,7 +50,7 @@ public final class com/apollographql/apollo/api/ApolloOptionalAdapter : com/apol
 }
 
 public final class com/apollographql/apollo/api/ApolloRequest : com/apollographql/apollo/api/ExecutionOptions {
-	public synthetic fun <init> (Lcom/apollographql/apollo/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo/api/ExecutionContext;Ljava/lang/String;Lcom/apollographql/apollo/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZLjava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo/api/Operation;Ljava/util/UUID;Ljava/util/Map;Lcom/apollographql/apollo/api/OnError;Lcom/apollographql/apollo/api/ExecutionContext;Ljava/lang/String;Lcom/apollographql/apollo/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCanBeBatched ()Ljava/lang/Boolean;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public fun getExecutionContext ()Lcom/apollographql/apollo/api/ExecutionContext;
@@ -60,6 +60,7 @@ public final class com/apollographql/apollo/api/ApolloRequest : com/apollographq
 	public fun getHttpMethod ()Lcom/apollographql/apollo/api/http/HttpMethod;
 	public final fun getIgnoreApolloClientHttpHeaders ()Ljava/lang/Boolean;
 	public fun getIgnoreUnknownKeys ()Ljava/lang/Boolean;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
 	public final fun getOperation ()Lcom/apollographql/apollo/api/Operation;
 	public final fun getRequestUuid ()Ljava/util/UUID;
 	public final fun getRetryOnError ()Ljava/lang/Boolean;
@@ -94,6 +95,7 @@ public final class com/apollographql/apollo/api/ApolloRequest$Builder : com/apol
 	public fun getHttpMethod ()Lcom/apollographql/apollo/api/http/HttpMethod;
 	public final fun getIgnoreApolloClientHttpHeaders ()Ljava/lang/Boolean;
 	public fun getIgnoreUnknownKeys ()Ljava/lang/Boolean;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
 	public final fun getOperation ()Lcom/apollographql/apollo/api/Operation;
 	public final fun getRequestUuid ()Ljava/util/UUID;
 	public final fun getRetryOnError ()Ljava/lang/Boolean;
@@ -108,6 +110,7 @@ public final class com/apollographql/apollo/api/ApolloRequest$Builder : com/apol
 	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
 	public fun ignoreUnknownKeys (Ljava/lang/Boolean;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
 	public synthetic fun ignoreUnknownKeys (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
 	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
 	public final fun retryOnError (Ljava/lang/Boolean;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo/api/ApolloRequest$Builder;
@@ -803,6 +806,15 @@ public final class com/apollographql/apollo/api/ObjectType$Builder {
 	public final fun keyFields (Ljava/util/List;)Lcom/apollographql/apollo/api/ObjectType$Builder;
 }
 
+public final class com/apollographql/apollo/api/OnError : java/lang/Enum {
+	public static final field HALT Lcom/apollographql/apollo/api/OnError;
+	public static final field NULL Lcom/apollographql/apollo/api/OnError;
+	public static final field PROPAGATE Lcom/apollographql/apollo/api/OnError;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo/api/OnError;
+	public static fun values ()[Lcom/apollographql/apollo/api/OnError;
+}
+
 public abstract interface class com/apollographql/apollo/api/Operation : com/apollographql/apollo/api/Executable {
 	public abstract fun document ()Ljava/lang/String;
 	public abstract fun id ()Ljava/lang/String;
@@ -904,6 +916,7 @@ public abstract interface class com/apollographql/apollo/api/Query$Data : com/ap
 public final class com/apollographql/apollo/api/RequestParameters {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public final fun getExtensions ()Ljava/util/Map;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
 	public final fun getOperationName ()Ljava/lang/String;
 	public final fun getQuery ()Ljava/lang/String;
 	public final fun getUploads ()Ljava/util/Map;

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -23,6 +23,18 @@ final enum class com.apollographql.apollo.api.http/HttpMethod : kotlin/Enum<com.
     final fun values(): kotlin/Array<com.apollographql.apollo.api.http/HttpMethod> // com.apollographql.apollo.api.http/HttpMethod.values|values#static(){}[0]
 }
 
+final enum class com.apollographql.apollo.api/OnError : kotlin/Enum<com.apollographql.apollo.api/OnError> { // com.apollographql.apollo.api/OnError|null[0]
+    enum entry HALT // com.apollographql.apollo.api/OnError.HALT|null[0]
+    enum entry NULL // com.apollographql.apollo.api/OnError.NULL|null[0]
+    enum entry PROPAGATE // com.apollographql.apollo.api/OnError.PROPAGATE|null[0]
+
+    final val entries // com.apollographql.apollo.api/OnError.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.apollographql.apollo.api/OnError> // com.apollographql.apollo.api/OnError.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.apollographql.apollo.api/OnError // com.apollographql.apollo.api/OnError.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.apollographql.apollo.api/OnError> // com.apollographql.apollo.api/OnError.values|values#static(){}[0]
+}
+
 abstract interface <#A: com.apollographql.apollo.api/Executable.Data> com.apollographql.apollo.api/Executable { // com.apollographql.apollo.api/Executable|null[0]
     abstract fun adapter(): com.apollographql.apollo.api/Adapter<#A> // com.apollographql.apollo.api/Executable.adapter|adapter(){}[0]
     abstract fun rootField(): com.apollographql.apollo.api/CompiledField // com.apollographql.apollo.api/Executable.rootField|rootField(){}[0]
@@ -317,6 +329,8 @@ final class <#A: com.apollographql.apollo.api/Operation.Data> com.apollographql.
         final fun <get-ignoreApolloClientHttpHeaders>(): kotlin/Boolean? // com.apollographql.apollo.api/ApolloRequest.ignoreApolloClientHttpHeaders.<get-ignoreApolloClientHttpHeaders>|<get-ignoreApolloClientHttpHeaders>(){}[0]
     final val ignoreUnknownKeys // com.apollographql.apollo.api/ApolloRequest.ignoreUnknownKeys|{}ignoreUnknownKeys[0]
         final fun <get-ignoreUnknownKeys>(): kotlin/Boolean? // com.apollographql.apollo.api/ApolloRequest.ignoreUnknownKeys.<get-ignoreUnknownKeys>|<get-ignoreUnknownKeys>(){}[0]
+    final val onError // com.apollographql.apollo.api/ApolloRequest.onError|{}onError[0]
+        final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.api/ApolloRequest.onError.<get-onError>|<get-onError>(){}[0]
     final val operation // com.apollographql.apollo.api/ApolloRequest.operation|{}operation[0]
         final fun <get-operation>(): com.apollographql.apollo.api/Operation<#A> // com.apollographql.apollo.api/ApolloRequest.operation.<get-operation>|<get-operation>(){}[0]
     final val requestUuid // com.apollographql.apollo.api/ApolloRequest.requestUuid|{}requestUuid[0]
@@ -359,6 +373,8 @@ final class <#A: com.apollographql.apollo.api/Operation.Data> com.apollographql.
             final fun <get-ignoreApolloClientHttpHeaders>(): kotlin/Boolean? // com.apollographql.apollo.api/ApolloRequest.Builder.ignoreApolloClientHttpHeaders.<get-ignoreApolloClientHttpHeaders>|<get-ignoreApolloClientHttpHeaders>(){}[0]
         final var ignoreUnknownKeys // com.apollographql.apollo.api/ApolloRequest.Builder.ignoreUnknownKeys|{}ignoreUnknownKeys[0]
             final fun <get-ignoreUnknownKeys>(): kotlin/Boolean? // com.apollographql.apollo.api/ApolloRequest.Builder.ignoreUnknownKeys.<get-ignoreUnknownKeys>|<get-ignoreUnknownKeys>(){}[0]
+        final var onError // com.apollographql.apollo.api/ApolloRequest.Builder.onError|{}onError[0]
+            final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.api/ApolloRequest.Builder.onError.<get-onError>|<get-onError>(){}[0]
         final var requestUuid // com.apollographql.apollo.api/ApolloRequest.Builder.requestUuid|{}requestUuid[0]
             final fun <get-requestUuid>(): com.benasher44.uuid/Uuid? // com.apollographql.apollo.api/ApolloRequest.Builder.requestUuid.<get-requestUuid>|<get-requestUuid>(){}[0]
         final var retryOnError // com.apollographql.apollo.api/ApolloRequest.Builder.retryOnError|{}retryOnError[0]
@@ -384,6 +400,7 @@ final class <#A: com.apollographql.apollo.api/Operation.Data> com.apollographql.
         final fun httpMethod(com.apollographql.apollo.api.http/HttpMethod?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.httpMethod|httpMethod(com.apollographql.apollo.api.http.HttpMethod?){}[0]
         final fun ignoreApolloClientHttpHeaders(kotlin/Boolean?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.ignoreApolloClientHttpHeaders|ignoreApolloClientHttpHeaders(kotlin.Boolean?){}[0]
         final fun ignoreUnknownKeys(kotlin/Boolean?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.ignoreUnknownKeys|ignoreUnknownKeys(kotlin.Boolean?){}[0]
+        final fun onError(com.apollographql.apollo.api/OnError?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.onError|onError(com.apollographql.apollo.api.OnError?){}[0]
         final fun requestUuid(com.benasher44.uuid/Uuid): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.requestUuid|requestUuid(com.benasher44.uuid.Uuid){}[0]
         final fun retryOnError(kotlin/Boolean?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.retryOnError|retryOnError(kotlin.Boolean?){}[0]
         final fun sendApqExtensions(kotlin/Boolean?): com.apollographql.apollo.api/ApolloRequest.Builder<#A1> // com.apollographql.apollo.api/ApolloRequest.Builder.sendApqExtensions|sendApqExtensions(kotlin.Boolean?){}[0]
@@ -1157,6 +1174,8 @@ final class com.apollographql.apollo.api/RequestParameters { // com.apollographq
 
     final val extensions // com.apollographql.apollo.api/RequestParameters.extensions|{}extensions[0]
         final fun <get-extensions>(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // com.apollographql.apollo.api/RequestParameters.extensions.<get-extensions>|<get-extensions>(){}[0]
+    final val onError // com.apollographql.apollo.api/RequestParameters.onError|{}onError[0]
+        final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.api/RequestParameters.onError.<get-onError>|<get-onError>(){}[0]
     final val operationName // com.apollographql.apollo.api/RequestParameters.operationName|{}operationName[0]
         final fun <get-operationName>(): kotlin/String // com.apollographql.apollo.api/RequestParameters.operationName.<get-operationName>|<get-operationName>(){}[0]
     final val query // com.apollographql.apollo.api/RequestParameters.query|{}query[0]

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloRequest.kt
@@ -28,6 +28,9 @@ class ApolloRequest<D : Operation.Data>
 private constructor(
     val operation: Operation<D>,
     val requestUuid: Uuid,
+    val extensions: Map<String, ApolloJsonElement>?,
+    @ApolloExperimental
+    val onError: OnError?,
     override val executionContext: ExecutionContext,
     override val url: String?,
     override val httpMethod: HttpMethod?,
@@ -41,7 +44,6 @@ private constructor(
     val retryOnError: Boolean?,
     val failFastIfOffline: Boolean?,
     val sendEnhancedClientAwareness: Boolean,
-    val extensions: Map<String, ApolloJsonElement>?,
 ) : ExecutionOptions {
 
   fun newBuilder(): Builder<D> = newBuilder(operation)
@@ -98,6 +100,8 @@ private constructor(
     var sendEnhancedClientAwareness: Boolean = true
       private set
     var extensions: Map<String, ApolloJsonElement>? = null
+      private set
+    var onError: OnError? = null
       private set
 
     fun requestUuid(requestUuid: Uuid) = apply {
@@ -172,6 +176,10 @@ private constructor(
       this.extensions = extensions
     }
 
+    fun onError(onError: OnError?): Builder<D> = apply {
+      this.onError = onError
+    }
+
     fun build(): ApolloRequest<D> {
       return ApolloRequest(
           operation = operation,
@@ -189,7 +197,8 @@ private constructor(
           ignoreUnknownKeys = ignoreUnknownKeys,
           sendEnhancedClientAwareness = sendEnhancedClientAwareness,
           url = url,
-          extensions = extensions
+          extensions = extensions,
+          onError = onError,
       )
     }
   }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloRequest.kt
@@ -101,6 +101,7 @@ private constructor(
       private set
     var extensions: Map<String, ApolloJsonElement>? = null
       private set
+    @ApolloExperimental
     var onError: OnError? = null
       private set
 
@@ -176,6 +177,7 @@ private constructor(
       this.extensions = extensions
     }
 
+    @ApolloExperimental
     fun onError(onError: OnError?): Builder<D> = apply {
       this.onError = onError
     }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OnError.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/OnError.kt
@@ -1,0 +1,10 @@
+package com.apollographql.apollo.api
+
+import com.apollographql.apollo.annotations.ApolloExperimental
+
+@ApolloExperimental
+enum class OnError {
+  NULL,
+  PROPAGATE,
+  HALT
+}

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/RequestParameters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/RequestParameters.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.api
 
+import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.api.http.HttpBody
 import com.apollographql.apollo.api.http.UploadsHttpBody
 import com.apollographql.apollo.api.json.ApolloJsonElement
@@ -22,13 +23,23 @@ import okio.ByteString
  * @property extensions additional parameters for the request.
  * @property uploads files to upload.
  */
-class RequestParameters(
+class RequestParameters internal constructor(
     val query: String?,
     val operationName: String,
     val variables: Map<String, ApolloJsonElement>,
     val extensions: Map<String, ApolloJsonElement>,
     val uploads: Map<String, Upload>,
-)
+    @ApolloExperimental
+    val onError: OnError?,
+) {
+  constructor(
+      query: String?,
+      operationName: String,
+      variables: Map<String, ApolloJsonElement>,
+      extensions: Map<String, ApolloJsonElement>,
+      uploads: Map<String, Upload>,
+  ) : this(query, operationName, variables, extensions, uploads, null)
+}
 
 fun <D : Operation.Data> ApolloRequest<D>.toRequestParameters(): RequestParameters {
   val sendApqExtensions = sendApqExtensions ?: false
@@ -51,13 +62,15 @@ fun <D : Operation.Data> ApolloRequest<D>.toRequestParameters(): RequestParamete
     ext.put("persistedQuery", mapOf(
         "version" to 1,
         "sha256Hash" to operation.id()
-    ))
+    )
+    )
   }
   if (sendEnhancedClientAwarenessExtensions) {
     ext.put("clientLibrary", mapOf(
         "name" to "apollo-kotlin",
         "version" to apolloApiVersion
-    ))
+    )
+    )
   }
   if (extensions != null) {
     ext.putAll(extensions)
@@ -74,7 +87,8 @@ fun <D : Operation.Data> ApolloRequest<D>.toRequestParameters(): RequestParamete
          * The map path should start at the root and contain the "variables" part.
          */
         "variables." + it.key
-      }
+      },
+      onError = onError
   )
 }
 
@@ -115,6 +129,9 @@ internal fun RequestParameters.toMapUnsafe(): Map<String, Any?> {
     }
     if (extensions.isNotEmpty()) {
       put("extensions", extensions)
+    }
+    if (onError != null) {
+      put("onError", onError.toString())
     }
   }
 }

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -1654,19 +1654,21 @@ public final class com/apollographql/apollo/compiler/ir/IrOperationType$Subscrip
 
 public final class com/apollographql/apollo/compiler/ir/IrOperations {
 	public static final field Companion Lcom/apollographql/apollo/compiler/ir/IrOperations$Companion;
-	public fun <init> (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;ZLjava/util/List;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Lcom/apollographql/apollo/compiler/UsedCoordinates;
 	public final fun component4 ()Z
 	public final fun component5 ()Z
 	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;Ljava/util/List;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo/compiler/ir/IrOperations;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;ZLjava/util/List;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/compiler/ir/IrOperations;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/UsedCoordinates;ZZLjava/lang/String;ZLjava/util/List;ILjava/lang/Object;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCodegenModels ()Ljava/lang/String;
 	public final fun getDecapitalizeFields ()Z
+	public final fun getErrorAware ()Z
 	public final fun getFlattenModels ()Z
 	public final fun getFragmentDefinitions ()Ljava/util/List;
 	public final fun getFragments ()Ljava/util/List;

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinCodegen.kt
@@ -75,6 +75,7 @@ private fun buildOutput(
     targetLanguage: TargetLanguage,
     kotlinOutputTransform: Transform<KotlinOutput>?,
     generateAsInternal: Boolean,
+    errorAware: Boolean,
     block: OutputBuilder.(KotlinResolver) -> Unit,
 ): KotlinOutput {
 
@@ -92,6 +93,7 @@ private fun buildOutput(
   val resolver = KotlinResolver(
       upstreamCodegenMetadata = upstreamCodegenMetadata,
       requiresOptInAnnotation = requiresOptInAnnotation,
+      errorAware = errorAware
   )
 
   val outputBuilder = OutputBuilder()
@@ -174,6 +176,7 @@ internal object KotlinCodegen {
         targetLanguage = targetLanguage,
         kotlinOutputTransform = kotlinOutputTransform,
         generateAsInternal = generateAsInternal,
+        errorAware = false // not needed for the schema sources
     ) { resolver ->
       val context = KotlinSchemaContext(
           generateMethods = generateMethods,
@@ -251,7 +254,8 @@ internal object KotlinCodegen {
         requiresOptInAnnotation = requiresOptInAnnotation,
         targetLanguage = targetLanguage,
         kotlinOutputTransform = kotlinOutputTransform,
-        generateAsInternal = generateAsInternal
+        generateAsInternal = generateAsInternal,
+        errorAware = irOperations.errorAware
     ) { resolver ->
       val context = KotlinOperationsContext(
           generateMethods = generateMethods,
@@ -340,7 +344,8 @@ internal object KotlinCodegen {
         requiresOptInAnnotation = requiresOptInAnnotation,
         targetLanguage = targetLanguage,
         kotlinOutputTransform = null,
-        generateAsInternal = generateAsInternal
+        generateAsInternal = generateAsInternal,
+        errorAware = false // not needed for the schema sources
     ) { resolver ->
       val context = KotlinDataBuilderContext(
           generateMethods = generateMethods,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
@@ -41,6 +41,7 @@ import com.squareup.kotlinpoet.buildCodeBlock
 internal class KotlinResolver(
     upstreamCodegenMetadata: CodegenMetadata,
     private val requiresOptInAnnotation: String?,
+    private val errorAware: Boolean,
 ) {
   private val upstreamEntries = upstreamCodegenMetadata.entries.associate { it.key to it.className.toKotlinPoetClassName() }
   private val upstreamScalarAdapters = upstreamCodegenMetadata.scalarAdapters
@@ -182,12 +183,14 @@ internal class KotlinResolver(
       is IrCompositeType2 -> null
     }
   }
-
   internal fun adapterInitializer(type: IrType, requiresBuffering: Boolean, jsExport: Boolean): CodeBlock {
+    return adapterInitializer(type, errorAware, requiresBuffering, jsExport)
+  }
+  internal fun adapterInitializer(type: IrType, errorAware: Boolean, requiresBuffering: Boolean, jsExport: Boolean): CodeBlock {
     return when {
       type.optional -> {
         val presentFun = MemberName("com.apollographql.apollo.api", "present")
-        CodeBlock.of("%L.%M()", adapterInitializer(type.optional(false), requiresBuffering, jsExport), presentFun)
+        CodeBlock.of("%L.%M()", adapterInitializer(type.optional(false), false, requiresBuffering, jsExport), presentFun)
       }
 
       type.catchTo != IrCatchTo.NoCatch -> {
@@ -201,14 +204,12 @@ internal class KotlinResolver(
         }
       }
 
-      type.maybeError -> {
-        adapterInitializer(type.maybeError(false), requiresBuffering, jsExport).let {
-          CodeBlock.of("%L.%M()", it, KotlinSymbols.errorAware)
-        }
+      errorAware -> {
+        CodeBlock.of("%L.%M()", adapterInitializer(type, false, requiresBuffering, jsExport), KotlinSymbols.errorAware)
       }
 
       type.nullable -> {
-        val initializer = adapterInitializer(type.nullable(false), requiresBuffering, jsExport)
+        val initializer = adapterInitializer(type.nullable(false), false, requiresBuffering, jsExport)
 
         val nonNullableBuiltin = when (initializer.toString()) {
           KotlinSymbols.StringAdapter.canonicalName -> KotlinSymbols.NullableStringAdapter
@@ -218,7 +219,7 @@ internal class KotlinResolver(
           KotlinSymbols.AnyAdapter.canonicalName -> KotlinSymbols.NullableAnyAdapter
           else -> null
         }
-        return if (nonNullableBuiltin != null) {
+        if (nonNullableBuiltin != null) {
           CodeBlock.of("%M", nonNullableBuiltin)
         } else {
           val nullableFun = MemberName("com.apollographql.apollo.api", "nullable")
@@ -229,7 +230,7 @@ internal class KotlinResolver(
       else -> {
         when (type) {
           is IrListType -> {
-            adapterInitializer(type.ofType, requiresBuffering, jsExport).list(jsExport)
+            adapterInitializer(type.ofType, false, requiresBuffering, jsExport).list(jsExport)
           }
 
           is IrScalarType -> {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperations.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperations.kt
@@ -39,6 +39,7 @@ data class IrOperations(
     val flattenModels: Boolean,
     val decapitalizeFields: Boolean,
     val codegenModels: String,
+    val errorAware: Boolean,
 
     val fragmentDefinitions: List<@Serializable(with = GQLFragmentDefinitionSerializer::class) GQLFragmentDefinition>,
 )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
@@ -207,7 +207,8 @@ internal class IrOperationsBuilder(
         flattenModels = flattenModels,
         decapitalizeFields = decapitalizeFields,
         fragmentDefinitions = fragmentDefinitions,
-        codegenModels = codegenModels
+        codegenModels = codegenModels,
+        errorAware = schema.errorAware
     )
   }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrType.kt
@@ -61,9 +61,8 @@ sealed interface IrType {
   val catchTo: IrCatchTo
 
   /**
-   * This type may be an error
-   * true if the type is nullable in the server schema.
-   * Used to generate error aware adapters
+   * Whether this type is nullable in the schema, regardless of semantic nullability.
+   * This is used for `@catchByDefault`
    */
   val maybeError: Boolean
 
@@ -219,31 +218,31 @@ internal fun IrType.replacePlaceholder(newPath: String): IrType {
 internal fun GQLType.toIr(schema: Schema): IrType {
   return when (this) {
     is GQLNonNullType -> type.toIr(schema).copyWith(nullable = false, maybeError = false)
-    is GQLListType -> IrListType(ofType = type.toIr(schema), nullable = true, maybeError = schema.errorAware)
+    is GQLListType -> IrListType(ofType = type.toIr(schema), nullable = true, maybeError = true)
     is GQLNamedType -> {
       when (schema.typeDefinition(name)) {
         is GQLScalarTypeDefinition -> {
-          IrScalarType(name, nullable = true, maybeError = schema.errorAware)
+          IrScalarType(name, nullable = true, maybeError = true)
         }
 
         is GQLEnumTypeDefinition -> {
-          IrEnumType(name, nullable = true, maybeError = schema.errorAware)
+          IrEnumType(name, nullable = true, maybeError = true)
         }
 
         is GQLInputObjectTypeDefinition -> {
-          IrInputObjectType(name, nullable = true, maybeError = schema.errorAware)
+          IrInputObjectType(name, nullable = true, maybeError = true)
         }
 
         is GQLObjectTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = schema.errorAware)
+          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = true)
         }
 
         is GQLInterfaceTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = schema.errorAware)
+          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = true)
         }
 
         is GQLUnionTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = schema.errorAware)
+          IrModelType(MODEL_UNKNOWN, nullable = true, maybeError = true)
         }
       }
     }

--- a/libraries/apollo-debug-server/build.gradle.kts
+++ b/libraries/apollo-debug-server/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
         implementation(project(":apollo-normalized-cache-api"))
         implementation(project(":apollo-ast"))
         api(project(":apollo-runtime"))
-        implementation(libs.apollo.execution)
+        implementation(libs.apollo.execution.runtime)
       }
     }
     getByName("jvmTest") {

--- a/libraries/apollo-execution/api/apollo-execution.api
+++ b/libraries/apollo-execution/api/apollo-execution.api
@@ -32,7 +32,7 @@ public final class com/apollographql/apollo/execution/ExecutableSchema$Builder {
 	public final fun addInstrumentation (Lcom/apollographql/apollo/execution/Instrumentation;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
 	public final fun build ()Lcom/apollographql/apollo/execution/ExecutableSchema;
 	public final fun mutationRoot (Lcom/apollographql/apollo/execution/RootResolver;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
-	public final fun onError (Lcom/apollographql/apollo/execution/OnError;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
 	public final fun parserOptions (Lcom/apollographql/apollo/ast/ParserOptions;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
 	public final fun persistedDocumentCache (Lcom/apollographql/apollo/execution/PersistedDocumentCache;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
 	public final fun queryRoot (Lcom/apollographql/apollo/execution/RootResolver;)Lcom/apollographql/apollo/execution/ExecutableSchema$Builder;
@@ -60,7 +60,7 @@ public final class com/apollographql/apollo/execution/FloatCoercing : com/apollo
 public final class com/apollographql/apollo/execution/GraphQLRequest {
 	public final fun getDocument ()Ljava/lang/String;
 	public final fun getExtensions ()Ljava/util/Map;
-	public final fun getOnError ()Lcom/apollographql/apollo/execution/OnError;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
 	public final fun getOperationName ()Ljava/lang/String;
 	public final fun getVariables ()Ljava/util/Map;
 }
@@ -72,14 +72,14 @@ public final class com/apollographql/apollo/execution/GraphQLRequest$Builder {
 	public final fun extensions (Ljava/util/Map;)Lcom/apollographql/apollo/execution/GraphQLRequest$Builder;
 	public final fun getDocument ()Ljava/lang/String;
 	public final fun getExtensions ()Ljava/util/Map;
-	public final fun getOnError ()Lcom/apollographql/apollo/execution/OnError;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
 	public final fun getOperationName ()Ljava/lang/String;
 	public final fun getVariables ()Ljava/util/Map;
-	public final fun onError (Lcom/apollographql/apollo/execution/OnError;)Lcom/apollographql/apollo/execution/GraphQLRequest$Builder;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/execution/GraphQLRequest$Builder;
 	public final fun operationName (Ljava/lang/String;)Lcom/apollographql/apollo/execution/GraphQLRequest$Builder;
 	public final fun setDocument (Ljava/lang/String;)V
 	public final fun setExtensions (Ljava/util/Map;)V
-	public final fun setOnError (Lcom/apollographql/apollo/execution/OnError;)V
+	public final fun setOnError (Lcom/apollographql/apollo/api/OnError;)V
 	public final fun setOperationName (Ljava/lang/String;)V
 	public final fun setVariables (Ljava/util/Map;)V
 	public final fun variables (Ljava/util/Map;)Lcom/apollographql/apollo/execution/GraphQLRequest$Builder;
@@ -142,15 +142,6 @@ public final class com/apollographql/apollo/execution/JsonCoercing : com/apollog
 	public fun deserialize (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun parseLiteral (Lcom/apollographql/apollo/ast/GQLValue;)Ljava/lang/Object;
 	public fun serialize (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo/execution/OnError : java/lang/Enum {
-	public static final field HALT Lcom/apollographql/apollo/execution/OnError;
-	public static final field NULL Lcom/apollographql/apollo/execution/OnError;
-	public static final field PROPAGATE Lcom/apollographql/apollo/execution/OnError;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo/execution/OnError;
-	public static fun values ()[Lcom/apollographql/apollo/execution/OnError;
 }
 
 public abstract interface class com/apollographql/apollo/execution/OperationCallback {

--- a/libraries/apollo-execution/api/apollo-execution.klib.api
+++ b/libraries/apollo-execution/api/apollo-execution.klib.api
@@ -6,18 +6,6 @@
 // - Show declarations: true
 
 // Library unique name: <com.apollographql.apollo:apollo-execution>
-final enum class com.apollographql.apollo.execution/OnError : kotlin/Enum<com.apollographql.apollo.execution/OnError> { // com.apollographql.apollo.execution/OnError|null[0]
-    enum entry HALT // com.apollographql.apollo.execution/OnError.HALT|null[0]
-    enum entry NULL // com.apollographql.apollo.execution/OnError.NULL|null[0]
-    enum entry PROPAGATE // com.apollographql.apollo.execution/OnError.PROPAGATE|null[0]
-
-    final val entries // com.apollographql.apollo.execution/OnError.entries|#static{}entries[0]
-        final fun <get-entries>(): kotlin.enums/EnumEntries<com.apollographql.apollo.execution/OnError> // com.apollographql.apollo.execution/OnError.entries.<get-entries>|<get-entries>#static(){}[0]
-
-    final fun valueOf(kotlin/String): com.apollographql.apollo.execution/OnError // com.apollographql.apollo.execution/OnError.valueOf|valueOf#static(kotlin.String){}[0]
-    final fun values(): kotlin/Array<com.apollographql.apollo.execution/OnError> // com.apollographql.apollo.execution/OnError.values|values#static(){}[0]
-}
-
 abstract fun interface com.apollographql.apollo.execution/FieldCallback { // com.apollographql.apollo.execution/FieldCallback|null[0]
     abstract fun onFieldCompleted(kotlin/Any?) // com.apollographql.apollo.execution/FieldCallback.onFieldCompleted|onFieldCompleted(kotlin.Any?){}[0]
 }
@@ -78,7 +66,7 @@ final class com.apollographql.apollo.execution/ExecutableSchema { // com.apollog
         final fun addInstrumentation(com.apollographql.apollo.execution/Instrumentation): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.addInstrumentation|addInstrumentation(com.apollographql.apollo.execution.Instrumentation){}[0]
         final fun build(): com.apollographql.apollo.execution/ExecutableSchema // com.apollographql.apollo.execution/ExecutableSchema.Builder.build|build(){}[0]
         final fun mutationRoot(com.apollographql.apollo.execution/RootResolver): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.mutationRoot|mutationRoot(com.apollographql.apollo.execution.RootResolver){}[0]
-        final fun onError(com.apollographql.apollo.execution/OnError): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.onError|onError(com.apollographql.apollo.execution.OnError){}[0]
+        final fun onError(com.apollographql.apollo.api/OnError): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.onError|onError(com.apollographql.apollo.api.OnError){}[0]
         final fun parserOptions(com.apollographql.apollo.ast/ParserOptions): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.parserOptions|parserOptions(com.apollographql.apollo.ast.ParserOptions){}[0]
         final fun persistedDocumentCache(com.apollographql.apollo.execution/PersistedDocumentCache?): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.persistedDocumentCache|persistedDocumentCache(com.apollographql.apollo.execution.PersistedDocumentCache?){}[0]
         final fun queryRoot(com.apollographql.apollo.execution/RootResolver): com.apollographql.apollo.execution/ExecutableSchema.Builder // com.apollographql.apollo.execution/ExecutableSchema.Builder.queryRoot|queryRoot(com.apollographql.apollo.execution.RootResolver){}[0]
@@ -96,7 +84,7 @@ final class com.apollographql.apollo.execution/GraphQLRequest { // com.apollogra
     final val extensions // com.apollographql.apollo.execution/GraphQLRequest.extensions|{}extensions[0]
         final fun <get-extensions>(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // com.apollographql.apollo.execution/GraphQLRequest.extensions.<get-extensions>|<get-extensions>(){}[0]
     final val onError // com.apollographql.apollo.execution/GraphQLRequest.onError|{}onError[0]
-        final fun <get-onError>(): com.apollographql.apollo.execution/OnError? // com.apollographql.apollo.execution/GraphQLRequest.onError.<get-onError>|<get-onError>(){}[0]
+        final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.execution/GraphQLRequest.onError.<get-onError>|<get-onError>(){}[0]
     final val operationName // com.apollographql.apollo.execution/GraphQLRequest.operationName|{}operationName[0]
         final fun <get-operationName>(): kotlin/String? // com.apollographql.apollo.execution/GraphQLRequest.operationName.<get-operationName>|<get-operationName>(){}[0]
     final val variables // com.apollographql.apollo.execution/GraphQLRequest.variables|{}variables[0]
@@ -112,8 +100,8 @@ final class com.apollographql.apollo.execution/GraphQLRequest { // com.apollogra
             final fun <get-extensions>(): kotlin.collections/Map<kotlin/String, kotlin/Any?>? // com.apollographql.apollo.execution/GraphQLRequest.Builder.extensions.<get-extensions>|<get-extensions>(){}[0]
             final fun <set-extensions>(kotlin.collections/Map<kotlin/String, kotlin/Any?>?) // com.apollographql.apollo.execution/GraphQLRequest.Builder.extensions.<set-extensions>|<set-extensions>(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
         final var onError // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError|{}onError[0]
-            final fun <get-onError>(): com.apollographql.apollo.execution/OnError? // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError.<get-onError>|<get-onError>(){}[0]
-            final fun <set-onError>(com.apollographql.apollo.execution/OnError?) // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError.<set-onError>|<set-onError>(com.apollographql.apollo.execution.OnError?){}[0]
+            final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError.<get-onError>|<get-onError>(){}[0]
+            final fun <set-onError>(com.apollographql.apollo.api/OnError?) // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError.<set-onError>|<set-onError>(com.apollographql.apollo.api.OnError?){}[0]
         final var operationName // com.apollographql.apollo.execution/GraphQLRequest.Builder.operationName|{}operationName[0]
             final fun <get-operationName>(): kotlin/String? // com.apollographql.apollo.execution/GraphQLRequest.Builder.operationName.<get-operationName>|<get-operationName>(){}[0]
             final fun <set-operationName>(kotlin/String?) // com.apollographql.apollo.execution/GraphQLRequest.Builder.operationName.<set-operationName>|<set-operationName>(kotlin.String?){}[0]
@@ -124,7 +112,7 @@ final class com.apollographql.apollo.execution/GraphQLRequest { // com.apollogra
         final fun build(): com.apollographql.apollo.execution/GraphQLRequest // com.apollographql.apollo.execution/GraphQLRequest.Builder.build|build(){}[0]
         final fun document(kotlin/String?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.document|document(kotlin.String?){}[0]
         final fun extensions(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.extensions|extensions(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
-        final fun onError(com.apollographql.apollo.execution/OnError?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError|onError(com.apollographql.apollo.execution.OnError?){}[0]
+        final fun onError(com.apollographql.apollo.api/OnError?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.onError|onError(com.apollographql.apollo.api.OnError?){}[0]
         final fun operationName(kotlin/String?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.operationName|operationName(kotlin.String?){}[0]
         final fun variables(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): com.apollographql.apollo.execution/GraphQLRequest.Builder // com.apollographql.apollo.execution/GraphQLRequest.Builder.variables|variables(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
     }

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.execution
 
 import com.apollographql.apollo.api.ExecutionContext
+import com.apollographql.apollo.api.OnError
 import com.apollographql.apollo.ast.*
 import com.apollographql.apollo.execution.internal.OperationContext
 import com.apollographql.apollo.execution.internal.PreparedRequest

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/GraphQLRequest.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/GraphQLRequest.kt
@@ -3,6 +3,7 @@
 package com.apollographql.apollo.execution
 
 import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.api.OnError
 import com.apollographql.apollo.api.http.internal.urlDecode
 import com.apollographql.apollo.api.json.jsonReader
 import com.apollographql.apollo.api.json.readAny
@@ -11,11 +12,6 @@ import okio.Buffer
 import okio.BufferedSource
 import okio.use
 
-enum class OnError {
-  NULL,
-  PROPAGATE,
-  HALT
-}
 
 /**
  * @property document the document. Can be null if persisted queries are used.

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
@@ -2,7 +2,29 @@ package com.apollographql.apollo.execution.internal
 
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.ExecutionContext
-import com.apollographql.apollo.ast.*
+import com.apollographql.apollo.api.OnError
+import com.apollographql.apollo.ast.GQLBooleanValue
+import com.apollographql.apollo.ast.GQLDirective
+import com.apollographql.apollo.ast.GQLEnumTypeDefinition
+import com.apollographql.apollo.ast.GQLField
+import com.apollographql.apollo.ast.GQLFragmentDefinition
+import com.apollographql.apollo.ast.GQLFragmentSpread
+import com.apollographql.apollo.ast.GQLInlineFragment
+import com.apollographql.apollo.ast.GQLInputObjectTypeDefinition
+import com.apollographql.apollo.ast.GQLInterfaceTypeDefinition
+import com.apollographql.apollo.ast.GQLListType
+import com.apollographql.apollo.ast.GQLNamedType
+import com.apollographql.apollo.ast.GQLNonNullType
+import com.apollographql.apollo.ast.GQLObjectTypeDefinition
+import com.apollographql.apollo.ast.GQLOperationDefinition
+import com.apollographql.apollo.ast.GQLScalarTypeDefinition
+import com.apollographql.apollo.ast.GQLSelection
+import com.apollographql.apollo.ast.GQLType
+import com.apollographql.apollo.ast.GQLUnionTypeDefinition
+import com.apollographql.apollo.ast.GQLVariableValue
+import com.apollographql.apollo.ast.Schema
+import com.apollographql.apollo.ast.definitionFromScope
+import com.apollographql.apollo.ast.responseName
 import com.apollographql.apollo.execution.Coercing
 import com.apollographql.apollo.execution.ExternalValue
 import com.apollographql.apollo.execution.ExternalValueOrDeferred
@@ -10,7 +32,6 @@ import com.apollographql.apollo.execution.FieldCallback
 import com.apollographql.apollo.execution.GraphQLResponse
 import com.apollographql.apollo.execution.Instrumentation
 import com.apollographql.apollo.execution.InternalValue
-import com.apollographql.apollo.execution.OnError
 import com.apollographql.apollo.execution.OperationCallback
 import com.apollographql.apollo.execution.OperationInfo
 import com.apollographql.apollo.execution.ResolveInfo
@@ -25,8 +46,19 @@ import com.apollographql.apollo.execution.SubscriptionResponse
 import com.apollographql.apollo.execution.TypeResolver
 import com.apollographql.apollo.execution.finalize
 import com.apollographql.apollo.execution.leafCoercingSerialize
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * Bags of constant properties used while resolving the operation.

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/prepare.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/prepare.kt
@@ -5,13 +5,13 @@ package com.apollographql.apollo.execution.internal
 
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.api.OnError
 import com.apollographql.apollo.ast.*
 import com.apollographql.apollo.execution.Coercing
 import com.apollographql.apollo.execution.ErrorPersistedDocument
 import com.apollographql.apollo.execution.ExternalValue
 import com.apollographql.apollo.execution.GraphQLRequest
 import com.apollographql.apollo.execution.InternalValue
-import com.apollographql.apollo.execution.OnError
 import com.apollographql.apollo.execution.PersistedDocument
 import com.apollographql.apollo.execution.PersistedDocumentCache
 import com.apollographql.apollo.execution.ValidPersistedDocument

--- a/libraries/apollo-execution/src/concurrentTest/kotlin/test/ExecutionTest.kt
+++ b/libraries/apollo-execution/src/concurrentTest/kotlin/test/ExecutionTest.kt
@@ -4,10 +4,10 @@ package test
 
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.api.ExecutionContext
+import com.apollographql.apollo.api.OnError
 import com.apollographql.apollo.ast.ParserOptions
 import com.apollographql.apollo.execution.ExecutableSchema
 import com.apollographql.apollo.execution.GraphQLRequest
-import com.apollographql.apollo.execution.OnError
 import com.apollographql.apollo.execution.SubscriptionResponse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -97,7 +97,7 @@ dependencies {
   testImplementation(libs.assertj)
   testImplementation(libs.okhttp.mockwebserver)
   testImplementation(libs.okhttp.tls)
-  testImplementation(libs.apollo.execution)
+  testImplementation(libs.apollo.execution.runtime)
   testImplementation(libs.apollo.execution.http4k)
   testImplementation(gradleTestKit())
   testImplementation(platform(libs.http4k.bom))

--- a/libraries/apollo-runtime/api/android/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/android/apollo-runtime.api
@@ -31,6 +31,7 @@ public final class com/apollographql/apollo/ApolloCall : com/apollographql/apoll
 	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public fun ignoreUnknownKeys (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public synthetic fun ignoreUnknownKeys (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/ApolloCall;
 	public final fun retryOnError (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;

--- a/libraries/apollo-runtime/api/apollo-runtime.klib.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.klib.api
@@ -211,6 +211,7 @@ final class <#A: com.apollographql.apollo.api/Operation.Data> com.apollographql.
     final fun httpMethod(com.apollographql.apollo.api.http/HttpMethod?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.httpMethod|httpMethod(com.apollographql.apollo.api.http.HttpMethod?){}[0]
     final fun ignoreApolloClientHttpHeaders(kotlin/Boolean?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.ignoreApolloClientHttpHeaders|ignoreApolloClientHttpHeaders(kotlin.Boolean?){}[0]
     final fun ignoreUnknownKeys(kotlin/Boolean?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.ignoreUnknownKeys|ignoreUnknownKeys(kotlin.Boolean?){}[0]
+    final fun onError(com.apollographql.apollo.api/OnError?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.onError|onError(com.apollographql.apollo.api.OnError?){}[0]
     final fun retryOnError(kotlin/Boolean?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.retryOnError|retryOnError(kotlin.Boolean?){}[0]
     final fun sendApqExtensions(kotlin/Boolean?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.sendApqExtensions|sendApqExtensions(kotlin.Boolean?){}[0]
     final fun sendDocument(kotlin/Boolean?): com.apollographql.apollo/ApolloCall<#A> // com.apollographql.apollo/ApolloCall.sendDocument|sendDocument(kotlin.Boolean?){}[0]

--- a/libraries/apollo-runtime/api/jvm/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/jvm/apollo-runtime.api
@@ -31,6 +31,7 @@ public final class com/apollographql/apollo/ApolloCall : com/apollographql/apoll
 	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public fun ignoreUnknownKeys (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public synthetic fun ignoreUnknownKeys (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/ApolloCall;
 	public final fun retryOnError (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo/ApolloCall;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloCall.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.api.MutableExecutionOptions
+import com.apollographql.apollo.api.OnError
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.http.HttpHeader
 import com.apollographql.apollo.api.http.HttpMethod
@@ -115,6 +116,11 @@ class ApolloCall<D : Operation.Data> internal constructor(
 
   fun extensions(extensions: Map<String, ApolloJsonElement>) = apply {
     requestBuilder.extensions(extensions)
+  }
+
+  @ApolloExperimental
+  fun onError(onError: OnError?) = apply {
+    requestBuilder.onError(onError)
   }
 
   fun copy(): ApolloCall<D> {

--- a/tests/on-error/build.gradle.kts
+++ b/tests/on-error/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 apolloTest()
 
 dependencies {
-  implementation(libs.apollo.api)
+  implementation(libs.apollo.runtime)
   implementation(libs.apollo.testingsupport.internal)
-  implementation(libs.apollo.execution)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
+  testImplementation(libs.apollo.mockserver)
 }
 
 apollo {

--- a/tests/on-error/build.gradle.kts
+++ b/tests/on-error/build.gradle.kts
@@ -1,7 +1,3 @@
-@file:OptIn(ApolloExperimental::class)
-
-import com.apollographql.apollo.annotations.ApolloExperimental
-
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.apollographql.apollo")
@@ -11,14 +7,14 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.api)
+  implementation(libs.apollo.testingsupport.internal)
+  implementation(libs.apollo.execution)
   testImplementation(libs.junit)
-  testImplementation(libs.apollo.execution.runtime)
   testImplementation(libs.okhttp)
 }
 
 apollo {
   service("service") {
-    packageName.set("fragment.arguments")
-    allowFragmentArguments.set(true)
+    packageName.set("com.example")
   }
 }

--- a/tests/on-error/src/main/graphql/operations.graphql
+++ b/tests/on-error/src/main/graphql/operations.graphql
@@ -4,3 +4,9 @@ query GetA {
     g
   }
 }
+
+query GetH {
+  a {
+    h @catch(to: NULL, levels: [1])
+  }
+}

--- a/tests/on-error/src/main/graphql/operations.graphql
+++ b/tests/on-error/src/main/graphql/operations.graphql
@@ -1,0 +1,5 @@
+query GetA {
+  a {
+    f
+  }
+}

--- a/tests/on-error/src/main/graphql/operations.graphql
+++ b/tests/on-error/src/main/graphql/operations.graphql
@@ -1,5 +1,6 @@
 query GetA {
   a {
-    f
+    f @catch(to: NULL)
+    g
   }
 }

--- a/tests/on-error/src/main/graphql/schema.graphqls
+++ b/tests/on-error/src/main/graphql/schema.graphqls
@@ -12,4 +12,5 @@ type Query {
 type A {
   f: String!
   g: String!
+  h: [String!]!
 }

--- a/tests/on-error/src/main/graphql/schema.graphqls
+++ b/tests/on-error/src/main/graphql/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  a: A!
+}
+
+type A {
+  f: String!
+}

--- a/tests/on-error/src/main/graphql/schema.graphqls
+++ b/tests/on-error/src/main/graphql/schema.graphqls
@@ -1,7 +1,15 @@
+extend schema @link(
+  url: "https://specs.apollo.dev/nullability/v0.4",
+  import: ["@semanticNonNull", "@semanticNonNullField", "@catch", "CatchTo", "@catchByDefault"]
+)
+
+extend schema @catchByDefault(to: NULL)
+
 type Query {
   a: A!
 }
 
 type A {
   f: String!
+  g: String!
 }

--- a/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
+++ b/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
@@ -1,0 +1,161 @@
+package test
+
+import com.apollographql.apollo.api.getOrNull
+import com.apollographql.apollo.api.getOrThrow
+import com.apollographql.apollo.api.graphQLErrorOrNull
+import `null`.FragmentsQuery
+import `null`.NullAndNonNullQuery
+import `null`.PriceNullQuery
+import `null`.ProductIgnoreErrorsQuery
+import `null`.ProductNullQuery
+import `null`.ProductQuery
+import `null`.ProductResultQuery
+import `null`.ProductThrowQuery
+import `null`.UserNullQuery
+import `null`.UserQuery
+import `null`.UserResultQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class OnErrorTest {
+  @Test
+  fun userOnUserNameError() {
+    val es = ExecutableSchema
+    val response = UserQuery().parseResponse(userNameError)
+    assertNull(response.exception)
+  }
+
+  @Test
+  fun userResultOnUserNameError() {
+    val response = UserResultQuery().parseResponse(userNameError)
+
+    assertNull(response.data?.user?.getOrNull()?.name)
+  }
+
+  @Test
+  fun userNullOnUserNameError() {
+    val response = UserNullQuery().parseResponse(userNameError)
+
+    assertNull(response.data!!.user?.name)
+  }
+
+  @Test
+  fun userOnUserSuccess() {
+    val response = UserQuery().parseResponse(userSuccess)
+
+    assertEquals("Pancakes", response.data!!.user?.name)
+  }
+
+  @Test
+  fun userResultOnUserSuccess() {
+    val response = UserResultQuery().parseResponse(userSuccess)
+
+    assertEquals("Pancakes", response.data!!.user.getOrThrow().name)
+  }
+
+  @Test
+  fun userNullOnUserSuccess() {
+    val response = UserNullQuery().parseResponse(userSuccess)
+
+    assertEquals("Pancakes", response.data!!.user!!.name)
+  }
+
+  @Test
+  fun productOnProductPriceError() {
+    val response = ProductQuery().parseResponse(productPriceError)
+
+    assertNotNull(response.data)
+    assertNull(response.exception)
+  }
+
+  @Test
+  fun productThrowOnProductPriceError() {
+    val response = ProductThrowQuery().parseResponse(productPriceError)
+
+    assertNull(response.data)
+  }
+
+  @Test
+  fun productResultOnProductPriceError() {
+    val response = ProductResultQuery().parseResponse(productPriceError)
+
+    assertNull(null, response.data?.product?.getOrNull()?.price)
+  }
+
+  @Test
+  fun productNullOnProductPriceError() {
+    val response = ProductNullQuery().parseResponse(productPriceError)
+
+    assertNull(response.data?.product?.price)
+    assertNotNull(response.data)
+  }
+
+  @Test
+  fun productIgnoreErrorsOnProductPriceError() {
+    val response = ProductIgnoreErrorsQuery().parseResponse(productPriceError)
+
+    assertNotNull(response.data?.product)
+    assertNull(response.data?.product?.price)
+    assertEquals("cannot resolve price", response.errors?.single()?.message)
+  }
+
+  @Test
+  fun productPriceNullOnProductPriceError() {
+    val response = PriceNullQuery().parseResponse(productPriceError)
+
+    assertNotNull(response.data?.product)
+    assertNull(response.data?.product?.price)
+    assertEquals("cannot resolve price", response.errors?.single()?.message)
+  }
+
+  @Test
+  fun productPriceNullOnProductPriceNull() {
+    val response = PriceNullQuery().parseResponse(productPriceNull)
+
+    assertNotNull(response.data?.product)
+    assertNull(response.data?.product?.price)
+    assertNull(response.errors)
+  }
+
+  @Test
+  fun nullAndNonNull() {
+    val response = NullAndNonNullQuery().parseResponse("""
+      {
+        "data": { "nonNull": 42, "nullable": null }
+      }
+    """.trimIndent())
+
+    // plus(0) is only used to check that `nonNull` is non nullable
+    assertEquals(42, response.data!!.nonNull.plus(0))
+  }
+
+  @Test
+  fun fragments() {
+    val response = FragmentsQuery().parseResponse("""
+      {
+        "data":  {"__typename": "Query", "nonNull": 42, "nullable": null }
+      }
+    """.trimIndent())
+
+    // nonNull has explicit @catch(to: NULL)
+    assertEquals(42, response.data!!.nonNull?.plus(0))
+    // nonNull is the same field but from a different fragment
+    assertEquals(42, response.data!!.queryDetails.nonNull.getOrThrow().plus(0))
+  }
+
+  @Test
+  fun fragmentErrors() {
+    val response = FragmentsQuery().parseResponse("""
+      {
+        "errors": [{"message": "Oops", "path": ["nullable"] }],
+        "data": {"__typename": "Query", "nonNull": 42, "nullable": null }
+      }
+    """.trimIndent())
+
+    assertEquals(null, response.data!!.nullable?.plus(0))
+    // nonNull is the same field but from a different fragment and can have different @catch
+    assertEquals("Oops", response.data!!.queryDetails.nullable.graphQLErrorOrNull()?.message)
+  }
+}

--- a/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
+++ b/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
@@ -1,19 +1,11 @@
 package test
 
-import com.apollographql.apollo.api.getOrNull
-import com.apollographql.apollo.api.getOrThrow
-import com.apollographql.apollo.api.graphQLErrorOrNull
-import `null`.FragmentsQuery
-import `null`.NullAndNonNullQuery
-import `null`.PriceNullQuery
-import `null`.ProductIgnoreErrorsQuery
-import `null`.ProductNullQuery
-import `null`.ProductQuery
-import `null`.ProductResultQuery
-import `null`.ProductThrowQuery
-import `null`.UserNullQuery
-import `null`.UserQuery
-import `null`.UserResultQuery
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.OnError
+import com.apollographql.mockserver.MockServer
+import com.apollographql.mockserver.enqueueString
+import com.example.GetAQuery
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -21,141 +13,27 @@ import kotlin.test.assertNull
 
 class OnErrorTest {
   @Test
-  fun userOnUserNameError() {
-    val es = ExecutableSchema
-    val response = UserQuery().parseResponse(userNameError)
-    assertNull(response.exception)
-  }
-
-  @Test
-  fun userResultOnUserNameError() {
-    val response = UserResultQuery().parseResponse(userNameError)
-
-    assertNull(response.data?.user?.getOrNull()?.name)
-  }
-
-  @Test
-  fun userNullOnUserNameError() {
-    val response = UserNullQuery().parseResponse(userNameError)
-
-    assertNull(response.data!!.user?.name)
-  }
-
-  @Test
-  fun userOnUserSuccess() {
-    val response = UserQuery().parseResponse(userSuccess)
-
-    assertEquals("Pancakes", response.data!!.user?.name)
-  }
-
-  @Test
-  fun userResultOnUserSuccess() {
-    val response = UserResultQuery().parseResponse(userSuccess)
-
-    assertEquals("Pancakes", response.data!!.user.getOrThrow().name)
-  }
-
-  @Test
-  fun userNullOnUserSuccess() {
-    val response = UserNullQuery().parseResponse(userSuccess)
-
-    assertEquals("Pancakes", response.data!!.user!!.name)
-  }
-
-  @Test
-  fun productOnProductPriceError() {
-    val response = ProductQuery().parseResponse(productPriceError)
-
-    assertNotNull(response.data)
-    assertNull(response.exception)
-  }
-
-  @Test
-  fun productThrowOnProductPriceError() {
-    val response = ProductThrowQuery().parseResponse(productPriceError)
-
-    assertNull(response.data)
-  }
-
-  @Test
-  fun productResultOnProductPriceError() {
-    val response = ProductResultQuery().parseResponse(productPriceError)
-
-    assertNull(null, response.data?.product?.getOrNull()?.price)
-  }
-
-  @Test
-  fun productNullOnProductPriceError() {
-    val response = ProductNullQuery().parseResponse(productPriceError)
-
-    assertNull(response.data?.product?.price)
-    assertNotNull(response.data)
-  }
-
-  @Test
-  fun productIgnoreErrorsOnProductPriceError() {
-    val response = ProductIgnoreErrorsQuery().parseResponse(productPriceError)
-
-    assertNotNull(response.data?.product)
-    assertNull(response.data?.product?.price)
-    assertEquals("cannot resolve price", response.errors?.single()?.message)
-  }
-
-  @Test
-  fun productPriceNullOnProductPriceError() {
-    val response = PriceNullQuery().parseResponse(productPriceError)
-
-    assertNotNull(response.data?.product)
-    assertNull(response.data?.product?.price)
-    assertEquals("cannot resolve price", response.errors?.single()?.message)
-  }
-
-  @Test
-  fun productPriceNullOnProductPriceNull() {
-    val response = PriceNullQuery().parseResponse(productPriceNull)
-
-    assertNotNull(response.data?.product)
-    assertNull(response.data?.product?.price)
-    assertNull(response.errors)
-  }
-
-  @Test
-  fun nullAndNonNull() {
-    val response = NullAndNonNullQuery().parseResponse("""
-      {
-        "data": { "nonNull": 42, "nullable": null }
-      }
-    """.trimIndent())
-
-    // plus(0) is only used to check that `nonNull` is non nullable
-    assertEquals(42, response.data!!.nonNull.plus(0))
-  }
-
-  @Test
-  fun fragments() {
-    val response = FragmentsQuery().parseResponse("""
-      {
-        "data":  {"__typename": "Query", "nonNull": 42, "nullable": null }
-      }
-    """.trimIndent())
-
-    // nonNull has explicit @catch(to: NULL)
-    assertEquals(42, response.data!!.nonNull?.plus(0))
-    // nonNull is the same field but from a different fragment
-    assertEquals(42, response.data!!.queryDetails.nonNull.getOrThrow().plus(0))
-  }
-
-  @Test
-  fun fragmentErrors() {
-    val response = FragmentsQuery().parseResponse("""
-      {
-        "errors": [{"message": "Oops", "path": ["nullable"] }],
-        "data": {"__typename": "Query", "nonNull": 42, "nullable": null }
-      }
-    """.trimIndent())
-
-    assertEquals(null, response.data!!.nullable?.plus(0))
-    // nonNull is the same field but from a different fragment and can have different @catch
-    assertEquals("Oops", response.data!!.queryDetails.nullable.graphQLErrorOrNull()?.message)
+  fun onErrorNullDoesNotPropagateErrors(): Unit = runBlocking {
+    MockServer().use { mockServer ->
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .build()
+          .use { apolloClient ->
+            mockServer.enqueueString(
+                // language=JSON
+                """
+              {
+                "errors": [{ "message": "oops", "path": ["a", "f"] }],
+                "data": { "a": { "f": null, "g": "g" } }
+              }
+            """.trimIndent())
+            val response = apolloClient.query(GetAQuery())
+                .onError(OnError.NULL)
+                .execute()
+            assertNotNull(response.data?.a)
+            assertNull(response.data?.a?.f)
+            assertEquals("g", response.data?.a?.g)
+          }
+    }
   }
 }

--- a/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
+++ b/tests/on-error/src/test/kotlin/test/OnErrorTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.api.OnError
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueString
 import com.example.GetAQuery
+import com.example.GetHQuery
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,6 +34,32 @@ class OnErrorTest {
             assertNotNull(response.data?.a)
             assertNull(response.data?.a?.f)
             assertEquals("g", response.data?.a?.g)
+          }
+    }
+  }
+
+  @Test
+  fun onErrorNullDoesNotPropagateErrorsInLists(): Unit = runBlocking {
+    MockServer().use { mockServer ->
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .build()
+          .use { apolloClient ->
+            mockServer.enqueueString(
+                // language=JSON
+                """
+              {
+                "errors": [{ "message": "oops", "path": ["a", "h", 1] }],
+                "data": { "a": { "h": ["h", null]} }
+              }
+            """.trimIndent())
+            val response = apolloClient.query(GetHQuery())
+                .onError(OnError.NULL)
+                .execute()
+            assertNotNull(response.data?.a)
+            assertEquals("h", response.data?.a?.h?.get(0))
+            assertNull(response.data?.a?.h?.get(1))
+            assertEquals("oops", response.errors?.get(0)?.message)
           }
     }
   }

--- a/tests/sample-server/build.gradle.kts
+++ b/tests/sample-server/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
   implementation(libs.apollo.annotations)
   implementation(libs.kotlinx.coroutines)
   implementation(libs.atomicfu.library)
-  implementation(libs.apollo.execution)
+  implementation(libs.apollo.execution.runtime)
 
   implementation(platform(libs.http4k.bom))
   implementation(libs.http4k.core)

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -63,6 +63,7 @@ listOf(
     "no-runtime",
     "normalization-tests",
     "number_scalar",
+    "on-error",
     "optimistic-data",
     "optional-variables",
     "outofbounds",


### PR DESCRIPTION
Previously only execution supported it. Moves `OnError` to `apollo-api`