### PR TITLE
Expose services as a `NamedDomainObjectCollection`

### DIFF
--- a/libraries/apollo-gradle-plugin/api/apollo-gradle-plugin.api
+++ b/libraries/apollo-gradle-plugin/api/apollo-gradle-plugin.api
@@ -25,7 +25,7 @@ public final class com/apollographql/apollo/gradle/api/ApolloDependencies {
 	public final fun getRuntime ()Lorg/gradle/api/artifacts/Dependency;
 }
 
-public abstract interface class com/apollographql/apollo/gradle/api/ApolloExtension {
+public abstract interface class com/apollographql/apollo/gradle/api/ApolloExtension : com/apollographql/apollo/gradle/api/ApolloServicesContainer {
 	public abstract fun createAllAndroidVariantServices (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun createAllKotlinSourceSetServices (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun getDeps ()Lcom/apollographql/apollo/gradle/api/ApolloDependencies;
@@ -101,6 +101,10 @@ public abstract interface class com/apollographql/apollo/gradle/api/ApolloGradle
 	public abstract fun getWarnOnDeprecatedUsages ()Ljava/lang/Boolean;
 }
 
+public abstract interface class com/apollographql/apollo/gradle/api/ApolloServicesContainer {
+	public abstract fun getServices ()Lorg/gradle/api/NamedDomainObjectCollection;
+}
+
 public abstract interface class com/apollographql/apollo/gradle/api/CompilerPlugin {
 	public abstract fun argument (Ljava/lang/String;Ljava/lang/Object;)V
 }
@@ -133,7 +137,7 @@ public final class com/apollographql/apollo/gradle/api/SchemaConnection {
 	public final fun getTask ()Lorg/gradle/api/tasks/TaskProvider;
 }
 
-public abstract interface class com/apollographql/apollo/gradle/api/Service {
+public abstract interface class com/apollographql/apollo/gradle/api/Service : org/gradle/api/Named {
 	public abstract fun dataBuildersOutputDirConnection (Lorg/gradle/api/Action;)V
 	public abstract fun dependsOn (Ljava/lang/Object;)V
 	public abstract fun dependsOn (Ljava/lang/Object;Z)V
@@ -167,7 +171,6 @@ public abstract interface class com/apollographql/apollo/gradle/api/Service {
 	public abstract fun getIncludes ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getJsExport ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getNullableFieldStyle ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOperationManifest ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getOperationManifestFormat ()Lorg/gradle/api/provider/Property;

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -6,7 +6,7 @@ import org.gradle.api.provider.Property
 /**
  * The entry point for configuring the apollo plugin.
  */
-interface ApolloExtension {
+interface ApolloExtension : ApolloServicesContainer {
 
   /**
    * Registers a new [Service]

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloServicesContainer.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloServicesContainer.kt
@@ -1,0 +1,17 @@
+package com.apollographql.apollo.gradle.api
+
+import org.gradle.api.NamedDomainObjectCollection
+
+/**
+ * Exposes Apollo [Service] instances as a Gradle named collection.
+ */
+interface ApolloServicesContainer {
+
+  /**
+   * The services registered on the Apollo extension.
+   *
+   * This collection is read-only: services must be registered with `apollo.service("name") { }`.
+   * Attempting to mutate it directly (e.g. `services.add(...)`) throws [UnsupportedOperationException].
+   */
+  val services: NamedDomainObjectCollection<Service>
+}

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -5,6 +5,7 @@ package com.apollographql.apollo.gradle.api
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.annotations.ApolloExperimental
 import org.gradle.api.Action
+import org.gradle.api.Named
 import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.component.SoftwareComponent
@@ -24,9 +25,7 @@ import org.gradle.api.tasks.TaskProvider
  *
  * The queries will be compiled and verified against the schema to generate the models.
  */
-interface Service {
-  val name: String
-
+interface Service : Named {
   /**
    * Operation files to include.
    * The values are interpreted as in [org.gradle.api.tasks.util.PatternFilterable]

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo.gradle.ComponentFilter
 import com.apollographql.apollo.gradle.api.ApolloDependencies
 import com.apollographql.apollo.gradle.api.ApolloExtension
 import com.apollographql.apollo.gradle.api.ApolloGradleToolingModel
+import com.apollographql.apollo.gradle.api.ApolloServicesContainer
 import com.apollographql.apollo.gradle.api.SchemaConnection
 import com.apollographql.apollo.gradle.api.Service
 import com.apollographql.apollo.gradle.getAgpVersion
@@ -31,6 +32,7 @@ import com.apollographql.apollo.gradle.task.registerApolloGenerateSourcesTask
 import com.apollographql.apollo.gradle.task.registerApolloRegisterOperationsTask
 import gratatouille.wiring.capitalizeFirstLetter
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -56,10 +58,10 @@ import javax.inject.Inject
 
 abstract class DefaultApolloExtension(
     private val project: Project,
-) : ApolloExtension {
+    private val servicesContainer: ApolloServicesContainer,
+) : ApolloExtension, ApolloServicesContainer by servicesContainer {
 
   private var codegenOnGradleSyncConfigured: Boolean = false
-  private val services = mutableListOf<DefaultService>()
   private val generateApolloSources: TaskProvider<Task>
   private val generateApolloProjectModel: TaskProvider<out Task>
   private var hasExplicitService = false
@@ -91,7 +93,12 @@ abstract class DefaultApolloExtension(
   internal val agp
     get() = agpOrNull ?: error("Apollo: androidComponents extension not found, is the Android Gradle Plugin applied?")
 
-  internal fun getServiceInfos(project: Project): List<ApolloGradleToolingModel.ServiceInfo> = services.map { service ->
+  final override val services: NamedDomainObjectCollection<Service> = servicesContainer.services
+
+  private val defaultServices
+    get() = services.withType(DefaultService::class.java)
+
+  internal fun getServiceInfos(project: Project): List<ApolloGradleToolingModel.ServiceInfo> = defaultServices.map { service ->
     DefaultServiceInfo(
         name = service.name,
         schemaFiles = service.schemaFilesSnapshot(project),
@@ -113,7 +120,7 @@ abstract class DefaultApolloExtension(
     }
   }
 
-  internal fun getServiceTelemetryData(): List<ApolloGradleToolingModel.TelemetryData.ServiceTelemetryData> = services.map { service ->
+  internal fun getServiceTelemetryData(): List<ApolloGradleToolingModel.TelemetryData.ServiceTelemetryData> = defaultServices.map { service ->
     DefaultServiceTelemetryData(
         codegenModels = service.codegenModels.orNull,
         failOnWarnings = service.failOnWarnings.orNull,
@@ -231,7 +238,7 @@ abstract class DefaultApolloExtension(
         taskName = ModelNames.generateApolloProjectModel(),
         taskDescription = "Generate Apollo project model",
 
-        serviceNames = project.provider { services.map { it.name }.toSet() },
+        serviceNames = project.provider { defaultServices.names },
         apolloTasksDependencies = project.provider {
           project.configurations.getByName("apolloTasks").files.map { it.absolutePath }.toSet()
         },
@@ -244,7 +251,7 @@ abstract class DefaultApolloExtension(
         androidAgpVersion = project.provider { agpOrNull?.version },
         apolloGenerateSourcesDuringGradleSync = generateSourcesDuringGradleSync,
         apolloLinkSqlite = linkSqlite,
-        usedServiceOptions = project.provider { services.flatMap { it.telemetryUsedOptions() }.toSet() }
+        usedServiceOptions = project.provider { defaultServices.flatMap { it.telemetryUsedOptions() }.toSet() }
     )
 
     project.afterEvaluate {
@@ -290,9 +297,15 @@ abstract class DefaultApolloExtension(
   override fun service(name: String, action: Action<Service>) {
     hasExplicitService = false
 
-    val service = project.objects.newInstance(DefaultService::class.java, project, name)
-    action.execute(service)
+    check(!services.names.contains(name)) {
+      """Apollo: there is already a service named "$name", please use another name.
+        |To configure an existing one, you can use `apollo.services.named("$name").configure {}`
+      """.trimMargin()
+    }
 
+    val service = project.objects.newInstance(DefaultService::class.java, project, name)
+
+    action.execute(service)
     registerService(service)
     sanityChecks(service)
 
@@ -404,10 +417,10 @@ abstract class DefaultApolloExtension(
   }
 
   private fun registerService(service: DefaultService) {
-    check(services.find { it.name == service.name } == null) {
-      "There is already a service named ${service.name}, please use another name"
+    check(servicesContainer is DefaultApolloServicesContainer) {
+      "Apollo: unexpected ApolloServicesContainer implementation ${servicesContainer::class.java.name}"
     }
-    services.add(service)
+    servicesContainer.mutableServices.add(service)
 
     if (service.graphqlSourceDirectorySet.isReallyEmpty) {
       val dir = File(project.projectDir, "src/${project.mainSourceSet()}/graphql/")

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloServicesContainer.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloServicesContainer.kt
@@ -1,0 +1,45 @@
+package com.apollographql.apollo.gradle.internal
+
+import com.apollographql.apollo.gradle.api.ApolloServicesContainer
+import com.apollographql.apollo.gradle.api.Service
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Provider
+import javax.inject.Inject
+
+/**
+ * Default implementation of [ApolloServicesContainer], used to store the services created.
+ */
+internal abstract class DefaultApolloServicesContainer @Inject constructor(objectFactory: ObjectFactory) : ApolloServicesContainer {
+  /**
+   * The real, mutable container. Internal only: services must be registered through
+   * `apollo.service("name") { }`, which adds to this container.
+   */
+  internal val mutableServices: NamedDomainObjectContainer<Service> =
+    objectFactory.domainObjectContainer(Service::class.java)
+
+  override val services: NamedDomainObjectCollection<Service> = object : NamedDomainObjectCollection<Service> by mutableServices {
+    override fun add(element: Service): Boolean = throwReadOnlyAdd()
+    override fun addAll(elements: Collection<Service>): Boolean = throwReadOnlyAdd()
+    override fun addLater(provider: Provider<out Service>): Unit = throwReadOnlyAdd()
+    override fun addAllLater(provider: Provider<out Iterable<Service>>): Unit = throwReadOnlyAdd()
+
+    override fun remove(element: Service): Boolean = throwReadOnlyRemove()
+    override fun removeAll(elements: Collection<Service>): Boolean = throwReadOnlyRemove()
+    override fun retainAll(elements: Collection<Service>): Boolean = throwReadOnlyRemove()
+    override fun clear(): Unit = throwReadOnlyRemove()
+
+    override fun iterator(): MutableIterator<Service> = object : MutableIterator<Service> by mutableServices.iterator() {
+      override fun remove(): Unit = throwReadOnlyRemove()
+    }
+
+    private fun throwReadOnlyAdd(): Nothing = throw UnsupportedOperationException(
+        "Apollo: the services collection is read-only. Use `apollo.service(\"name\") { }` to register a service.",
+    )
+
+    private fun throwReadOnlyRemove(): Nothing = throw UnsupportedOperationException(
+        "Apollo: the services collection is read-only. It is not possible to remove a service.",
+    )
+  }
+}

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -10,7 +10,6 @@ import com.apollographql.apollo.gradle.api.Registry
 import com.apollographql.apollo.gradle.api.Service
 import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.file.FileCollection
@@ -18,7 +17,7 @@ import org.gradle.api.file.RegularFileProperty
 import java.io.File
 import javax.inject.Inject
 
-abstract class DefaultService @Inject constructor(val project: Project, override val name: String) : Service {
+abstract class DefaultService @Inject constructor(val project: Project, private val serviceName: String) : Service {
 
   internal val pluginsArguments = mutableMapOf<String, Any?>()
   internal var hasPlugin: Boolean = false
@@ -273,6 +272,8 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   override fun issueSeverity(name: String, severity: String) {
     issueSeverities.put(name, severity)
   }
+
+  override fun getName(): String = serviceName
 }
 
 internal fun DefaultService.fallbackFiles(project: Project, block: (ConfigurableFileTree) -> Unit): FileCollection {

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/apolloPlugin.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/apolloPlugin.kt
@@ -13,7 +13,13 @@ import javax.inject.Inject
 
 @GPlugin(id = "com.apollographql.apollo")
 fun apolloPlugin(project: Project) {
-  val apolloExtension: DefaultApolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project) as DefaultApolloExtension
+  val apolloExtension: DefaultApolloExtension = project.extensions.create(
+      ApolloExtension::class.java,
+      "apollo",
+      DefaultApolloExtension::class.java,
+      project,
+      project.objects.newInstance(DefaultApolloServicesContainer::class.java)
+  ) as DefaultApolloExtension
 
   project.configureDefaultVersionsResolutionStrategy()
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/GradleToolingTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/GradleToolingTests.kt
@@ -59,16 +59,16 @@ class GradleToolingTests {
       Assert.assertEquals(emptyList<String>(), toolingModel.serviceInfos.flatMap { it.upstreamProjectPaths })
 
       val serviceInfo0 = toolingModel.serviceInfos[0]
-      Assert.assertEquals("starwars", serviceInfo0.name)
-      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars")), serviceInfo0.graphqlSrcDirs)
-      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars/example/schema.json")), serviceInfo0.schemaFiles)
-      Assert.assertEquals("https://example.com", serviceInfo0.endpointUrl)
-      Assert.assertEquals(mapOf("header1" to "value1"), serviceInfo0.endpointHeaders)
+      Assert.assertEquals("githunt", serviceInfo0.name)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt")), serviceInfo0.graphqlSrcDirs)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt/schema.json")), serviceInfo0.schemaFiles)
 
       val serviceInfo1 = toolingModel.serviceInfos[1]
-      Assert.assertEquals("githunt", serviceInfo1.name)
-      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt")), serviceInfo1.graphqlSrcDirs)
-      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt/schema.json")), serviceInfo1.schemaFiles)
+      Assert.assertEquals("starwars", serviceInfo1.name)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars")), serviceInfo1.graphqlSrcDirs)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars/example/schema.json")), serviceInfo1.schemaFiles)
+      Assert.assertEquals("https://example.com", serviceInfo1.endpointUrl)
+      Assert.assertEquals(mapOf("header1" to "value1"), serviceInfo1.endpointHeaders)
     }
   }
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/KotlinDSLTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/KotlinDSLTests.kt
@@ -4,29 +4,89 @@ import util.TestUtils
 import util.generatedSource
 import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class KotlinDSLTests {
   @Test
-  fun `generated accessors do not expose DefaultApolloExtension`() {
+  fun `DefaultApolloExtension should expose a NamedDomainObjectCollection`() {
     val apolloConfiguration = """
       apollo {
-        println("apollo has ${'$'}{services.size} services")
+        service("service") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
       }
+
+      println("apollo has ${'$'}{apollo.services.size} services")
     """.trimIndent()
 
     TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
-      var exception: Exception? = null
-      try {
-        TestUtils.executeGradle(dir)
-      } catch (e: UnexpectedBuildFailure) {
-        exception = e
-        Truth.assertThat(e.message).contains("Unresolved reference 'services'.")
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("apollo has 1 services")
+    }
+  }
+
+  @Test
+  fun `services can be accessed by name via Named interface`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
       }
-      Assert.assertNotNull(exception)
+
+      println("service schemaFiles count is ${'$'}{apollo.services.named("starwars").get().schemaFiles.count()}")
+    """.trimIndent()
+
+    TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("service schemaFiles count is 1")
+    }
+  }
+
+  @Test
+  fun `services collection reflects multiple registered services`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+        service("githunt") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+      }
+
+      println("apollo has ${'$'}{apollo.services.size} services")
+      println("names: ${'$'}{apollo.services.names}")
+    """.trimIndent()
+
+    TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("apollo has 2 services")
+      Truth.assertThat(message).contains("names: [githunt, starwars]")
+    }
+  }
+
+  @Test
+  fun `service name is accessible through Named interface after registration`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+      }
+      println("name: ${'$'}{apollo.services.named("starwars").get().name}")
+    """.trimIndent()
+
+    TestUtils.withGeneratedAccessorsProject(apolloConfiguration) {dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("name: starwars")
     }
   }
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/MultiServicesTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/MultiServicesTests.kt
@@ -67,6 +67,33 @@ class MultiServicesTests {
   }
 
   @Test
+  fun `duplicate service names throw an error`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          packageName.set("starwars")
+          srcDir("src/main/graphql/starwars")
+        }
+        service("starwars") {
+          packageName.set("githunt")
+          srcDir("src/main/graphql/githunt")
+        }
+      }
+    """.trimIndent()
+    withMultipleServicesProject(apolloConfiguration) { dir ->
+      try {
+        TestUtils.executeGradle(dir)
+        fail("expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        MatcherAssert.assertThat(
+            e.message,
+            containsString("To configure an existing one, you can use `apollo.services.named(\"starwars\").configure {}`")
+        )
+      }
+    }
+  }
+
+  @Test
   fun `can specify services explicitly`() {
     val apolloConfiguration = """
       apollo {

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServiceTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServiceTests.kt
@@ -301,4 +301,19 @@ class ServiceTests {
       assertTrue(dir.generatedSource("com/example/fragment/SpeciesInformationImpl.kt").isFile)
     }
   }
+
+  @Test
+  fun `service name is consistent via Named interface`() {
+    val config = """
+      apollo {
+        service("myService") {
+          packageNamesFromFilePaths()
+        }
+      }
+    """.trimIndent()
+    withSimpleProject(config) { dir ->
+      val result = TestUtils.executeTask("generateApolloSources", dir)
+      assertEquals(TaskOutcome.SUCCESS, result.task(":generateMyServiceApolloSources")?.outcome)
+    }
+  }
 }

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServicesContainerTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServicesContainerTests.kt
@@ -1,0 +1,121 @@
+package test
+
+import com.google.common.truth.Truth
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Assert.fail
+import org.junit.Test
+import util.TestUtils
+import util.TestUtils.withGeneratedAccessorsProject
+
+class ServicesContainerTests {
+
+  @Test
+  fun `apollo services collection is accessible with zero services`() {
+    val apolloConfiguration = """
+      println("services count: ${'$'}{apollo.services.size}")
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("services count: 0")
+    }
+  }
+
+  @Test
+  fun `apollo services collection is empty by default`() {
+    val apolloConfiguration = """
+      println("services empty: ${'$'}{apollo.services.isEmpty()}")
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("services empty: true")
+    }
+  }
+
+  @Test
+  fun `apollo services names can be iterated`() {
+    val apolloConfiguration = """
+      apollo {
+        service("alpha") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+        service("beta") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+      }
+      println("names: ${'$'}{apollo.services.map { it.name }.joinToString(",")}")
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("alpha")
+      Truth.assertThat(message).contains("beta")
+    }
+  }
+
+  @Test
+  fun `apollo services can be accessed by index`() {
+    val apolloConfiguration = """
+      apollo {
+        service("first") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+        service("second") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+      }
+      println("first: ${'$'}{apollo.services.first().name}")
+      println("second: ${'$'}{apollo.services.last().name}")
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      val message = TestUtils.executeGradle(dir).output
+      Truth.assertThat(message).contains("first: first")
+      Truth.assertThat(message).contains("second: second")
+    }
+  }
+
+  @Test
+  fun `apollo services collection is read-only for adding`() {
+    val apolloConfiguration = """
+      val service = project.objects.newInstance(com.apollographql.apollo.gradle.internal.DefaultService::class.java, project, "starwars")
+      apollo.services.add(service)
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      try {
+        TestUtils.executeGradle(dir)
+        fail("expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        Truth.assertThat(e.message).contains("the services collection is read-only")
+      }
+    }
+  }
+
+  @Test
+  fun `apollo services collection is read-only for removing`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          srcDir("src/main/graphql/com/example")
+          schemaFiles.from(file("src/main/graphql/com/example/schema.json"))
+        }
+      }
+      apollo.services.clear()
+    """.trimIndent()
+
+    withGeneratedAccessorsProject(apolloConfiguration) { dir ->
+      try {
+        TestUtils.executeGradle(dir)
+        fail("expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        Truth.assertThat(e.message).contains("the services collection is read-only")
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Up until now, Apollo services were kept internally as a `MutableList<DefaultService>` without any public API for looking them up or configuring them post-creation. This made it pretty much impossible to tweak a service defined in one module from another.

Now, with the new `apollo.services.named("service").configure {}` API, downstream modules and convention plugins can finally configure an already-registered service by name.

## Changes

- **New `ApolloServicesContainer` interface**: this exposes `val services: NamedDomainObjectCollection<Service>` on `ApolloExtension`.
- **`Service` extends Gradle's `Named`**: this replaces the standalone `name` property. It lets you look up services by name through `NamedDomainObjectCollection`.
- **`ApolloExtension` extends `ApolloServicesContainer`**: it delegates to a `DefaultApolloServicesContainer` using `by` delegation.
- **Backed by `DomainObjectContainer`**: we've swapped out `MutableList<DefaultService>` for Gradle's managed `DomainObjectContainer`, which gives us handy methods like `named()`, `matching()`, and other usual collection operations without extra work.
- **Read-only exposed collection**: trying to directly mutate it (like `add`, `remove`, `clear`, etc.) will throw an `UnsupportedOperationException`, with a message guiding users to `apollo.service("name") { }`.
- **Better duplicate-name error**: duplicate names are caught earlier (right in `service()`) and the error message recommends `apollo.services.named("name").configure {}` as the fix.

## Breaking changes

1. **Services are now sorted alphabetically, not by insertion order.** Gradle's `NamedDomainObjectContainer` holds elements in a `SortedSet` keyed by `name`. If you loop through `apollo.services` or depend on `first()`/`last()` ordering, expect a shift: it’ll be `[alpha, beta]` instead of `[beta, alpha]` if `beta` was added first. We updated the `GradleToolingTests` to reflect this (the service assertions were reordered).

2. **`Service.name` moved to `Named.getName()`.** It’s still source-compatible (the property is still `name`), but the API dump (`apollo-gradle-plugin.api`) now shows `getName()` being inherited from `org.gradle.api.Named`, not originally declared on `Service`.

3. **`services` is now a public API on `ApolloExtension`.** Before, the backing list was a `private val` and couldn’t be accessed from build scripts. Now, `apollo.services` is available for everyone and returns a read-only collection. If someone had a local script variable named `services`, it might just overshadow this new property.

---

This is basically a proposal to allow configuration outside of the main `service` registry. In one of my projects, I have the main configuration in a [convention plugin](https://github.com/alvr/katana/blob/77b19d396128add297112c0bf0fddb5667e8995a/build-logic/katana-convention/src/main/kotlin/dev/alvr/katana/buildlogic/mp/data/KatanaMultiplatformDataRemotePlugin.kt#L49-L76). To avoid having to configure all the modules in the same plugin, I prefer to configure them in their own module; otherwise, there would be an endless number of conditions for each module. You can also be able to use typesafe project accessors if enabled.

`common/media/data/gradle.build.kts`
```kotlin
apollo.services.named("service").configure {
    generateAsInternal = false
}
```

`feature/lists/data/gradle.build.kts`
```kotlin
apollo.services.named("service").configure {
    dependsOn(projects.common.media.data)
}
```