### PR TITLE
Make it possible to use the cache 1.0.4 with v5 on K/N

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -574,6 +574,8 @@ public final class com/apollographql/apollo/api/Error {
 }
 
 public final class com/apollographql/apollo/api/Error$Builder {
+	public final synthetic fun -locations (Ljava/util/List;)Lcom/apollographql/apollo/api/Error$Builder;
+	public final synthetic fun -path (Ljava/util/List;)Lcom/apollographql/apollo/api/Error$Builder;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun build ()Lcom/apollographql/apollo/api/Error;
 	public final fun extensions (Ljava/util/Map;)Lcom/apollographql/apollo/api/Error$Builder;

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -1090,8 +1090,10 @@ final class com.apollographql.apollo.api/Error { // com.apollographql.apollo.api
 
         final fun build(): com.apollographql.apollo.api/Error // com.apollographql.apollo.api/Error.Builder.build|build(){}[0]
         final fun extensions(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.extensions|extensions(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
+        final fun locations(kotlin.collections/List<com.apollographql.apollo.api/Error.Location>): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.locations|locations(kotlin.collections.List<com.apollographql.apollo.api.Error.Location>){}[0]
         final fun locations(kotlin.collections/List<com.apollographql.apollo.api/Error.Location>?): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.locations|locations(kotlin.collections.List<com.apollographql.apollo.api.Error.Location>?){}[0]
         final fun nonStandardFields(kotlin.collections/Map<kotlin/String, kotlin/Any?>?): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.nonStandardFields|nonStandardFields(kotlin.collections.Map<kotlin.String,kotlin.Any?>?){}[0]
+        final fun path(kotlin.collections/List<kotlin/Any>): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.path|path(kotlin.collections.List<kotlin.Any>){}[0]
         final fun path(kotlin.collections/List<kotlin/Any>?): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.path|path(kotlin.collections.List<kotlin.Any>?){}[0]
         final fun putExtension(kotlin/String, kotlin/Any?): com.apollographql.apollo.api/Error.Builder // com.apollographql.apollo.api/Error.Builder.putExtension|putExtension(kotlin.String;kotlin.Any?){}[0]
     }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Error.kt
@@ -1,6 +1,8 @@
 package com.apollographql.apollo.api
 
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmSynthetic
 
 /**
  * Represents an error response returned from the GraphQL server
@@ -48,7 +50,21 @@ constructor(
       this.locations = locations
     }
 
+    @JvmName("-locations")
+    @JvmSynthetic
+    @Deprecated("synthetic function for compatibility with the cache linked against Apollo 4", level = DeprecationLevel.HIDDEN)
+    fun locations(locations: List<Location>) = apply {
+      this.locations = locations
+    }
+
     fun path(path: List<Any>?) = apply {
+      this.path = path
+    }
+
+    @JvmName("-path")
+    @JvmSynthetic
+    @Deprecated("synthetic function for compatibility with the cache linked against Apollo 4", level = DeprecationLevel.HIDDEN)
+    fun path(path: List<Any>) = apply {
       this.path = path
     }
 


### PR DESCRIPTION
Fix K/N ABI
On native, making a function parameter nullable is a binary breaking change.
To fix that, we introduce back the non-nullable version as hidden.
