### PR TITLE
Fix CatchToResult toJson

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
@@ -437,7 +437,8 @@ private class CatchToResultAdapter<T>(private val wrappedAdapter: Adapter<T>) : 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: FieldResult<T>) {
     when (value) {
       is FieldResult.Success -> wrappedAdapter.toJson(writer, customScalarAdapters, value.getOrThrow())
-      else -> Unit // ignore errors
+      // write the null the server sent for the errored field, so that the enclosing object stays well-formed
+      else -> writer.nullValue()
     }
   }
 }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
@@ -437,7 +437,10 @@ private class CatchToResultAdapter<T>(private val wrappedAdapter: Adapter<T>) : 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: FieldResult<T>) {
     when (value) {
       is FieldResult.Success -> wrappedAdapter.toJson(writer, customScalarAdapters, value.getOrThrow())
-      // write the null the server sent for the errored field, so that the enclosing object stays well-formed
+      /**
+       * Write the null the server sent for the errored field, so that the enclosing object stays well-formed.
+       * When writing to the cache, the errors are transmitted out of band.
+       */
       else -> writer.nullValue()
     }
   }

--- a/tests/catch/src/main/graphql/shared/operations.graphql
+++ b/tests/catch/src/main/graphql/shared/operations.graphql
@@ -46,5 +46,14 @@ query PriceNull {
   }
 }
 
+query UserResultAndProduct {
+  user @catch(to: RESULT) {
+    name
+  }
+  product {
+    price
+  }
+}
+
 
 

--- a/tests/catch/src/test/kotlin/test/CatchResultTest.kt
+++ b/tests/catch/src/test/kotlin/test/CatchResultTest.kt
@@ -1,8 +1,14 @@
 package test
 
+import com.apollographql.apollo.api.CustomScalarAdapters
+import com.apollographql.apollo.api.Error
+import com.apollographql.apollo.api.FieldResult
+import com.apollographql.apollo.api.Query
 import com.apollographql.apollo.api.graphQLErrorOrNull
 import com.apollographql.apollo.api.getOrNull
 import com.apollographql.apollo.api.getOrThrow
+import com.apollographql.apollo.api.json.MapJsonWriter
+import com.apollographql.apollo.exception.ApolloGraphQLException
 import result.PriceNullQuery
 import result.ProductIgnoreErrorsQuery
 import result.ProductNullQuery
@@ -10,6 +16,7 @@ import result.ProductQuery
 import result.ProductResultQuery
 import result.UserNullQuery
 import result.UserQuery
+import result.UserResultAndProductQuery
 import result.UserResultQuery
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -107,4 +114,41 @@ class CatchResultTest {
     assertNull(response.data?.product?.getOrNull()?.price)
     assertNull(response.errors)
   }
+
+  @Test
+  fun composeFailureFollowedBySibling() {
+    val data = UserResultAndProductQuery.Data(
+        user = userFailure,
+        product = FieldResult.Success(UserResultAndProductQuery.Product(price = FieldResult.Success("10"))),
+    )
+
+    assertEquals(
+        mapOf("user" to null, "product" to mapOf("price" to "10")),
+        UserResultAndProductQuery().compose(data)
+    )
+  }
+
+  @Test
+  fun composeFailureAsLastField() {
+    val data = UserResultQuery.Data(user = userFailure)
+
+    assertEquals(mapOf("user" to null), UserResultQuery().compose(data))
+  }
+
+  @Test
+  fun composeRoundTripsParsedFailure() {
+    val data = UserResultQuery().parseResponse(userNameError).data!!
+
+    assertEquals(mapOf("user" to mapOf("name" to null)), UserResultQuery().compose(data))
+  }
+}
+
+private val userFailure = FieldResult.Failure(
+    ApolloGraphQLException(Error.Builder("cannot resolve user").path(listOf("user")).build())
+)
+
+private fun <D : Query.Data> Query<D>.compose(data: D): Any? {
+  val writer = MapJsonWriter()
+  adapter().toJson(writer, CustomScalarAdapters.Empty, data)
+  return writer.root()
 }


### PR DESCRIPTION
Fixes #6983 
  
`CatchToResultAdapter.toJson` writes nothing for a `FieldResult.Failure` (`else -> Unit`), leaving the `JsonWriter` with a
dangling field name. Composing any later sibling throws `IllegalStateException: Check failed.` from `MapJsonWriter.name`,
and a `Failure` in the last position is silently omitted from the composed output. This surfaces through the normalized
cache, which composes every response before writing it (full analysis and stack trace in the issue).

The fix writes the `null` the server sent for the errored field, mirroring `CatchToNullAdapter`.

### Tests

The existing catch tests only exercise parsing, and no operation had a RESULT-caught field followed by a sibling, so this
adds a `UserResultAndProduct` operation to `tests/catch` and three regression tests to `CatchResultTest`:

- `composeFailureFollowedBySibling` — threw `IllegalStateException` before the fix
- `composeFailureAsLastField` — composed `{}` instead of `{user=null}` before the fix
- `composeRoundTripsParsedFailure` — parse → compose symmetry for the existing `userNameError` fixture

All three fail on `main` without the fix; `:catch:test` and `:catch-responseBased:test` pass with it.