### PR TITLE
Migrate Develocity publishing to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Maven Central](https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fapollographql%2Fapollo%2Fapollo-api-jvm%2Fmaven-metadata.xml&style=flat-square&label=maven-central&color=%235C96B2&strategy=latestProperty
 )](https://central.sonatype.com/namespace/com.apollographql.apollo)
 
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A&style=flat-square)](https://ge.apollographql.com/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A&style=flat-square)](https://community.develocity.cloud/scans?search.rootProjectNames=apollo-kotlin)
 
   </div>
   <h1 align="center">Apollo Kotlin</h1>

--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -2,7 +2,8 @@
 def isCI = System.getenv("CI") != null
 
 develocity {
-  server = "https://ge.apollographql.com"
+  server = "https://community.develocity.cloud"
+  projectId = "apollo"
   allowUntrustedServer = false
 
   buildScan {


### PR DESCRIPTION
# Migrate Develocity publishing to the OSS Community Develocity Instance

This migrates the project's Build Scan® and Build Cache publishing from the dedicated `ge.apollographql.com` instance to the shared, Gradle-managed **OSS Community Develocity Instance** at <https://community.develocity.cloud> (project `apollo`).

## Changes
- `gradle/ge.gradle` — point `server` at `https://community.develocity.cloud` and set `projectId = "apollo"`.
- `README.md` — update the "Revved up by Develocity" badge to link to the community instance.

## Action required: update the CI access-key secret
CI already passes `DEVELOCITY_ACCESS_KEY`; only its **value** needs to change to the new host.

1. Repo **Settings → Secrets and variables → Actions**
2. Update (or add) the `DEVELOCITY_ACCESS_KEY` secret to:

   ```
   community.develocity.cloud=<the apollo-ci access key shared with you>
   ```

   The `community.develocity.cloud=` prefix is required — without the host, the key is silently ignored.

## Local builds (optional)
Contributors can provision a personal key for the new instance:

```
./gradlew provisionDevelocityAccessKey
```

## Note on this PR's own CI run
This PR is from a fork, so its CI run can't read the repository secret and won't publish a scan. After merge, CI on this repository will publish to <https://community.develocity.cloud>.
